### PR TITLE
feat(amplify-util-mock): use separate directory for mock resolvers

### DIFF
--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -43,8 +43,9 @@ export class APITest {
       await checkJavaVersion(context);
       this.apiName = await this.getAppSyncAPI(context);
       this.ddbClient = await this.startDynamoDBLocalServer(context);
-      const resolverDirectory = await this.getResolverTemplateDirectory(context);
-      this.resolverOverrideManager = new ResolverOverrides(resolverDirectory);
+      const mockDirectory = await this.getMockResolverTemplateDirectory(context);
+      const customResolversDirectory = await this.getCustomResolverTemplateDirectory(context);
+      this.resolverOverrideManager = new ResolverOverrides(mockDirectory, customResolversDirectory);
       this.apiParameters = await this.loadAPIParameters(context);
       this.appSyncSimulator = new AmplifyAppSyncSimulator({
         port,
@@ -288,10 +289,15 @@ export class APITest {
     }
   }
 
-  private async getResolverTemplateDirectory(context) {
+  private async getMockResolverTemplateDirectory(context) {
     const apiDirectory = await this.getAPIBackendDirectory(context);
-    return apiDirectory;
+    return path.join(apiDirectory, 'mock');
   }
+
+  private async getCustomResolverTemplateDirectory(context) {
+    return await this.getAPIBackendDirectory(context);
+  }
+
   private async registerWatcher(context: any): Promise<chokidar.FSWatcher> {
     const watchDir = await this.getAPIBackendDirectory(context);
     return chokidar.watch(watchDir, {


### PR DESCRIPTION
#### Description of changes
- changes to mock to use a separate directory instead of the custom resolvers one

#### Issue #[9571](https://github.com/aws-amplify/amplify-cli/issues/9571)

#### Description of how you validated changes
- manual mock testing
 
#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
