### PR TITLE
chore: pin colors version

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -77,7 +77,7 @@
     "ci-info": "^2.0.0",
     "cli-table3": "^0.6.0",
     "cloudform-types": "^4.2.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "ejs": "^3.0.1",
     "enquirer": "^2.3.6",
     "env-editor": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9994,7 +9994,7 @@ colors@1.0.x:
   resolved "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.2, colors@^1.2.1, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
There is currently an issue caused by our dependency on the "colors" package. This is discussed in https://github.com/npkgz/cli-progress/issues/116 with remediation recommendation of pinning to version `1.4.0`.

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

is being thrown during `npm install` in low memory environments (such as from amplify studio/console containers)