### PR TITLE
fix: fix amplify pull and init to regenerated frontend configuration 

### DIFF
--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -41,9 +41,7 @@ export async function generateFiles(context: $TSContext) {
     default: {},
   });
 
-  if (!context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
-    await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
-  }
+  await context.amplify.onCategoryOutputsChange(context, currentAmplifyMeta);
 
   return context;
 }

--- a/packages/amplify-cli/src/commands/env/checkout.ts
+++ b/packages/amplify-cli/src/commands/env/checkout.ts
@@ -21,8 +21,15 @@ export const run = async context => {
   localEnvInfo.envName = envName;
   stateManager.setLocalEnvInfo(undefined, localEnvInfo);
 
-  // Setup exeinfo
+  if (localEnvInfo.noUpdateBackend) {
+    context.print.error(
+      `The local environment configuration does not allow modifying the backend.\nUse amplify env pull --envName ${envName}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
 
+  // Setup exeinfo
   context.amplify.constructExeInfo(context);
   context.exeInfo.forcePush = false;
   context.exeInfo.isNewEnv = false;

--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -23,10 +23,15 @@ export async function onSuccess(context: $TSContext) {
   const backendDirPath = pathManager.getBackendDirPath(projectPath);
   const currentBackendDirPath = pathManager.getCurrentCloudBackendDirPath(projectPath);
 
-  fs.ensureDirSync(amplifyDirPath);
-  fs.ensureDirSync(dotConfigDirPath);
-  fs.ensureDirSync(backendDirPath);
-  fs.ensureDirSync(currentBackendDirPath);
+  if (context.exeInfo.isNewProject) {
+    fs.ensureDirSync(amplifyDirPath);
+    fs.ensureDirSync(dotConfigDirPath);
+    fs.ensureDirSync(backendDirPath);
+    fs.ensureDirSync(currentBackendDirPath);
+  } else {
+    // new env init. cleanup currentCloudBackend dir
+    fs.emptyDirSync(currentBackendDirPath);
+  }
 
   const providerPlugins = getProviderPlugins(context);
   const providerOnSuccessTasks: (() => Promise<any>)[] = [];

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -13,6 +13,25 @@ const FILE_EXTENSION_MAP = {
   angular: 'graphql',
 };
 
+const AMPLIFY_RESERVED_EXPORT_KEYS = [
+  // cognito
+  'Auth',
+  'CredentialsProvider',
+  'CognitoUserPool',
+  'GoogleSignIn',
+  'FacebookSignIn',
+  // s3
+  'S3TransferUtility',
+  // Analytics
+  'PinpointAnalytics',
+  'PinpointTargeting',
+  // Others
+  'DynamoDBObjectMapper',
+  'AppSync',
+  'Lex',
+  'Sumerian',
+];
+
 const fileNames = ['queries', 'mutations', 'subscriptions'];
 
 function deleteAmplifyConfig(context) {
@@ -158,11 +177,13 @@ function getCurrentAWSConfig(context) {
 
 function getCustomConfigs(cloudAWSConfig, currentAWSConfig) {
   const customConfigs = {};
-  Object.keys(currentAWSConfig).forEach(key => {
-    if (!cloudAWSConfig[key]) {
-      customConfigs[key] = currentAWSConfig[key];
-    }
-  });
+  Object.keys(currentAWSConfig)
+    .filter(k => !AMPLIFY_RESERVED_EXPORT_KEYS.includes(k))
+    .forEach(key => {
+      if (!cloudAWSConfig[key]) {
+        customConfigs[key] = currentAWSConfig[key];
+      }
+    });
   return customConfigs;
 }
 

--- a/packages/amplify-frontend-flutter/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-flutter/lib/frontend-config-creator.js
@@ -10,6 +10,25 @@ const FILE_EXTENSION_MAP = {
 
 const fileNames = ['queries', 'mutations', 'subscriptions'];
 
+const AMPLIFY_RESERVED_EXPORT_KEYS = [
+  // cognito
+  'Auth',
+  'CredentialsProvider',
+  'CognitoUserPool',
+  'GoogleSignIn',
+  'FacebookSignIn',
+  // s3
+  'S3TransferUtility',
+  // Analytics
+  'PinpointAnalytics',
+  'PinpointTargeting',
+  // Others
+  'DynamoDBObjectMapper',
+  'AppSync',
+  'Lex',
+  'Sumerian',
+];
+
 function deleteAmplifyConfig(context) {
   const { srcDirPath, projectPath } = getSrcDir(context);
   // delete amplify configuration
@@ -152,11 +171,13 @@ function getCurrentAWSConfig(context) {
 
 function getCustomConfigs(cloudAWSConfig, currentAWSConfig) {
   const customConfigs = {};
-  Object.keys(currentAWSConfig).forEach(key => {
-    if (!cloudAWSConfig[key]) {
-      customConfigs[key] = currentAWSConfig[key];
-    }
-  });
+  Object.keys(currentAWSConfig)
+    .filter(k => !AMPLIFY_RESERVED_EXPORT_KEYS.includes(k))
+    .forEach(key => {
+      if (!cloudAWSConfig[key]) {
+        customConfigs[key] = currentAWSConfig[key];
+      }
+    });
   return customConfigs;
 }
 

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -5,6 +5,24 @@ const fs = require('fs-extra');
 const graphQLConfig = require('graphql-config');
 const amplifyConfigHelper = require('./amplify-config-helper');
 
+const AMPLIFY_RESERVED_EXPORT_KEYS = [
+  // cognito
+  'Auth',
+  'CredentialsProvider',
+  'CognitoUserPool',
+  'GoogleSignIn',
+  'FacebookSignIn',
+  // s3
+  'S3TransferUtility',
+  // Analytics
+  'PinpointAnalytics',
+  'PinpointTargeting',
+  // Others
+  'DynamoDBObjectMapper',
+  'AppSync',
+  'Lex',
+  'Sumerian',
+];
 function deleteAmplifyConfig(context) {
   const srcDirPath = getSrcDir(context);
   // delete aws configuration and amplify configuration
@@ -142,11 +160,13 @@ function getCurrentAWSConfig(context) {
 
 function getCustomConfigs(cloudAWSConfig, currentAWSConfig) {
   const customConfigs = {};
-  Object.keys(currentAWSConfig).forEach(key => {
-    if (!cloudAWSConfig[key]) {
-      customConfigs[key] = currentAWSConfig[key];
-    }
-  });
+  Object.keys(currentAWSConfig)
+    .filter(k => !AMPLIFY_RESERVED_EXPORT_KEYS.includes(k))
+    .forEach(key => {
+      if (!cloudAWSConfig[key]) {
+        customConfigs[key] = currentAWSConfig[key];
+      }
+    });
   return customConfigs;
 }
 

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -4,10 +4,70 @@ const fs = require('fs-extra');
 const graphQLConfig = require('graphql-config');
 const { isPackaged } = require('amplify-cli-core');
 
-const CUSTOM_CONFIG_DENY_LIST = [
+const MOCK_RESERVED_EXPORT_KEYS = [
   'aws_user_files_s3_dangerously_connect_to_http_endpoint_for_testing',
   'aws_appsync_dangerously_connect_to_http_endpoint_for_testing',
 ];
+
+// These are the set of keys that are reserved for amplify and customers are not allowed to override
+const AMPLIFY_RESERVED_EXPORT_KEYS = [
+  // General
+  'aws_project_region',
+  // cognito
+  'aws_cognito_identity_pool_id',
+  'aws_cognito_region',
+  'aws_user_pools_id',
+  'aws_user_pools_web_client_id',
+  'oauth',
+  'federationTarget',
+  'aws_cognito_username_attributes',
+  'aws_cognito_social_providers',
+  'aws_cognito_signup_attributes',
+  'aws_cognito_mfa_configuration',
+  'aws_cognito_mfa_types',
+  'aws_cognito_password_protection_settings',
+  'aws_cognito_verification_mechanisms',
+
+  // S3
+  'aws_user_files_s3_bucket',
+  'aws_user_files_s3_bucket_region',
+
+  // AppSync
+  'aws_appsync_graphqlEndpoint',
+  'aws_appsync_region',
+  'aws_appsync_authenticationType',
+  'aws_appsync_apiKey',
+  // API Gateway
+  'aws_cloud_logic_custom',
+
+  // Pinpoint
+  'aws_mobile_analytics_app_id',
+  'aws_mobile_analytics_app_region',
+
+  // DynamoDB
+  'aws_dynamodb_all_tables_region',
+  'aws_dynamodb_table_schemas',
+
+  // S3AndCloudFront
+  'aws_content_delivery_bucket',
+  'aws_content_delivery_bucket_region',
+  'aws_content_delivery_url',
+
+  // lex
+  'aws_bots',
+  'aws_bots_config',
+
+  // Sumerian
+  'XR',
+
+  // Predictions
+  'predictions',
+
+  // Geo
+  'geo',
+];
+
+const CUSTOM_CONFIG_DENY_LIST = [...MOCK_RESERVED_EXPORT_KEYS, ...AMPLIFY_RESERVED_EXPORT_KEYS];
 
 const FILE_EXTENSION_MAP = {
   javascript: 'js',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change fixes 2 issues. 
1. When a new environment is initialized, the frontend configuration files (like aws-exports.js) were not updated before a push was performed. This was due to CLI trying to retain custom configuration value that might have been added externally. Created a list of configuration keys that are reserved for the CLI and can't be overriden
2. When a project is pulled and used for frontend development, pulling it again did not update the configuration file. This change includes fix for that

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fix #9416
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
