### PR TITLE
test: update uibuilder junit settings

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -48,5 +48,11 @@
       "json",
       "node"
     ]
+  },
+  "jest-junit": {
+    "outputDirectory": "reports/junit/",
+    "outputName": "js-test-results.xml",
+    "usePathForSuiteName": "true",
+    "addFileAttribute": "true"
   }
 }


### PR DESCRIPTION
This commit updates amplify-util-uibuilder to use jest-junit
settings consistent with other packages in the repo. This also
allows the report output to be picked up by the project's
.gitignore instead of creating an untracked file each time
the test suite is run.