### PR TITLE
Revert "fix: populating custom resource stack with account/region placeholders"

### DIFF
--- a/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
+++ b/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
@@ -14,11 +14,7 @@ export async function generateCloudFormationFromCDK(resourceName: string) {
 
   const amplifyResourceProps: AmplifyResourceProps = { category: categoryName, resourceName };
 
-  const env = {
-    region: 'Aws.region',
-    account: 'Aws.accountId',
-  };
-  const customStack: cdk.Stack = new cdkStack(undefined, undefined, { env }, amplifyResourceProps);
+  const customStack: cdk.Stack = new cdkStack(undefined, undefined, undefined, amplifyResourceProps);
 
   // @ts-ignore
   JSONUtilities.writeJson(path.join(targetDir, 'build', `${resourceName}-cloudformation-template.json`), customStack._toCloudFormation());


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#9361
Breaking e2e test `packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts`