### PR TITLE
Fix APIGW parameters.json getting ignored and overwritten

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -62,7 +62,7 @@ export class ApigwStackTransform {
   }
 
   generateCfnInputParameters() {
-    this.cfnInputParams = {};
+    this.cfnInputParams = stateManager.getResourceParametersJson(undefined, AmplifyCategories.API, this.resourceName);
   }
 
   generateStack(authResourceName?: string, pathsWithUserPoolGroups: [string, Path][] = []) {


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
`apgw-stack-transform` previously never loaded `parameters.json` and then would overwrite it at the end, resulting in any parameters defined there getting lost and causing the definitions to not be used when they are needed in the push state (`push-resources.ts` loads the `parameters.json` file, since it was deleted, the additional parameters were previously dropped). Now it loads the parameters and writes them back to disk.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
I tested them against a project I am working on and it resolved the issue I was encountering (parameters.json was getting deleted and I could not define parameters).

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes (there were several tests not working on Windows due to different path separators)
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
