### PR TITLE
fix: GraphQL V2 fix for codegen

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -51,7 +51,7 @@
     "amplify-category-xr": "3.2.12",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-console-hosting": "2.2.12",
     "amplify-container-hosting": "2.4.10",
     "amplify-dotnet-function-runtime-provider": "1.6.6",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -78,7 +78,7 @@
     "ajv": "^6.12.3",
     "amplify-cli-core": "2.4.7",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-util-import": "2.2.12",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.963.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -30,7 +30,7 @@
     "amplify-appsync-simulator": "2.3.4",
     "amplify-category-function": "3.3.12",
     "amplify-cli-core": "2.4.7",
-    "amplify-codegen": "2.26.22",
+    "amplify-codegen": "2.26.23",
     "amplify-dynamodb-simulator": "2.2.12",
     "amplify-provider-awscloudformation": "5.8.7",
     "amplify-storage-simulator": "1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,24 @@
     strip-indent "^3.0.0"
     ts-dedent "^1.1.0"
 
+"@aws-amplify/appsync-modelgen-plugin@1.29.13":
+  version "1.29.13"
+  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-1.29.13.tgz#b2feaa6630de5c7363c5688cbfeb5058c027b4e9"
+  integrity sha512-RnEs8jDgQukHqZddxusjz5dOQz0NoFTkTo6hJBhSlUJJ/vgjrYKW4VmMiM5aDwb9wskK+jcogLQr/9AbLaX6zQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^1.12.2"
+    "@graphql-codegen/visitor-plugin-common" "1.12.2"
+    "@graphql-tools/utils" "^6.0.18"
+    "@types/node" "^12.12.6"
+    "@types/pluralize" "0.0.29"
+    chalk "^3.0.0"
+    change-case "^4.1.1"
+    dart-style "1.3.2-dev"
+    lower-case-first "^2.0.1"
+    pluralize "^8.0.0"
+    strip-indent "^3.0.0"
+    ts-dedent "^1.1.0"
+
 "@aws-amplify/auth@4.3.19":
   version "4.3.19"
   resolved "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.19.tgz#76ad277fabef91ef22055538b25cb5c16b3d3e00"
@@ -7590,7 +7608,60 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+<<<<<<< HEAD
 amplify-codegen@2.26.22:
+=======
+amplify-cli-core@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-2.4.3.tgz#db6d5a99d5722b0ca74ee696442d1c0b26dc5dbf"
+  integrity sha512-i0kIALnxbqitDQ3j77tmO9wo7AA1gqQpRYSdboSwXy8DBJHjYTgeiGXHk/xYWmGoi4WQ990nWLMmVtnAtOeA7g==
+  dependencies:
+    ajv "^6.12.3"
+    amplify-cli-logger "1.1.0"
+    amplify-prompts "1.6.0"
+    chalk "^4.1.1"
+    ci-info "^2.0.0"
+    cloudform-types "^4.2.0"
+    dotenv "^8.2.0"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    globby "^11.0.3"
+    hjson "^3.2.1"
+    js-yaml "^4.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.1"
+    open "^7.3.1"
+    proxy-agent "^5.0.0"
+    semver "^7.3.5"
+    typescript-json-schema "^0.51.0"
+    which "^2.0.2"
+
+amplify-codegen@2.26.23:
+  version "2.26.23"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-2.26.23.tgz#1ffb2d6c585c887c701fbc1e7813c05848106c92"
+  integrity sha512-MQN1XSCQ8BQ6NVyTTaM31VDyQ0JUEBvJfLe8+LmqVVJ7LR0gaLKTfR5QmSjjhRyEnUjE0ukMciPwGBTygIgkWg==
+  dependencies:
+    "@aws-amplify/appsync-modelgen-plugin" "1.29.13"
+    "@aws-amplify/graphql-docs-generator" "2.4.2"
+    "@aws-amplify/graphql-types-generator" "2.8.6"
+    "@graphql-codegen/core" "1.8.3"
+    amplify-codegen-appsync-model-plugin "^1.22.3"
+    amplify-graphql-docs-generator "^2.2.1"
+    amplify-graphql-types-generator "^2.7.0"
+    chalk "^3.0.0"
+    fs-extra "^8.1.0"
+    glob-all "^3.1.0"
+    glob-parent "^5.1.1"
+    graphql "^14.5.8"
+    graphql-config "^2.2.1"
+    inquirer "^7.3.3"
+    js-yaml "^4.0.0"
+    ora "^4.0.3"
+    semver "^7.3.5"
+    slash "^3.0.0"
+
+amplify-codegen@^2.23.1:
+>>>>>>> 4b9935198... fix: GraphQL V2 fix for codegen
   version "2.26.22"
   resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.26.22.tgz#fecbbc49ed3f8a68de15022888a3d2bc47f6c237"
   integrity sha512-2+y8ZLwqgI3EdjOk41bGrdfJycUFVwvieUwtbHx69QWL1eJnFbvnpOo2b8rFEzmGoOezNYPu1WlSxiR1UTSr8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,24 +65,6 @@
     "@aws-amplify/api-graphql" "2.2.18"
     "@aws-amplify/api-rest" "2.0.29"
 
-"@aws-amplify/appsync-modelgen-plugin@1.29.12":
-  version "1.29.12"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-1.29.12.tgz#b51d412325dd36991b29a9ff41c21cb4d2fe258d"
-  integrity sha512-l+t5CHn1upGHB1n22CjhVthVIspJEX3GpbEx0hixLzWmRmS4WxY6q6CWxn/HRZWkiNY+zQ37LU/27r1p1pQYkQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.12.2"
-    "@graphql-codegen/visitor-plugin-common" "1.12.2"
-    "@graphql-tools/utils" "^6.0.18"
-    "@types/node" "^12.12.6"
-    "@types/pluralize" "0.0.29"
-    chalk "^3.0.0"
-    change-case "^4.1.1"
-    dart-style "1.3.2-dev"
-    lower-case-first "^2.0.1"
-    pluralize "^8.0.0"
-    strip-indent "^3.0.0"
-    ts-dedent "^1.1.0"
-
 "@aws-amplify/appsync-modelgen-plugin@1.29.13":
   version "1.29.13"
   resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-1.29.13.tgz#b2feaa6630de5c7363c5688cbfeb5058c027b4e9"
@@ -7608,65 +7590,12 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-<<<<<<< HEAD
-amplify-codegen@2.26.22:
-=======
-amplify-cli-core@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-2.4.3.tgz#db6d5a99d5722b0ca74ee696442d1c0b26dc5dbf"
-  integrity sha512-i0kIALnxbqitDQ3j77tmO9wo7AA1gqQpRYSdboSwXy8DBJHjYTgeiGXHk/xYWmGoi4WQ990nWLMmVtnAtOeA7g==
-  dependencies:
-    ajv "^6.12.3"
-    amplify-cli-logger "1.1.0"
-    amplify-prompts "1.6.0"
-    chalk "^4.1.1"
-    ci-info "^2.0.0"
-    cloudform-types "^4.2.0"
-    dotenv "^8.2.0"
-    execa "^5.1.1"
-    fs-extra "^8.1.0"
-    globby "^11.0.3"
-    hjson "^3.2.1"
-    js-yaml "^4.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.1"
-    open "^7.3.1"
-    proxy-agent "^5.0.0"
-    semver "^7.3.5"
-    typescript-json-schema "^0.51.0"
-    which "^2.0.2"
-
 amplify-codegen@2.26.23:
   version "2.26.23"
   resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-2.26.23.tgz#1ffb2d6c585c887c701fbc1e7813c05848106c92"
   integrity sha512-MQN1XSCQ8BQ6NVyTTaM31VDyQ0JUEBvJfLe8+LmqVVJ7LR0gaLKTfR5QmSjjhRyEnUjE0ukMciPwGBTygIgkWg==
   dependencies:
     "@aws-amplify/appsync-modelgen-plugin" "1.29.13"
-    "@aws-amplify/graphql-docs-generator" "2.4.2"
-    "@aws-amplify/graphql-types-generator" "2.8.6"
-    "@graphql-codegen/core" "1.8.3"
-    amplify-codegen-appsync-model-plugin "^1.22.3"
-    amplify-graphql-docs-generator "^2.2.1"
-    amplify-graphql-types-generator "^2.7.0"
-    chalk "^3.0.0"
-    fs-extra "^8.1.0"
-    glob-all "^3.1.0"
-    glob-parent "^5.1.1"
-    graphql "^14.5.8"
-    graphql-config "^2.2.1"
-    inquirer "^7.3.3"
-    js-yaml "^4.0.0"
-    ora "^4.0.3"
-    semver "^7.3.5"
-    slash "^3.0.0"
-
-amplify-codegen@^2.23.1:
->>>>>>> 4b9935198... fix: GraphQL V2 fix for codegen
-  version "2.26.22"
-  resolved "https://registry.yarnpkg.com/amplify-codegen/-/amplify-codegen-2.26.22.tgz#fecbbc49ed3f8a68de15022888a3d2bc47f6c237"
-  integrity sha512-2+y8ZLwqgI3EdjOk41bGrdfJycUFVwvieUwtbHx69QWL1eJnFbvnpOo2b8rFEzmGoOezNYPu1WlSxiR1UTSr8Q==
-  dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "1.29.12"
     "@aws-amplify/graphql-docs-generator" "2.4.2"
     "@aws-amplify/graphql-types-generator" "2.8.6"
     "@graphql-codegen/core" "1.8.3"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Bumping the amplify-codegen version to v2.26.23.
Several fixes for modelgen with GraphQL V2 transformer. The tests are done by all amplify library teams.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
