### PR TITLE
fix: #9341 - handle auth and api dependency in state files correctly

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -10,7 +10,7 @@ import {
 import { printer } from 'amplify-prompts';
 import * as fs from 'fs-extra';
 import { readTransformerConfiguration, TRANSFORM_CURRENT_VERSION, writeTransformerConfiguration } from 'graphql-transformer-core';
-import _, { has } from 'lodash';
+import _ from 'lodash';
 import * as path from 'path';
 import { v4 as uuid } from 'uuid';
 import { category } from '../../category-constants';
@@ -149,7 +149,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
     this.context.amplify.updateamplifyMetaAfterResourceUpdate(category, apiName, 'output', { authConfig });
     this.context.amplify.updateBackendConfigAfterResourceUpdate(category, apiName, 'output', { authConfig });
 
-    // If we have cognito configured no but before update it was not there then add dependsOn for the API
+    // If we have cognito configured now but before update it was not there then add dependsOn for the API
     if (this.hasCognitoAuthMode(authConfig) && !this.hasCognitoAuthMode(previousAuthConfig)) {
       const dependsOn: Array<DependsOnEntry> = this.createDependsOnFromAuthConfig(authConfig);
       const authResourceName = checkIfAuthExists();

--- a/packages/amplify-category-auth/src/commands/auth/remove.ts
+++ b/packages/amplify-category-auth/src/commands/auth/remove.ts
@@ -12,9 +12,11 @@ export const run = async (context: $TSContext) => {
   const dependentResources = Object.keys(meta).some(e => {
     return ['analytics', 'api', 'storage', 'function'].includes(e) && Object.keys(meta[e]).length > 0;
   });
+
   if (dependentResources) {
     printer.info(messages.dependenciesExists);
   }
+
   const authResourceName = Object.keys(meta.auth).filter(resourceKey => {
     return meta.auth[resourceKey].service === AmplifySupportedService.COGNITO;
   });

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
@@ -231,8 +231,9 @@ describe('remove-resource', () => {
     it('throw an error when the dependent resources has a specified resource', async () => {
       await expect(removeResource(context as any, 'function', 'lambdaLayer1')).resolves.toBeUndefined();
 
-      expect(printer.error).toBeCalledWith('Resource cannot be removed because it has a dependency on another resource');
-      expect(printer.error).toBeCalledWith('Dependency: Lambda - lambda1');
+      expect(printer.error).toBeCalledWith('Resource cannot be removed because it has a dependency on another resource.');
+      expect(printer.error).toBeCalledWith('Dependency:');
+      expect(printer.error).toBeCalledWith('  - Lambda - lambda1');
       expect(printer.error).toBeCalledWith('An error occurred when removing the resources from the local directory');
       expect(context.usageData.emitError).toBeCalledWith(
         new Error('Resource cannot be removed because it has a dependency on another resource'),

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-resource.ts
@@ -125,20 +125,32 @@ const deleteResourceFiles = async (context: $TSContext, category: string, resour
   const amplifyMeta = stateManager.getMeta();
   if (!force) {
     const { allResources } = await context.amplify.getResourceStatus();
+    const dependencies: Array<{ service: string; resourceName: string }> = [];
     allResources.forEach(resourceItem => {
       if (resourceItem.dependsOn) {
         resourceItem.dependsOn.forEach(dependsOnItem => {
           if (dependsOnItem.category === category && dependsOnItem.resourceName === resourceName) {
-            printer.error('Resource cannot be removed because it has a dependency on another resource');
-            printer.error(`Dependency: ${resourceItem.service} - ${resourceItem.resourceName}`);
-            const error = new Error('Resource cannot be removed because it has a dependency on another resource');
-            error.stack = undefined;
-            throw error;
+            dependencies.push({ service: resourceItem.service, resourceName: resourceItem.resourceName });
           }
         });
       }
     });
+
+    if (dependencies.length > 0) {
+      printer.error('Resource cannot be removed because it has a dependency on another resource.');
+
+      printer.error(`Dependency:`);
+      dependencies.forEach(dependency => {
+        printer.error(`  - ${dependency.service} - ${dependency.resourceName}`);
+      });
+
+      const error = new Error('Resource cannot be removed because it has a dependency on another resource');
+      error.stack = undefined;
+
+      throw error;
+    }
   }
+
   const serviceName: string = amplifyMeta[category][resourceName].service;
   const resourceValues = {
     service: serviceName,


### PR DESCRIPTION
#### Description of changes

When a GraphQL API is added/updated in a project, currently there is no `dependsOn` managed between the two resources,  and then the `auth` resource was removed, the `push` operation failed.

This PR updates the `add` and `update` functionality to properly manage the `dependsOn` between the two resources if the API has Cognito auth mode configured.

This PR also updates the `remove` behavior to list all the dependent resources, not just the first one in the error message.

#### Issue #, if available

Fixes #9341
 
#### Description of how you validated changes

Manual testing, updated unit test for remove

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
