### PR TITLE
fix: allow init with auth role name overrides

### DIFF
--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -1,4 +1,7 @@
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
 export function override(props: any): void {
-  props.authRole.roleName = 'mockRole';
+  props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
   return props;
 }

--- a/packages/amplify-e2e-tests/src/__tests__/init.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init.test.ts
@@ -19,6 +19,11 @@ import {
   getEnvVars,
   getProjectMeta,
 } from 'amplify-e2e-core';
+
+import {
+  addEnvironment,
+} from '../environment/env';
+
 import { JSONUtilities } from 'amplify-cli-core';
 import { SandboxApp } from '../types/SandboxApp';
 
@@ -157,7 +162,7 @@ describe('amplify init', () => {
     fs.writeFileSync(localEnvPath, JSON.stringify(localEnvData, null, 2));
   });
 
-  it('should init the project and override root and push', async () => {
+  it.only('should init the project and override root and push', async () => {
     await initJSProjectWithProfile(projRoot, {});
     const meta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(meta.Region).toBeDefined();
@@ -174,6 +179,11 @@ describe('amplify init', () => {
     fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
     await amplifyPushOverride(projRoot);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
-    expect(newEnvMeta.AuthRoleName).toEqual('mockRole');
+    expect(newEnvMeta.AuthRoleName).toContain('mockRole');
+
+    // create a new env, and the override should remain in place
+    await addEnvironment(projRoot, { envName: 'envb' });
+    const newestEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
+    expect(newestEnvMeta.AuthRoleName).toContain('mockRole');
   });
 });

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
@@ -49,6 +49,6 @@ describe('amplify init', () => {
     fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
     await amplifyPushOverride(projRoot, true);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
-    expect(newEnvMeta.AuthRoleName).toEqual('mockRole');
+    expect(newEnvMeta.AuthRoleName).toContain('mockRole');
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR enables applying auth role overrides to new environments

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/9643

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

```
amplify-dev init
amplify-dev override project
amplify-dev push
amplify-dev add env envb
```

Without this change, the result is that `envb` uses an auth role that does not match the override. With this change, `envb` uses an auth role that _does_ match the override.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
