### PR TITLE
fix: split policies for both legacy and migrated REST APIs

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/convert-deprecated-apigw-paths.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/convert-deprecated-apigw-paths.test.ts
@@ -1,0 +1,73 @@
+import { JSONUtilities } from 'amplify-cli-core';
+
+jest.mock('amplify-cli-core');
+
+const JSONUtilities_mock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
+
+import { convertDeperecatedRestApiPaths } from '../../../provider-utils/awscloudformation/convert-deprecated-apigw-paths';
+
+describe('test apigw path migrate', () => {
+  it('migrates valid input successfully', async () => {
+    JSONUtilities_mock.readJson.mockReturnValueOnce({
+      paths: [
+        {
+          name: '/mockOpenPath',
+          lambdaFunction: 'mockOpenLambda',
+          privacy: {
+            open: true,
+          },
+        },
+        {
+          name: '/mockPrivatePath',
+          lambdaFunction: 'mockPrivateLambda',
+          privacy: {
+            auth: ['/GET', '/POST'],
+            private: true,
+          },
+        },
+        {
+          name: '/mockLegacyPath',
+          lambdaFunction: 'mockLegacyLambda',
+          privacy: {
+            auth: 'rw',
+            private: true,
+          },
+        },
+      ],
+    });
+
+    const convertedPaths = convertDeperecatedRestApiPaths('mockFileName.json', 'mock/file/path/mockFileName.json', 'mockApi');
+    expect(convertedPaths).toMatchObject({
+      '/mockOpenPath': {
+        permissions: {
+          setting: 'open',
+        },
+        lambdaFunction: 'mockOpenLambda',
+      },
+      '/mockPrivatePath': {
+        permissions: {
+          setting: 'private',
+          auth: ['read', 'create'],
+        },
+        lambdaFunction: 'mockPrivateLambda',
+      },
+      '/mockLegacyPath': {
+        permissions: {
+          setting: 'private',
+          auth: ['create', 'read', 'update', 'delete'],
+        },
+        lambdaFunction: 'mockLegacyLambda',
+      },
+    });
+  });
+
+  it('throws on invalid input', async () => {
+    JSONUtilities_mock.readJson.mockReturnValueOnce({});
+    expect(() => convertDeperecatedRestApiPaths('mockFileName.json', 'mock/file/path/mockFileName.json', 'mockApi')).toThrow();
+
+    JSONUtilities_mock.readJson.mockReturnValueOnce({
+      paths: [],
+    });
+    expect(() => convertDeperecatedRestApiPaths('mockFileName.json', 'mock/file/path/mockFileName.json', 'mockApi')).toThrow();
+  });
+});

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -24,6 +24,7 @@ import { getAppSyncApiResourceName } from './provider-utils/awscloudformation/ut
 export { NETWORK_STACK_LOGICAL_ID } from './category-constants';
 export { addAdminQueriesApi, updateAdminQueriesApi } from './provider-utils/awscloudformation/';
 export { DEPLOYMENT_MECHANISM } from './provider-utils/awscloudformation/base-api-stack';
+export { convertDeperecatedRestApiPaths } from './provider-utils/awscloudformation/convert-deprecated-apigw-paths';
 export { getContainers } from './provider-utils/awscloudformation/docker-compose';
 export { EcsAlbStack } from './provider-utils/awscloudformation/ecs-alb-stack';
 export { EcsStack } from './provider-utils/awscloudformation/ecs-apigw-stack';

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/apigw-stack-transform.ts
@@ -203,7 +203,7 @@ export class ApigwStackTransform {
         try {
           overrideCode = await fs.readFile(overrideJSFilePath, 'utf-8');
         } catch (error) {
-          formatter.list(['No override file found', `To override ${this.resourceName} run amplify override auth`]);
+          formatter.list(['No override file found', `To override ${this.resourceName} run amplify override api`]);
           return;
         }
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cdk-stack-builder/types.ts
@@ -34,7 +34,7 @@ type AmplifyCDKL1 = {
   addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void;
   addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void;
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void;
-  addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void;
+  addCfnParameter(props: cdk.CfnParameterProps, logicalId: string, value?: any): void;
   addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void;
 };
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/convert-deprecated-apigw-paths.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/convert-deprecated-apigw-paths.ts
@@ -70,8 +70,8 @@ export function convertDeperecatedRestApiPaths(
   return paths;
 }
 
-function _convertDeprecatedPermissionStringToCRUD(deprecatedPrivacy: string) {
-  let privacyList: string[];
+function _convertDeprecatedPermissionStringToCRUD(deprecatedPrivacy: string): CrudOperation[] {
+  let privacyList: CrudOperation[];
   if (deprecatedPrivacy === 'r') {
     privacyList = [CrudOperation.READ];
   } else if (deprecatedPrivacy === 'rw') {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/convert-deprecated-apigw-paths.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/convert-deprecated-apigw-paths.ts
@@ -1,0 +1,92 @@
+import { $TSObject, JSONUtilities } from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
+import { CrudOperation, PermissionSetting } from './cdk-stack-builder/types';
+
+export function convertDeperecatedRestApiPaths(
+  deprecatedParametersFileName: string,
+  deprecatedParametersFilePath: string,
+  resourceName: string,
+) {
+  let deprecatedParameters: $TSObject;
+  try {
+    deprecatedParameters = JSONUtilities.readJson<$TSObject>(deprecatedParametersFilePath);
+  } catch (e) {
+    printer.error(`Error reading ${deprecatedParametersFileName} file for ${resourceName} resource`);
+    throw e;
+  }
+
+  let paths = {};
+
+  if (!Array.isArray(deprecatedParameters.paths) || deprecatedParameters.paths.length < 1) {
+    throw new Error(`Expected paths to be defined in "${deprecatedParametersFilePath}", but none found.`);
+  }
+
+  deprecatedParameters.paths.forEach((path: $TSObject) => {
+    let pathPermissionSetting =
+      path.privacy?.open === true
+        ? PermissionSetting.OPEN
+        : path.privacy?.private === true
+        ? PermissionSetting.PRIVATE
+        : PermissionSetting.PROTECTED;
+
+    let auth;
+    let guest;
+    let groups;
+    // convert deprecated permissions to CRUD structure
+    if (typeof path.privacy?.auth === 'string' && ['r', 'rw'].includes(path.privacy.auth)) {
+      auth = _convertDeprecatedPermissionStringToCRUD(path.privacy.auth);
+    } else if (Array.isArray(path.privacy?.auth)) {
+      auth = _convertDeprecatedPermissionArrayToCRUD(path.privacy.auth);
+    }
+
+    if (typeof path.privacy?.unauth === 'string' && ['r', 'rw'].includes(path.privacy.unauth)) {
+      guest = _convertDeprecatedPermissionStringToCRUD(path.privacy.unauth);
+    } else if (Array.isArray(path.privacy?.unauth)) {
+      guest = _convertDeprecatedPermissionArrayToCRUD(path.privacy.unauth);
+    }
+
+    if (path.privacy?.userPoolGroups) {
+      groups = {};
+      for (const [userPoolGroupName, crudOperations] of Object.entries(path.privacy.userPoolGroups)) {
+        if (typeof crudOperations === 'string' && ['r', 'rw'].includes(crudOperations)) {
+          groups[userPoolGroupName] = _convertDeprecatedPermissionStringToCRUD(crudOperations);
+        } else if (Array.isArray(crudOperations)) {
+          groups[userPoolGroupName] = _convertDeprecatedPermissionArrayToCRUD(crudOperations);
+        }
+      }
+    }
+
+    paths[path.name] = {
+      permissions: {
+        setting: pathPermissionSetting,
+        auth,
+        guest,
+        groups,
+      },
+      lambdaFunction: path.lambdaFunction,
+    };
+  });
+
+  return paths;
+}
+
+function _convertDeprecatedPermissionStringToCRUD(deprecatedPrivacy: string) {
+  let privacyList: string[];
+  if (deprecatedPrivacy === 'r') {
+    privacyList = [CrudOperation.READ];
+  } else if (deprecatedPrivacy === 'rw') {
+    privacyList = [CrudOperation.CREATE, CrudOperation.READ, CrudOperation.UPDATE, CrudOperation.DELETE];
+  }
+  return privacyList;
+}
+
+function _convertDeprecatedPermissionArrayToCRUD(deprecatedPrivacyArray: string[]): CrudOperation[] {
+  const opMap: Record<string, CrudOperation> = {
+    '/POST': CrudOperation.CREATE,
+    '/GET': CrudOperation.READ,
+    '/PUT': CrudOperation.UPDATE,
+    '/PATCH': CrudOperation.UPDATE,
+    '/DELETE': CrudOperation.DELETE,
+  };
+  return Array.from(new Set(deprecatedPrivacyArray.map(op => opMap[op])));
+}

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/apigw-ext-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/apigw-ext-migration.test.ts
@@ -10,7 +10,6 @@ import {
   updateAuthAddAdminQueries,
   updateAuthAdminQueriesWithExtMigration,
   getProjectMeta,
-  amplifyPushForceWithYesFlag,
 } from 'amplify-e2e-core';
 import { addRestApiOldDx } from '../../../migration-helpers/api';
 import { v4 as uuid } from 'uuid';
@@ -58,20 +57,6 @@ describe('API Gateway CDK migration', () => {
     const authCliInputs = getCLIInputs(projRoot, 'auth', authName);
     expect(authCliInputs).toBeDefined();
 
-    const adminQueriesCliInputs = getCLIInputs(projRoot, 'api', 'AdminQueries');
-    expect(adminQueriesCliInputs).toBeDefined();
-  });
-
-  it('migrates rest apis on push', async () => {
-    await addRestApiOldDx(projRoot, { existingLambda: false, apiName: 'restapimig' });
-    await addAuthWithDefault(projRoot);
-    await updateAuthAddAdminQueries(projRoot);
-    await amplifyPushAuth(projRoot);
-
-    await amplifyPushForceWithYesFlag(projRoot, true);
-
-    const cliInputs = getCLIInputs(projRoot, 'api', 'restapimig');
-    expect(cliInputs).toBeDefined();
     const adminQueriesCliInputs = getCLIInputs(projRoot, 'api', 'AdminQueries');
     expect(adminQueriesCliInputs).toBeDefined();
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, the CLI will ensure all REST APIs have been migrated to ensure that the policy splitting is done correctly. This PR makes older APIs compatible with the policy splitting logic, and migration on push is no longer required. Override migration is only prompted for on `amplify update api` after this change.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available https://github.com/aws-amplify/amplify-cli/issues/9225

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually created api, `apigw-ext-migration.test.ts` and `yarn test` pass

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
