### PR TITLE
Remove pricing plan walkthrough

### DIFF
--- a/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
@@ -3,10 +3,11 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
@@ -20,7 +21,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();

--- a/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
@@ -5,11 +5,9 @@ exports.handler = async function (event, context) {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
     if (event.RequestType == 'Create') {
       const params = {
-        CollectionName: event.ResourceProperties.collectionName
+        CollectionName: event.ResourceProperties.collectionName,
+        PricingPlan: 'RequestBasedUsage'
       };
-      // if (params.PricingPlan !== 'RequestBasedUsage') {
-      //   params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      // }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
       console.log('create resource response data' + JSON.stringify(res));
@@ -21,11 +19,9 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Update') {
       const params = {
-        CollectionName: event.ResourceProperties.collectionName
+        CollectionName: event.ResourceProperties.collectionName,
+        PricingPlan: 'RequestBasedUsage'
       };
-      // if (params.PricingPlan !== 'RequestBasedUsage') {
-      //   params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      // }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();
       console.log('update resource response data' + JSON.stringify(res));

--- a/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-geofence-collection-resource-handler.js
@@ -5,12 +5,11 @@ exports.handler = async function (event, context) {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
     if (event.RequestType == 'Create') {
       const params = {
-        CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        CollectionName: event.ResourceProperties.collectionName
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
+      // if (params.PricingPlan !== 'RequestBasedUsage') {
+      //   params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
+      // }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
       console.log('create resource response data' + JSON.stringify(res));
@@ -22,12 +21,11 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Update') {
       const params = {
-        CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        CollectionName: event.ResourceProperties.collectionName
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
+      // if (params.PricingPlan !== 'RequestBasedUsage') {
+      //   params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
+      // }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();
       console.log('update resource response data' + JSON.stringify(res));

--- a/packages/amplify-category-geo/resources/custom-map-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-map-resource-handler.js
@@ -3,13 +3,14 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       let params = {
         MapName: event.ResourceProperties.mapName,
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -23,7 +24,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       let params = {
         MapName: event.ResourceProperties.mapName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();

--- a/packages/amplify-category-geo/resources/custom-map-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-map-resource-handler.js
@@ -8,7 +8,8 @@ exports.handler = async function (event, context) {
         MapName: event.ResourceProperties.mapName,
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
-        }
+        },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -21,7 +22,8 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Update') {
       let params = {
-        MapName: event.ResourceProperties.mapName
+        MapName: event.ResourceProperties.mapName,
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();
@@ -34,7 +36,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       let params = {
-        MapName: event.ResourceProperties.mapName,
+        MapName: event.ResourceProperties.mapName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deleteMap(params).promise();

--- a/packages/amplify-category-geo/resources/custom-map-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-map-resource-handler.js
@@ -8,8 +8,7 @@ exports.handler = async function (event, context) {
         MapName: event.ResourceProperties.mapName,
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
-        },
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        }
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -22,8 +21,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Update') {
       let params = {
-        MapName: event.ResourceProperties.mapName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        MapName: event.ResourceProperties.mapName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();

--- a/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
@@ -7,7 +7,6 @@ exports.handler = async function (event, context) {
       const params = {
         IndexName: event.ResourceProperties.indexName,
         DataSource: event.ResourceProperties.dataSource,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
@@ -25,7 +24,6 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },

--- a/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
@@ -10,6 +10,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -27,6 +28,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();
@@ -40,7 +42,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       const params = {
-        IndexName: event.ResourceProperties.indexName,
+        IndexName: event.ResourceProperties.indexName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deletePlaceIndex(params).promise();

--- a/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
+++ b/packages/amplify-category-geo/resources/custom-place-index-resource-handler.js
@@ -3,6 +3,7 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
@@ -10,7 +11,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -28,7 +29,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
@@ -67,9 +67,6 @@ Object {
     "collectionName": Object {
       "Type": "String",
     },
-    "dataProvider": Object {
-      "Type": "String",
-    },
     "env": Object {
       "Type": "String",
     },
@@ -99,9 +96,6 @@ Object {
               },
             ],
           ],
-        },
-        "dataSource": Object {
-          "Ref": "dataProvider",
         },
         "env": Object {
           "Ref": "env",
@@ -426,9 +420,6 @@ Object {
     "collectionName": Object {
       "Type": "String",
     },
-    "dataProvider": Object {
-      "Type": "String",
-    },
     "env": Object {
       "Type": "String",
     },
@@ -458,9 +449,6 @@ Object {
               },
             ],
           ],
-        },
-        "dataSource": Object {
-          "Ref": "dataProvider",
         },
         "env": Object {
           "Ref": "env",

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
@@ -125,10 +125,11 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
@@ -142,7 +143,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();
@@ -478,10 +479,11 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
@@ -495,7 +497,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/geofenceCollectionStack.test.ts.snap
@@ -76,9 +76,6 @@ Object {
     "isDefault": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
   },
   "Resources": Object {
     "CustomGeofenceCollection": Object {
@@ -109,9 +106,6 @@ Object {
         "env": Object {
           "Ref": "env",
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -140,11 +134,8 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Create') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        PricingPlan: 'RequestBasedUsage'
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
       console.log('create resource response data' + JSON.stringify(res));
@@ -157,11 +148,8 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        PricingPlan: 'RequestBasedUsage'
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();
       console.log('update resource response data' + JSON.stringify(res));
@@ -447,9 +435,6 @@ Object {
     "isDefault": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
   },
   "Resources": Object {
     "CustomGeofenceCollection": Object {
@@ -480,9 +465,6 @@ Object {
         "env": Object {
           "Ref": "env",
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -511,11 +493,8 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Create') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        PricingPlan: 'RequestBasedUsage'
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createGeofenceCollection(params).promise();
       console.log('create resource response data' + JSON.stringify(res));
@@ -528,11 +507,8 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         CollectionName: event.ResourceProperties.collectionName,
-        PricingPlan: event.ResourceProperties.pricingPlan
+        PricingPlan: 'RequestBasedUsage'
       };
-      if (params.PricingPlan !== 'RequestBasedUsage') {
-        params['PricingPlanDataSource'] = event.ResourceProperties.dataSource;
-      }
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateGeofenceCollection(params).promise();
       console.log('update resource response data' + JSON.stringify(res));

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
@@ -123,13 +123,14 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       let params = {
         MapName: event.ResourceProperties.mapName,
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -143,7 +144,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       let params = {
         MapName: event.ResourceProperties.mapName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();
@@ -467,13 +468,14 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       let params = {
         MapName: event.ResourceProperties.mapName,
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -487,7 +489,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       let params = {
         MapName: event.ResourceProperties.mapName,
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/mapStack.test.ts.snap
@@ -65,9 +65,6 @@ Object {
     "mapStyle": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
     "unauthRoleName": Object {
       "Type": "String",
     },
@@ -101,9 +98,6 @@ Object {
         "mapStyle": Object {
           "Ref": "mapStyle",
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -135,7 +129,7 @@ exports.handler = async function (event, context) {
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
         },
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -149,7 +143,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       let params = {
         MapName: event.ResourceProperties.mapName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();
@@ -162,7 +156,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       let params = {
-        MapName: event.ResourceProperties.mapName,
+        MapName: event.ResourceProperties.mapName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deleteMap(params).promise();
@@ -415,9 +409,6 @@ Object {
     "mapStyle": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
     "unauthRoleName": Object {
       "Type": "String",
     },
@@ -451,9 +442,6 @@ Object {
         "mapStyle": Object {
           "Ref": "mapStyle",
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -485,7 +473,7 @@ exports.handler = async function (event, context) {
         Configuration: {
           Style: event.ResourceProperties.mapStyle,
         },
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createMap(params).promise();
@@ -499,7 +487,7 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       let params = {
         MapName: event.ResourceProperties.mapName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updateMap(params).promise();
@@ -512,7 +500,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       let params = {
-        MapName: event.ResourceProperties.mapName,
+        MapName: event.ResourceProperties.mapName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deleteMap(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
@@ -63,9 +63,6 @@ Object {
     "isDefault": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
     "unauthRoleName": Object {
       "Type": "String",
     },
@@ -102,9 +99,6 @@ Object {
             ],
           ],
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -134,10 +128,10 @@ exports.handler = async function (event, context) {
       const params = {
         IndexName: event.ResourceProperties.indexName,
         DataSource: event.ResourceProperties.dataSource,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -152,10 +146,10 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();
@@ -169,7 +163,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       const params = {
-        IndexName: event.ResourceProperties.indexName,
+        IndexName: event.ResourceProperties.indexName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deletePlaceIndex(params).promise();
@@ -419,9 +413,6 @@ Object {
     "isDefault": Object {
       "Type": "String",
     },
-    "pricingPlan": Object {
-      "Type": "String",
-    },
     "unauthRoleName": Object {
       "Type": "String",
     },
@@ -458,9 +449,6 @@ Object {
             ],
           ],
         },
-        "pricingPlan": Object {
-          "Ref": "pricingPlan",
-        },
         "region": Object {
           "Fn::FindInMap": Array [
             "RegionMapping",
@@ -490,10 +478,10 @@ exports.handler = async function (event, context) {
       const params = {
         IndexName: event.ResourceProperties.indexName,
         DataSource: event.ResourceProperties.dataSource,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -508,10 +496,10 @@ exports.handler = async function (event, context) {
     if (event.RequestType == 'Update') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
-        PricingPlan: event.ResourceProperties.pricingPlan,
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
+        PricingPlan: 'RequestBasedUsage'
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();
@@ -525,7 +513,7 @@ exports.handler = async function (event, context) {
     }
     if (event.RequestType == 'Delete') {
       const params = {
-        IndexName: event.ResourceProperties.indexName,
+        IndexName: event.ResourceProperties.indexName
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.deletePlaceIndex(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
+++ b/packages/amplify-category-geo/src/__tests__/service-stacks/__snapshots__/placeIndexStack.test.ts.snap
@@ -124,6 +124,7 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
@@ -131,7 +132,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -149,7 +150,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();
@@ -474,6 +475,7 @@ const aws = require('aws-sdk');
 exports.handler = async function (event, context) {
   try {
     console.log('REQUEST RECEIVED:' + JSON.stringify(event));
+    const pricingPlan = 'RequestBasedUsage';
     if (event.RequestType == 'Create') {
       const params = {
         IndexName: event.ResourceProperties.indexName,
@@ -481,7 +483,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.createPlaceIndex(params).promise();
@@ -499,7 +501,7 @@ exports.handler = async function (event, context) {
         DataSourceConfiguration: {
           IntendedUse: event.ResourceProperties.dataSourceIntendedUse,
         },
-        PricingPlan: 'RequestBasedUsage'
+        PricingPlan: pricingPlan
       };
       const locationClient = new aws.Location({ apiVersion: '2020-11-19', region: event.ResourceProperties.region });
       const res = await locationClient.updatePlaceIndex(params).promise();

--- a/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
@@ -205,35 +205,3 @@ describe('Test reading the resource meta information', () => {
         expect(async () => await readResourceMetaParameters(ServiceName.GeofenceCollection, nonExistingGeofenceCollection)).rejects.toThrowError(errorMessage(nonExistingGeofenceCollection));
     });
 });
-
-describe('Test reading the current pricing plan for Geo resources', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        stateManager.getMeta = jest.fn().mockReturnValue({
-            geo: {
-                map1: map1Params,
-                map2: map2Params,
-                placeIndex1: placeIndex1Params,
-                placeIndex2: placeIndex2Params,
-                geofenceCollection1: geofenceCollection1Params,
-                geofenceCollection2: geofenceCollection2Params
-            }
-        });
-    });
-});
-
-describe('Test updating the pricing plan for all Geo resources', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        stateManager.getMeta = jest.fn().mockReturnValue({
-            geo: {
-                map1: map1Params,
-                placeIndex1: placeIndex1Params,
-                geofenceCollection1: geofenceCollection1Params
-            }
-        });
-        pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
-        JSONUtilities.readJson = jest.fn().mockReturnValue({});
-        JSONUtilities.writeJson = jest.fn().mockReturnValue('');
-    });
-});

--- a/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
@@ -1,10 +1,10 @@
 import { EsriMapStyleType, MapParameters } from '../../service-utils/mapParams';
-import { merge, updateDefaultResource, readResourceMetaParameters, getGeoPricingPlan, updateGeoPricingPlan } from '../../service-utils/resourceUtils';
+import { merge, updateDefaultResource, readResourceMetaParameters } from '../../service-utils/resourceUtils';
 import { stateManager, $TSContext, pathManager, JSONUtilities } from 'amplify-cli-core';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { MapStyle } from '../../service-utils/mapParams';
 import { DataSourceIntendedUse } from '../../service-utils/placeIndexParams';
-import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
+import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 import { category } from '../../constants';
 
 describe('parameter merge utility function works as expected', () => {
@@ -40,7 +40,6 @@ const map1Params = {
     isDefault: false,
     providerPlugin: provider,
     mapStyle: MapStyle.VectorEsriNavigation,
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.AuthorizedAndGuestUsers
 };
 const map2Params = {
@@ -48,7 +47,6 @@ const map2Params = {
     isDefault: true,
     providerPlugin: provider,
     mapStyle: MapStyle.VectorEsriStreets,
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.AuthorizedUsers
 };
 const placeIndex1Params = {
@@ -57,7 +55,6 @@ const placeIndex1Params = {
     providerPlugin: provider,
     dataProvider: DataProvider.Esri,
     dataSourceIntendedUse: DataSourceIntendedUse.Storage,
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.AuthorizedAndGuestUsers
 };
 const placeIndex2Params = {
@@ -66,7 +63,6 @@ const placeIndex2Params = {
     providerPlugin: provider,
     dataProvider: DataProvider.Here,
     dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.AuthorizedUsers
 };
 const geofenceCollection1Params = {
@@ -75,7 +71,6 @@ const geofenceCollection1Params = {
     providerPlugin: provider,
     dataProvider: DataProvider.Esri,
     groupPermissions: {},
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.CognitoGroups
 };
 const geofenceCollection2Params = {
@@ -84,7 +79,6 @@ const geofenceCollection2Params = {
     providerPlugin: provider,
     dataProvider: DataProvider.Here,
     groupPermissions: {},
-    pricingPlan: PricingPlan.MobileAssetManagement,
     accessType: AccessType.CognitoGroups
 };
 
@@ -226,17 +220,6 @@ describe('Test reading the current pricing plan for Geo resources', () => {
             }
         });
     });
-
-    it('reads the current Geo pricing plan correctly', async() => {
-        const actualPricingPlan = await getGeoPricingPlan();
-        expect(actualPricingPlan).toEqual(map1Params.pricingPlan);
-    });
-
-    it('gives the default pricing plan if none available', async() => {
-        stateManager.getMeta = jest.fn().mockReturnValue({});
-        const actualPricingPlan = await getGeoPricingPlan();
-        expect(actualPricingPlan).toEqual(PricingPlan.RequestBasedUsage);
-    });
 });
 
 describe('Test updating the pricing plan for all Geo resources', () => {
@@ -252,31 +235,5 @@ describe('Test updating the pricing plan for all Geo resources', () => {
         pathManager.getBackendDirPath = jest.fn().mockReturnValue('');
         JSONUtilities.readJson = jest.fn().mockReturnValue({});
         JSONUtilities.writeJson = jest.fn().mockReturnValue('');
-    });
-
-    it('updates given pricing plan correctly for all Geo resources in project', async() => {
-        mockContext.amplify.updateamplifyMetaAfterResourceUpdate = jest.fn();
-        const updatedPricingPlan = PricingPlan.MobileAssetTracking;
-        // check that current pricing plan is not same as pricing plan to be updated
-        expect(map1Params.pricingPlan).not.toEqual(updatedPricingPlan);
-        expect(placeIndex1Params.pricingPlan).not.toEqual(updatedPricingPlan);
-        expect(geofenceCollection1Params.pricingPlan).not.toEqual(updatedPricingPlan);
-
-        // update the pricing plan
-        await updateGeoPricingPlan(mockContext, updatedPricingPlan);
-
-        expect(mockContext.amplify.updateamplifyMetaAfterResourceUpdate).toBeCalledTimes(3);
-        expect(mockContext.amplify.updateamplifyMetaAfterResourceUpdate).toBeCalledWith(
-            category, 'map1', 'pricingPlan', updatedPricingPlan);
-        expect(mockContext.amplify.updateamplifyMetaAfterResourceUpdate).toBeCalledWith(
-            category, 'placeIndex1', 'pricingPlan', updatedPricingPlan);
-        expect(mockContext.amplify.updateamplifyMetaAfterResourceUpdate).toBeCalledWith(
-            category, 'geofenceCollection1', 'pricingPlan', updatedPricingPlan);
-        
-        // pricing plan is also updated in the resource stack parameters
-        expect(JSONUtilities.writeJson).toBeCalledTimes(3);
-        expect(JSONUtilities.writeJson).toBeCalledWith("geo/map1/parameters.json", {"pricingPlan": updatedPricingPlan});
-        expect(JSONUtilities.writeJson).toBeCalledWith("geo/placeIndex1/parameters.json", {"pricingPlan": updatedPricingPlan});
-        expect(JSONUtilities.writeJson).toBeCalledWith("geo/geofenceCollection1/parameters.json", {"pricingPlan": updatedPricingPlan});
     });
 });

--- a/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
@@ -6,7 +6,7 @@ import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 
 jest.mock('amplify-cli-core');
 
-describe('Test Map resource utility functions', () => {
+describe('Test resource utility functions', () => {
     const map1Params = {
         service: ServiceName.Map,
         isDefault: false,
@@ -41,7 +41,6 @@ describe('Test Map resource utility functions', () => {
         service: ServiceName.GeofenceCollection,
         isDefault: false,
         providerPlugin: provider,
-        dataProvider: DataProvider.Esri,
         accessType: AccessType.CognitoGroups
     };
 
@@ -109,7 +108,6 @@ describe('Test Map resource utility functions', () => {
         const getCurrentGeofenceCollectionParameters = require('../../service-utils/geofenceCollectionUtils').getCurrentGeofenceCollectionParameters;
         const geofenceCollectionParams = await getCurrentGeofenceCollectionParameters('geofenceCollection1');
         expect({
-            dataProvider: geofenceCollection1Params.dataProvider,
             accessType: geofenceCollection1Params.accessType,
             isDefault: geofenceCollection1Params.isDefault,
             groupPermissions: groupPermissions

--- a/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/serviceUtils.test.ts
@@ -2,7 +2,7 @@ import { stateManager, JSONUtilities, pathManager } from 'amplify-cli-core';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { getMapStyleComponents, MapStyle } from '../../service-utils/mapParams';
 import { DataSourceIntendedUse } from '../../service-utils/placeIndexParams';
-import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
+import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 
 jest.mock('amplify-cli-core');
 
@@ -12,7 +12,6 @@ describe('Test Map resource utility functions', () => {
         isDefault: false,
         providerPlugin: provider,
         mapStyle: MapStyle.VectorEsriNavigation,
-        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedAndGuestUsers
     };
     const map2Params = {
@@ -20,7 +19,6 @@ describe('Test Map resource utility functions', () => {
         isDefault: true,
         providerPlugin: provider,
         mapStyle: MapStyle.VectorEsriStreets,
-        pricingPlan: PricingPlan.MobileAssetManagement,
         accessType: AccessType.AuthorizedUsers
     };
     const placeIndex1Params = {
@@ -29,7 +27,6 @@ describe('Test Map resource utility functions', () => {
         providerPlugin: provider,
         dataProvider: DataProvider.Esri,
         dataSourceIntendedUse: DataSourceIntendedUse.Storage,
-        pricingPlan: PricingPlan.RequestBasedUsage,
         accessType: AccessType.AuthorizedAndGuestUsers
     };
     const placeIndex2Params = {
@@ -38,7 +35,6 @@ describe('Test Map resource utility functions', () => {
         providerPlugin: provider,
         dataProvider: DataProvider.Here,
         dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
-        pricingPlan: PricingPlan.MobileAssetManagement,
         accessType: AccessType.AuthorizedUsers
     };
     const geofenceCollection1Params = {
@@ -46,7 +42,6 @@ describe('Test Map resource utility functions', () => {
         isDefault: false,
         providerPlugin: provider,
         dataProvider: DataProvider.Esri,
-        pricingPlan: PricingPlan.MobileAssetManagement,
         accessType: AccessType.CognitoGroups
     };
 
@@ -72,7 +67,6 @@ describe('Test Map resource utility functions', () => {
         const mapParams = await getCurrentMapParameters('map1');
         expect({
             ...getMapStyleComponents(map1Params.mapStyle),
-            pricingPlan: map1Params.pricingPlan,
             accessType: map1Params.accessType,
             isDefault: map1Params.isDefault,
             groupPermissions: groupPermissions
@@ -97,7 +91,6 @@ describe('Test Map resource utility functions', () => {
         expect({
             dataProvider: placeIndex1Params.dataProvider,
             dataSourceIntendedUse: placeIndex1Params.dataSourceIntendedUse,
-            pricingPlan: placeIndex1Params.pricingPlan,
             accessType: placeIndex1Params.accessType,
             isDefault: placeIndex1Params.isDefault,
             groupPermissions: groupPermissions
@@ -117,7 +110,6 @@ describe('Test Map resource utility functions', () => {
         const geofenceCollectionParams = await getCurrentGeofenceCollectionParameters('geofenceCollection1');
         expect({
             dataProvider: geofenceCollection1Params.dataProvider,
-            pricingPlan: geofenceCollection1Params.pricingPlan,
             accessType: geofenceCollection1Params.accessType,
             isDefault: geofenceCollection1Params.isDefault,
             groupPermissions: groupPermissions

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/geofenceCollectionWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/geofenceCollectionWalkthrough.test.ts
@@ -1,6 +1,6 @@
 import { $TSContext, $TSObject, stateManager, pathManager, JSONUtilities, $TSAny } from 'amplify-cli-core';
 import { GeofenceCollectionParameters } from '../../service-utils/geofenceCollectionParams';
-import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
+import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
 import { printer, prompter } from 'amplify-prompts';
@@ -25,8 +25,7 @@ describe('Geofence Collection walkthrough works as expected', () => {
     };
     const mockPlaceIndexResource = {
         resourceName: 'placeIndex12345',
-        service: ServiceName.PlaceIndex,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        service: ServiceName.PlaceIndex
     };
 
     const mockGroupPermissions: Record<string, string[]> = {};
@@ -43,7 +42,6 @@ describe('Geofence Collection walkthrough works as expected', () => {
         },
         name: mockGeofenceCollectionName,
         dataProvider: DataProvider.Esri,
-        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.CognitoGroups,
         isDefault: false,
         groupPermissions: mockGroupPermissions

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/mapWalkthrough.test.ts
@@ -1,6 +1,6 @@
 import { $TSContext, $TSObject, stateManager, pathManager, JSONUtilities } from 'amplify-cli-core';
 import { EsriMapStyleType, getGeoMapStyle, MapParameters, MapStyle } from '../../service-utils/mapParams';
-import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
+import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 import { provider, ServiceName, apiDocs } from '../../service-utils/constants';
 import { category } from '../../constants';
 import { printer, prompter } from 'amplify-prompts';
@@ -17,20 +17,17 @@ describe('Map walkthrough works as expected', () => {
     const mockMapResource = {
         resourceName: mockMapName,
         service: service,
-        mapStyle: MapStyle.VectorEsriStreets,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        mapStyle: MapStyle.VectorEsriStreets
     };
     const secondaryMapResource = {
         resourceName: secondaryMapName,
         service: service,
         isDefault: false,
-        mapStyle: MapStyle.VectorEsriStreets,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        mapStyle: MapStyle.VectorEsriStreets
     };
     const mockPlaceIndexResource = {
         resourceName: 'placeIndex12345',
-        service: ServiceName.PlaceIndex,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        service: ServiceName.PlaceIndex
     };
 
     const mockMapParameters: MapParameters = {
@@ -42,7 +39,6 @@ describe('Map walkthrough works as expected', () => {
         name: mockMapName,
         mapStyleType: EsriMapStyleType.Streets,
         dataProvider: DataProvider.Esri,
-        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
         isDefault: false,
         groupPermissions: [mockUserPoolGroup]
@@ -210,7 +206,7 @@ describe('Map walkthrough works as expected', () => {
 
         expect({ ...mockMapParameters, isDefault: true }).toMatchObject(mapParams);
         // map default setting question is skipped
-        expect(prompter.yesOrNo).toBeCalledTimes(2);
+        expect(prompter.yesOrNo).toBeCalledTimes(1);
         expect(prompter.yesOrNo).toBeCalledWith('Do you want to configure advanced settings?', false);
     });
 

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
@@ -1,6 +1,6 @@
 import { $TSContext, $TSObject, stateManager, pathManager, JSONUtilities } from 'amplify-cli-core';
 import { DataSourceIntendedUse, PlaceIndexParameters } from '../../service-utils/placeIndexParams';
-import { AccessType, DataProvider, PricingPlan } from '../../service-utils/resourceParams';
+import { AccessType, DataProvider } from '../../service-utils/resourceParams';
 import { provider, ServiceName } from '../../service-utils/constants';
 import { category } from '../../constants';
 import { printer, prompter } from 'amplify-prompts';
@@ -16,18 +16,15 @@ describe('Search walkthrough works as expected', () => {
     const mockUserPoolGroup: string = 'mockCognitoGroup';
     const mockMapResource = {
         resourceName: 'map12345',
-        service: ServiceName.Map,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        service: ServiceName.Map
     };
     const mockPlaceIndexResource = {
         resourceName: mockPlaceIndexName,
-        service: service,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        service: service
     };
     const secondaryPlaceIndexResource = {
         resourceName: secondaryPlaceIndexName,
-        service: service,
-        pricingPlan: PricingPlan.MobileAssetTracking
+        service: service
     };
     const mockPlaceIndexParameters: PlaceIndexParameters = {
         providerContext: {
@@ -38,7 +35,6 @@ describe('Search walkthrough works as expected', () => {
         name: mockPlaceIndexName,
         dataProvider: DataProvider.Esri,
         dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
-        pricingPlan: PricingPlan.MobileAssetTracking,
         accessType: AccessType.AuthorizedUsers,
         isDefault: false,
         groupPermissions: [mockUserPoolGroup]
@@ -205,7 +201,7 @@ describe('Search walkthrough works as expected', () => {
 
         expect({ ...mockPlaceIndexParameters, isDefault: true }).toMatchObject(indexParams);
         // place index default setting question is skipped
-        expect(prompter.yesOrNo).toBeCalledTimes(2);
+        expect(prompter.yesOrNo).toBeCalledTimes(1);
         expect(prompter.yesOrNo).toBeCalledWith('Do you want to configure advanced settings?', false);
     });
 

--- a/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-walkthroughs/placeIndexWalkthrough.test.ts
@@ -33,7 +33,7 @@ describe('Search walkthrough works as expected', () => {
             projectName: projectName
         },
         name: mockPlaceIndexName,
-        dataProvider: DataProvider.Esri,
+        dataProvider: DataProvider.Here,
         dataSourceIntendedUse: DataSourceIntendedUse.SingleUse,
         accessType: AccessType.AuthorizedUsers,
         isDefault: false,

--- a/packages/amplify-category-geo/src/provider-controllers/geofenceCollection.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/geofenceCollection.ts
@@ -4,7 +4,7 @@ import { category } from '../constants';
 import { updateDefaultGeofenceCollectionWalkthrough, createGeofenceCollectionWalkthrough, updateGeofenceCollectionWalkthrough } from '../service-walkthroughs/geofenceCollectionWalkthrough';
 import { convertToCompleteGeofenceCollectionParams, GeofenceCollectionParameters } from '../service-utils/geofenceCollectionParams';
 import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { printNextStepsSuccessMessage, setProviderContext, insufficientInfoForUpdateError } from './index';
+import { printNextStepsSuccessMessage, setProviderContext } from './index';
 import { ServiceName } from '../service-utils/constants';
 import { printer } from 'amplify-prompts';
 

--- a/packages/amplify-category-geo/src/provider-controllers/map.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/map.ts
@@ -73,7 +73,6 @@ export const addMapResourceHeadless = async (
     providerContext: setProviderContext(context, ServiceName.Map),
     name: config.name,
     accessType: config.accessType,
-    pricingPlan: config.pricingPlan,
     isDefault: config.setAsDefault,
     ...getMapStyleComponents(config.mapStyle)
   };

--- a/packages/amplify-category-geo/src/service-stacks/geofenceCollectionStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/geofenceCollectionStack.ts
@@ -35,7 +35,6 @@ export class GeofenceCollectionStack extends BaseStack {
       `auth${this.authResourceName}UserPoolId`,
       'collectionName',
       'dataProvider',
-      'pricingPlan',
       'env',
       'isDefault'
     );
@@ -87,7 +86,6 @@ export class GeofenceCollectionStack extends BaseStack {
     geoUpdateDeleteCollectionStatement.addResources(geofenceCollectionARN);
 
     const dataSource = this.parameters.get('dataProvider')!.valueAsString;
-    const collectionPricingPlan = this.parameters.get('pricingPlan')!.valueAsString;
 
     const customGeofenceCollectionLambdaCode = fs.readFileSync(customGeofenceCollectionLambdaCodePath, 'utf-8');
     const customGeofenceCollectionLambda = new lambda.Function(this, 'CustomGeofenceCollectionLambda', {
@@ -105,7 +103,6 @@ export class GeofenceCollectionStack extends BaseStack {
       properties: {
         collectionName: this.geofenceCollectionName,
         dataSource: dataSource,
-        pricingPlan: collectionPricingPlan,
         region: this.geofenceCollectionRegion,
         env: cdk.Fn.ref('env')
       },

--- a/packages/amplify-category-geo/src/service-stacks/geofenceCollectionStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/geofenceCollectionStack.ts
@@ -34,7 +34,6 @@ export class GeofenceCollectionStack extends BaseStack {
     inputParameters.push(
       `auth${this.authResourceName}UserPoolId`,
       'collectionName',
-      'dataProvider',
       'env',
       'isDefault'
     );
@@ -85,8 +84,6 @@ export class GeofenceCollectionStack extends BaseStack {
     geoUpdateDeleteCollectionStatement.addActions('geo:UpdateGeofenceCollection', 'geo:DeleteGeofenceCollection');
     geoUpdateDeleteCollectionStatement.addResources(geofenceCollectionARN);
 
-    const dataSource = this.parameters.get('dataProvider')!.valueAsString;
-
     const customGeofenceCollectionLambdaCode = fs.readFileSync(customGeofenceCollectionLambdaCodePath, 'utf-8');
     const customGeofenceCollectionLambda = new lambda.Function(this, 'CustomGeofenceCollectionLambda', {
       code: lambda.Code.fromInline(customGeofenceCollectionLambdaCode),
@@ -102,7 +99,6 @@ export class GeofenceCollectionStack extends BaseStack {
       resourceType: 'Custom::LambdaCallout',
       properties: {
         collectionName: this.geofenceCollectionName,
-        dataSource: dataSource,
         region: this.geofenceCollectionRegion,
         env: cdk.Fn.ref('env')
       },

--- a/packages/amplify-category-geo/src/service-stacks/mapStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/mapStack.ts
@@ -38,7 +38,6 @@ export class MapStack extends BaseStack {
       'unauthRoleName',
       'mapName',
       'mapStyle',
-      'pricingPlan',
       'env',
       'isDefault'
     );
@@ -86,8 +85,6 @@ export class MapStack extends BaseStack {
 
     const mapStyle = this.parameters.get('mapStyle')!.valueAsString;
 
-    const mapPricingPlan = this.parameters.get('pricingPlan')!.valueAsString;
-
     const customMapLambdaCode = fs.readFileSync(customMapLambdaCodePath, 'utf-8');
     const customMapLambda = new lambda.Function(this, 'CustomMapLambda', {
       code: lambda.Code.fromInline(customMapLambdaCode),
@@ -104,7 +101,6 @@ export class MapStack extends BaseStack {
       properties: {
         mapName: this.mapName,
         mapStyle: mapStyle,
-        pricingPlan: mapPricingPlan,
         region: this.mapRegion,
         env: cdk.Fn.ref('env'),
       },

--- a/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/placeIndexStack.ts
@@ -39,7 +39,6 @@ export class PlaceIndexStack extends BaseStack {
       'indexName',
       'dataProvider',
       'dataSourceIntendedUse',
-      'pricingPlan',
       'env',
       'isDefault'
     );
@@ -87,8 +86,6 @@ export class PlaceIndexStack extends BaseStack {
 
     const dataSourceIntendedUse = this.parameters.get('dataSourceIntendedUse')!.valueAsString;
 
-    const indexPricingPlan = this.parameters.get('pricingPlan')!.valueAsString;
-
     const customPlaceIndexLambdaCode = fs.readFileSync(customPlaceIndexLambdaCodePath, 'utf-8');
     const customPlaceIndexLambda = new lambda.Function(this, 'CustomPlaceIndexLambda', {
       code: lambda.Code.fromInline(customPlaceIndexLambdaCode),
@@ -106,7 +103,6 @@ export class PlaceIndexStack extends BaseStack {
         indexName: this.placeIndexName,
         dataSource: dataSource,
         dataSourceIntendedUse: dataSourceIntendedUse,
-        pricingPlan: indexPricingPlan,
         region: this.placeIndexRegion,
         env: cdk.Fn.ref('env'),
       },

--- a/packages/amplify-category-geo/src/service-utils/constants.ts
+++ b/packages/amplify-category-geo/src/service-utils/constants.ts
@@ -10,7 +10,6 @@ export const previewBanner = 'Amplify Geo category is in developer preview and n
 export const chooseServiceMessageAdd = 'Select which capability you want to add:';
 export const chooseServiceMessageUpdate = 'Select which capability you want to update:';
 export const chooseServiceMessageRemove = 'Select which capability you want to remove:';
-export const choosePricingPlan = `The following choices will update the pricing plan for ALL Geo resources in the project. Learn more at ${apiDocs.pricingPlan}`;
 export const parametersFileName = 'parameters.json';
 export const provider = 'awscloudformation';
 export const customMapLambdaCodePath = path.join(__dirname, '../../resources/custom-map-resource-handler.js');

--- a/packages/amplify-category-geo/src/service-utils/geofenceCollectionParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/geofenceCollectionParams.ts
@@ -12,7 +12,7 @@ export type GeofenceCollectionParameters = ResourceParameters & {
  * check if all necessary geofence collection configuration parameters are available
  */
 export const isCompleteGeofenceCollectionParams = (partial: Partial<GeofenceCollectionParameters>): partial is GeofenceCollectionParameters => {
-    const requiredFields = ['providerContext', 'name', 'dataProvider', 'accessType', 'isDefault'];
+    const requiredFields = ['providerContext', 'name', 'accessType', 'isDefault'];
     const missingField = requiredFields.find(field => !_.keys(partial).includes(field));
     return !missingField;
 };

--- a/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
@@ -65,18 +65,17 @@ export const modifyGeofenceCollectionResource = async (
 
   const geofenceCollectionMetaParameters = constructGeofenceCollectionMetaParameters(parameters, authResourceName);
 
-  const paramsToUpdate = ['accessType', 'dependsOn', 'dataProvider'];
+  const paramsToUpdate = ['accessType', 'dependsOn'];
   paramsToUpdate.forEach(param => {
     context.amplify.updateamplifyMetaAfterResourceUpdate(category, parameters.name, param, (geofenceCollectionMetaParameters as $TSObject)[param]);
   });
 };
 
 function saveCFNParameters(
-  parameters: Pick<GeofenceCollectionParameters, 'name' | 'dataProvider' | 'isDefault'>,
+  parameters: Pick<GeofenceCollectionParameters, 'name' | 'isDefault'>,
 ) {
   const params = {
     collectionName: parameters.name,
-    dataProvider: parameters.dataProvider,
     isDefault: parameters.isDefault
   };
   updateParametersFile(params, parameters.name, parametersFileName);
@@ -105,7 +104,6 @@ export const constructGeofenceCollectionMetaParameters = (params: GeofenceCollec
     isDefault: params.isDefault,
     providerPlugin: provider,
     service: ServiceName.GeofenceCollection,
-    dataProvider: params.dataProvider,
     accessType: params.accessType,
     dependsOn: dependsOnResources
   };
@@ -117,7 +115,7 @@ export const constructGeofenceCollectionMetaParameters = (params: GeofenceCollec
  */
 export type GeofenceCollectionMetaParameters = Pick<
   GeofenceCollectionParameters,
-  'isDefault' | 'accessType' | 'dataProvider'
+  'isDefault' | 'accessType'
 > & {
   providerPlugin: string;
   service: string;
@@ -128,7 +126,6 @@ export const getCurrentGeofenceCollectionParameters = async (collectionName: str
   const currentCollectionMetaParameters = (await readResourceMetaParameters(ServiceName.GeofenceCollection, collectionName)) as GeofenceCollectionMetaParameters;
   const currentCollectionParameters = await readGeofenceCollectionParams(collectionName);
   return {
-    dataProvider: currentCollectionMetaParameters.dataProvider,
     accessType: currentCollectionMetaParameters.accessType,
     isDefault: currentCollectionMetaParameters.isDefault,
     groupPermissions: currentCollectionParameters.groupPermissions

--- a/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/geofenceCollectionUtils.ts
@@ -10,7 +10,6 @@ import {
   updateDefaultResource,
   readResourceMetaParameters,
   getAuthResourceName,
-  updateGeoPricingPlan,
   ResourceDependsOn
 } from './resourceUtils';
 import { App } from '@aws-cdk/core';
@@ -40,11 +39,6 @@ export const createGeofenceCollectionResource = async (context: $TSContext, para
     await updateDefaultResource(context, ServiceName.GeofenceCollection);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   context.amplify.updateamplifyMetaAfterResourceAdd(category, parameters.name, geofenceCollectionMetaParameters);
 };
 
@@ -69,26 +63,20 @@ export const modifyGeofenceCollectionResource = async (
     await updateDefaultResource(context, ServiceName.GeofenceCollection, parameters.name);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   const geofenceCollectionMetaParameters = constructGeofenceCollectionMetaParameters(parameters, authResourceName);
 
-  const paramsToUpdate = ['pricingPlan', 'accessType', 'dependsOn', 'dataProvider'];
+  const paramsToUpdate = ['accessType', 'dependsOn', 'dataProvider'];
   paramsToUpdate.forEach(param => {
     context.amplify.updateamplifyMetaAfterResourceUpdate(category, parameters.name, param, (geofenceCollectionMetaParameters as $TSObject)[param]);
   });
 };
 
 function saveCFNParameters(
-  parameters: Pick<GeofenceCollectionParameters, 'name' | 'dataProvider' | 'pricingPlan' | 'isDefault'>,
+  parameters: Pick<GeofenceCollectionParameters, 'name' | 'dataProvider' | 'isDefault'>,
 ) {
   const params = {
     collectionName: parameters.name,
     dataProvider: parameters.dataProvider,
-    pricingPlan: parameters.pricingPlan,
     isDefault: parameters.isDefault
   };
   updateParametersFile(params, parameters.name, parametersFileName);
@@ -118,7 +106,6 @@ export const constructGeofenceCollectionMetaParameters = (params: GeofenceCollec
     providerPlugin: provider,
     service: ServiceName.GeofenceCollection,
     dataProvider: params.dataProvider,
-    pricingPlan: params.pricingPlan,
     accessType: params.accessType,
     dependsOn: dependsOnResources
   };
@@ -130,7 +117,7 @@ export const constructGeofenceCollectionMetaParameters = (params: GeofenceCollec
  */
 export type GeofenceCollectionMetaParameters = Pick<
   GeofenceCollectionParameters,
-  'isDefault' | 'pricingPlan' | 'accessType' | 'dataProvider'
+  'isDefault' | 'accessType' | 'dataProvider'
 > & {
   providerPlugin: string;
   service: string;
@@ -142,7 +129,6 @@ export const getCurrentGeofenceCollectionParameters = async (collectionName: str
   const currentCollectionParameters = await readGeofenceCollectionParams(collectionName);
   return {
     dataProvider: currentCollectionMetaParameters.dataProvider,
-    pricingPlan: currentCollectionMetaParameters.pricingPlan,
     accessType: currentCollectionMetaParameters.accessType,
     isDefault: currentCollectionMetaParameters.isDefault,
     groupPermissions: currentCollectionParameters.groupPermissions

--- a/packages/amplify-category-geo/src/service-utils/mapUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapUtils.ts
@@ -11,7 +11,6 @@ import {
   updateDefaultResource,
   readResourceMetaParameters,
   checkAuthConfig,
-  updateGeoPricingPlan,
   getAuthResourceName,
   ResourceDependsOn
 } from './resourceUtils';
@@ -41,11 +40,6 @@ export const createMapResource = async (context: $TSContext, parameters: MapPara
     await updateDefaultResource(context, ServiceName.Map);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   context.amplify.updateamplifyMetaAfterResourceAdd(category, parameters.name, mapMetaParameters);
 };
 
@@ -66,11 +60,6 @@ export const modifyMapResource = async (context: $TSContext, parameters: MapPara
     await updateDefaultResource(context, ServiceName.Map, parameters.name);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   const mapMetaParameters = constructMapMetaParameters(parameters, authResourceName);
 
   const paramsToUpdate = ['accessType', 'pricingPlan', 'dependsOn'];
@@ -79,7 +68,7 @@ export const modifyMapResource = async (context: $TSContext, parameters: MapPara
   });
 };
 
-function saveCFNParameters(parameters: Pick<MapParameters, 'name' | 'mapStyleType' | 'dataProvider' | 'pricingPlan' | 'isDefault'>) {
+function saveCFNParameters(parameters: Pick<MapParameters, 'name' | 'mapStyleType' | 'dataProvider' | 'isDefault'>) {
   const params = {
     authRoleName: {
       Ref: 'AuthRoleName',
@@ -89,7 +78,6 @@ function saveCFNParameters(parameters: Pick<MapParameters, 'name' | 'mapStyleTyp
     },
     mapName: parameters.name,
     mapStyle: getGeoMapStyle(parameters.dataProvider, parameters.mapStyleType),
-    pricingPlan: parameters.pricingPlan,
     isDefault: parameters.isDefault,
   };
   updateParametersFile(params, parameters.name, parametersFileName);
@@ -119,7 +107,6 @@ export const constructMapMetaParameters = (params: MapParameters, authResourceNa
     providerPlugin: provider,
     service: ServiceName.Map,
     mapStyle: getGeoMapStyle(params.dataProvider, params.mapStyleType),
-    pricingPlan: params.pricingPlan,
     accessType: params.accessType,
     dependsOn: dependsOnResources
   };
@@ -129,7 +116,7 @@ export const constructMapMetaParameters = (params: MapParameters, authResourceNa
 /**
  * The Meta information stored for a Map Resource
  */
-export type MapMetaParameters = Pick<MapParameters, 'isDefault' | 'pricingPlan' | 'accessType'> & {
+export type MapMetaParameters = Pick<MapParameters, 'isDefault' | 'accessType'> & {
   providerPlugin: string;
   service: string;
   mapStyle: string;
@@ -142,7 +129,6 @@ export const getCurrentMapParameters = async (mapName: string): Promise<Partial<
   return {
     mapStyleType: getMapStyleComponents(currentMapMetaParameters.mapStyle).mapStyleType,
     dataProvider: getMapStyleComponents(currentMapMetaParameters.mapStyle).dataProvider,
-    pricingPlan: currentMapMetaParameters.pricingPlan,
     accessType: currentMapMetaParameters.accessType,
     isDefault: currentMapMetaParameters.isDefault,
     groupPermissions: currentMapParameters.groupPermissions

--- a/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
@@ -16,6 +16,7 @@ import {
 import { App } from '@aws-cdk/core';
 import { getTemplateMappings } from '../provider-controllers';
 import * as path from 'path';
+import { DataProvider } from './resourceParams';
 
 const placeIndexParamsFileName = 'place-index-params.json';
 
@@ -79,7 +80,7 @@ function saveCFNParameters(
       Ref: 'UnauthRoleName',
     },
     indexName: parameters.name,
-    dataProvider: parameters.dataProvider,
+    dataProvider: parameters.dataProvider === DataProvider.Esri ? 'Esri' : 'Here',
     dataSourceIntendedUse: parameters.dataSourceIntendedUse,
     isDefault: parameters.isDefault,
   };

--- a/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/placeIndexUtils.ts
@@ -10,7 +10,6 @@ import {
   updateDefaultResource,
   readResourceMetaParameters,
   checkAuthConfig,
-  updateGeoPricingPlan,
   getAuthResourceName,
   ResourceDependsOn
 } from './resourceUtils';
@@ -41,11 +40,6 @@ export const createPlaceIndexResource = async (context: $TSContext, parameters: 
     await updateDefaultResource(context, ServiceName.PlaceIndex);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   context.amplify.updateamplifyMetaAfterResourceAdd(category, parameters.name, placeIndexMetaParameters);
 };
 
@@ -66,11 +60,6 @@ export const modifyPlaceIndexResource = async (context: $TSContext, parameters: 
     await updateDefaultResource(context, ServiceName.PlaceIndex, parameters.name);
   }
 
-  // update the pricing plan for All Geo resources
-  if (parameters.pricingPlan) {
-    await updateGeoPricingPlan(context, parameters.pricingPlan);
-  }
-
   const placeIndexMetaParameters = constructPlaceIndexMetaParameters(parameters, authResourceName);
 
   const paramsToUpdate = ['accessType', 'pricingPlan', 'dependsOn'];
@@ -80,7 +69,7 @@ export const modifyPlaceIndexResource = async (context: $TSContext, parameters: 
 };
 
 function saveCFNParameters(
-  parameters: Pick<PlaceIndexParameters, 'name' | 'dataProvider' | 'dataSourceIntendedUse' | 'pricingPlan' | 'isDefault'>,
+  parameters: Pick<PlaceIndexParameters, 'name' | 'dataProvider' | 'dataSourceIntendedUse' | 'isDefault'>,
 ) {
   const params = {
     authRoleName: {
@@ -92,7 +81,6 @@ function saveCFNParameters(
     indexName: parameters.name,
     dataProvider: parameters.dataProvider,
     dataSourceIntendedUse: parameters.dataSourceIntendedUse,
-    pricingPlan: parameters.pricingPlan,
     isDefault: parameters.isDefault,
   };
   updateParametersFile(params, parameters.name, parametersFileName);
@@ -123,7 +111,6 @@ export const constructPlaceIndexMetaParameters = (params: PlaceIndexParameters, 
     service: ServiceName.PlaceIndex,
     dataProvider: params.dataProvider,
     dataSourceIntendedUse: params.dataSourceIntendedUse,
-    pricingPlan: params.pricingPlan,
     accessType: params.accessType,
     dependsOn: dependsOnResources
   };
@@ -135,7 +122,7 @@ export const constructPlaceIndexMetaParameters = (params: PlaceIndexParameters, 
  */
 export type PlaceIndexMetaParameters = Pick<
   PlaceIndexParameters,
-  'isDefault' | 'pricingPlan' | 'accessType' | 'dataSourceIntendedUse' | 'dataProvider'
+  'isDefault' | 'accessType' | 'dataSourceIntendedUse' | 'dataProvider'
 > & {
   providerPlugin: string;
   service: string;
@@ -148,7 +135,6 @@ export const getCurrentPlaceIndexParameters = async (indexName: string): Promise
   return {
     dataProvider: currentIndexMetaParameters.dataProvider,
     dataSourceIntendedUse: currentIndexMetaParameters.dataSourceIntendedUse,
-    pricingPlan: currentIndexMetaParameters.pricingPlan,
     accessType: currentIndexMetaParameters.accessType,
     isDefault: currentIndexMetaParameters.isDefault,
     groupPermissions: currentIndexParameters.groupPermissions

--- a/packages/amplify-category-geo/src/service-utils/resourceParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceParams.ts
@@ -6,16 +6,9 @@ import { ProviderContext } from 'amplify-cli-core';
 export type ResourceParameters = {
     providerContext: ProviderContext,
     name: string,
-    pricingPlan: PricingPlan,
     accessType: AccessType,
     isDefault: boolean,
     dataProvider: DataProvider
-}
-
-export enum PricingPlan {
-    RequestBasedUsage = 'RequestBasedUsage',
-    MobileAssetTracking = 'MobileAssetTracking',
-    MobileAssetManagement = 'MobileAssetManagement'
 }
 
 export enum AccessType {

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import _ from 'lodash';
 import { BaseStack } from '../service-stacks/baseStack';
 import { parametersFileName, ServiceName } from './constants';
-import { PricingPlan, ResourceParameters, AccessType } from './resourceParams';
+import { ResourceParameters, AccessType } from './resourceParams';
 import os from 'os';
 import { getMapIamPolicies } from './mapUtils';
 import { getPlaceIndexIamPolicies } from './placeIndexUtils';
@@ -103,45 +103,6 @@ export const updateDefaultResource = async (
 export const geoServiceExists = async (service: ServiceName): Promise<boolean> => {
   const serviceMeta = await getGeoServiceMeta(service);
   return serviceMeta && Object.keys(serviceMeta).length > 0;
-}
-
-/**
- * Get the pricing plan for Geo resources
- */
-export const getGeoPricingPlan = async (): Promise<PricingPlan> => {
-  const geoMeta = stateManager.getMeta()?.[category];
-  let pricingPlan = PricingPlan.RequestBasedUsage;
-  if (geoMeta !== undefined) {
-    Object.keys(geoMeta).forEach(resource => {
-      pricingPlan = geoMeta[resource].pricingPlan || pricingPlan;
-    });
-  }
-  return pricingPlan;
-}
-
-/**
- * Update Geo pricing plan
- */
-export const updateGeoPricingPlan = async (context: $TSContext, pricingPlan: PricingPlan) => {
-  const geoMeta = stateManager.getMeta()?.[category];
-  if (geoMeta !== undefined) {
-    Object.keys(geoMeta).forEach(resource => {
-      // update pricing plan in meta for all Geo resources
-      context.amplify.updateamplifyMetaAfterResourceUpdate(
-        category,
-        resource,
-        'pricingPlan',
-        pricingPlan
-      );
-
-      // update CFN parameters for all Geo resources
-      updateParametersFile(
-        { pricingPlan: pricingPlan },
-        resource,
-        parametersFileName
-      );
-    });
-  }
 }
 
 /**

--- a/packages/amplify-category-geo/src/service-walkthroughs/geofenceCollectionWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/geofenceCollectionWalkthrough.ts
@@ -6,7 +6,7 @@ import { ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentGeofenceCollectionParameters, crudPermissionsMap } from '../service-utils/geofenceCollectionUtils';
 import { getGeoServiceMeta, updateDefaultResource, checkGeoResourceExists } from '../service-utils/resourceUtils';
-import { dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
+import { getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
 import { AccessType } from '../service-utils/resourceParams';
 import { printer, prompter, alphanumeric, byValues } from 'amplify-prompts';
 
@@ -25,9 +25,6 @@ export const createGeofenceCollectionWalkthrough = async (
 
   // get the access
   parameters = merge(parameters, await geofenceCollectionAccessWalkthrough(context, parameters));
-
-  // get the data provider
-  parameters = merge(parameters, await dataProviderWalkthrough(parameters, ServiceName.GeofenceCollection));
 
   // ask if the geofence collection should be set as a default. Default to true if it's the only geofence collection
   const currentGeofenceCollectionResources = await getGeoServiceMeta(ServiceName.GeofenceCollection);
@@ -157,7 +154,6 @@ export const updateGeofenceCollectionWalkthrough = async (
     // overwrite the parameters based on user input
 
     parameters.groupPermissions = (await geofenceCollectionAccessWalkthrough(context, parameters)).groupPermissions;
-    parameters.dataProvider = (await dataProviderWalkthrough(parameters, ServiceName.GeofenceCollection)).dataProvider;
 
     const otherCollectionResources = collectionResourceNames.filter(collectionResourceName => collectionResourceName != resourceToUpdate);
     // if this is the only geofence collection, default cannot be removed

--- a/packages/amplify-category-geo/src/service-walkthroughs/geofenceCollectionWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/geofenceCollectionWalkthrough.ts
@@ -5,9 +5,9 @@ import { GeofenceCollectionParameters } from '../service-utils/geofenceCollectio
 import { ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentGeofenceCollectionParameters, crudPermissionsMap } from '../service-utils/geofenceCollectionUtils';
-import { getGeoServiceMeta, updateDefaultResource, geoServiceExists, getGeoPricingPlan, checkGeoResourceExists } from '../service-utils/resourceUtils';
-import { pricingPlanWalkthrough, dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
-import { AccessType, DataProvider, PricingPlan } from '../service-utils/resourceParams';
+import { getGeoServiceMeta, updateDefaultResource, checkGeoResourceExists } from '../service-utils/resourceUtils';
+import { dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
+import { AccessType } from '../service-utils/resourceParams';
 import { printer, prompter, alphanumeric, byValues } from 'amplify-prompts';
 
 const geofencingServiceFriendlyName = getServiceFriendlyName(ServiceName.GeofenceCollection);
@@ -26,23 +26,8 @@ export const createGeofenceCollectionWalkthrough = async (
   // get the access
   parameters = merge(parameters, await geofenceCollectionAccessWalkthrough(context, parameters));
 
-  // initiate pricing plan walkthrough if this is the first geofence collection added
-  // or if the current pricing plan is RequestBasedUsage
-  const currentPricingPlan = await getGeoPricingPlan();
-  if (!(await geoServiceExists(ServiceName.GeofenceCollection)) || currentPricingPlan === PricingPlan.RequestBasedUsage) {
-    parameters = merge(parameters, await geofenceCollectionPricingPlanWalkthrough(context, parameters));
-  }
-  else {
-      // If the geofence collection is not the first and the pricing plan is set to something other than RequestBasedUsage
-      // Then pricing plan can be set in Advanced settings
-      printer.info('Available advanced settings:');
-      printer.info(`- Pricing Plan (current: ${currentPricingPlan})`);
-      printer.info(`- Data Provider for Pricing Plan (current: ${parameters.dataProvider ? parameters.dataProvider : 'Esri'})`);
-      const showAdvancedSettings = await prompter.yesOrNo('Do you want to configure advanced settings?', false);
-      if (showAdvancedSettings) {
-        parameters = merge(parameters, await geofenceCollectionPricingPlanWalkthrough(context, parameters));
-      }
-  }
+  // get the data provider
+  parameters = merge(parameters, await dataProviderWalkthrough(parameters, ServiceName.GeofenceCollection));
 
   // ask if the geofence collection should be set as a default. Default to true if it's the only geofence collection
   const currentGeofenceCollectionResources = await getGeoServiceMeta(ServiceName.GeofenceCollection);
@@ -172,15 +157,7 @@ export const updateGeofenceCollectionWalkthrough = async (
     // overwrite the parameters based on user input
 
     parameters.groupPermissions = (await geofenceCollectionAccessWalkthrough(context, parameters)).groupPermissions;
-    printer.info('Available advanced settings:');
-    printer.info(`- Pricing Plan (current: ${parameters.pricingPlan})`);
-    printer.info(`- Data Provider for Pricing Plan (current: ${parameters.dataProvider ? parameters.dataProvider : 'Esri'})`);
-    const showAdvancedSettings = await prompter.yesOrNo('Do you want to update advanced settings?', false);
-    if (showAdvancedSettings) {
-        const pricingPlanSelections = await geofenceCollectionPricingPlanWalkthrough(context, parameters);
-        parameters.pricingPlan = pricingPlanSelections.pricingPlan;
-        parameters.dataProvider = pricingPlanSelections.dataProvider;
-    }
+    parameters.dataProvider = (await dataProviderWalkthrough(parameters, ServiceName.GeofenceCollection)).dataProvider;
 
     const otherCollectionResources = collectionResourceNames.filter(collectionResourceName => collectionResourceName != resourceToUpdate);
     // if this is the only geofence collection, default cannot be removed
@@ -221,24 +198,4 @@ export const updateDefaultGeofenceCollectionWalkthrough = async (
         await updateDefaultResource(context, ServiceName.GeofenceCollection, defaultIndexName);
     }
     return currentDefault;
-}
-
-/**
- * Walkthrough to get the pricing plan and pricing plan data source for a Geofence Collection
- * @param context The Amplify Context object
- * @param parameters The configurations of the geofence collection resource
- */
-export const geofenceCollectionPricingPlanWalkthrough = async (
-    context: $TSContext,
-    parameters: Partial<GeofenceCollectionParameters>
-): Promise<Partial<GeofenceCollectionParameters>> => {
-    parameters.pricingPlan = (await pricingPlanWalkthrough(context, parameters, true)).pricingPlan;
-    if (parameters.pricingPlan !== PricingPlan.RequestBasedUsage) {
-        parameters.dataProvider = (await dataProviderWalkthrough(parameters, ServiceName.GeofenceCollection)).dataProvider;
-    }
-    else {
-        // set the default data provider
-        parameters.dataProvider = DataProvider.Esri;
-    }
-    return parameters;
 }

--- a/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
@@ -5,9 +5,9 @@ import { MapParameters, getGeoMapStyle, MapStyle, getMapStyleComponents, EsriMap
 import { apiDocs, ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentMapParameters, getMapFriendlyNames } from '../service-utils/mapUtils';
-import { getGeoServiceMeta, updateDefaultResource, geoServiceExists, getGeoPricingPlan, checkGeoResourceExists} from '../service-utils/resourceUtils';
-import { resourceAccessWalkthrough, pricingPlanWalkthrough, defaultResourceQuestion } from './resourceWalkthrough';
-import { DataProvider, PricingPlan } from '../service-utils/resourceParams';
+import { getGeoServiceMeta, updateDefaultResource, checkGeoResourceExists} from '../service-utils/resourceUtils';
+import { resourceAccessWalkthrough, defaultResourceQuestion } from './resourceWalkthrough';
+import { DataProvider } from '../service-utils/resourceParams';
 import { printer, formatter, prompter, alphanumeric } from 'amplify-prompts';
 
 /**
@@ -25,15 +25,8 @@ export const createMapWalkthrough = async (
   // get the access
   parameters = merge(parameters, await resourceAccessWalkthrough(context, parameters, ServiceName.Map));
 
-  // initiate pricing plan walkthrough if this is the first Map added
-  let includePricingPlanInAdvancedWalkthrough = true;
-  if (!(await geoServiceExists(ServiceName.Map))) {
-    parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters, false));
-    includePricingPlanInAdvancedWalkthrough = false;
-  }
-
   // optional advanced walkthrough
-  parameters = merge(parameters, await mapAdvancedWalkthrough(context, parameters, includePricingPlanInAdvancedWalkthrough));
+  parameters = merge(parameters, await mapAdvancedWalkthrough(context, parameters));
 
   // ask if the map should be set as a default. Default to true if it's the only map
   const currentMapResources = await getGeoServiceMeta(ServiceName.Map);
@@ -68,14 +61,9 @@ export const mapNameWalkthrough = async (context: any): Promise<Partial<MapParam
 
 export const mapAdvancedWalkthrough = async (
     context: $TSContext,
-    parameters: Partial<MapParameters>,
-    includePricingPlan: boolean
+    parameters: Partial<MapParameters>
 ): Promise<Partial<MapParameters>> => {
-    const currentPricingPlan = parameters.pricingPlan || await getGeoPricingPlan() || PricingPlan.RequestBasedUsage;
     const advancedSettingOptions: string[] = ['Map style & Map data provider (default: Streets provided by Esri)'];
-    if (includePricingPlan) {
-        advancedSettingOptions.push(`Map pricing plan (current: ${currentPricingPlan})`);
-    }
     printer.info('Available advanced settings:');
     formatter.list(advancedSettingOptions);
     printer.blankLine();
@@ -83,19 +71,10 @@ export const mapAdvancedWalkthrough = async (
     if(await prompter.yesOrNo('Do you want to configure advanced settings?', false)) {
         // get the map style parameters
         parameters = merge(parameters, await mapStyleWalkthrough(parameters));
-
-        if (includePricingPlan) {
-            // get the pricing plan
-            parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters, false));
-        }
-        else {
-            parameters.pricingPlan = currentPricingPlan;
-        }
     }
     else {
         parameters.dataProvider = DataProvider.Esri;
         parameters.mapStyleType = EsriMapStyleType.Streets;
-        parameters.pricingPlan = currentPricingPlan;
     }
 
     return parameters;
@@ -160,14 +139,6 @@ export const updateMapWalkthrough = async (
     const mapAccessSettings = (await resourceAccessWalkthrough(context, parameters, ServiceName.Map));
     parameters.accessType = mapAccessSettings.accessType;
     parameters.groupPermissions = mapAccessSettings.groupPermissions;
-
-    // enable flow to update the pricing plan for Map
-    printer.info('Available advanced settings:');
-    printer.info(`- Pricing Plan (current: ${parameters.pricingPlan})`);
-    const showAdvancedSettings = await prompter.yesOrNo('Do you want to update advanced settings?', false);
-    if (showAdvancedSettings) {
-        parameters.pricingPlan = (await pricingPlanWalkthrough(context, parameters, false)).pricingPlan;
-    }
 
     const otherMapResources = mapResourceNames.filter(mapResourceName => mapResourceName != resourceToUpdate);
     // if this is the only map, default cannot be removed

--- a/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
@@ -73,6 +73,9 @@ export const placeIndexAdvancedWalkthrough = async (
     if(await prompter.yesOrNo('Do you want to configure advanced settings?', false)) {
         // get the place index data provider
         parameters = merge(parameters, await dataProviderWalkthrough(parameters, ServiceName.PlaceIndex));
+
+        // get the data storage setting
+        parameters = merge(parameters, await placeIndexDataStorageWalkthrough(parameters));
     }
     else {
       parameters.dataProvider = DataProvider.Here;
@@ -82,7 +85,7 @@ export const placeIndexAdvancedWalkthrough = async (
     return parameters;
 };
 
-export const placeIndexDataStorageWalkthrough = async (context:$TSContext, parameters: Partial<PlaceIndexParameters>): Promise<Partial<PlaceIndexParameters>> => {
+export const placeIndexDataStorageWalkthrough = async (parameters: Partial<PlaceIndexParameters>): Promise<Partial<PlaceIndexParameters>> => {
   const areResultsStored = await prompter.yesOrNo(
     `Do you want to cache or store the results of search operations? Refer ${apiDocs.dataSourceUsage}`,
     parameters.dataSourceIntendedUse === DataSourceIntendedUse.Storage

--- a/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
@@ -64,7 +64,7 @@ export const placeIndexAdvancedWalkthrough = async (
     context: $TSContext,
     parameters: Partial<PlaceIndexParameters>
 ): Promise<Partial<PlaceIndexParameters>> => {
-    const advancedSettingOptions: string[] = ['Search data provider (default: Esri)'];
+    const advancedSettingOptions: string[] = ['Search data provider (default: HERE)'];
     advancedSettingOptions.push('Search result storage location (default: no result storage)');
     printer.info('Available advanced settings:');
     formatter.list(advancedSettingOptions);
@@ -75,7 +75,7 @@ export const placeIndexAdvancedWalkthrough = async (
         parameters = merge(parameters, await dataProviderWalkthrough(parameters, ServiceName.PlaceIndex));
     }
     else {
-      parameters.dataProvider = DataProvider.Esri;
+      parameters.dataProvider = DataProvider.Here;
       parameters.dataSourceIntendedUse = DataSourceIntendedUse.SingleUse;
     }
 

--- a/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/placeIndexWalkthrough.ts
@@ -5,9 +5,9 @@ import { DataSourceIntendedUse, PlaceIndexParameters } from '../service-utils/pl
 import { apiDocs, ServiceName } from '../service-utils/constants';
 import { $TSContext } from 'amplify-cli-core';
 import { getCurrentPlaceIndexParameters } from '../service-utils/placeIndexUtils';
-import { getGeoServiceMeta, updateDefaultResource, geoServiceExists, getGeoPricingPlan, checkGeoResourceExists } from '../service-utils/resourceUtils';
-import { resourceAccessWalkthrough, pricingPlanWalkthrough, dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
-import { DataProvider, PricingPlan } from '../service-utils/resourceParams';
+import { getGeoServiceMeta, updateDefaultResource, checkGeoResourceExists } from '../service-utils/resourceUtils';
+import { resourceAccessWalkthrough, dataProviderWalkthrough, getServiceFriendlyName, defaultResourceQuestion } from './resourceWalkthrough';
+import { DataProvider } from '../service-utils/resourceParams';
 import { printer, formatter, prompter, alphanumeric } from 'amplify-prompts';
 
 const searchServiceFriendlyName = getServiceFriendlyName(ServiceName.PlaceIndex);
@@ -26,15 +26,8 @@ export const createPlaceIndexWalkthrough = async (
   // get the access
   parameters = merge(parameters, await resourceAccessWalkthrough(context, parameters, ServiceName.PlaceIndex));
 
-  // initiate pricing plan walkthrough if this is the first Place Index added
-  let includePricingPlanInAdvancedWalkthrough = true;
-  if (!(await geoServiceExists(ServiceName.PlaceIndex))) {
-    parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters, false));
-    includePricingPlanInAdvancedWalkthrough = false;
-  }
-
   // optional advanced walkthrough
-  parameters = merge(parameters, await placeIndexAdvancedWalkthrough(context, parameters, includePricingPlanInAdvancedWalkthrough));
+  parameters = merge(parameters, await placeIndexAdvancedWalkthrough(context, parameters));
 
   // ask if the place index should be set as a default. Default to true if it's the only place index
   const currentPlaceIndexResources = await getGeoServiceMeta(ServiceName.PlaceIndex);
@@ -69,14 +62,9 @@ export const placeIndexNameWalkthrough = async (context: any): Promise<Partial<P
 
 export const placeIndexAdvancedWalkthrough = async (
     context: $TSContext,
-    parameters: Partial<PlaceIndexParameters>,
-    includePricingPlan: boolean
+    parameters: Partial<PlaceIndexParameters>
 ): Promise<Partial<PlaceIndexParameters>> => {
-    const currentPricingPlan = parameters.pricingPlan || await getGeoPricingPlan() || PricingPlan.RequestBasedUsage;
     const advancedSettingOptions: string[] = ['Search data provider (default: Esri)'];
-    if (includePricingPlan) {
-        advancedSettingOptions.push(`Search pricing plan (current: ${currentPricingPlan})`);
-    }
     advancedSettingOptions.push('Search result storage location (default: no result storage)');
     printer.info('Available advanced settings:');
     formatter.list(advancedSettingOptions);
@@ -85,27 +73,10 @@ export const placeIndexAdvancedWalkthrough = async (
     if(await prompter.yesOrNo('Do you want to configure advanced settings?', false)) {
         // get the place index data provider
         parameters = merge(parameters, await dataProviderWalkthrough(parameters, ServiceName.PlaceIndex));
-
-        if (includePricingPlan) {
-            // get the pricing plan
-            parameters = merge(parameters, await pricingPlanWalkthrough(context, parameters));
-        }
-        else {
-            parameters.pricingPlan = currentPricingPlan;
-        }
-
-        // get the place index data storage option if the pricing plan is RequestBasedUsage
-        if (parameters.pricingPlan === PricingPlan.RequestBasedUsage) {
-          parameters = merge(parameters, await placeIndexDataStorageWalkthrough(context, parameters));
-        }
-        else {
-          parameters.dataSourceIntendedUse = DataSourceIntendedUse.SingleUse;
-        }
     }
     else {
       parameters.dataProvider = DataProvider.Esri;
       parameters.dataSourceIntendedUse = DataSourceIntendedUse.SingleUse;
-      parameters.pricingPlan = currentPricingPlan;
     }
 
     return parameters;
@@ -158,14 +129,6 @@ export const updatePlaceIndexWalkthrough = async (
     const placeIndexAccessSettings = (await resourceAccessWalkthrough(context, parameters, ServiceName.PlaceIndex));
     parameters.accessType = placeIndexAccessSettings.accessType;
     parameters.groupPermissions = placeIndexAccessSettings.groupPermissions;
-
-    // enable flow to update the pricing plan for Place Index
-    printer.info('Available advanced settings:');
-    printer.info(`- Pricing Plan (current: ${parameters.pricingPlan})`);
-    const showAdvancedSettings = await prompter.yesOrNo('Do you want to update advanced settings?', false);
-    if (showAdvancedSettings) {
-        parameters.pricingPlan = (await pricingPlanWalkthrough(context, parameters, false)).pricingPlan;
-    }
 
     const otherIndexResources = indexResourceNames.filter(indexResourceName => indexResourceName != resourceToUpdate);
     // if this is the only place index, default cannot be removed

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -100,7 +100,7 @@ export async function dataProviderWalkthrough<T extends ResourceParameters>(
     );
     const provider = (Object.keys(DataProvider).find(key => DataProvider[key as keyof typeof DataProvider] === dataProviderInput)) as DataProvider;
     if (provider === DataProvider.Esri) {
-        printer.warn(`This resource with ${DataProvider.Esri} data provider does not support tracking and routing commercial assets. Refer to ${apiDocs.pricingPlan} `);
+        printer.warn(`${DataProvider.Esri} does not support tracking and routing commercial assets. Refer to ${apiDocs.pricingPlan} `);
     }
     parameters.dataProvider = provider;
     return parameters;

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -96,7 +96,7 @@ export async function dataProviderWalkthrough<T extends ResourceParameters>(
     const dataProviderInput = await prompter.pick<'one', string>(
         dataProviderPrompt,
         Object.values(DataProvider),
-        { initial: (parameters.dataProvider === DataProvider.Here) ? 1 : 0 }
+        { initial: (parameters.dataProvider === DataProvider.Esri) ? 0 : 1 }
     );
     const provider = (Object.keys(DataProvider).find(key => DataProvider[key as keyof typeof DataProvider] === dataProviderInput)) as DataProvider;
     if (provider === DataProvider.Esri) {

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -1,5 +1,5 @@
 import { AccessType, DataProvider, ResourceParameters } from "../service-utils/resourceParams";
-import { ServiceName } from "../service-utils/constants";
+import { apiDocs, ServiceName } from "../service-utils/constants";
 import { prompter, printer, byValue, byValues } from 'amplify-prompts';
 import { $TSContext } from "amplify-cli-core";
 
@@ -99,6 +99,9 @@ export async function dataProviderWalkthrough<T extends ResourceParameters>(
         { initial: (parameters.dataProvider === DataProvider.Here) ? 1 : 0 }
     );
     const provider = (Object.keys(DataProvider).find(key => DataProvider[key as keyof typeof DataProvider] === dataProviderInput)) as DataProvider;
+    if (provider === DataProvider.Esri) {
+        printer.warn(`This resource with ${DataProvider.Esri} data provider does not support tracking and routing commercial assets. Refer to ${apiDocs.pricingPlan} `);
+    }
     parameters.dataProvider = provider;
     return parameters;
 };

--- a/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/resourceWalkthrough.ts
@@ -1,8 +1,7 @@
 import { AccessType, DataProvider, ResourceParameters } from "../service-utils/resourceParams";
-import { ServiceName, choosePricingPlan, apiDocs } from "../service-utils/constants";
-import { PricingPlan } from "../service-utils/resourceParams";
-import { $TSContext, open } from "amplify-cli-core";
-import { byValue, byValues, printer, prompter } from 'amplify-prompts';
+import { ServiceName } from "../service-utils/constants";
+import { prompter, printer, byValue, byValues } from 'amplify-prompts';
+import { $TSContext } from "amplify-cli-core";
 
 export async function resourceAccessWalkthrough<T extends ResourceParameters & { groupPermissions: string[] }>(
     context: $TSContext,
@@ -83,89 +82,6 @@ export async function resourceAccessWalkthrough<T extends ResourceParameters & {
             parameters.accessType = AccessType.CognitoGroups;
         }
     }
-    return parameters;
-};
-
-export async function pricingPlanWalkthrough<T extends ResourceParameters>(
-    context: $TSContext,
-    parameters: Partial<T>,
-    extendedFlow?: boolean
-): Promise<Partial<T>> {
-    let pricingPlan: PricingPlan = parameters.pricingPlan ? parameters.pricingPlan : PricingPlan.RequestBasedUsage;
-
-    printer.info(choosePricingPlan);
-
-    const pricingPlanBusinessTypeChoices = [
-        { name: "No, I do not track or direct any assets", value: PricingPlan.RequestBasedUsage },
-        { name: "No, I only need to track or direct consumers' personal mobile devices", value: PricingPlan.RequestBasedUsage },
-        { name: 'Yes, I track or direct commercial assets (For example, any mobile object that is tracked by a company in support of its business)', value: 'Unknown' },
-        { name: 'Learn More', value: 'LearnMore'}
-    ];
-
-    const pricingPlanChoiceDefaultIndex = pricingPlan === PricingPlan.RequestBasedUsage ? 0 : 2;
-    const assetsQuestion = 'Are you tracking or directing commercial assets for your business in your app?';
-
-    let pricingPlanBusinessTypeChoice = await prompter.pick<'one', string>(
-        assetsQuestion,
-        pricingPlanBusinessTypeChoices,
-        { initial: pricingPlanChoiceDefaultIndex }
-    );
-    while (pricingPlanBusinessTypeChoice === 'LearnMore') {
-        open(apiDocs.pricingPlan, { wait: false });
-        pricingPlanBusinessTypeChoice = await prompter.pick<'one', string>(
-            assetsQuestion,
-            pricingPlanBusinessTypeChoices,
-            { initial: pricingPlanChoiceDefaultIndex }
-        );
-    }
-
-    if (pricingPlanBusinessTypeChoice === PricingPlan.RequestBasedUsage) {
-        pricingPlan = PricingPlan.RequestBasedUsage;
-    }
-    else {
-        let mapsSearchUsability = true;
-        if (extendedFlow === true) {
-            mapsSearchUsability = await prompter.yesOrNo(
-                'Does your app need Maps, Location Search or Routing?',
-                pricingPlan !== PricingPlan.RequestBasedUsage
-            )
-        }
-        if (mapsSearchUsability === true) {
-            const pricingPlanRoutingChoice = await prompter.yesOrNo(
-                'Does your app provide routing or route optimization for commercial assets?',
-                pricingPlan === PricingPlan.MobileAssetManagement ? true : false
-            );
-            pricingPlan = pricingPlanRoutingChoice ? PricingPlan.MobileAssetManagement : PricingPlan.MobileAssetTracking;
-        }
-        else {
-            const pricingPlanChoices = [
-                { name: 'Request Based Usage', value: PricingPlan.RequestBasedUsage },
-                { name: 'Mobile Asset Tracking', value: PricingPlan.MobileAssetTracking },
-                { name: 'Mobile Asset Management', value: PricingPlan.MobileAssetManagement },
-                { name: 'Learn More', value: 'LearnMore'}
-            ];
-            const pricingPlanQuestion = "Based on your use case, you may use any of the pricing plans. Select the pricing plan for ALL your Geo resources in the project. We recommend you start with 'Request Based Usage' and then consider one of the other pricing plans as your usage scales";
-
-            let pricingPlanChoice = await prompter.pick<'one', string>(
-                pricingPlanQuestion,
-                pricingPlanChoices,
-                { initial: 0 }
-            );
-            while (pricingPlanChoice === 'LearnMore') {
-                open(apiDocs.pricingPlan, { wait: false });
-                pricingPlanChoice = await prompter.pick<'one', string>(
-                    pricingPlanQuestion,
-                    pricingPlanChoices,
-                    { initial: 0 }
-                );
-            }
-
-            pricingPlan = pricingPlanChoice as PricingPlan;
-        }
-    }
-    parameters.pricingPlan = pricingPlan;
-
-    printer.info(`Successfully set ${pricingPlan} pricing plan for your Geo resources.`);
     return parameters;
 };
 

--- a/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
@@ -48,9 +48,6 @@
                       "VectorHereBerlin"
                   ]
               },
-              "pricingPlan": {
-                  "$ref": "#/definitions/PricingPlan"
-              },
               "accessType": {
                   "$ref": "#/definitions/AccessType"
               },
@@ -63,17 +60,7 @@
               "name",
               "mapStyle",
               "accessType",
-              "pricingPlan",
               "setAsDefault"
-          ]
-      },
-      "PricingPlan": {
-          "description": "The pricing plan for amazon location service.",
-          "type": "string",
-          "enum": [
-              "RequestBasedUsage",
-              "MobileAssetTracking",
-              "MobileAssetManagement"
           ]
       },
       "AccessType": {

--- a/packages/amplify-headless-interface/src/interface/geo/add.ts
+++ b/packages/amplify-headless-interface/src/interface/geo/add.ts
@@ -16,18 +16,11 @@ export interface GeoServiceConfiguration {
   serviceName: string;
   name: string;
   accessType: AccessType;
-  pricingPlan: PricingPlan;
   setAsDefault: boolean;
 }
 export interface MapConfiguration extends GeoServiceConfiguration {
   serviceName: "Map";
   mapStyle: MapStyle;
-}
-
-export enum PricingPlan {
-  RequestBasedUsage = "RequestBasedUsage",
-  MobileAssetTracking = "MobileAssetTracking",
-  MobileAssetManagement = "MobileAssetManagement"
 }
 
 export enum AccessType {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Location service team updated their APIs to only allow `RequestBasedUsage` pricing plan for Geo resources thereby deprecating the Asset based pricing plans. The below list of changes are necessary in Amplify CLI Geo plugin to accommodate that change.

- Removes the pricing plan walkthrough from `add/update` commands. Set the `PricingPlan` value for a geo resource to always be `RequestBasedUsage`.
- Removes the `dataProvider` from geofence collection walkthrough as this corresponds to `PricingPlanDataSource` which is no longer required if `PricingPlan` is always `RequestBasedUsage`.
- Warn when `Esri` data provider is chosen that the resource cannot be used for tracking/routing commercial assets.
- Change the default data provider to `HERE`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit testing, JS sample app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
