### PR TITLE
fix: apply cfn pre-push transformer to nested api stacks

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
@@ -1,11 +1,22 @@
-import { mergeUserConfigWithTransformOutput } from '../../graphql-transformer/utils';
+import { mergeUserConfigWithTransformOutput, writeDeploymentToDisk } from '../../graphql-transformer/utils';
+import { prePushCfnTemplateModifier } from '../../pre-push-cfn-processor/pre-push-cfn-modifier';
 import { TransformerProjectConfig, DeploymentResources } from '@aws-amplify/graphql-transformer-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+jest.mock('fs-extra');
+jest.mock('../../pre-push-cfn-processor/pre-push-cfn-modifier');
+
+const fs_mock = fs as jest.Mocked<typeof fs>;
+const prePushCfnTemplateModifier_mock = prePushCfnTemplateModifier as jest.MockedFunction<typeof prePushCfnTemplateModifier>;
+
+fs_mock.readdirSync.mockReturnValue([]);
 
 describe('graphql transformer utils', () => {
   let userConfig: TransformerProjectConfig;
   let transformerOutput: DeploymentResources;
 
-  beforeAll(() => {
+  beforeEach(() => {
     transformerOutput = {
       resolvers: {
         'Query.listTodos.req.vtl': '## [Start] List Request. **\n' + '#set( $limit = $util.defaultIfNull($context.args.limit, 100) )\n',
@@ -20,6 +31,30 @@ describe('graphql transformer utils', () => {
         Resources: {},
       },
     } as DeploymentResources;
+  });
+
+  describe('writeDeploymentToDisk', () => {
+    it('executes the CFN pre-push processor on nested api stacks before writing to disk', async () => {
+      transformerOutput.stacks['TestStack'] = { Resources: { TestResource: { Type: 'testtest' } } };
+      transformerOutput.resolvers = {};
+      let hasTransformedTemplate = false;
+      let hasWrittenTransformedTemplate = false;
+      prePushCfnTemplateModifier_mock.mockImplementation(async () => {
+        hasTransformedTemplate = true;
+      });
+      fs_mock.writeFileSync.mockImplementation(filepath => {
+        if (typeof filepath === 'string' && filepath.includes(`${path.sep}stacks${path.sep}`)) {
+          if (hasTransformedTemplate) {
+            hasWrittenTransformedTemplate = true;
+          } else {
+            throw new Error('prePushCfnTemplateModifier was not applied to template before writing to disk');
+          }
+        }
+      });
+
+      await writeDeploymentToDisk(transformerOutput, path.join('test', 'deployment'), undefined, {});
+      expect(hasWrittenTransformedTemplate).toBe(true);
+    });
   });
 
   describe('mergeUserConfigWithTransformOutput', () => {

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -10,6 +10,7 @@ import { ResourceConstants } from 'graphql-transformer-common';
 import { pullAllBy, find } from 'lodash';
 import { isAmplifyAdminApp } from '../utils/admin-helpers';
 import { printer } from 'amplify-prompts';
+import { prePushCfnTemplateModifier } from '../pre-push-cfn-processor/pre-push-cfn-modifier';
 
 const ROOT_STACK_FILE_NAME = 'cloudformation-template.json';
 const PARAMETERS_FILE_NAME = 'parameters.json';
@@ -306,12 +307,12 @@ export async function writeDeploymentToDisk(
     const fullFileName = fileNameParts.join('.');
     throwIfNotJSONExt(fullFileName);
     const fullStackPath = path.normalize(stackRootPath + '/' + fullFileName);
-    let stackString: any = deployment.stacks[stackFileName];
-    stackString =
-      typeof stackString === 'string'
-        ? deployment.stacks[stackFileName]
-        : JSONUtilities.stringify(deployment.stacks[stackFileName], { minify });
-    fs.writeFileSync(fullStackPath, stackString);
+    let stackContent = deployment.stacks[stackFileName];
+    if (typeof stackContent === 'string') {
+      stackContent = JSON.parse(stackContent);
+    }
+    await prePushCfnTemplateModifier(stackContent);
+    fs.writeFileSync(fullStackPath, JSONUtilities.stringify(stackContent, { minify }));
   }
 
   // Write any functions to disk


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Applies the CFN template pre-processor to nested API stacks. The template pre-processor is responsible for applying certain resource config across all CLI generated resources such as S3 encryption and IAM role permissions boundaries.

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/9583
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manually tested and added unit test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
