### PR TITLE
fix: do not update idp if credentials not present

### DIFF
--- a/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
@@ -36,11 +36,15 @@ exports.handler = (event, context, callback) => {
             requestParams = null;
           }
         } else {
-          requestParams.ProviderDetails = {
-            client_id: providerCreds.client_id,
-            client_secret: providerCreds.client_secret,
-            authorize_scopes: providerMeta.authorize_scopes,
-          };
+          if (providerCreds.client_id && providerCreds.client_secret) {
+            requestParams.ProviderDetails = {
+              client_id: providerCreds.client_id,
+              client_secret: providerCreds.client_secret,
+              authorize_scopes: providerMeta.authorize_scopes,
+            };
+          } else {
+            requestParams = null;
+          }
         }
         return requestParams;
       };

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -1234,11 +1234,15 @@ exports.handler = (event, context, callback) => {
             requestParams = null;
           }
         } else {
-          requestParams.ProviderDetails = {
-            client_id: providerCreds.client_id,
-            client_secret: providerCreds.client_secret,
-            authorize_scopes: providerMeta.authorize_scopes,
-          };
+          if (providerCreds.client_id && providerCreds.client_secret) {
+            requestParams.ProviderDetails = {
+              client_id: providerCreds.client_id,
+              client_secret: providerCreds.client_secret,
+              authorize_scopes: providerMeta.authorize_scopes,
+            };
+          } else {
+            requestParams = null;
+          }
         }
         return requestParams;
       };

--- a/packages/amplify-e2e-tests/src/__tests__/auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_1.test.ts
@@ -14,6 +14,10 @@ import {
   initAndroidProjectWithProfile,
   getCLIInputs,
   setCLIInputs,
+  getAppId,
+  addAuthWithDefaultSocial,
+  updateAuthSignInSignOutUrl,
+  amplifyPull,
 } from 'amplify-e2e-core';
 import { addAuthWithDefault, runAmplifyAuthConsole, removeAuthWithDefault } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
@@ -43,6 +47,31 @@ describe('amplify add auth...', () => {
     const userPool = await getUserPool(id, meta.providers.awscloudformation.Region);
     expect(userPool.UserPool).toBeDefined();
   });
+
+  it('...should init a project and add auth with defaults, pull project and push again', async () => {
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      name: 'authtest',
+    });
+    await addAuthWithDefaultSocial(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    const appId = getAppId(projRoot);
+    const projRootPullAuth = await createNewProjectDir('authPullTest');
+    await amplifyPull(projRootPullAuth, {
+      emptyDir: true,
+      noUpdateBackend: false,
+      appId
+    });
+    await updateAuthSignInSignOutUrl(projRootPullAuth, {
+      signinUrl: 'https://www.google.com/',
+      signoutUrl: 'https://www.nytimes.com/',
+      updatesigninUrl: 'http://localhost:3003/',
+      updatesignoutUrl: 'http://localhost:3004/',
+    });
+    await amplifyPushAuth(projRootPullAuth);
+    deleteProjectDir(projRootPullAuth);
+  });
+
   it('...should init an IOS project and add default auth', async () => {
     await initIosProjectWithProfile(projRoot, defaultsSettings);
     await addAuthWithDefault(projRoot, {});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
On a pull when and then executing another push the auth the idp updater/creator custom lambda resource throws an error since the credentials do not exist
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
