### PR TITLE
fix: listX operations with no args where authField is used in primaryKey

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -127,3 +127,71 @@ $util.unauthorized()
 $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
+
+exports[`test owner fields on primaryKey create authfilter for scan operation 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#set( $isAuthorized = false )
+#set( $primaryFieldMap = {} )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$util.isNull($ctx.args.parent) )
+    #set( $parentClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
+    #if( $util.isString($ctx.args.parent) )
+      #set( $parentCondition = ($parentClaim == $ctx.args.parent) )
+    #else
+      #set( $parentCondition = ($parentClaim == $util.defaultIfNull($ctx.args.parent.get(\\"eq\\"), \\"___xamznone____\\")) )
+    #end
+    #if( $parentCondition )
+      #set( $isAuthorized = true )
+      $util.qr($ctx.stash.put(\\"authFilter\\", null))
+    #end
+  #else
+    $util.qr($primaryFieldMap.put(\\"parent\\", $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\")))
+  #end
+  #if( !$util.isNull($ctx.args.child) )
+    #set( $childClaim = $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\") )
+    #if( $util.isString($ctx.args.child) )
+      #set( $childCondition = ($childClaim == $ctx.args.child) )
+    #else
+      #set( $childCondition = ($childClaim == $util.defaultIfNull($ctx.args.child.get(\\"eq\\"), \\"___xamznone____\\")) )
+    #end
+    #if( $childCondition )
+      #set( $isAuthorized = true )
+      $util.qr($ctx.stash.put(\\"authFilter\\", null))
+    #end
+  #else
+    $util.qr($primaryFieldMap.put(\\"child\\", $util.defaultIfNull($ctx.identity.claims.get(\\"sub\\"), \\"___xamznone____\\")))
+  #end
+  #if( !$isAuthorized && !$primaryFieldMap.isEmpty() )
+    #if( $util.isNull($ctx.args.parent) )
+      #set( $authFilter = $util.defaultIfNull($ctx.stash.get(\\"authFilter\\").get(\\"or\\"), []) )
+      #foreach( $entry in $primaryFieldMap.entrySet() )
+        #set( $filterMap = {} )
+        #if( $util.isList($entry.value) )
+          $util.qr($filterMap.put($entry.key, { \\"in\\": $entry.value }))
+        #else
+          $util.qr($filterMap.put($entry.key, { \\"eq\\": $entry.value }))
+        #end
+        $util.qr($authFilter.add($filterMap))
+      #end
+      $util.qr($ctx.stash.put(\\"authFilter\\", { \\"or\\": $authFilter }))
+    #else
+      #if( $util.isNull($ctx.stash.authFilter) )
+        #set( $modelQueryExpression = $ctx.stash.modelQueryExpression )
+        #foreach( $entry in $primaryFieldMap.entrySet() )
+          #set( $modelQueryExpression.expression = \\"\${modelQueryExpression.expression} AND #\${entry.key} = :\${entry.key}\\" )
+          $util.qr($modelQueryExpression.expressionNames.put(\\"#\${entry.key}\\", $entry.key))
+          $util.qr($modelQueryExpression.expressionValues.put(\\":\${entry.key}\\", $util.dynamodb.toDynamoDB($entry.value)))
+        #end
+        $util.qr($ctx.stash.put(\\"modelQueryExpression\\", $modelQueryExpression))
+        #set( $isAuthorized = true )
+      #end
+    #end
+  #end
+#end
+#if( !$isAuthorized && $util.isNull($ctx.stash.authFilter) )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/query.ts
@@ -114,6 +114,7 @@ const generateAuthOnModelQueryExpression = (
   roles: Array<RoleDefinition>,
   primaryFields: Array<string>,
   isIndexQuery = false,
+  primaryKey: string | undefined = undefined,
 ): Array<Expression> => {
   const modelQueryExpression = new Array<Expression>();
   const primaryRoles = roles.filter(r => primaryFields.includes(r.entity));
@@ -204,22 +205,42 @@ const generateAuthOnModelQueryExpression = (
         );
       }
       modelQueryExpression.push(
+        // if no args where provided to the listX operation
+        // @model will create a scan operation we add these primary fields in the auth filter
         iff(
-          and([
-            not(ref(IS_AUTHORIZED_FLAG)),
-            methodCall(ref('util.isNull'), ref('ctx.stash.authFilter')),
-            not(ref('primaryFieldMap.isEmpty()')),
-          ]),
-          compoundExpression([
-            set(ref('modelQueryExpression'), ref('ctx.stash.modelQueryExpression')),
-            forEach(ref('entry'), ref('primaryFieldMap.entrySet()'), [
-              set(ref('modelQueryExpression.expression'), str('${modelQueryExpression.expression} AND #${entry.key} = :${entry.value}')),
-              qref(ref('modelQueryExpression.expressionNames.put("#${entry.key}", $entry.key)')),
-              qref(ref('modelQueryExpression.expressionValues.put(":${entry.value}", $util.dynamodb.toDynamoDB($entry.value))')),
+          and([not(ref(IS_AUTHORIZED_FLAG)), not(ref('primaryFieldMap.isEmpty()'))]),
+          ifElse(
+            methodCall(ref('util.isNull'), ref(`ctx.args.${primaryKey}`)),
+            compoundExpression([
+              set(ref('authFilter'), methodCall(ref('util.defaultIfNull'), ref('ctx.stash.get("authFilter").get("or")'), list([]))),
+              forEach(ref('entry'), ref('primaryFieldMap.entrySet()'), [
+                // we are using the filter map so we can test this assignment in mock
+                set(ref('filterMap'), obj({})),
+                ifElse(
+                  methodCall(ref('util.isList'), ref('entry.value')),
+                  qref(methodCall(ref('filterMap.put'), ref('entry.key'), raw('{ "in": $entry.value }'))),
+                  qref(methodCall(ref('filterMap.put'), ref('entry.key'), raw('{ "eq": $entry.value }'))),
+                ),
+                qref(methodCall(ref('authFilter.add'), ref('filterMap'))),
+              ]),
+              qref(methodCall(ref('ctx.stash.put'), str('authFilter'), raw('{ "or": $authFilter }'))),
             ]),
-            qref(methodCall(ref('ctx.stash.put'), str('modelQueryExpression'), ref('modelQueryExpression'))),
-            set(ref(IS_AUTHORIZED_FLAG), bool(true)),
-          ]),
+            // if authfilter is null, the partitionkey is provided in the args, and there is still values in the fieldmap then we are dealing with sortKeys
+            // we need to append the sort keys to the model query expression
+            iff(
+              methodCall(ref('util.isNull'), ref('ctx.stash.authFilter')),
+              compoundExpression([
+                set(ref('modelQueryExpression'), ref('ctx.stash.modelQueryExpression')),
+                forEach(ref('entry'), ref('primaryFieldMap.entrySet()'), [
+                  set(ref('modelQueryExpression.expression'), str('${modelQueryExpression.expression} AND #${entry.key} = :${entry.key}')),
+                  qref(ref('modelQueryExpression.expressionNames.put("#${entry.key}", $entry.key)')),
+                  qref(ref('modelQueryExpression.expressionValues.put(":${entry.key}", $util.dynamodb.toDynamoDB($entry.value))')),
+                ]),
+                qref(methodCall(ref('ctx.stash.put'), str('modelQueryExpression'), ref('modelQueryExpression'))),
+                set(ref(IS_AUTHORIZED_FLAG), bool(true)),
+              ]),
+            ),
+          ),
         ),
       );
     }
@@ -319,6 +340,7 @@ export const generateAuthExpressionForQueries = (
   fields: ReadonlyArray<FieldDefinitionNode>,
   primaryFields: Array<string>,
   isIndexQuery = false,
+  primaryKey: string | undefined = undefined,
 ): string => {
   const { cognitoStaticRoles, cognitoDynamicRoles, oidcStaticRoles, oidcDynamicRoles, apiKeyRoles, iamRoles, lambdaRoles } =
     splitRoles(roles);
@@ -344,7 +366,7 @@ export const generateAuthExpressionForQueries = (
         compoundExpression([
           ...generateStaticRoleExpression(cognitoStaticRoles),
           ...generateAuthFilter(getNonPrimaryFieldRoles(cognitoDynamicRoles), fields),
-          ...generateAuthOnModelQueryExpression(cognitoDynamicRoles, primaryFields, isIndexQuery),
+          ...generateAuthOnModelQueryExpression(cognitoDynamicRoles, primaryFields, isIndexQuery, primaryKey),
         ]),
       ),
     );
@@ -356,7 +378,7 @@ export const generateAuthExpressionForQueries = (
         compoundExpression([
           ...generateStaticRoleExpression(oidcStaticRoles),
           ...generateAuthFilter(getNonPrimaryFieldRoles(oidcDynamicRoles), fields),
-          ...generateAuthOnModelQueryExpression(oidcDynamicRoles, primaryFields, isIndexQuery),
+          ...generateAuthOnModelQueryExpression(oidcDynamicRoles, primaryFields, isIndexQuery, primaryKey),
         ]),
       ),
     );

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -153,6 +153,14 @@ export const getTable = (ctx: TransformerContextProvider, def: ObjectTypeDefinit
   }
 };
 
+/**
+ *
+ * given the keySchema from a DynamoDBDataSource it will return the parititonKey
+ */
+export const getPartitionKey = (ks: any): string => {
+  return ks.find((att: any) => att.keyType === 'HASH')!.attributeName;
+};
+
 export const extendTypeWithDirectives = (
   ctx: TransformerTransformSchemaStepContextProvider,
   typeName: string,

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -1,4 +1,5 @@
 import { AuthTransformer } from '@aws-amplify/graphql-auth-transformer';
+import { IndexTransformer, PrimaryKeyTransformer } from '@aws-amplify/graphql-index-transformer';
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
 import { AppSyncAuthConfiguration } from '@aws-amplify/graphql-transformer-interfaces';
@@ -538,5 +539,120 @@ describe('@model field auth', () => {
       // since the only two roles have access to these fields there are no field resolvers
       expect(out.resolvers?.[`Student.${field}.req.vtl`]).not.toBeDefined();
     });
+  });
+});
+
+describe('@model @primaryIndex @index auth', () => {
+  let vtlTemplate: VelocityTemplateSimulator;
+  let transformer: GraphQLTransform;
+
+  const ownerRequest: AppSyncGraphQLExecutionContext = {
+    requestAuthorizationMode: AmplifyAppSyncSimulatorAuthenticationType.AMAZON_COGNITO_USER_POOLS,
+    jwt: getJWTToken(USER_POOL_ID, 'user1', 'user1@test.com'),
+    headers: {},
+    sourceIp: '',
+  };
+
+  beforeEach(() => {
+    const authConfig: AppSyncAuthConfiguration = {
+      defaultAuthentication: {
+        authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      },
+      additionalAuthenticationProviders: [],
+    };
+    transformer = new GraphQLTransform({
+      authConfig,
+      featureFlags: {
+        getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+          if (name === 'secondaryKeyAsGSI') {
+            return true;
+          }
+          return defaultValue;
+        }),
+        getNumber: jest.fn(),
+        getObject: jest.fn(),
+        getString: jest.fn(),
+      },
+      transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()],
+    });
+    vtlTemplate = new VelocityTemplateSimulator({ authConfig });
+  });
+
+  test('listX operations', () => {
+    const validSchema = `
+    type FamilyMember @model @auth(rules: [
+      { allow: owner, ownerField: "parent", operations: [read] },
+      { allow: owner, ownerField: "child", operations: [read] } 
+    ]){
+      parent: ID! @primaryKey(sortKeyFields: ["child"]) @index(name: "byParent", queryField: "byParent")
+      child: ID! @index(name: "byChild", queryField: "byChild")
+      createdAt: AWSDateTime
+      updatedAt: AWSDateTime
+    }`;
+
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+
+    // should expect no errors and there should be an authfilter
+    const listAuthRequestTemplate = out.resolvers['Query.listFamilyMembers.auth.1.req.vtl'];
+    expect(listAuthRequestTemplate).toBeDefined();
+    let listAuthVTLRequest = vtlTemplate.render(listAuthRequestTemplate, {
+      context: {},
+      requestParameters: ownerRequest,
+    });
+    expect(listAuthVTLRequest.hadException).toEqual(false);
+    expect(listAuthVTLRequest.stash.authFilter).toEqual(
+      expect.objectContaining({
+        or: expect.arrayContaining([
+          expect.objectContaining({ child: { eq: ownerRequest.jwt['cognito:username'] } }),
+          expect.objectContaining({ parent: { eq: ownerRequest.jwt['cognito:username'] } }),
+        ]),
+      }),
+    );
+
+    // should still change model query expression if the partition key is provided
+    // adding the modelQueryExpression and arg to simulate partitionkey being added
+    listAuthVTLRequest = vtlTemplate.render(listAuthRequestTemplate, {
+      context: {
+        arguments: {
+          parent: 'user10',
+        },
+        stash: {
+          modelQueryExpression: {
+            expression: '#parent = :parent',
+            expressionNames: {
+              '#parent': 'parent',
+            },
+            expressionValues: {
+              ':parent': {
+                S: '$ctx.args.parent',
+              },
+            },
+          },
+        },
+      },
+      requestParameters: ownerRequest,
+    });
+    expect(listAuthVTLRequest.hadException).toEqual(false);
+    expect(listAuthVTLRequest.stash.authFilter).not.toBeDefined();
+    // the $ctx.args.parent is not resolving in mock vtl engine
+    // not an issue in the service the index e2e tests this scenario
+    expect(listAuthVTLRequest.stash.modelQueryExpression).toMatchInlineSnapshot(`
+      Object {
+        "expression": "#parent = :parent AND #child = :child",
+        "expressionNames": Object {
+          "#child": "child",
+          "#parent": "parent",
+        },
+        "expressionValues": Object {
+          ":child": Object {
+            "S": "user1",
+          },
+          ":parent": Object {
+            "S": "$ctx.args.parent",
+          },
+        },
+      }
+    `);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- update listX primaryField (auth field that is a part of the primaryKey) to append to authFilter instead of appending to `ModelQueryExpression`
- if primaryKey (aka partitionKey) is in the args for listX, any other rules which don't use the sort key will be used first. If those are not applicable, any auth rules on the sort Key will be used to modify the request. If all else fails the request is unauthorized.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- unit
- vtl mock
- e2e

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
