### PR TITLE
chore: manually bump amplify-category-geo version

### DIFF
--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-geo",
-  "version": "2.3.1",
+  "version": "2.3.3",
   "description": "Amplify CLI plugin to manage the Geo resources for the project",
   "repository": {
     "type": "git",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -43,7 +43,7 @@
     "amplify-app": "4.2.14",
     "amplify-category-analytics": "3.2.13",
     "amplify-category-function": "3.3.14",
-    "amplify-category-geo": "2.3.1",
+    "amplify-category-geo": "2.3.3",
     "amplify-category-hosting": "3.2.13",
     "amplify-category-interactions": "3.2.13",
     "amplify-category-notifications": "2.19.4",


### PR DESCRIPTION
A stray beta version already exists on GitHub and npm which
prevented a release from going through. This commit bumps
the version to unblock the release.
