### PR TITLE
fix: handle failed pushes from cognito drift

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -193,6 +193,9 @@ const context_stub = {
     dependsOnBlock: jest.fn(),
     updateamplifyMetaAfterResourceAdd: jest.fn(),
   },
+  print: {
+    error: jest.fn(),
+  },
 };
 
 const context_stub_typed = context_stub as unknown as $TSContext;
@@ -239,5 +242,26 @@ describe('Check Auth Template', () => {
     const authTransform2 = new AmplifyAuthTransform(resourceName);
     const mock_template2 = await authTransform2.transform(context_stub_typed);
     expect(mock_template2.Resources?.UserPool.Properties).not.toContain('UsernameConfiguration');
+  });
+
+  it('should validate cfn parameters if no original', () => {
+    const resourceName = 'mockResource';
+    const authTransform = new AmplifyAuthTransform(resourceName);
+    const isValid = authTransform.validateCfnParameters(context_stub_typed, false, { requiredAttributes: ['email'] });
+    expect(isValid).toBe(true);
+  });
+
+  it('should validate cfn parameters if match', () => {
+    const resourceName = 'mockResource';
+    const authTransform = new AmplifyAuthTransform(resourceName);
+    const isValid = authTransform.validateCfnParameters(context_stub_typed, { requiredAttributes: ['email'] }, { requiredAttributes: ['email'] });
+    expect(isValid).toBe(true);
+  });
+
+  it('should not validate cfn parameters if no match', () => {
+    const resourceName = 'mockResource';
+    const authTransform = new AmplifyAuthTransform(resourceName);
+    const isValid = authTransform.validateCfnParameters(context_stub_typed, { requiredAttributes: ['email'] }, { requiredAttributes: ['email', 'phone_number'] });
+    expect(isValid).toBe(false);
   });
 });

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -1,5 +1,6 @@
 import { AmplifyAuthTransform } from '../../../../provider-utils/awscloudformation/auth-stack-builder';
 import { $TSContext } from 'amplify-cli-core';
+import process from 'process';
 
 jest.mock('amplify-cli-core', () => ({
   ...(jest.requireActual('amplify-cli-core') as {}),
@@ -259,9 +260,11 @@ describe('Check Auth Template', () => {
   });
 
   it('should not validate cfn parameters if no match', () => {
+    // @ts-ignore
+    process.exit = jest.fn();
     const resourceName = 'mockResource';
     const authTransform = new AmplifyAuthTransform(resourceName);
-    const isValid = authTransform.validateCfnParameters(context_stub_typed, { requiredAttributes: ['email'] }, { requiredAttributes: ['email', 'phone_number'] });
-    expect(isValid).toBe(false);
+    authTransform.validateCfnParameters(context_stub_typed, { requiredAttributes: ['email'] }, { requiredAttributes: ['email', 'phone_number'] });
+    expect(process.exit).toBeCalledTimes(1);
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -229,7 +229,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
       'parameters.json',
     );
 
-    const oldParameters = fs.existsSync(parametersJSONFilePath) ? fs.readJSONSync(parametersJSONFilePath) : false;
+    const oldParameters = fs.readJSONSync(parametersJSONFilePath, { throws: false });
 
     const roles = {
       authRoleArn: {
@@ -271,9 +271,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
       parameters = Object.assign(parameters, { triggers: JSON.stringify(this._cognitoStackProps.triggers) });
     }
 
-    if (!this.validateCfnParameters(context, oldParameters, parameters)) {
-      process.exit(1);
-    }
+    this.validateCfnParameters(context, oldParameters, parameters);
 
     //save parameters
     JSONUtilities.writeJson(parametersJSONFilePath, parameters);
@@ -288,7 +286,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
     }
 
     const cliInputsFilePath = path.join(pathManager.getBackendDirPath(), this._category, this.resourceName, 'cli-inputs.json');
-    const containsAll = (arr1: string[], arr2: string[]) => arr2.every(arr2 => arr1.includes(arr2));
+    const containsAll = (arr1: string[], arr2: string[]) => arr2.every(arr2Item => arr1.includes(arr2Item));
     const sameMembers = (arr1: string[], arr2: string[]) => arr1.length === arr2.length && containsAll(arr2, arr1);
     if (!sameMembers(oldParameters.requiredAttributes ?? [], parametersJson.requiredAttributes ?? [])) {
       context.print.error(
@@ -298,7 +296,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
           oldParameters.requiredAttributes,
         )} is required by Cognito configuration. Update ${cliInputsFilePath} to continue.`,
       );
-      return false;
+      process.exit(1);
     }
     return true;
   }


### PR DESCRIPTION
This PR addresses issues reported on https://github.com/aws-amplify/amplify-cli/issues/9525 by informing customers of drift between Cognito user pool configuration and their requested parameters in cli-inputs.json, rather than waiting for CloudFormation to eventually fail and roll back with an error message that is tricky to track down how to fix it.