### PR TITLE
fix: fix modify gql schema base case; scope auth notif to v2

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/auth-notifications.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/auth-notifications.test.ts
@@ -1,6 +1,12 @@
 import { collectDirectivesByType } from 'graphql-transformer-core';
 import { displayAuthNotification, hasFieldAuthDirectives } from '../../../extensions/amplify-helpers/auth-notifications';
 import { parse } from 'graphql';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock('amplify-cli-core');
+
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
+FeatureFlags_mock.getNumber.mockReturnValue(2);
 
 describe('displayAuthNotification', () => {
   it('level "off" returns true', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- scopes the auth notification to v2 transformer
- fixes the recursive updates to schema files by using a returned base case rather than setting a variable

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->



<!-- Also, please reference any associated PRs for documentation updates. -->



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
