### PR TITLE
GraphQL auth transformer: support dynamic groups on list entity field

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -135,13 +135,13 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $primaryFieldMap = {} )
 #if( $util.authType() == \\"User Pool Authorization\\" )
   #if( !$util.isNull($ctx.args.parent) )
-    #set( $parentClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
+    #set( $parentClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
     #if( $util.isString($ctx.args.parent) )
-      #set( $parentCondition = ($parentClaim == $ctx.args.parent) )
+      #set( $parentCondition0 = ($parentClaim0 == $ctx.args.parent) )
     #else
-      #set( $parentCondition = ($parentClaim == $util.defaultIfNull($ctx.args.parent.get(\\"eq\\"), \\"___xamznone____\\")) )
+      #set( $parentCondition0 = ($parentClaim0 == $util.defaultIfNull($ctx.args.parent.get(\\"eq\\"), \\"___xamznone____\\")) )
     #end
-    #if( $parentCondition )
+    #if( $parentCondition0 )
       #set( $isAuthorized = true )
       $util.qr($ctx.stash.put(\\"authFilter\\", null))
     #end
@@ -149,13 +149,13 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     $util.qr($primaryFieldMap.put(\\"parent\\", $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\")))
   #end
   #if( !$util.isNull($ctx.args.child) )
-    #set( $childClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
+    #set( $childClaim1 = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
     #if( $util.isString($ctx.args.child) )
-      #set( $childCondition = ($childClaim == $ctx.args.child) )
+      #set( $childCondition1 = ($childClaim1 == $ctx.args.child) )
     #else
-      #set( $childCondition = ($childClaim == $util.defaultIfNull($ctx.args.child.get(\\"eq\\"), \\"___xamznone____\\")) )
+      #set( $childCondition1 = ($childClaim1 == $util.defaultIfNull($ctx.args.child.get(\\"eq\\"), \\"___xamznone____\\")) )
     #end
-    #if( $childCondition )
+    #if( $childCondition1 )
       #set( $isAuthorized = true )
       $util.qr($ctx.stash.put(\\"authFilter\\", null))
     #end

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -83,21 +83,18 @@ const generateAuthOnRelationalModelQueryExpression = (
         modelQueryExpression.push(
           set(ref(`primaryRole${idx}`), getOwnerClaim(role.claim!)),
           ifElse(
-            and([
-              parens(not(ref(`util.isNull($ctx.${claim}.${field})`))),
-              parens(equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`))),
-            ]),
-            compoundExpression([
-              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
-              qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
-            ]),
+            not(ref(`util.isNull($ctx.${claim}.${field})`)),
             iff(
-              and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]),
+              equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`)),
               compoundExpression([
-                qref(methodCall(ref(`ctx.${claim}.put`), str(field), ref(`primaryRole${idx}`))),
+                qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
                 set(ref(IS_AUTHORIZED_FLAG), bool(true)),
               ]),
             ),
+            compoundExpression([
+              qref(methodCall(ref(`ctx.${claim}.put`), str(field), ref(`primaryRole${idx}`))),
+              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+            ]),
           ),
         );
       } else if (role.strategy === 'groups') {
@@ -105,21 +102,18 @@ const generateAuthOnRelationalModelQueryExpression = (
         modelQueryExpression.push(
           set(ref(`primaryRole${idx}`), getIdentityClaimExp(str(role.claim!), str(NONE_VALUE))),
           ifElse(
-            and([
-              parens(not(ref(`util.isNull($ctx.${claim}.${field})`))),
-              parens(equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`))),
-            ]),
-            compoundExpression([
-              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
-              qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
-            ]),
+            not(ref(`util.isNull($ctx.${claim}.${field})`)),
             iff(
-              and([not(ref(IS_AUTHORIZED_FLAG)), methodCall(ref('util.isNull'), ref('ctx.stash.authFilter'))]),
+              equals(ref(`ctx.${claim}.${field}`), ref(`primaryRole${idx}`)),
               compoundExpression([
-                qref(methodCall(ref(`ctx.${claim}.put`), str(field), ref(`primaryRole${idx}`))),
+                qref(methodCall(ref('ctx.stash.put'), str('authFilter'), nul())),
                 set(ref(IS_AUTHORIZED_FLAG), bool(true)),
               ]),
             ),
+            compoundExpression([
+              qref(methodCall(ref(`ctx.${claim}.put`), str(field), ref(`primaryRole${idx}`))),
+              set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+            ]),
           ),
         );
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This is the next work to support parsing dynamic groups claim into a list of groups and with these changes those will be compared against an entity field of list type e.g.:

```graphql
  type Post @model @auth(rules: [{ allow: groups, groupsField: "groups" }]) {
      id: ID!
      title: String!
      groups: [String!]
      createdAt: String
      updatedAt: String
  }
```

And the generated authorization logic will look something like this:

```
#if( $util.authType() == "User Pool Authorization" )
  #if( !$isAuthorized )
    #set( $authFilter = [] )
    #set( $groups0 = $util.defaultIfNull($ctx.identity.claims.get("cognito:groups"), []) )
    #if( $util.isString($groups0) )
      #if( $util.isList($util.parseJson($groups0)) )
        #set( $groups0 = $util.parseJson($groups0) )
      #else
        #set( $groups0 = [$groups0] )
      #end
    #end
    #foreach( $group in $groups0 )
      #if( !$group.isEmpty() )
        $util.qr($authFilter.add({"groups": { "contains": $group }}))
      #end
    #end
    #if( !$authFilter.isEmpty() )
      $util.qr($ctx.stash.put("authFilter", { "or": $authFilter }))
    #end
  #end
#end
```

I added as well a refactoring commit to separate the logic for adding authorization checks for `owner` strategy from the `groups` one. This change will be useful in my next PRs as the authorization checks are slightly different.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

Previous PR with support for entity field of type String: https://github.com/aws-amplify/amplify-cli/pull/9466
Related issue ticket: aws-amplify/amplify-category-api#132

#### Description of how you validated changes

Added some unit tests and also manually tested it on a project by copying the built files.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
