### PR TITLE
fix(graphql): allow iam private rule to access update mutation when authenticated by cognito

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
@@ -97,6 +97,45 @@ $util.toJson({\\"version\\":\\"2018-05-29\\",\\"payload\\":{}})
 ## [End] Authorization Steps. **"
 `;
 
+exports[`Test simple model with private IAM auth rule, few operations, and amplify admin app is not enabled 1`] = `
+"## [Start] Authorization Steps. **
+$util.qr($ctx.stash.put(\\"hasAuth\\", true))
+#if( $ctx.error )
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+#set( $inputFields = $util.parseJson($util.toJson($ctx.args.input.keySet())) )
+#set( $isAuthorized = false )
+#set( $allowedFields = [] )
+#set( $nullAllowedFields = [] )
+#set( $deniedFields = {} )
+#if( $util.authType() == \\"IAM Authorization\\" )
+  #if( ($ctx.identity.userArn == $ctx.stash.authRole) || ($ctx.identity.cognitoIdentityPoolId == \\"testIdentityPoolId\\" && $ctx.identity.cognitoIdentityAuthType == \\"authenticated\\") )
+    #set( $isAuthorized = true )
+  #end
+#end
+#if( $util.authType() == \\"User Pool Authorization\\" )
+
+#end
+#if( !$isAuthorized && $allowedFields.isEmpty() && $nullAllowedFields.isEmpty() )
+$util.unauthorized()
+#end
+#if( !$isAuthorized )
+  #foreach( $entry in $util.map.copyAndRetainAllKeys($ctx.args.input, $inputFields).entrySet() )
+    #if( $util.isNull($entry.value) && !$nullAllowedFields.contains($entry.key) )
+      $util.qr($deniedFields.put($entry.key, \\"\\"))
+    #end
+  #end
+  #foreach( $deniedField in $util.list.copyAndRemoveAll($inputFields, $allowedFields) )
+    $util.qr($deniedFields.put($deniedField, \\"\\"))
+  #end
+#end
+#if( $deniedFields.keySet().size() > 0 )
+  $util.error(\\"Unauthorized on \${deniedFields.keySet()}\\", \\"Unauthorized\\")
+#end
+$util.toJson({})
+## [End] Authorization Steps. **"
+`;
+
 exports[`admin roles should be return the field name inside field resolvers 1`] = `
 "## [Start] Field Authorization Steps. **
 #set( $isAuthorized = false )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -243,6 +243,7 @@ test('Test simple model with private IAM auth rule, few operations, and amplify 
   expect(out.schema).toContain('listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection @aws_iam');
 
   expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toMatchSnapshot();
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toContain(`#if( ($ctx.identity.userArn == $ctx.stash.authRole) || ($ctx.identity.cognitoIdentityPoolId == "testIdentityPoolId" && $ctx.identity.cognitoIdentityAuthType == "authenticated") )`);
 });
 
 test('Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth', () => {

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/amplify-admin-auth.test.ts
@@ -205,7 +205,7 @@ test('Test simple model with private auth rule, few operations, and amplify admi
 
 test('Test simple model with private IAM auth rule, few operations, and amplify admin app is not enabled', () => {
   const validSchema = `
-      type Post @model @auth(rules: [{allow: private, provider: iam, operations: [read]}]) {
+      type Post @model @auth(rules: [{allow: private, provider: iam, operations: [read, update]}]) {
           id: ID!
           title: String!
           createdAt: String
@@ -223,7 +223,12 @@ test('Test simple model with private IAM auth rule, few operations, and amplify 
         },
       ],
     },
-    transformers: [new ModelTransformer(), new AuthTransformer()],
+    transformers: [
+      new ModelTransformer(), 
+      new AuthTransformer( {
+        identityPoolId: 'testIdentityPoolId',
+      })
+    ],
   });
   const out = transformer.transform(validSchema);
   expect(out).toBeDefined();
@@ -236,6 +241,8 @@ test('Test simple model with private IAM auth rule, few operations, and amplify 
 
   expect(out.schema).toContain('getPost(id: ID!): Post @aws_iam');
   expect(out.schema).toContain('listPosts(filter: ModelPostFilterInput, limit: Int, nextToken: String): ModelPostConnection @aws_iam');
+
+  expect(out.resolvers['Mutation.updatePost.auth.1.res.vtl']).toMatchSnapshot();
 });
 
 test('Test simple model with AdminUI enabled should add IAM policy only for fields that have explicit IAM auth', () => {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -114,7 +114,7 @@ const iamExpression = (
           ),
         );
       } else {
-        expression.push(iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true))));
+        expression.push(iamCheck(role.claim!, set(ref(IS_AUTHORIZED_FLAG), bool(true)), identityPoolId));
       }
     }
   } else {


### PR DESCRIPTION
#### Description of changes

Allow `update` mutation to respect cognito authentication for IAM private rule.

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-cli/issues/9502

#### Description of how you validated changes
- Manual test
- yarn test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
