### PR TITLE
chore: add test schema library package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -304,6 +304,7 @@ module.exports = {
     '/packages/amplify-cli-logger/lib',
     '/packages/amplify-e2e-core/lib',
     '/packages/amplify-function-plugin-interface/lib',
+    '/packages/amplify-graphql-schema-test-library/lib',
     '/packages/amplify-headless-interface/lib',
     '/packages/amplify-migration-tests/lib',
     '/packages/amplify-prompts/lib',

--- a/packages/amplify-graphql-schema-test-library/.npmignore
+++ b/packages/amplify-graphql-schema-test-library/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/amplify-graphql-schema-test-library/CHANGELOG.md
+++ b/packages/amplify-graphql-schema-test-library/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/amplify-graphql-schema-test-library/README.md
+++ b/packages/amplify-graphql-schema-test-library/README.md
@@ -1,0 +1,1 @@
+# `amplify-graphql-schema-test-library`

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@aws-amplify/graphql-schema-test-library",
+  "version": "1.0.0",
+  "description": "Library of valid and unsupported Amplify GraphQL Transformer schemas",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "directory": "packages/amplify-graphql-schema-test-library"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "keywords": [
+    "graphql",
+    "cloudformation",
+    "aws",
+    "amplify"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "clean": "rimraf ./lib",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@aws-amplify/graphql-auth-transformer": "0.5.8",
+    "@aws-amplify/graphql-default-value-transformer": "0.5.11",
+    "@aws-amplify/graphql-function-transformer": "0.7.6",
+    "@aws-amplify/graphql-http-transformer": "0.8.6",
+    "@aws-amplify/graphql-index-transformer": "0.8.6",
+    "@aws-amplify/graphql-model-transformer": "0.10.6",
+    "@aws-amplify/graphql-predictions-transformer": "0.6.6",
+    "@aws-amplify/graphql-relational-transformer": "0.6.16",
+    "@aws-amplify/graphql-searchable-transformer": "0.10.6",
+    "@aws-amplify/graphql-transformer-core": "0.15.5",
+    "@aws-amplify/graphql-transformer-interfaces": "1.12.6"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.(ts|tsx)?$": "ts-jest"
+    },
+    "testRegex": "(src/__tests__/.*.test.ts)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true
+  }
+}

--- a/packages/amplify-graphql-schema-test-library/src/__tests__/index.test.ts
+++ b/packages/amplify-graphql-schema-test-library/src/__tests__/index.test.ts
@@ -1,0 +1,105 @@
+import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { DefaultValueTransformer } from '@aws-amplify/graphql-default-value-transformer';
+import { FunctionTransformer } from '@aws-amplify/graphql-function-transformer';
+import { HttpTransformer } from '@aws-amplify/graphql-http-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
+import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
+import { PredictionsTransformer } from '@aws-amplify/graphql-predictions-transformer';
+import {
+  BelongsToTransformer,
+  HasManyTransformer,
+  HasOneTransformer,
+  ManyToManyTransformer,
+} from '@aws-amplify/graphql-relational-transformer';
+import { SearchableModelTransformer } from '@aws-amplify/graphql-searchable-transformer';
+import { ConflictHandlerType, GraphQLTransform, GraphQLTransformOptions } from '@aws-amplify/graphql-transformer-core';
+import { TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { schemas, TransformerPlatform, TransformerSchema, TransformerVersion } from '..';
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+const defaultDataStoreConfig = {
+  resolverConfig: {
+    project: {
+      ConflictDetection: 'VERSION',
+      ConflictHandler: ConflictHandlerType.AUTOMERGE,
+    },
+  },
+} as any;
+
+for (const [name, schema] of Object.entries(schemas)) {
+  test(`schema '${name}' passes or fails as expected`, () => {
+    if (!isTransformerVersionSupported(schema, TransformerVersion.v2)) {
+      throw new Error('only v2 schemas are currently supported');
+    }
+
+    if (isPlatformSupported(schema, TransformerPlatform.api)) {
+      expectToPass(name, schema, createV2Transformer());
+    } else {
+      expectToFail(name, schema, createV2Transformer());
+    }
+
+    if (isPlatformSupported(schema, TransformerPlatform.dataStore)) {
+      expectToPass(name, schema, createV2Transformer({ ...defaultDataStoreConfig }));
+    } else {
+      expectToFail(name, schema, createV2Transformer({ ...defaultDataStoreConfig }));
+    }
+  });
+}
+
+function expectToPass(name: string, schema: TransformerSchema, transformer: GraphQLTransform): void {
+  try {
+    transformer.transform(schema.sdl);
+  } catch (err) {
+    console.log(err);
+    throw new Error(`schema '${name}' unexpectedly failed with error: ${err}`);
+  }
+}
+
+function expectToFail(name: string, schema: TransformerSchema, transformer: GraphQLTransform): void {
+  try {
+    transformer.transform(schema.sdl);
+  } catch (err) {
+    return;
+  }
+
+  throw new Error(`schema '${name}' unexpectedly passed`);
+}
+
+function createV2Transformer(options: Partial<Writeable<GraphQLTransformOptions>> = {}): GraphQLTransform {
+  options.transformers ??= getV2DefaultTransformerList();
+
+  return new GraphQLTransform(options as GraphQLTransformOptions);
+}
+
+function getV2DefaultTransformerList(): TransformerPluginProvider[] {
+  const modelTransformer = new ModelTransformer();
+  const indexTransformer = new IndexTransformer();
+  const hasOneTransformer = new HasOneTransformer();
+  const authTransformer = new AuthTransformer({
+    adminRoles: ['testAdminRoleName'],
+    identityPoolId: 'identityPoolId',
+  });
+
+  return [
+    modelTransformer,
+    new FunctionTransformer(),
+    new HttpTransformer(),
+    new PredictionsTransformer({ bucketName: 'testBucketName' }),
+    new PrimaryKeyTransformer(),
+    indexTransformer,
+    new BelongsToTransformer(),
+    new HasManyTransformer(),
+    hasOneTransformer,
+    new ManyToManyTransformer(modelTransformer, indexTransformer, hasOneTransformer, authTransformer),
+    new DefaultValueTransformer(),
+    authTransformer,
+    new SearchableModelTransformer(),
+  ];
+}
+
+function isTransformerVersionSupported(schema: TransformerSchema, version: TransformerVersion): boolean {
+  return (schema.transformerVersion & version) !== 0;
+}
+
+function isPlatformSupported(schema: TransformerSchema, platform: TransformerPlatform): boolean {
+  return (schema.supportedPlatforms & platform) !== 0;
+}

--- a/packages/amplify-graphql-schema-test-library/src/index.ts
+++ b/packages/amplify-graphql-schema-test-library/src/index.ts
@@ -1,0 +1,294 @@
+/* eslint-disable no-bitwise */
+
+// The TransformerVersion and TransformerPlatform enums use bit flags to easily combine
+// values. For example, if a schema is only supported on JS and iOS, this can be represented
+// as (TransformerPlatform.js | TransformerPlatform.ios). Similarly, if a schema is supported
+// on all platforms but Flutter with DataStore enabled, the flags can be set like this:
+// (TransformerPlatform.all & ~TransformerPlatform.flutterDataStore). Ideally, we should be
+// working toward a state where TransformerPlatform.all is the only value needed.
+
+export const enum TransformerVersion {
+  v1 = 1 << 0,
+  v2 = 1 << 1,
+  all = ~0,
+}
+
+export const enum TransformerPlatform {
+  none = 0,
+  api = 1 << 0,
+  dataStore = 1 << 1,
+  js = 1 << 2,
+  jsDataStore = 1 << 3,
+  ios = 1 << 4,
+  iosDataStore = 1 << 5,
+  android = 1 << 6,
+  androidDataStore = 1 << 7,
+  flutter = 1 << 8,
+  flutterDataStore = 1 << 9,
+  all = ~0,
+}
+
+export type TransformerSchema = {
+  description: string;
+  transformerVersion: TransformerVersion;
+  supportedPlatforms: TransformerPlatform;
+  sdl: string;
+};
+
+export const schemas: { [key: string]: TransformerSchema } = {
+  '@model-simple': {
+    description: 'Simple @model schema',
+    transformerVersion: TransformerVersion.all,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Todo @model {
+        id: ID!
+        name: String!
+      }
+    `,
+  },
+  'v2-primary-key-with-composite-sort-key': {
+    description: '@primaryKey with a composite sort key',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Test @model {
+        email: String! @primaryKey(sortKeyFields: ["kind", "other"])
+        kind: Int!
+        other: AWSDateTime!
+        yetAnother: String
+        andAnother: String!
+      }
+    `,
+  },
+  'v2-index-with-queryfield': {
+    description: '@index with queryField',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Test @model {
+        email: String!
+        createdAt: AWSDateTime!
+        category: String! @index(name: "CategoryGSI", sortKeyFields: "createdAt", queryField: "testsByCategory")
+        description: String
+      }
+    `,
+  },
+  'v2-recursive-has-one-dependency': {
+    description: 'Recursive @hasOne relationship',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Item @model {
+        id: ID!
+        item: Item @hasOne
+      }
+    `,
+  },
+  'v2-recursive-has-many-dependency': {
+    description: 'Recursive @hasMany relationship',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Item @model {
+        id: ID!
+        items: [Item] @hasMany
+      }
+    `,
+  },
+  'v2-cyclic-has-one-dependency': {
+    description: 'Cyclic @hasOne dependency between two models',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms:
+      TransformerPlatform.api |
+      TransformerPlatform.js |
+      TransformerPlatform.ios |
+      TransformerPlatform.android |
+      TransformerPlatform.flutter,
+    sdl: `
+      type Blog @model {
+        id: ID!
+        posts: Post @hasOne
+      }
+      type Post @model {
+        id: ID!
+        blog: Blog @hasOne
+      }
+    `,
+  },
+  'v2-cyclic-has-many-dependency': {
+    description: 'Cyclic @hasMany dependency between two models',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms:
+      TransformerPlatform.api |
+      TransformerPlatform.js |
+      TransformerPlatform.ios |
+      TransformerPlatform.android |
+      TransformerPlatform.flutter,
+    sdl: `
+      type Blog @model {
+        id: ID!
+        posts: [Post] @hasMany
+      }
+      type Post @model {
+        id: ID!
+        blog: [Blog] @hasMany
+      }
+    `,
+  },
+  '@default-string-value': {
+    description: '@default sets a default value for a string field',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Todo @model {
+        content: String @default(value: "My new Todo")
+      }
+    `,
+  },
+  '@hasOne-implicit-fields': {
+    description: '@hasOne with implicit fields parameter',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Project @model {
+        id: ID!
+        name: String
+        team: Team @hasOne
+      }
+
+      type Team @model {
+        id: ID!
+        name: String!
+      }
+    `,
+  },
+  '@hasOne-explicit-fields': {
+    description: '@hasOne with explicit fields parameter',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Project @model {
+        id: ID!
+        name: String
+        teamID: ID
+        team: Team @hasOne(fields: ["teamID"])
+      }
+
+      type Team @model {
+        id: ID!
+        name: String!
+      }
+    `,
+  },
+  '@hasMany-implicit-parameters': {
+    description: '@hasMany with implicit parameters',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @hasMany
+      }
+
+      type Comment @model {
+        id: ID!
+        content: String!
+      }
+    `,
+  },
+  '@hasMany-explicit-parameters': {
+    description: '@hasMany with explicit parameters',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+      }
+
+      type Comment @model {
+        id: ID!
+        postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+        content: String!
+      }
+    `,
+  },
+  '@hasOne-with-@belongsTo-with-implicit-parameters': {
+    description: '@belongsTo with implicit parameters referencing @hasOne',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Project @model {
+        id: ID!
+        name: String
+        team: Team @hasOne
+      }
+
+      type Team @model {
+        id: ID!
+        name: String!
+        project: Project @belongsTo
+      }
+    `,
+  },
+  '@hasOne-with-@belongsTo-with-explicit-parameters': {
+    description: '@belongsTo with explicit parameters referencing @hasOne',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Project @model {
+        id: ID!
+        name: String
+        team: Team @hasOne
+      }
+
+      type Team @model {
+        id: ID!
+        name: String!
+        projectID: ID
+        project: Project @belongsTo(fields: ["projectID"])
+      }
+    `,
+  },
+  '@hasMany-with-@belongsTo-with-implicit-parameters': {
+    description: '@belongsTo with implicit parameters referencing @hasMany',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+      }
+
+      type Comment @model {
+        id: ID!
+        postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+        content: String!
+        post: Post @belongsTo
+      }
+    `,
+  },
+  '@hasMany-with-@belongsTo-with-explicit-parameters': {
+    description: '@belongsTo with explicit parameters referencing @hasMany',
+    transformerVersion: TransformerVersion.v2,
+    supportedPlatforms: TransformerPlatform.all,
+    sdl: `
+      type Post @model {
+        id: ID!
+        title: String!
+        comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+      }
+
+      type Comment @model {
+        id: ID!
+        postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+        content: String!
+        post: Post @belongsTo(fields: ["postID"])
+      }
+    `,
+  },
+};

--- a/packages/amplify-graphql-schema-test-library/tsconfig.json
+++ b/packages/amplify-graphql-schema-test-library/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "references": [
+    {"path": "../amplify-graphql-transformer-core"},
+    {"path": "../amplify-graphql-transformer-interfaces"},
+    {"path": "../graphql-mapping-template"},
+    {"path": "../graphql-transformer-common"}
+  ]
+}


### PR DESCRIPTION
This commit adds the initial version of a new package, `@aws-amplify/graphql-schema-test-library`, which is intended to contain a collection of schemas that can be shared among teams for common validation.

cc: @alharris-at. Are there any specific schemas you'd like to see included here? I'd like to balance including schemas that codegen can test and finds useful, while not duplicating the CLI's full test suite.