### PR TITLE
fix: separate out subscription errors from field level resolver generation

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -591,6 +591,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: true,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'showFieldAuthNotification',
+        type: 'boolean',
+        defaultValueForExistingProjects: true,
+        defaultValueForNewProjects: false,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/auth-notifications.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/auth-notifications.test.ts
@@ -1,0 +1,112 @@
+import { collectDirectivesByType } from 'graphql-transformer-core';
+import { displayAuthNotification, hasFieldAuthDirectives } from '../../../extensions/amplify-helpers/auth-notifications';
+import { parse } from 'graphql';
+
+describe('displayAuthNotification', () => {
+  it('level "off" returns true', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model(subscriptions: { level: off }) {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(true);
+  });
+
+  it('level "null" returns true', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model(subscriptions: { level: null }) {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(true);
+  });
+
+  it('subscriptions is null returns true', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model(subscriptions: null) {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(true);
+  });
+
+  it('"public" returns false', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model(subscriptions: { level: public }) {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(false);
+  });
+
+  it('"on" returns false', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model(subscriptions: { level: on }) {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(false);
+  });
+
+  it('absent value returns false', () => {
+    const map: any = collectDirectivesByType(`
+      type MyModel @model {
+        id: ID!
+      }
+    `);
+    const set: Set<string> = new Set(['MyModel']);
+
+    expect(displayAuthNotification(map, set)).toBe(false);
+  });
+});
+
+describe('hasFieldAuthDirectives', () => {
+  it('returns types with field auth directives', () => {
+    const doc = parse(`
+      type TypeWithFieldAuth @auth(rules: { allow: private, operations: [read] }) {
+        fieldWithAuth: String! @auth(rules: { allow: groups, group: "admin" })
+      }
+
+      type TypeWithoutFieldAuth @auth(rules: { allow: private, operations: [read] }) {
+        fieldWithoutAuth: String!
+      }
+    `);
+
+    const result = hasFieldAuthDirectives(doc);
+
+    expect(result).toContain('TypeWithFieldAuth');
+    expect(result).not.toContain('TypeWithoutFieldAuth');
+  });
+
+  it('returns empty set when no field auth', () => {
+    const doc = parse(`
+      type TypeWithoutFieldAuth @auth(rules: { allow: private, operations: [read] }) {
+        fieldWithoutAuth: String!
+      }
+    `);
+
+    const result = hasFieldAuthDirectives(doc);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty set with nullable and field auth', () => {
+    const doc = parse(`
+      type TypeWithFieldAuth @auth(rules: { allow: private, operations: [read] }) {
+        fieldWithAuth: String @auth(rules: { allow: groups, group: "admin" })
+      }
+    `);
+
+    const result = hasFieldAuthDirectives(doc);
+    expect(result.size).toBe(0);
+  });
+});

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -15,6 +15,7 @@ import { printer, prompter } from 'amplify-prompts';
 import { collectDirectivesByTypeNames, readProjectConfiguration } from 'graphql-transformer-core';
 import path from 'path';
 import fs from 'fs-extra';
+import { notifyFieldAuthSecurityChange } from '../extensions/amplify-helpers/auth-notifications';
 
 const spinner = ora('');
 
@@ -43,6 +44,7 @@ async function syncCurrentCloudBackend(context: $TSContext) {
     });
 
     await notifySecurityEnhancement(context);
+    await notifyFieldAuthSecurityChange(context);
 
     spinner.start(`Fetching updates to backend environment: ${currentEnv} from the cloud.`);
     await sequential(pullCurrentCloudTasks);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/auth-notifications.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/auth-notifications.ts
@@ -1,0 +1,138 @@
+import { $TSAny, $TSContext, stateManager, exitOnNextTick, FeatureFlags, pathManager } from 'amplify-cli-core';
+import { collectDirectivesByType, readProjectConfiguration } from 'graphql-transformer-core';
+import { printer, prompter } from 'amplify-prompts';
+import { DocumentNode, FieldNode, DirectiveNode, FieldDefinitionNode, parse } from 'graphql';
+import path from 'path';
+import fs from 'fs-extra';
+
+async function setNotificationFlag(projectPath: string, flagName: string, value: boolean): Promise<void> {
+  await FeatureFlags.ensureFeatureFlag('graphqltransformer', flagName);
+
+  let config = stateManager.getCLIJSON(projectPath, undefined, {
+    throwIfNotExist: false,
+    preserveComments: true,
+  });
+
+  config.features.graphqltransformer[flagName] = value;
+  stateManager.setCLIJSON(projectPath, config);
+  await FeatureFlags.reloadValues();
+}
+
+export async function notifyFieldAuthSecurityChange(context: $TSContext): Promise<void> {
+  const flagName = 'showfieldauthnotification';
+  const dontShowNotification = !FeatureFlags.getBoolean(`graphqltransformer.${flagName}`);
+
+  if (dontShowNotification) return;
+
+  const projectPath = pathManager.findProjectRoot() ?? process.cwd();
+  const meta = stateManager.getMeta(projectPath);
+
+  const apiNames = Object.entries(meta?.api || {})
+    .filter(([_, apiResource]) => (apiResource as $TSAny).service === 'AppSync')
+    .map(([name]) => name);
+
+  const doesNotHaveGqlApi = apiNames.length < 1;
+
+  if (doesNotHaveGqlApi) {
+    return await setNotificationFlag(projectPath, flagName, false);
+  }
+
+  const apiName = apiNames[0];
+  const apiResourceDir = pathManager.getResourceDirectoryPath(projectPath, 'api', apiName);
+  const project = await readProjectConfiguration(apiResourceDir);
+  const directiveMap = collectDirectivesByType(project.schema);
+  const doc: DocumentNode = parse(project.schema);
+  const fieldDirectives: Set<string> = hasFieldAuthDirectives(doc);
+
+  if (displayAuthNotification(directiveMap, fieldDirectives)) {
+    printer.blankLine();
+    const continueChange = await prompter.yesOrNo(
+      `This version of Amplify CLI introduces additional security enhancements for your GraphQL API. ` +
+        `The changes are applied automatically with this deployment. This change won't impact your client code. Continue`,
+    );
+
+    if (!continueChange) {
+      await context.usageData.emitSuccess();
+      exitOnNextTick(0);
+    }
+
+    modifyGraphQLSchema(apiResourceDir);
+  }
+
+  await setNotificationFlag(projectPath, flagName, false);
+}
+
+async function modifyGraphQLSchema(apiResourceDir: string): Promise<void> {
+  const schemaFilePath = path.join(apiResourceDir, 'schema.graphql');
+  const schemaDirectoryPath = path.join(apiResourceDir, 'schema');
+  const schemaFileExists = fs.existsSync(schemaFilePath);
+  const schemaDirectoryExists = fs.existsSync(schemaDirectoryPath);
+
+  if (schemaFileExists) {
+    fs.appendFile(schemaFilePath, ' ');
+  } else if (schemaDirectoryExists) {
+    await modifyGraphQLSchemaDirectory(schemaDirectoryPath, false);
+  }
+}
+
+async function modifyGraphQLSchemaDirectory(schemaDirectoryPath: string, modified: boolean): Promise<void> {
+  const files = await fs.readdir(schemaDirectoryPath);
+
+  if (modified) return;
+
+  for (const fileName of files) {
+    const isHiddenFile = fileName.indexOf('.') === 0;
+
+    if (isHiddenFile) {
+      continue;
+    }
+
+    const fullPath = path.join(schemaDirectoryPath, fileName);
+    const stats = await fs.lstat(fullPath);
+
+    if (stats.isDirectory()) {
+      await modifyGraphQLSchemaDirectory(fullPath, modified);
+    } else if (stats.isFile() && !modified) {
+      fs.appendFile(fullPath, ' ');
+      break;
+    }
+  }
+}
+
+export function displayAuthNotification(directiveMap: any, fieldDirectives: Set<string>): boolean {
+  return Object.keys(directiveMap).some((typeName: string) => {
+    const typeObj = directiveMap[typeName];
+    const modelDirective = typeObj.find((dir: DirectiveNode) => dir.name.value === 'model');
+
+    const subscriptionOff: boolean = (modelDirective?.arguments || []).some((arg: any) => {
+      if (arg.name.value === 'subscriptions') {
+        const subscriptionNull = arg.value.kind === 'NullValue';
+        const levelFieldOffOrNull = arg.value?.fields?.some(({ name, value }) => {
+          return name.value === 'level' && (value.value === 'off' || value.kind === 'NullValue');
+        });
+
+        return levelFieldOffOrNull || subscriptionNull;
+      }
+    });
+
+    return subscriptionOff && fieldDirectives.has(typeName);
+  });
+}
+
+export function hasFieldAuthDirectives(doc: DocumentNode): Set<string> {
+  const haveFieldAuthDir: Set<string> = new Set();
+
+  doc.definitions?.forEach((def: any) => {
+    const withAuth: FieldNode[] = (def.fields || []).filter((field: FieldDefinitionNode) => {
+      const nonNullable = field.type.kind === 'NonNullType';
+      const hasAuth = field.directives?.some(dir => dir.name.value === 'auth');
+      return hasAuth && nonNullable;
+    });
+
+    if (withAuth.length > 0) {
+      haveFieldAuthDir.add(def.name.value);
+    }
+  });
+
+  return haveFieldAuthDir;
+}

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
@@ -110,3 +110,85 @@ Object {
   "Type": "AWS::IAM::ManagedPolicy",
 }
 `;
+
+exports[`subscription disabled and userPools configured with non-nullable (required) fields top level private and field level group auth generates field resolver for required field with expected group role 1`] = `
+"## [Start] Field Authorization Steps. **
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $staticGroupRoles = [{\\"claim\\":\\"cognito:groups\\",\\"entity\\":\\"admin\\"}] )
+    #foreach( $groupRole in $staticGroupRoles )
+      #set( $groupsInToken = $util.defaultIfNull($ctx.identity.claims.get($groupRole.claim), []) )
+      #if( $groupsInToken.contains($groupRole.entity) )
+        #set( $isAuthorized = true )
+        #break
+      #end
+    #end
+  #end
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Field Authorization Steps. **"
+`;
+
+exports[`subscription disabled and userPools configured with non-nullable (required) fields top level private and field level owner auth generates field resolver for required field with expected owner claim 1`] = `
+"## [Start] Field Authorization Steps. **
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $ownerEntity0 == $ownerClaim0 )
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Field Authorization Steps. **"
+`;
+
+exports[`subscription disabled and userPools configured with nullable fields top level private and field level group auth generates field resolver for field with expected group roles 1`] = `
+"## [Start] Field Authorization Steps. **
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $staticGroupRoles = [{\\"claim\\":\\"cognito:groups\\",\\"entity\\":\\"admin\\"}] )
+    #foreach( $groupRole in $staticGroupRoles )
+      #set( $groupsInToken = $util.defaultIfNull($ctx.identity.claims.get($groupRole.claim), []) )
+      #if( $groupsInToken.contains($groupRole.entity) )
+        #set( $isAuthorized = true )
+        #break
+      #end
+    #end
+  #end
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Field Authorization Steps. **"
+`;
+
+exports[`subscription disabled and userPools configured with nullable fields top level private and field level owner auth generates field resolver for field with expected owner claim 1`] = `
+"## [Start] Field Authorization Steps. **
+#set( $isAuthorized = false )
+#if( $util.authType() == \\"User Pool Authorization\\" )
+  #if( !$isAuthorized )
+    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+    #if( $ownerEntity0 == $ownerClaim0 )
+      #set( $isAuthorized = true )
+    #end
+  #end
+#end
+#if( !$isAuthorized )
+$util.unauthorized()
+#end
+$util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
+## [End] Field Authorization Steps. **"
+`;

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -345,7 +345,8 @@ Static group authorization should perform as expected.`,
         const needsFieldResolver = allowedRoles.length < fieldReadRoles.length;
         if (needsFieldResolver && field.type.kind === Kind.NON_NULL_TYPE) {
           errorFields.push(field.name.value);
-        } else if (hasRelationalDirective(field)) {
+        }
+        if (hasRelationalDirective(field)) {
           this.protectRelationalResolver(context, def, modelName, field, needsFieldResolver ? allowedRoles : null);
         } else if (needsFieldResolver) {
           this.protectFieldResolver(context, def, modelName, field.name.value, allowedRoles);
@@ -372,7 +373,7 @@ Static group authorization should perform as expected.`,
             this.protectDeleteResolver(context, def, mutation.typeName, mutation.fieldName, acm);
             break;
           default:
-            throw new TransformerContractError('Unkown Mutation field type');
+            throw new TransformerContractError('Unknown Mutation field type');
         }
       }
 

--- a/packages/graphql-transformer-core/src/index.ts
+++ b/packages/graphql-transformer-core/src/index.ts
@@ -4,7 +4,7 @@ import { TransformerContext } from './TransformerContext';
 import { Transformer } from './Transformer';
 import { ITransformer } from './ITransformer';
 import { GraphQLTransform } from './GraphQLTransform';
-import { collectDirectiveNames, collectDirectivesByTypeNames } from './collectDirectives';
+import { collectDirectiveNames, collectDirectivesByType, collectDirectivesByTypeNames } from './collectDirectives';
 import { stripDirectives } from './stripDirectives';
 import { DeploymentResources } from './DeploymentResources';
 import {
@@ -50,6 +50,7 @@ export {
   Transformer,
   ITransformer,
   collectDirectiveNames,
+  collectDirectivesByType,
   collectDirectivesByTypeNames,
   stripDirectives,
   buildAPIProject,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This pull requests separates out generation of field-level resolvers from checking for errors on types with subscriptions configured.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
