### PR TITLE
fix(amplify-storage-simulator): fix schema of events emitted

### DIFF
--- a/packages/amplify-util-mock/src/storage/storage.ts
+++ b/packages/amplify-util-mock/src/storage/storage.ts
@@ -12,10 +12,10 @@ const port = 20005; // port for S3
 /**
  * @returns Name of S3 resource or undefined
  */
- async function invokeS3GetResourceName(context) {
-   const s3ResourceName = await context.amplify.invokePluginMethod(context, 'storage', undefined, 's3GetResourceName', [context]);
-   return s3ResourceName;
- }
+async function invokeS3GetResourceName(context) {
+  const s3ResourceName = await context.amplify.invokePluginMethod(context, 'storage', undefined, 's3GetResourceName', [context]);
+  return s3ResourceName;
+}
 
 /**
  * Return the cli-inputs.json
@@ -23,13 +23,10 @@ const port = 20005; // port for S3
  * @param s3ResourceName
  * @returns
  */
- async function invokeS3GetUserInputs(context, s3ResourceName) {
-   const s3UserInputs = await context.amplify.invokePluginMethod(context, 'storage', undefined, 's3GetUserInput', [
-     context,
-     s3ResourceName,
-   ]);
-   return s3UserInputs;
- }
+async function invokeS3GetUserInputs(context, s3ResourceName) {
+  const s3UserInputs = await context.amplify.invokePluginMethod(context, 'storage', undefined, 's3GetUserInput', [context, s3ResourceName]);
+  return s3UserInputs;
+}
 
 export class StorageTest {
   private storageName: string;
@@ -101,7 +98,7 @@ export class StorageTest {
       for (let obj of lambdaConfig) {
         let prefix_arr = obj.Filter;
         if (prefix_arr === undefined) {
-          let eventName = String(eventObj.Records[0].event.eventName).split(':')[0];
+          let eventName = String(eventObj.Records[0].eventName).split(':')[0];
           if (eventName === 'ObjectRemoved' || eventName === 'ObjectCreated') {
             triggerName = String(obj.Function.Ref).split('function')[1].split('Arn')[0];
             break;


### PR DESCRIPTION
#### Description of changes


The structure and names of events emitted by storage simulator was incorrect.
Properties such as eventName, eventSource etc were not direct descendants of the Record object, they were descendants of an "event" property within the Record.  This does not match the schema of the events delivered to the Lambda functions with an S3 trigger.

Additionally the event names were being constructed using the request method, which is all uppercase and does not match the actual event names.

Ref: [Event Message Structure ](
https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html)

Also added some error handling around `fs.writeFile` in `handlRequestPut`. Since the mock S3 Server relies on request method and not the operation (ie: PutObject etc) to determine the action to take,  scenarios such as CopyObject being used in the t function would be treated as PutObject requests and cause the mock storage server to crash,without cleaning up. (ie: resolver files for graphql mock would remain).   Logging a warning and not crashing seemed "good enough" for this, any other handling would probably require more refactoring than is practical right now.

*Breaking Change?*
Not really, though it might break a trigger function that is in active development and never been deployed. Any target function that was relying on the incorrect structure would not have worked when deployed unless their was already a logic branch in the function to handle the incorrect structure.


#### Issue #, if available

N/A

#### Description of how you validated changes

Added additional tests to validate schema of emitted events.

All tests in `yarn test` pass.

Tested running amplify mock with linked local, functions still triggered and events have correct structure and eventNames.




#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [X] `yarn test` passes 
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
