### PR TITLE
chore: manually bump @aws-amplify/graphql-auth-transformer version

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -38,7 +38,7 @@
     "@aws-amplify/amplify-category-custom": "2.3.13",
     "@aws-amplify/amplify-category-storage": "3.1.10",
     "@aws-amplify/amplify-util-uibuilder": "1.2.5",
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-cdk/cloudformation-diff": "~1.124.0",
     "amplify-app": "4.2.15",
     "amplify-category-analytics": "3.2.14",

--- a/packages/amplify-graphql-auth-transformer/package.json
+++ b/packages/amplify-graphql-auth-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/graphql-auth-transformer",
-  "version": "0.5.12",
+  "version": "0.6.3",
   "description": "Amplify GraphQL @auth Transformer",
   "repository": {
     "type": "git",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-amplify/graphql-default-value-transformer": "0.5.13",
     "@aws-amplify/graphql-function-transformer": "0.7.8",
     "@aws-amplify/graphql-http-transformer": "0.8.8",

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -27,7 +27,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-amplify/graphql-index-transformer": "0.8.8",
     "@aws-amplify/graphql-model-transformer": "0.10.8",
     "@aws-amplify/graphql-transformer-core": "0.15.7",

--- a/packages/amplify-graphql-schema-test-library/package.json
+++ b/packages/amplify-graphql-schema-test-library/package.json
@@ -27,7 +27,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-amplify/graphql-default-value-transformer": "0.5.13",
     "@aws-amplify/graphql-function-transformer": "0.7.8",
     "@aws-amplify/graphql-http-transformer": "0.8.8",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aws-amplify/cli-extensibility-helper": "2.3.9",
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-amplify/graphql-default-value-transformer": "0.5.13",
     "@aws-amplify/graphql-function-transformer": "0.7.8",
     "@aws-amplify/graphql-http-transformer": "0.8.8",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -45,7 +45,7 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
-    "@aws-amplify/graphql-auth-transformer": "0.5.12",
+    "@aws-amplify/graphql-auth-transformer": "0.6.3",
     "@aws-amplify/graphql-default-value-transformer": "0.5.13",
     "@aws-amplify/graphql-function-transformer": "0.7.8",
     "@aws-amplify/graphql-http-transformer": "0.8.8",


### PR DESCRIPTION
This commit bumps the `@auth` v2 version number to avoid conflicting with stray beta releases.