### PR TITLE
fix: GraphQL V2 fix for codegen

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -51,7 +51,7 @@
     "amplify-category-xr": "3.2.12",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-console-hosting": "2.2.12",
     "amplify-container-hosting": "2.4.10",
     "amplify-dotnet-function-runtime-provider": "1.6.6",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -78,7 +78,7 @@
     "ajv": "^6.12.3",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-util-import": "2.2.12",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.963.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -30,7 +30,7 @@
     "amplify-appsync-simulator": "2.3.4",
     "amplify-category-function": "3.3.12",
     "amplify-cli-core": "2.4.7",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-dynamodb-simulator": "2.2.12",
     "amplify-provider-awscloudformation": "5.8.7",
     "amplify-storage-simulator": "1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,24 @@
     strip-indent "^3.0.0"
     ts-dedent "^1.1.0"
 
+"@aws-amplify/appsync-modelgen-plugin@1.29.13":
+  version "1.29.13"
+  resolved "http://localhost:4873/@aws-amplify%2fappsync-modelgen-plugin/-/appsync-modelgen-plugin-1.29.13.tgz#65d8c36f9d475874454917c3ba392b1a3fd0df36"
+  integrity sha512-pog5NcIKUilO3J7v/nXwxt3R5meI4eE58yW4gp5sMdCAzkLzoKhzO9mjVKiG/xK7DdYUkimTe3/PSZSTaHDyjQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^1.12.2"
+    "@graphql-codegen/visitor-plugin-common" "1.12.2"
+    "@graphql-tools/utils" "^6.0.18"
+    "@types/node" "^12.12.6"
+    "@types/pluralize" "0.0.29"
+    chalk "^3.0.0"
+    change-case "^4.1.1"
+    dart-style "1.3.2-dev"
+    lower-case-first "^2.0.1"
+    pluralize "^8.0.0"
+    strip-indent "^3.0.0"
+    ts-dedent "^1.1.0"
+
 "@aws-amplify/auth@4.3.19":
   version "4.3.19"
   resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.19.tgz#76ad277fabef91ef22055538b25cb5c16b3d3e00"
@@ -232,6 +250,17 @@
   version "2.4.2"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-2.4.2.tgz#cc3ef50cab77ee0ea23b735b279ae706e8d0b32d"
   integrity sha512-KvU26G1i/tTK+4ar6Kjo/vDDW7Ry8VT0NPqD9W+NPIUIrBcl8bG1qjm2asnnM9Jybedi2s7Gx9jci8pKd/BA0Q==
+  dependencies:
+    change-case "^4.1.1"
+    graphql "^14.5.8"
+    handlebars "4.7.7"
+    prettier "^1.19.1"
+    yargs "^15.1.0"
+
+"@aws-amplify/graphql-docs-generator@2.4.3":
+  version "2.4.3"
+  resolved "http://localhost:4873/@aws-amplify%2fgraphql-docs-generator/-/graphql-docs-generator-2.4.3.tgz#fffbf4796896f09fbd98cd027f1834bd65e42810"
+  integrity sha512-Z16Qt7ECWvKNxyz4UUmsDDdl6D8gVla0bGIUau31lUse8m8NokX7a1k0ImdJ2nNzBgYdOX8hCACELGF/bPKp/A==
   dependencies:
     change-case "^4.1.1"
     graphql "^14.5.8"
@@ -443,6 +472,31 @@
   version "2.8.6"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-2.8.6.tgz#1fcccb13a96523f12daa0364d811e2ae5c6fe37c"
   integrity sha512-u9q6NwDKVRh1BAQ/ugUwJkH/1bHBwQYXG0TZCQT56AKPhO9XNDuP4zDiedJ3oeQhxzbSYSUhdveJARVy5WCuhw==
+  dependencies:
+    "@babel/generator" "7.0.0-beta.4"
+    "@babel/types" "7.0.0-beta.4"
+    "@types/babel-generator" "^6.25.0"
+    "@types/fs-extra" "^8.1.0"
+    "@types/prettier" "^1.19.0"
+    "@types/rimraf" "^3.0.0"
+    babel-generator "^6.26.1"
+    babel-types "^6.26.0"
+    change-case "^4.1.1"
+    common-tags "^1.8.0"
+    core-js "^3.6.4"
+    fs-extra "^8.1.0"
+    glob "^7.1.6"
+    graphql "^14.5.8"
+    inflected "^2.0.4"
+    prettier "^1.19.1"
+    rimraf "^3.0.0"
+    source-map-support "^0.5.16"
+    yargs "^15.1.0"
+
+"@aws-amplify/graphql-types-generator@2.8.7":
+  version "2.8.7"
+  resolved "http://localhost:4873/@aws-amplify%2fgraphql-types-generator/-/graphql-types-generator-2.8.7.tgz#1828f3095f74dcba5620c14a7c51a218a67c0add"
+  integrity sha512-yzn5MZP5hhJR5GFaCYHpQTKst1ePkdRKRcDMKPy50PS1V2ISbUoNBhXRqA3gkh4fYBMIaMCeRxiNgPnzhwjE2w==
   dependencies:
     "@babel/generator" "7.0.0-beta.4"
     "@babel/types" "7.0.0-beta.4"
@@ -7887,7 +7941,31 @@ amplify-cli-core@2.4.3:
     typescript-json-schema "^0.51.0"
     which "^2.0.2"
 
-amplify-codegen@2.26.22, amplify-codegen@^2.23.1:
+amplify-codegen@2.26.23:
+  version "2.26.23"
+  resolved "http://localhost:4873/amplify-codegen/-/amplify-codegen-2.26.23.tgz#7b6cd3d780f5cc99b25280bcec4f8cfd58a9aaf4"
+  integrity sha512-GOcw0upZUiz7BY9xzYkGGPriPt06WI/zI2QNvqKpP6CNdq0kYsi2Rom8OpqBfDfeGSrZP14klhUw7o0PKMHo5g==
+  dependencies:
+    "@aws-amplify/appsync-modelgen-plugin" "1.29.13"
+    "@aws-amplify/graphql-docs-generator" "2.4.3"
+    "@aws-amplify/graphql-types-generator" "2.8.7"
+    "@graphql-codegen/core" "1.8.3"
+    amplify-codegen-appsync-model-plugin "^1.22.3"
+    amplify-graphql-docs-generator "^2.2.1"
+    amplify-graphql-types-generator "^2.7.0"
+    chalk "^3.0.0"
+    fs-extra "^8.1.0"
+    glob-all "^3.1.0"
+    glob-parent "^5.1.1"
+    graphql "^14.5.8"
+    graphql-config "^2.2.1"
+    inquirer "^7.3.3"
+    js-yaml "^4.0.0"
+    ora "^4.0.3"
+    semver "^7.3.5"
+    slash "^3.0.0"
+
+amplify-codegen@^2.23.1:
   version "2.26.22"
   resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.26.22.tgz#fecbbc49ed3f8a68de15022888a3d2bc47f6c237"
   integrity sha512-2+y8ZLwqgI3EdjOk41bGrdfJycUFVwvieUwtbHx69QWL1eJnFbvnpOo2b8rFEzmGoOezNYPu1WlSxiR1UTSr8Q==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Bumping the `amplify-codegen` version to `v2.26.23`.
Several fixes for modelgen with GraphQL V2 transformer. The tests are done by all amplify library teams.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
