### PR TITLE
fix: use paginated listComponents endpoint instead of exportComponents

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
+    "watch": "tsc -w",
     "test": "jest"
   },
   "author": "Amazon Web Services",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -21,7 +21,8 @@
     "amplify-cli-core": "2.4.18",
     "amplify-prompts": "1.6.3",
     "amplify-provider-awscloudformation": "5.9.11",
-    "aws-sdk": "2.1084.0"
+    "aws-sdk": "2.1084.0",
+    "p-limit": "^3.0.2"
   },
   "devDependencies": {
     "@aws-amplify/codegen-ui": "2.1.0"

--- a/packages/amplify-util-uibuilder/src/__tests__/syncAmplifyUiComponents.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/syncAmplifyUiComponents.test.ts
@@ -44,7 +44,24 @@ describe('should sync amplify ui builder components', () => {
     };
 
     aws_mock.AmplifyUIBuilder = jest.fn(() => ({
-      exportComponents: jest.fn(() => ({
+      listComponents: jest.fn(() => ({
+        promise: jest.fn(() => ({
+          entities: [
+            {
+              appId: 'd37nrm8rzt3oek',
+              bindingProperties: {},
+              componentType: 'Box',
+              environmentName: 'staging',
+              id: 's-s4mU579Ycf6JGHwhqT',
+              name: 'aawwdd',
+              overrides: {},
+              properties: {},
+              variants: [],
+            },
+          ],
+        })),
+      })),
+      getComponent: jest.fn(() => ({
         promise: jest.fn(() => ({
           entities: [
             {
@@ -94,7 +111,8 @@ describe('should sync amplify ui builder components', () => {
     process.env.UI_BUILDER_ENDPOINT = 'https://mock-endpoint.com';
     process.env.UI_BUILDER_REGION = 'mock-region';
     const service = await getAmplifyUIBuilderService(context, 'testEnv', 'testAppId');
-    expect(Object.keys(service)).toContain('exportComponents');
+    expect(Object.keys(service)).toContain('listComponents');
+    expect(Object.keys(service)).toContain('getComponent');
     expect(Object.keys(service)).toContain('exportThemes');
   });
   it('can listUiBuilderThemes', async () => {

--- a/packages/amplify-util-uibuilder/src/commands/utils/syncAmplifyUiBuilderComponents.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/syncAmplifyUiBuilderComponents.ts
@@ -6,7 +6,8 @@ import { extractArgs } from './extractArgs';
 import { $TSAny, $TSContext } from 'amplify-cli-core';
 import { Component, ListComponentsResponse } from 'aws-sdk/clients/amplifyuibuilder';
 import pLimit from 'p-limit'
-const limit = pLimit(5);
+const CONCURRENT_STUDIO_REQUESTS_LIMIT = 5;
+const limit = pLimit(CONCURRENT_STUDIO_REQUESTS_LIMIT);
 
 export const getEnvName = (context: $TSContext, envName?: string) => {
   const args = extractArgs(context);
@@ -61,7 +62,7 @@ export async function listUiBuilderComponents(context: $TSContext, envName?: str
     } while (nextToken);
 
     printer.debug(JSON.stringify(uiBuilderComponents, null, 2));
-    return { entities: uiBuilderComponents};
+    return { entities: uiBuilderComponents };
   } catch (e) {
     printer.debug(e);
     throw e;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR switches away from using `exportComponents` to pull ui components from Studio. For customers with a very large number of components, this method can blow up due to a lambda response size limit. 

Instead, the paginated `listComponents` endpoint is used in tandem with `getComponent` for each component returned.

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- pulled components manually against sample project
- updated unit tests
- e2e test coverage still passes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
