### PR TITLE
 fix: enable 'listBucket' access to entire bucket for trigger lambda

### DIFF
--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
@@ -1,0 +1,792 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test S3 transform generates correct CFN template Generated s3 template with all CLI configurations set with no overrides 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": Object {
+    "AuthReadAndList": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "AuthenticatedAllowList",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateAuthPrivate": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsAuthenticatedPrivate",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateAuthProtected": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsAuthenticatedProtected",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateAuthPublic": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsAuthenticatedPublic",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateAuthUploads": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsAuthenticatedUploads",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateGuestPublic": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsGuestPublic",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "CreateGuestUploads": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "s3PermissionsGuestUploads",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "GuestReadAndList": Object {
+      "Fn::Not": Array [
+        Object {
+          "Fn::Equals": Array [
+            Object {
+              "Ref": "GuestAllowList",
+            },
+            "DISALLOW",
+          ],
+        },
+      ],
+    },
+    "ShouldNotCreateEnvResources": Object {
+      "Fn::Equals": Array [
+        Object {
+          "Ref": "env",
+        },
+        "NONE",
+      ],
+    },
+  },
+  "Description": "S3 Resource for AWS Amplify CLI",
+  "Outputs": Object {
+    "BucketName": Object {
+      "Description": "Bucket name for the S3 bucket",
+      "Value": Object {
+        "Ref": "S3Bucket",
+      },
+    },
+    "Region": Object {
+      "Value": Object {
+        "Ref": "AWS::Region",
+      },
+    },
+  },
+  "Parameters": Object {
+    "AuthenticatedAllowList": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "GuestAllowList": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "authPolicyName": Object {
+      "Type": "String",
+    },
+    "authRoleName": Object {
+      "Type": "String",
+    },
+    "bucketName": Object {
+      "Type": "String",
+    },
+    "env": Object {
+      "Type": "String",
+    },
+    "functionS3TriggerMockTriggercafe2021Arn": Object {
+      "Default": "functionS3TriggerMockTriggercafe2021Arn",
+      "Type": "String",
+    },
+    "functionS3TriggerMockTriggercafe2021LambdaExecutionRole": Object {
+      "Default": "functionS3TriggerMockTriggercafe2021LambdaExecutionRole",
+      "Type": "String",
+    },
+    "functionS3TriggerMockTriggercafe2021Name": Object {
+      "Default": "functionS3TriggerMockTriggercafe2021Name",
+      "Type": "String",
+    },
+    "s3PermissionsAuthenticatedPrivate": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PermissionsAuthenticatedProtected": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PermissionsAuthenticatedPublic": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PermissionsAuthenticatedUploads": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PermissionsGuestPublic": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PermissionsGuestUploads": Object {
+      "Default": "DISALLOW",
+      "Type": "String",
+    },
+    "s3PrivatePolicy": Object {
+      "Default": "NONE",
+      "Type": "String",
+    },
+    "s3ProtectedPolicy": Object {
+      "Default": "NONE",
+      "Type": "String",
+    },
+    "s3PublicPolicy": Object {
+      "Default": "NONE",
+      "Type": "String",
+    },
+    "s3ReadPolicy": Object {
+      "Default": "NONE",
+      "Type": "String",
+    },
+    "s3UploadsPolicy": Object {
+      "Default": "NONE",
+      "Type": "String",
+    },
+    "selectedAuthenticatedPermissions": Object {
+      "Default": "NONE",
+      "Type": "CommaDelimitedList",
+    },
+    "selectedGuestPermissions": Object {
+      "Default": "NONE",
+      "Type": "CommaDelimitedList",
+    },
+    "triggerFunction": Object {
+      "Type": "String",
+    },
+    "unauthPolicyName": Object {
+      "Type": "String",
+    },
+    "unauthRoleName": Object {
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "S3AuthPrivatePolicy": Object {
+      "Condition": "CreateAuthPrivate",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Object {
+                "Fn::Split": Array [
+                  ",",
+                  Object {
+                    "Ref": "s3PermissionsAuthenticatedPrivate",
+                  },
+                ],
+              },
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/private/\${cognito-identity.amazonaws.com:sub}/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3PrivatePolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "authRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3AuthProtectedPolicy": Object {
+      "Condition": "CreateAuthProtected",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Object {
+                "Fn::Split": Array [
+                  ",",
+                  Object {
+                    "Ref": "s3PermissionsAuthenticatedProtected",
+                  },
+                ],
+              },
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/protected/\${cognito-identity.amazonaws.com:sub}/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3ProtectedPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "authRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3AuthPublicPolicy": Object {
+      "Condition": "CreateAuthPublic",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Object {
+                "Fn::Split": Array [
+                  ",",
+                  Object {
+                    "Ref": "s3PermissionsAuthenticatedPublic",
+                  },
+                ],
+              },
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/public/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3PublicPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "authRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3AuthReadPolicy": Object {
+      "Condition": "AuthReadAndList",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "S3Bucket",
+                    },
+                    "/protected/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Condition": Object {
+                "StringLike": Object {
+                  "s3:prefix": Array [
+                    "public/",
+                    "public/*",
+                    "protected/",
+                    "protected/*",
+                    "private/\${cognito-identity.amazonaws.com:sub}/",
+                    "private/\${cognito-identity.amazonaws.com:sub}/*",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "S3Bucket",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3ReadPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "authRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3AuthUploadPolicy": Object {
+      "Condition": "CreateAuthUploads",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Object {
+                "Fn::Split": Array [
+                  ",",
+                  Object {
+                    "Ref": "s3PermissionsAuthenticatedUploads",
+                  },
+                ],
+              },
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/uploads/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3UploadsPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "authRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3Bucket": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "TriggerPermissions",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Fn::If": Array [
+            "ShouldNotCreateEnvResources",
+            Object {
+              "Ref": "bucketName",
+            },
+            Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "bucketName",
+                  },
+                  Object {
+                    "Fn::Select": Array [
+                      3,
+                      Object {
+                        "Fn::Split": Array [
+                          "-",
+                          Object {
+                            "Ref": "AWS::StackName",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "-",
+                  Object {
+                    "Ref": "env",
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+        "CorsConfiguration": Object {
+          "CorsRules": Array [
+            Object {
+              "AllowedHeaders": Array [
+                "*",
+              ],
+              "AllowedMethods": Array [
+                "GET",
+                "HEAD",
+                "PUT",
+                "POST",
+                "DELETE",
+              ],
+              "AllowedOrigins": Array [
+                "*",
+              ],
+              "ExposedHeaders": Array [
+                "x-amz-server-side-encryption",
+                "x-amz-request-id",
+                "x-amz-id-2",
+                "ETag",
+              ],
+              "Id": "S3CORSRuleId1",
+              "MaxAge": 3000,
+            },
+          ],
+        },
+        "NotificationConfiguration": Object {
+          "LambdaConfigurations": Array [
+            Object {
+              "Event": "s3:ObjectCreated:*",
+              "Function": Object {
+                "Ref": "functionS3TriggerMockTriggercafe2021Arn",
+              },
+            },
+            Object {
+              "Event": "s3:ObjectRemoved:*",
+              "Function": Object {
+                "Ref": "functionS3TriggerMockTriggercafe2021Arn",
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "S3GuestPublicPolicy": Object {
+      "Condition": "CreateGuestPublic",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Object {
+                "Fn::Split": Array [
+                  ",",
+                  Object {
+                    "Ref": "s3PermissionsGuestPublic",
+                  },
+                ],
+              },
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/public/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3PublicPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "unauthRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3GuestReadPolicy": Object {
+      "Condition": "GuestReadAndList",
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "S3Bucket",
+                    },
+                    "/protected/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Condition": Object {
+                "StringLike": Object {
+                  "s3:prefix": Array [
+                    "public/",
+                    "public/*",
+                    "protected/",
+                    "protected/*",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "S3Bucket",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": Object {
+          "Ref": "s3ReadPolicy",
+        },
+        "Roles": Array [
+          Object {
+            "Ref": "unauthRoleName",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3TriggerBucketPolicy": Object {
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:aws:s3:::",
+                      Object {
+                        "Ref": "S3Bucket",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "amplify-lambda-execution-policy-storage",
+        "Roles": Array [
+          Object {
+            "Ref": "functionS3TriggerMockTriggercafe2021LambdaExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TriggerPermissions": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "functionS3TriggerMockTriggercafe2021Name",
+        },
+        "Principal": "s3.amazonaws.com",
+        "SourceAccount": Object {
+          "Ref": "AWS::AccountId",
+        },
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:aws:s3:::",
+              Object {
+                "Fn::If": Array [
+                  "ShouldNotCreateEnvResources",
+                  Object {
+                    "Ref": "bucketName",
+                  },
+                  Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        Object {
+                          "Ref": "bucketName",
+                        },
+                        Object {
+                          "Fn::Select": Array [
+                            3,
+                            Object {
+                              "Fn::Split": Array [
+                                "-",
+                                Object {
+                                  "Ref": "AWS::StackName",
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        "-",
+                        Object {
+                          "Ref": "env",
+                        },
+                      ],
+                    ],
+                  },
+                ],
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.test.ts
@@ -71,10 +71,6 @@ describe('Test DDB transform generates correct CFN template', () => {
     jest.spyOn(DynamoDBInputState.prototype, 'getCliInputPayload').mockImplementation(() => cliInputsJSON);
     const ddbTransform = new DDBStackTransform(resourceName);
     await ddbTransform.transform();
-
-    console.log(ddbTransform._cfn);
-    console.log(ddbTransform._cfnInputParams);
-
     expect(ddbTransform._cfn).toMatchSnapshot();
     expect(ddbTransform._cfnInputParams).toMatchSnapshot();
   });

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -3,7 +3,7 @@
 
 /* These tests test the AmplifyS3ResourceStackTransform and run the cdk builder tool which is used within this file */
 import * as uuid from 'uuid';
-import { $TSContext, CLISubCommandType, CLIInputSchemaValidator } from 'amplify-cli-core';
+import { $TSContext, CLISubCommandType, CLIInputSchemaValidator, AmplifySupportedService } from 'amplify-cli-core';
 import { AmplifyS3ResourceStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform';
 import {
     S3AccessType,
@@ -11,7 +11,6 @@ import {
     S3UserInputs
 } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/s3-user-input-types';
 import { S3InputState } from '../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state';
-import { S3MockDataBuilder } from '../service-walkthroughs/s3-walkthrough.test';
 import { AmplifyS3ResourceCfnStack } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder';
 import _ from 'lodash';
 
@@ -145,3 +144,60 @@ describe('Test S3 transform generates correct CFN template', () => {
 
   });
 });
+
+export class S3MockDataBuilder {
+  static mockBucketName = 'mock-stack-builder-bucket-name-99'; //s3 bucket naming rules allows alphanumeric and hyphens
+  static mockResourceName = 'mockResourceName';
+  static mockPolicyUUID = 'cafe2021';
+  static mockPolicyUUID2 = 'cafe2022';
+  static mockFunctionName = `S3Trigger${S3MockDataBuilder.mockPolicyUUID}`;
+  static mockFunctioName2 = `S3Trigger${S3MockDataBuilder.mockPolicyUUID2}`;
+  static mockExistingFunctionName1 = 'triggerHandlerFunction1';
+  static mockExistingFunctionName2 = 'triggerHandlerFunction2';
+  static mockFilePath = '';
+  static mockAuthMeta = {
+    service: 'Cognito',
+    providerPlugin: 'awscloudformation',
+    dependsOn: [],
+    customAuth: false,
+    frontendAuthConfig: {
+      loginMechanisms: ['PREFERRED_USERNAME'],
+      signupAttributes: ['EMAIL'],
+      passwordProtectionSettings: {
+        passwordPolicyMinLength: 8,
+        passwordPolicyCharacters: [],
+      },
+      mfaConfiguration: 'OFF',
+      mfaTypes: ['SMS'],
+      verificationMechanisms: ['EMAIL'],
+    },
+  };
+ 
+  mockGroupAccess = {
+    mockAdminGroup: [S3PermissionType.CREATE_AND_UPDATE, S3PermissionType.READ, S3PermissionType.DELETE],
+    mockGuestGroup: [S3PermissionType.READ],
+  };
+  defaultAuthPerms = [S3PermissionType.CREATE_AND_UPDATE, S3PermissionType.READ, S3PermissionType.DELETE];
+  defaultGuestPerms = [S3PermissionType.CREATE_AND_UPDATE, S3PermissionType.READ];
+
+  simpleAuth: S3UserInputs = {
+    resourceName: S3MockDataBuilder.mockResourceName,
+    bucketName: S3MockDataBuilder.mockBucketName,
+    policyUUID: S3MockDataBuilder.mockPolicyUUID,
+    storageAccess: S3AccessType.AUTH_ONLY,
+    guestAccess: [],
+    authAccess: this.defaultAuthPerms,
+    groupAccess: {},
+    triggerFunction: 'NONE',
+  };
+ 
+
+  constructor(startCliInputState: S3UserInputs | undefined) {
+  }
+
+ 
+  static getMockGetAllResourcesNoExistingLambdas() {
+    return [{ service: 'Cognito', serviceType: 'managed' }];
+  }
+
+}

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -1,0 +1,147 @@
+/* These tests test the S3StackBuilder */
+
+
+/* These tests test the AmplifyS3ResourceStackTransform and run the cdk builder tool which is used within this file */
+import * as uuid from 'uuid';
+import { $TSContext, CLISubCommandType, CLIInputSchemaValidator } from 'amplify-cli-core';
+import { AmplifyS3ResourceStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform';
+import {
+    S3AccessType,
+    S3PermissionType,
+    S3UserInputs
+} from '../../../../provider-utils/awscloudformation/service-walkthrough-types/s3-user-input-types';
+import { S3InputState } from '../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state';
+import { S3MockDataBuilder } from '../service-walkthroughs/s3-walkthrough.test';
+import { AmplifyS3ResourceCfnStack } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder';
+import _ from 'lodash';
+
+const mockContext = {
+    amplify: {
+      getProjectDetails: () => {
+        return {
+          projectConfig: {
+            projectName: 'mockProject',
+          },
+          amplifyMeta: {
+          providers : {
+              awscloudformation : { StackName : 'amplify-stackname' }
+          }
+      },
+        };
+      },
+      getUserPoolGroupList: () => {
+        return [];
+      },
+      // eslint-disable-next-line
+      getResourceStatus: () => {
+        return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
+      }, //eslint-disable-line
+      copyBatch: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+      updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+      pathManager: {
+        getBackendDirPath: jest.fn().mockReturnValue('mockTargetDir'),
+      },
+    },
+} as unknown as $TSContext;
+
+jest.mock('amplify-cli-core', () => ({
+  stateManager : {
+    getMeta : jest.fn( ()=>({
+        providers : {
+            awscloudformation : { StackName : 'amplify-stackname' }
+        }
+    })) 
+  },
+  CLISubCommandType : {
+        ADD : 'add',
+  },
+  AmplifyCategories : {
+        STORAGE : 'storage',
+  },
+  AmplifySupportedService : {
+      S3 : 's3'
+  },
+  buildOverrideDir: jest.fn().mockResolvedValue(false),
+  JSONUtilities: {
+    writeJson: jest.fn(),
+    readJson: jest.fn(),
+  },
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('mockbackendpath'),
+    getResourceDirectoryPath: jest.fn().mockReturnValue('mockresourcepath'),
+  },
+}));
+jest.mock('fs-extra', () => ({
+  readFileSync: () => jest.fn().mockReturnValue('{ "Cognito": { "provider": "aws"}}'),
+  existsSync:  jest.fn().mockReturnValue(true),
+  ensureDirSync: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('path', () => ({
+  join: jest.fn().mockReturnValue('mockjoinedpath'),
+  resolve: jest.fn().mockReturnValue('mockjoinedpath'),
+}));
+
+jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/s3-questions');
+jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough');
+
+describe('Test S3 transform generates correct CFN template', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Generated s3 template with all CLI configurations set with no overrides', async () => {
+    const resourceName = 'mockResource';
+    const bucketName = 'mockBucketName';
+    const [shortId] = uuid.v4().split('-');
+    const mockTriggerFunction = 'S3TriggerMockTriggercafe2021'
+    const cliInputs: S3UserInputs = {
+        resourceName : resourceName,
+        bucketName : bucketName,
+        policyUUID : shortId,
+        storageAccess : S3AccessType.AUTH_AND_GUEST,
+        guestAccess: [S3PermissionType.READ],
+        authAccess : [S3PermissionType.CREATE_AND_UPDATE, S3PermissionType.READ, S3PermissionType.DELETE],
+        triggerFunction: mockTriggerFunction,
+        adminTriggerFunction: undefined,
+        additionalTriggerFunctions: undefined,
+        groupAccess : undefined
+    }
+
+    const cliInputParams = {
+        bucketName: bucketName,
+        selectedGuestPermissions: [ 's3:GetObject', 's3:ListBucket' ],
+        selectedAuthenticatedPermissions: [
+        's3:PutObject',
+        's3:GetObject',
+        's3:ListBucket',
+        's3:DeleteObject'
+        ],
+        unauthRoleName: { Ref: 'UnauthRoleName' },
+        authRoleName: { Ref: 'AuthRoleName' },
+        triggerFunction: mockTriggerFunction,
+        s3PrivatePolicy: `Private_policy_${shortId}`,
+        s3ProtectedPolicy: `Protected_policy_${shortId}`,
+        s3PublicPolicy: `Public_policy_${shortId}`,
+        s3ReadPolicy: `read_policy_${shortId}`,
+        s3UploadsPolicy: `Uploads_policy_${shortId}`,
+        authPolicyName: `s3_amplify_${shortId}`,
+        unauthPolicyName: `s3_amplify_${shortId}`,
+        AuthenticatedAllowList: 'ALLOW',
+        GuestAllowList: 'ALLOW',
+        s3PermissionsAuthenticatedPrivate: 's3:PutObject,s3:GetObject,s3:DeleteObject',
+        s3PermissionsAuthenticatedProtected: 's3:PutObject,s3:GetObject,s3:DeleteObject',
+        s3PermissionsAuthenticatedPublic: 's3:PutObject,s3:GetObject,s3:DeleteObject',
+        s3PermissionsAuthenticatedUploads: 's3:PutObject',
+        s3PermissionsGuestPublic: 's3:GetObject',
+        s3PermissionsGuestUploads: 'DISALLOW'
+    }
+  
+    jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockImplementation(() => cliInputs);
+    const s3Transform = new AmplifyS3ResourceStackTransform( resourceName, mockContext );
+    await s3Transform.transform( CLISubCommandType.ADD );
+    expect(s3Transform.getCFN()).toMatchSnapshot();
+    expect( _.isEqual(s3Transform.getCFNInputParams(),cliInputParams ) ).toEqual(true);
+
+  });
+});

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -57,6 +57,10 @@ export class AmplifyS3ResourceStackTransform {
     return this.cfn;
   }
 
+  getCFNInputParams():AmplifyS3ResourceInputParameters {
+    return this.cfnInputParams;
+  }
+
   async transform(commandType: CLISubCommandType) {
     this.generateCfnInputParameters();
     // Generate cloudformation stack from cli-inputs.json
@@ -211,7 +215,6 @@ export class AmplifyS3ResourceStackTransform {
       // Render CFN Template string and store as member in this.cfn
       this.cfn = this.resourceTemplateObj.renderCloudFormationTemplate();
     }
-
     //Store cloudformation-template.json, Parameters.json and Update BackendConfig
     this._saveFilesToLocalFileSystem('cloudformation-template.json', this.cfn);
     this._saveFilesToLocalFileSystem('parameters.json', this.cfnInputParams);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
ListObjectsV2 command requires List permissions to the entire bucket before listing objects in subfolders.
List permissions are assigned using the "ListBucket" permission. Adding multiple statements to the policy required an update to the  s3-stack generator code.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#9439 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
1. Add logic in triggerLambda to list all objects in S3 bucket  and subfolders. 
2. Add predictions advance workflow for Rekognition lambda and verify list access permission still works for triggerLambda.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
