### PR TITLE
fix: parse dynamic groups custom claim to list

### DIFF
--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -42,6 +42,7 @@
     "md5": "^2.3.0"
   },
   "devDependencies": {
+    "@aws-amplify/graphql-index-transformer": "0.8.6",
     "@aws-amplify/graphql-searchable-transformer": "0.10.6",
     "@types/node": "^12.12.6"
   },

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -1,5 +1,6 @@
 import { AuthTransformer } from '../graphql-auth-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { IndexTransformer } from '@aws-amplify/graphql-index-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { ResourceConstants } from 'graphql-transformer-common';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
@@ -50,10 +51,65 @@ test('happy case with dynamic groups', () => {
     transformers: [new ModelTransformer(), new AuthTransformer()],
   });
   const out = transformer.transform(validSchema);
+
   expect(out).toBeDefined();
   expect(out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
     'AMAZON_COGNITO_USER_POOLS',
   );
+
+  expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain('#if( $util.isString($groupClaim0) )');
+  expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain('#if( $util.isList($util.parseJson($groupClaim0)) )');
+  expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain('#set( $groupClaim0 = $util.parseJson($groupClaim0) )');
+  expect(out.resolvers['Mutation.createPost.auth.1.req.vtl']).toContain('#set( $groupClaim0 = [$groupClaim0] )');
+
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain('#if( $util.isString($groupClaim0) )');
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain('#if( $util.isList($util.parseJson($groupClaim0)) )');
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain('#set( $groupClaim0 = $util.parseJson($groupClaim0) )');
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain('#set( $groupClaim0 = [$groupClaim0] )');
+
+  expect(out.resolvers['Mutation.deletePost.auth.1.res.vtl']).toContain('#if( $util.isString($groupClaim0) )');
+  expect(out.resolvers['Mutation.deletePost.auth.1.res.vtl']).toContain('#if( $util.isList($util.parseJson($groupClaim0)) )');
+  expect(out.resolvers['Mutation.deletePost.auth.1.res.vtl']).toContain('#set( $groupClaim0 = $util.parseJson($groupClaim0) )');
+  expect(out.resolvers['Mutation.deletePost.auth.1.res.vtl']).toContain('#set( $groupClaim0 = [$groupClaim0] )');
+});
+
+test(`'groups' @auth with dynamic groups and custom claim on index query`, () => {
+  const authConfig: AppSyncAuthConfiguration = {
+    defaultAuthentication: {
+      authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+    },
+    additionalAuthenticationProviders: [],
+  };
+  const validSchema = `
+    type Post @model @auth(rules: [{allow: groups, groupsField: "group", groupClaim: "tenants"}]) {
+        id: ID!
+        title: String!
+        userId: ID! @index(name: "byUser", queryField: "postsByUser")
+        group: String!
+        createdAt: String
+        updatedAt: String
+    }
+    `;
+  const transformer = new GraphQLTransform({
+    authConfig,
+    transformers: [new ModelTransformer(), new AuthTransformer(), new IndexTransformer()],
+  });
+  const out = transformer.transform(validSchema);
+
+  expect(out).toBeDefined();
+  expect(out.rootStack!.Resources![ResourceConstants.RESOURCES.GraphQLAPILogicalID].Properties.AuthenticationType).toEqual(
+    'AMAZON_COGNITO_USER_POOLS',
+  );
+
+  expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toContain('#if( $util.isString($role0) )');
+  expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toContain('#if( $util.isList($util.parseJson($role0)) )');
+  expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toContain('#set( $role0 = $util.parseJson($role0) )');
+  expect(out.resolvers['Query.listPosts.auth.1.req.vtl']).toContain('#set( $role0 = [$role0] )');
+
+  expect(out.resolvers['Post.postsByUser.auth.1.req.vtl']).toContain('#if( $util.isString($role0) )');
+  expect(out.resolvers['Post.postsByUser.auth.1.req.vtl']).toContain('#if( $util.isList($util.parseJson($role0)) )');
+  expect(out.resolvers['Post.postsByUser.auth.1.req.vtl']).toContain('#set( $role0 = $util.parseJson($role0) )');
+  expect(out.resolvers['Post.postsByUser.auth.1.req.vtl']).toContain('#set( $role0 = [$role0] )');
 });
 
 test('validation on @auth on a non-@model type', () => {
@@ -162,6 +218,13 @@ test('dynamic group auth generates authorized fields list correctly', () => {
         #set( $groupClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:groups\\"), []) )
         #set( $groupAllowedFields0 = [\\"id\\",\\"description\\"] )
         #set( $groupNullAllowedFields0 = [] )
+        #if( $util.isString($groupClaim0) )
+          #if( $util.isList($util.parseJson($groupClaim0)) )
+            #set( $groupClaim0 = $util.parseJson($groupClaim0) )
+          #else
+            #set( $groupClaim0 = [$groupClaim0] )
+          #end
+        #end
         #foreach( $userGroup in $groupClaim0 )
           #if( $groupEntity0.contains($userGroup) )
             #if( !$groupAllowedFields0.isEmpty() || !$groupNullAllowedFields0.isEmpty() )

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -76,6 +76,14 @@ const generateDynamicAuthReadExpression = (roles: Array<RoleDefinition>, fields:
           compoundExpression([
             set(ref(`groupEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.source.${role.entity!}`), nul())),
             set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim), list([]))),
+            iff(
+              methodCall(ref(`util.isString`), ref(`groupClaim${idx}`)),
+              ifElse(
+                methodCall(ref(`util.isList`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+              ),
+            ),
             entityIsList
               ? forEach(ref('userGroup'), ref(`groupClaim${idx}`), [
                   iff(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
@@ -17,6 +17,7 @@ import {
   equals,
   str,
   printBlock,
+  ifElse,
 } from 'graphql-mapping-template';
 import {
   getOwnerClaim,
@@ -193,6 +194,14 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>, fields: ReadonlyArr
               methodCall(ref('util.defaultIfNull'), ref(`ctx.args.input.${role.entity!}`), entityIsList ? list([]) : nul()),
             ),
             set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
+            iff(
+              methodCall(ref(`util.isString`), ref(`groupClaim${idx}`)),
+              ifElse(
+                methodCall(ref(`util.isList`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+              ),
+            ),
             set(ref(`groupAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
             forEach(ref('userGroup'), ref(`groupClaim${idx}`), [
               iff(

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -15,6 +15,7 @@ import {
   list,
   not,
   nul,
+  ifElse,
 } from 'graphql-mapping-template';
 import { emptyPayload, getIdentityClaimExp, getOwnerClaim, iamAdminRoleCheckExpression, iamCheck, setHasAuthExpression } from './helpers';
 import {
@@ -145,6 +146,14 @@ const dynamicGroupRoleExpression = (roles: Array<RoleDefinition>, fields: Readon
               methodCall(ref('util.defaultIfNull'), ref(`ctx.result.${role.entity}`), entityIsList ? list([]) : nul()),
             ),
             set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
+            iff(
+              methodCall(ref(`util.isString`), ref(`groupClaim${idx}`)),
+              ifElse(
+                methodCall(ref(`util.isList`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+              ),
+            ),
             forEach(ref('userGroup'), ref(`groupClaim${idx}`), [
               iff(
                 entityIsList

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -242,6 +242,14 @@ const dynamicGroupRoleExpression = (roles: Array<RoleDefinition>, fields: Readon
             set(ref(`groupClaim${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
             set(ref(`groupAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
             set(ref(`groupNullAllowedFields${idx}`), raw(JSON.stringify(role.nullAllowedFields))),
+            iff(
+              methodCall(ref(`util.isString`), ref(`groupClaim${idx}`)),
+              ifElse(
+                methodCall(ref(`util.isList`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), methodCall(ref(`util.parseJson`), ref(`groupClaim${idx}`))),
+                set(ref(`groupClaim${idx}`), list([ref(`groupClaim${idx}`)])),
+              ),
+            ),
             forEach(ref('userGroup'), ref(`groupClaim${idx}`), [
               iff(
                 entityIsList

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -283,6 +283,14 @@ const generateAuthFilter = (roles: Array<RoleDefinition>, fields: ReadonlyArray<
           ...[
             set(ref(`role${idx}`), getIdentityClaimExp(str(role.claim!), list([]))),
             iff(
+              methodCall(ref(`util.isString`), ref(`role${idx}`)),
+              ifElse(
+                methodCall(ref(`util.isList`), methodCall(ref(`util.parseJson`), ref(`role${idx}`))),
+                set(ref(`role${idx}`), methodCall(ref(`util.parseJson`), ref(`role${idx}`))),
+                set(ref(`role${idx}`), list([ref(`role${idx}`)])),
+              ),
+            ),
+            iff(
               not(methodCall(ref(`role${idx}.isEmpty`))),
               qref(methodCall(ref('authFilter.add'), raw(`{ "${role.entity}": { "in": $role${idx} } }`))),
             ),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

With this PR the custom claims specified for the dynamic groups will be parsed into a list so that it allows multiple dynamic groups to be specified and to fix the functionality which was working in the GraphQL Transformer v1. Currently it will either return items the user shouldn't even be allowed to access, or will thrown an `Unauthorized` error when accessing the items they should be allowed to view.
The custom claim included in the JWT could either be a string:

```json
{
  "tenants": "05949c86-6c1a-4f13-8bb5-bdbee322f0d6",
  ...
}
```

or a list:

```json
{
  "tenants": "[\"05949c86-6c1a-4f13-8bb5-bdbee322f0d6\",\"c812425e-77f3-4362-aac1-67da9aa30c3f\",\"b3c3ab8a-c89b-4690-884b-82a22e3f64d5\"]",
  ...
}
```

At the moment, the generated mutation for creating an entity, for example, doesn't parse the custom claim from JSON, but then it is assuming it to be a list and as a results it ends up in the wrong comparison:

```
#if( $util.authType() == "User Pool Authorization" )
  #if( !$isAuthorized )
    #set( $groupEntity0 = $util.defaultIfNull($ctx.args.input.organisationId, null) )
    #set( $groupClaim0 = $util.defaultIfNull($ctx.identity.claims.get("tenants"), []) )
    #set( $groupAllowedFields0 = [] )
    #foreach( $userGroup in $groupClaim0 )
      #if( $groupEntity0 == $userGroup )
        #if( !$groupAllowedFields0.isEmpty() )
          $util.qr($allowedFields.addAll($groupAllowedFields0))
        #else
          #set( $isAuthorized = true )
          #break
        #end
      #end
    #end
  #end
#end
```

The change I made in this PR the logic was added to first parse the custom claim into a list so that it could be iterated on and compared against the entity id:

```
#if( $util.authType() == "User Pool Authorization" )
  #if( !$isAuthorized )
    #set( $groupEntity0 = $util.defaultIfNull($ctx.args.input.organisationId, null) )
    #set( $groupClaim0 = $util.defaultIfNull($ctx.identity.claims.get("tenants:admin"), []) )
    #if( $util.isString($groupClaim0) ) <----------------------- the logic added starts here
      #if( $util.isList($util.parseJson($groupClaim0)) )
        #set( $groupClaim0 = $util.parseJson($groupClaim0) )
      #else
        #set( $groupClaim0 = [$groupClaim0] )
      #end
    #end <--------------------------------------------------- and ends here
    #set( $groupAllowedFields0 = [] )
    #foreach( $userGroup in $groupClaim0 )
      #if( $groupEntity0 == $userGroup )
        #if( !$groupAllowedFields0.isEmpty() )
          $util.qr($allowedFields.addAll($groupAllowedFields0))
        #else
          #set( $isAuthorized = true )
          #break
        #end
      #end
    #end
  #end
#end
```

In addition to that, there will be other changes necessary for fixing the resolvers generated for getting an entity by ID, index queries and field resolvers. I wanted to get some early feedback on these changes, an unless there is already some work in progress to fix this by the core Amplify team, I may be able to give it a try at some point and fix those cases in another PR as well. Thanks for your help!

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/9370

#### Description of how you validated changes

I applied the changes, then ran `yarn build` from the `amplify-cli` project and the copied the built files into the `node_modules/@aws-amplify/cli` package. Then I just ran `amplify push` on an actual project to test that the authorization rules are now applied correctly and it all worked well.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
