### PR TITLE
fix(api): container rest api push treats incorrect initial push behavior

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/base-api-stack.ts
@@ -120,7 +120,7 @@ export abstract class ContainersStack extends cdk.Stack {
     const { pipelineWithAwaiter } = this.pipeline({
       skipWait,
       service,
-      containersInfo,
+      containersInfo: containersInfo.filter(container => container.repository),
       gitHubSourceActionInfo,
     });
 
@@ -375,12 +375,10 @@ export abstract class ContainersStack extends cdk.Stack {
           secrets,
         });
 
-        if (build) {
-          containersInfo.push({
-            container,
-            repository,
-          });
-        }
+        containersInfo.push({
+          container,
+          repository,
+        });
 
         // TODO: should we use hostPort too? check network mode
         portMappings?.forEach(({ containerPort, protocol, hostPort }) => {


### PR DESCRIPTION
#### Description of changes

The logic that container rest api uses to determine the `isInitialPush` flag is flawed. This results in incorrect processing of the secret files even though there are no changes made to the api.

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/8384

#### Description of how you validated changes
- Manual test
- e2e test in local

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
