### PR TITLE
chore: use caret codegen for tag release

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -51,7 +51,7 @@
     "amplify-category-xr": "3.2.12",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "^2.26.22",
     "amplify-console-hosting": "2.2.12",
     "amplify-container-hosting": "2.4.10",
     "amplify-dotnet-function-runtime-provider": "1.6.6",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -78,7 +78,7 @@
     "ajv": "^6.12.3",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "^2.26.22",
     "amplify-util-import": "2.2.12",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.963.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -30,7 +30,7 @@
     "amplify-appsync-simulator": "2.3.4",
     "amplify-category-function": "3.3.12",
     "amplify-cli-core": "2.4.7",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "^2.26.22",
     "amplify-dynamodb-simulator": "2.2.12",
     "amplify-provider-awscloudformation": "5.8.7",
     "amplify-storage-simulator": "1.6.3",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Use caret version codegen in tag `amplify-codegen-e2e-tests`. This will be used by codegen repo e2e tests only.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
