### PR TITLE
test: print recorded screen frames when nextpect times out in E2E tests

### DIFF
--- a/packages/amplify-e2e-core/src/asciinema-recorder.ts
+++ b/packages/amplify-e2e-core/src/asciinema-recorder.ts
@@ -96,6 +96,10 @@ export class Recorder {
     return [JSON.stringify(this.recording.header), ...this.recording.frames.map(frame => JSON.stringify(frame))].join('\n');
   }
 
+  getRecordingFrames(): Readonly<RecordingFrame[]> {
+    return [...this.recording.frames];
+  }
+
   pauseRecording(): void {
     this.isPaused = true;
   }

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -385,11 +385,20 @@ function chain(context: Context): ExecutionContext {
       }
       if (code !== 0) {
         if (code === EXIT_CODE_TIMEOUT) {
+          const recordings = context.process?.getRecordingFrames() || [];
+          const lastScreen = recordings.length
+            ? recordings
+                .filter(f => f[1] === 'o')
+                .map(f => f[2])
+                .slice(-10)
+                .join('\n')
+            : 'No output';
           const err = new Error(
             `Killed the process as no output receive for ${context.noOutputTimeout / 1000} Sec. The no output timeout is set to ${
               context.noOutputTimeout / 1000
-            }`,
+            } seconds.\n\nLast 10 lines:👇🏽👇🏽👇🏽👇🏽\n\n\n\n\n${lastScreen}\n\n\n👆🏼👆🏼👆🏼👆🏼`,
           );
+          err.stack = undefined;
           return onError(err, true);
         } else if (code === 127) {
           // XXX(sam) Not how node works (anymore?), 127 is what /bin/sh returns,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
When E2E tests timeout in nexpect, to see the error one has to play the entire asciinema by loading the test report page from the artifact section. Updating the timeout error message to include the few lines of screen recording to surface it in the exception

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
