### PR TITLE
fix: allow pinpoint category removal after manual deletion

### DIFF
--- a/packages/amplify-category-notifications/lib/channel-Email.js
+++ b/packages/amplify-category-notifications/lib/channel-Email.js
@@ -77,7 +77,12 @@ async function enable(context, successMessage) {
   spinner.start('Updating Email Channel.');
   return new Promise((resolve, reject) => {
     context.exeInfo.pinpointClient.updateEmailChannel(params, (err, data) => {
-      if (err) {
+      if (err && err.code === 'NotFoundException') {
+        spinner.succeed(`Project with ID '${params.ApplicationId}' was already deleted from the cloud.`);
+        resolve({
+          id: params.ApplicationId,
+        });
+      } else if (err) {
         spinner.fail('update channel error');
         reject(err);
       } else {
@@ -112,7 +117,12 @@ async function disable(context) {
   spinner.start('Updating Email Channel.');
   return new Promise((resolve, reject) => {
     context.exeInfo.pinpointClient.updateEmailChannel(params, (err, data) => {
-      if (err) {
+      if (err && err.code === 'NotFoundException') {
+        spinner.succeed(`Project with ID '${params.ApplicationId}' was already deleted from the cloud.`);
+        resolve({
+          id: params.ApplicationId,
+        });
+      } else if (err) {
         spinner.fail('update channel error');
         reject(err);
       } else {

--- a/packages/amplify-category-notifications/lib/pinpoint-helper.js
+++ b/packages/amplify-category-notifications/lib/pinpoint-helper.js
@@ -220,7 +220,12 @@ async function deleteApp(context, pinpointAppId) {
   spinner.start('Deleting Pinpoint app.');
   return new Promise((resolve, reject) => {
     pinpointClient.deleteApp(params, (err, data) => {
-      if (err) {
+      if (err && err.code === 'NotFoundException') {
+        spinner.succeed(`Project with ID '${params.ApplicationId}' was already deleted from the cloud.`);
+        resolve({
+          Id: params.ApplicationId,
+        });
+      } else if (err) {
         spinner.fail('Pinpoint project deletion error');
         reject(err);
       } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR fixes an issue where, if a Pinpoint project is deleted manually via AWS Console, the `notifications` category could not be removed from the amplify project. It accomplishes this by treating a `NotFoundException` on deletion as a successful deletion.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/9036

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

```
amplify add notifications && amplify push
delete pinpoint manually
amplify remove notifications && amplify push
# note that everything seems to work on AWS console/amplify status
amplify pull/push no longer recreates the notifications category.
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
