### PR TITLE
fix(amplify-appsync-simulator): base-resolver for response and added…

### DIFF
--- a/packages/amplify-appsync-simulator/src/resolvers/base-resolver.ts
+++ b/packages/amplify-appsync-simulator/src/resolvers/base-resolver.ts
@@ -7,13 +7,13 @@ export abstract class AppSyncBaseResolver {
     try {
       this.getResponseMappingTemplate();
     } catch (e) {
-      throw new Error(`Missing request mapping template`);
+      throw new Error(`Missing response mapping template ${e.message}`);
     }
 
     try {
-      this.getResponseMappingTemplate();
+      this.getRequestMappingTemplate();
     } catch (e) {
-      throw new Error(`Missing request mapping template`);
+      throw new Error(`Missing request mapping template ${e.message}`);
     }
   }
   // abstract async resolve(source, args, context, info): Promise<any>;


### PR DESCRIPTION
… better error handling

This is addresses issue #9685.   Please review and applies as you want.  I did test localy but did not run the unit tests. 


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
1. Fix the message returned on exception they bother were _request_, and that leads people to look at the wrong template to resolve a template issue.
2. It never called the _request_ template, update the method to call both response and request
3. Added the message from the underlying exceptions.  It will have the error details from velocity which is much needed to make troubleshooting template syntax issues

Example of the fixed message thrown.  
```
Error: Missing response mapping template Error:Parse error on INLINE_TEMPLATE:2:
Lexical error on line 3. Unrecognized text.
...$err.type, $err.data. $err.info)  #end
-----------------------^
```


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/9685

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [ ?] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
