### PR TITLE
fix: use bash when calling yarn pkg-all

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -188,6 +188,7 @@ jobs:
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
             changeNpmGlobalPath
+            yarn yarn-use-bash
             yarn pkg-all
             unsetNpmRegistryUrl
       - save_cache:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -20,7 +20,7 @@ function generatePkgCli {
   yarn --production
 
   # Optimize package size
-  rm -rf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md
+  yarn rimraf **/*.d.ts **/*.js.map **/*.d.ts.map **/README.md **/readme.md **/Readme.md **/CHANGELOG.md **/changelog.md **/Changelog.md **/HISTORY.md **/history.md **/History.md
 
   # Restore .d.ts files required by @aws-amplify/codegen-ui at runtime
   cp ../node_modules/typescript/lib/*.d.ts node_modules/typescript/lib/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "setup-dev-win": "yarn dev-build && yarn link-win && yarn link-aa-win",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
-    "pkg-all": "yarn yarn-use-bash && source .circleci/local_publish_helpers.sh && generatePkgCli",
+    "pkg-all": "source .circleci/local_publish_helpers.sh && generatePkgCli",
     "pkg-all-local": "yarn verdaccio-start && yarn verdaccio-connect && yarn publish-to-verdaccio && yarn pkg-all && yarn verdaccio-disconnect",
     "publish:master": "lerna publish --canary --force-publish --preid=alpha --exact --include-merged-tags --conventional-prerelease --no-verify-access --yes",
     "publish:beta": "lerna publish --exact --dist-tag=beta --preid=beta --conventional-commits --conventional-prerelease --message 'chore(release): Publish [ci skip]' --no-verify-access --yes",


### PR DESCRIPTION
This pr _properly_ uses `yarn yarn-use-bash` and uses `rimraf` instead of `rm -rf`. This fixes the `build_pkg_binaries` pipeline step ([proof](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/5843/workflows/02640dbb-eb23-4a05-80cc-fafaeece9967/jobs/139587)). 