### PR TITLE
ci: ensure bash and dependencies are being used

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -155,6 +155,9 @@ function setAwsAccountCredentials {
 }
 
 function runE2eTest {
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        sudo apt-get install -y libatk-bridge2.0-0 libgtk-3.0 libasound2
+    fi
     if [ -z "$FIRST_RUN" ] || [ "$FIRST_RUN" == "true" ]; then
         startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
         setNpmRegistryUrlToLocal

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-aa-win",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
-    "pkg-all": "source .circleci/local_publish_helpers.sh && generatePkgCli",
+    "pkg-all": "yarn yarn-use-bash && source .circleci/local_publish_helpers.sh && generatePkgCli",
     "pkg-all-local": "yarn verdaccio-start && yarn verdaccio-connect && yarn publish-to-verdaccio && yarn pkg-all && yarn verdaccio-disconnect",
     "publish:master": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes",
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --no-verify-access --yes",


### PR DESCRIPTION
This PR fixes an issue where the pipeline is not using bash properly and has missing dependencies for the uibuilder.test.ts