### PR TITLE
fix(amplify-util-mock): do not delete overridden slot files on mock exit

### DIFF
--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -835,3 +835,18 @@ export function modifyRestAPI(projectDir: string, apiName: string) {
   const indexFilePath = path.join(projectDir, 'amplify', 'backend', 'api', apiName, 'src', 'express', 'index.js');
   fs.writeFileSync(indexFilePath, modifiedApi);
 }
+
+export function cancelAmplifyMockApi(cwd: string, settings: any = {}): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    spawn(getCLIPath(), ['mock', 'api'], { cwd, stripColors: true })
+      .wait('AppSync Mock endpoint is running')
+      .sendCtrlC()
+      .run((err: Error) => {
+        if (err && !/Killed the process as no output receive for/.test(err.message)) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+  });
+}

--- a/packages/amplify-e2e-tests/src/__tests__/mock-api.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/mock-api.test.ts
@@ -1,0 +1,57 @@
+import {
+  addApiWithBlankSchema,
+  addCustomResolver,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+  updateApiSchema,
+  cancelAmplifyMockApi,
+} from 'amplify-e2e-core';
+import { existsSync } from 'fs';
+import path from 'path';
+import { addCodegen } from '../codegen/add';
+import * as fs from 'fs-extra';
+
+describe('amplify mock api (GraphQL)', () => {
+  let projRoot: string;
+  let projFolderName: string;
+  let apiName: string;
+
+  beforeEach(async () => {
+    projFolderName = 'mockapi';
+    apiName = 'mockapi';
+    projRoot = await createNewProjectDir(projFolderName);
+  });
+
+  afterEach(async () => {
+    const metaFilePath = path.join(projRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+    if (existsSync(metaFilePath)) {
+      await deleteProject(projRoot);
+    }
+    deleteProjectDir(projRoot);
+  });
+
+  it('mock does not delete custom slot resolvers V2', async () => {
+    const projName = 'simplemodel';
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApiWithBlankSchema(projRoot, { apiName });
+    await updateApiSchema(projRoot, apiName, 'simple_model.graphql');
+
+    const resolverReqInitName = 'Query.getTodo.init.1.req.vtl';
+    const resolverReqName = 'Query.getTodo.req.vtl';
+    const resolver = '$util.unauthorized()';
+
+    await addCustomResolver(projRoot, apiName, resolverReqInitName, resolver);
+    await addCustomResolver(projRoot, apiName, resolverReqName, resolver);
+
+    await addCodegen(projRoot, {});
+    await cancelAmplifyMockApi(projRoot, {});
+
+    const resolversPath = path.join(projRoot, 'amplify', 'backend', 'api', apiName, 'resolvers');
+    const files = await fs.readdir(resolversPath);
+    expect(files.includes('Query.getTodo.init.1.req.vtl')).toBeTruthy();
+    expect(files.includes('Query.getTodo.req.vtl')).toBeTruthy();
+    expect(files).toHaveLength(3);
+  });
+});

--- a/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/transform.ts
@@ -430,7 +430,22 @@ export class GraphQLTransform {
       }
     }
     const schema = fileAssets.get('schema.graphql') || '';
+
+    const resolverEntries = context.resolvers.collectResolvers();
+    const userOverriddenSlots: string[] = [];
+    for (const [resolverName] of resolverEntries) {
+      const userSlots = this.userDefinedSlots[resolverName] || [];
+
+      userSlots.forEach(slot => {
+        const fileName = slot.requestResolver?.fileName;
+        if (fileName && fileName in resolvers) {
+          userOverriddenSlots.push(fileName);
+        }
+      });
+    }
+
     return {
+      userOverriddenSlots,
       functions,
       pipelineFunctions,
       stackMapping: {},

--- a/packages/amplify-graphql-transformer-core/src/transformation/types.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformation/types.ts
@@ -36,6 +36,8 @@ export interface ResolversFunctionsAndSchema {
   functions: Record<string, string>;
   // The full GraphQL schema.
   schema: string;
+  // List of the user overridden slots
+  userOverriddenSlots: string[];
 }
 export interface StackMapping {
   [resourceId: string]: string;

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-transformer/utils.test.ts
@@ -18,6 +18,7 @@ describe('graphql transformer utils', () => {
 
   beforeEach(() => {
     transformerOutput = {
+      userOverriddenSlots: [],
       resolvers: {
         'Query.listTodos.req.vtl': '## [Start] List Request. **\n' + '#set( $limit = $util.defaultIfNull($context.args.limit, 100) )\n',
       },

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -32,6 +32,7 @@ export class APITest {
   private ddbEmulator;
   private configOverrideManager: ConfigOverrideManager;
   private apiParameters: object = {};
+  private userOverriddenSlots: string[] = [];
 
   async start(context, port: number = MOCK_API_PORT, wsPort: number = 20003) {
     try {
@@ -91,7 +92,8 @@ export class APITest {
     await this.ensureDDBTables(config);
     config = this.configureDDBDataSource(config);
     this.transformerResult = await this.configureLambdaDataSource(context, config);
-    const overriddenTemplates = await this.resolverOverrideManager.sync(this.transformerResult.mappingTemplates);
+    this.userOverriddenSlots = transformerOutput.userOverriddenSlots;
+    const overriddenTemplates = await this.resolverOverrideManager.sync(this.transformerResult.mappingTemplates, this.userOverriddenSlots);
     return { ...this.transformerResult, mappingTemplates: overriddenTemplates };
   }
 
@@ -136,7 +138,7 @@ export class APITest {
 
         if (shouldReload) {
           context.print.info('Mapping template change detected. Reloading...');
-          const mappingTemplates = this.resolverOverrideManager.sync(this.transformerResult.mappingTemplates);
+          const mappingTemplates = this.resolverOverrideManager.sync(this.transformerResult.mappingTemplates, this.userOverriddenSlots);
           await this.appSyncSimulator.reload({
             ...this.transformerResult,
             mappingTemplates,

--- a/packages/amplify-util-mock/src/api/resolver-overrides.ts
+++ b/packages/amplify-util-mock/src/api/resolver-overrides.ts
@@ -38,7 +38,7 @@ export class ResolverOverrides {
     return this.updateContentMap(filePath);
   }
 
-  sync(transformerResolvers: { path: string; content: string }[]) {
+  sync(transformerResolvers: { path: string; content: string }[], userOverriddenSlots: string[]) {
     const filesToWrite: Map<string, string> = new Map();
     const filesToDelete: Set<string> = new Set();
     const result: {
@@ -52,7 +52,7 @@ export class ResolverOverrides {
       // deleted from last execution
       if (this.overrides.has(normalizedPath)) {
         const overriddenContent = this.contentMap.get(normalizedPath);
-        if (overriddenContent === resolver.content) {
+        if (overriddenContent === resolver.content && !userOverriddenSlots.includes(path.basename(normalizedPath))) {
           this.overrides.delete(normalizedPath);
         } else {
           r.content = overriddenContent;
@@ -109,6 +109,7 @@ export class ResolverOverrides {
     });
     return result;
   }
+
   /**
    * Stop synchronizing resolver content. This will delete all the resolvers except for
    * the ones which are not overridden


### PR DESCRIPTION
#### Description of changes
- mark userDefinedSlots in order to prevent the mock to delete them on exit

#### Issue #9571 

#### Description of how you validated changes
- manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
