### PR TITLE
fix: clean up missing and unused GraphQL v1 dependencies

### DIFF
--- a/packages/graphql-auth-transformer/package.json
+++ b/packages/graphql-auth-transformer/package.json
@@ -30,11 +30,11 @@
     "graphql-transformer-core": "7.3.4"
   },
   "devDependencies": {
-    "@types/node": "^12.12.6",
     "cloudform-types": "^4.2.0",
     "graphql-dynamodb-transformer": "7.2.13",
     "graphql-elasticsearch-transformer": "5.2.13",
     "graphql-function-transformer": "3.3.4",
+    "lodash": "^4.17.21",
     "rimraf": "^3.0.0"
   },
   "jest": {

--- a/packages/graphql-connection-transformer/package.json
+++ b/packages/graphql-connection-transformer/package.json
@@ -30,9 +30,6 @@
     "graphql-transformer-common": "4.22.4",
     "graphql-transformer-core": "7.3.4"
   },
-  "devDependencies": {
-    "@types/node": "^12.12.6"
-  },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/packages/graphql-dynamodb-transformer/package.json
+++ b/packages/graphql-dynamodb-transformer/package.json
@@ -33,8 +33,7 @@
     "pluralize": "^8.0.0"
   },
   "devDependencies": {
-    "@types/md5": "^2.3.1",
-    "@types/node": "^12.12.6"
+    "@types/md5": "^2.3.1"
   },
   "jest": {
     "transform": {

--- a/packages/graphql-http-transformer/package.json
+++ b/packages/graphql-http-transformer/package.json
@@ -28,9 +28,6 @@
     "graphql-transformer-common": "4.22.4",
     "graphql-transformer-core": "7.3.4"
   },
-  "devDependencies": {
-    "@types/node": "^12.12.6"
-  },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/packages/graphql-key-transformer/package.json
+++ b/packages/graphql-key-transformer/package.json
@@ -27,7 +27,8 @@
     "graphql-dynamodb-transformer": "7.2.13",
     "graphql-mapping-template": "4.20.3",
     "graphql-transformer-common": "4.22.4",
-    "graphql-transformer-core": "7.3.4"
+    "graphql-transformer-core": "7.3.4",
+    "lodash": "^4.17.21"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/graphql-transformer-common/package.json
+++ b/packages/graphql-transformer-common/package.json
@@ -29,8 +29,7 @@
     "pluralize": "8.0.0"
   },
   "devDependencies": {
-    "@types/md5": "^2.3.1",
-    "@types/node": "^12.12.6"
+    "@types/md5": "^2.3.1"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/graphql-transformer-core/package.json
+++ b/packages/graphql-transformer-core/package.json
@@ -29,7 +29,8 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "graphql": "^14.5.8",
-    "graphql-transformer-common": "4.22.4"
+    "graphql-transformer-common": "4.22.4",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/graphql-versioned-transformer/package.json
+++ b/packages/graphql-versioned-transformer/package.json
@@ -28,7 +28,6 @@
     "graphql-transformer-core": "7.3.4"
   },
   "devDependencies": {
-    "@types/node": "^12.12.6",
     "graphql-dynamodb-transformer": "7.2.13"
   },
   "jest": {


### PR DESCRIPTION
This commit cleans up the dependencies in the GraphQL Transformer
v1. The changes are based on the output of depcheck.