### PR TITLE
fix: remove functionName from transform-host lambdas

### DIFF
--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer-override.test.ts.snap
@@ -681,7 +681,6 @@ $utils.error($ctx.result.body)
               ],
             },
           },
-          "FunctionName": "predictionsLambda",
           "Handler": "predictionsLambda.handler",
           "Role": Object {
             "Fn::GetAtt": Array [

--- a/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
+++ b/packages/amplify-graphql-predictions-transformer/src/__tests__/__snapshots__/amplify-graphql-predictions-transformer.test.ts.snap
@@ -1281,7 +1281,6 @@ $utils.error($ctx.result.body)
             ],
           },
         },
-        "FunctionName": "predictionsLambda",
         "Handler": "predictionsLambda.handler",
         "Role": Object {
           "Fn::GetAtt": Array [

--- a/packages/amplify-graphql-transformer-core/src/transform-host.ts
+++ b/packages/amplify-graphql-transformer-core/src/transform-host.ts
@@ -205,7 +205,6 @@ export class DefaultTransformHost implements TransformHostProvider {
     const dummycode = `if __name__ == "__main__":`; // assing dummy code so as to be overriden later
     const fn = new Function(stack || this.api, functionName, {
       code: Code.fromInline(dummycode),
-      functionName,
       handler: handlerName,
       runtime,
       role,

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/lambda.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/lambda.ts
@@ -14,11 +14,12 @@ import {
  * @param cfnContext The parameters, exports and other context required to parse the CFN
  */
 export const lambdaFunctionHandler = (
-  _,
+  resourceName,
   resource: CloudFormationResource,
   cfnContext: CloudFormationParseContext,
 ): ProcessedLambdaFunction => {
-  const name: string = parseValue(resource.Properties.FunctionName, cfnContext);
+  // Use the resource name as a fallback in case the optional functionName is not present in CFN.
+  const name: string = parseValue(resource.Properties.FunctionName ?? resourceName, cfnContext);
   const handler = parseValue(resource.Properties.Handler, cfnContext);
   const cfnEnvVars = (resource?.Properties?.Environment as CloudFormationResourceProperty)?.Variables || {};
   const environment = Object.entries(cfnEnvVars).reduce(


### PR DESCRIPTION
The `@searchable` and `@predictions` directives create a Lambda
function via `context.api.host.addLambdaFunction()`. This commit
updates `addLambdaFunction()` to not set the optional `functionName`
in the CFN. This lets CFN generate a unique name.

The mock functionality also needed to be updated because mock
expects all Lambdas to have this optional property. If the CFN
does not contain a `functionName`, fall back to the resource name.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9480