### PR TITLE
test: remove outdated test

### DIFF
--- a/packages/amplify-util-uibuilder/src/__tests__/notifyMissingPackages.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/notifyMissingPackages.test.ts
@@ -55,22 +55,6 @@ describe('should notify when packages are missing', () => {
     expect(printerDependency.printer.warn).toBeCalledTimes(2);
   });
 
-  it('notifies for incorrect dependency version', async () => {
-    JSONUtilitiesDependency.JSONUtilities.readJson = jest.fn().mockImplementation(() => ({
-      projectPath: __dirname,
-      dependencies: { '@aws-amplify/ui-react': '1.0.0', 'aws-amplify': '1.0.0' },
-    }));
-    const context = {
-      input: {
-        options: {
-          localEnvFilePath: __dirname + '/mock.json',
-        },
-      },
-    };
-    notifyMissingPackages(context as any);
-    expect(printerDependency.printer.warn).toBeCalledTimes(1);
-  });
-
   it('notifies for partial missing dependencies', async () => {
     JSONUtilitiesDependency.JSONUtilities.readJson = jest.fn().mockImplementation(() => ({
       projectPath: __dirname,


### PR DESCRIPTION
this test is no longer meaningful because no specific dependency versions are required (all use `*`).