### PR TITLE
fix(searchable): unwrap _version field correctly when datastore is enabled

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
+++ b/packages/amplify-graphql-searchable-transformer/src/__tests__/__snapshots__/amplify-graphql-searchable-transformer.test.ts.snap
@@ -1226,6 +1226,144 @@ $util.toJson(null)
 }
 `;
 
+exports[`Test SearchableModelTransformer with datastore enabled vtl 1`] = `
+"#set( $args = $util.defaultIfNull($ctx.stash.transformedArgs, $ctx.args) )
+#set( $indexPath = \\"/post/doc/_search\\" )
+#set( $allowedAggFields = $util.defaultIfNull($ctx.stash.allowedAggFields, []) )
+#set( $aggFieldsFilterMap = $util.defaultIfNull($ctx.stash.aggFieldsFilterMap, {}) )
+#set( $nonKeywordFields = [] )
+#set( $keyFields = [\\"id\\"] )
+#set( $sortValues = [] )
+#set( $sortFields = [] )
+#set( $aggregateValues = {} )
+#set( $primaryKey = \\"id\\" )
+#if( !$util.isNullOrEmpty($args.sort) )
+  #foreach( $sortItem in $args.sort )
+    #if( $util.isNullOrEmpty($sortItem.field) )
+      $util.qr($sortFields.add($primaryKey))
+    #else
+      $util.qr($sortFields.add($sortItem.field))
+    #end
+    #if( $util.isNullOrEmpty($sortItem.field) )
+      #if( $nonKeywordFields.contains($primaryKey) )
+        #set( $sortField = $util.toJson($primaryKey) )
+      #else
+        #set( $sortField = $util.toJson(\\"\${primaryKey}.keyword\\") )
+      #end
+    #else
+      #if( $nonKeywordFields.contains($sortItem.field) )
+        #set( $sortField = $util.toJson($sortItem.field) )
+      #else
+        #set( $sortField = $util.toJson(\\"\${sortItem.field}.keyword\\") )
+      #end
+    #end
+    #if( $util.isNullOrEmpty($sortItem.direction) )
+      #set( $sortDirection = $util.toJson({\\"order\\": \\"desc\\"}) )
+    #else
+      #set( $sortDirection = $util.toJson({\\"order\\": $sortItem.direction}) )
+    #end
+    $util.qr($sortValues.add(\\"{$sortField: $sortDirection}\\"))
+  #end
+#end
+#foreach( $keyItem in $keyFields )
+  #if( !$sortFields.contains($keyItem) )
+    #if( $nonKeywordFields.contains($keyItem) )
+      #set( $sortField = $util.toJson($keyItem) )
+    #else
+      #set( $sortField = $util.toJson(\\"\${keyItem}.keyword\\") )
+    #end
+    #set( $sortDirection = $util.toJson({\\"order\\": \\"desc\\"}) )
+    $util.qr($sortValues.add(\\"{$sortField: $sortDirection}\\"))
+  #end
+#end
+#foreach( $aggItem in $args.aggregates )
+  #if( $allowedAggFields.contains($aggItem.field) )
+    #set( $aggFilter = { \\"match_all\\": {} } )
+  #elseif( $aggFieldsFilterMap.containsKey($aggItem.field) )
+    #set( $aggFilter = { \\"bool\\": { \\"should\\": $aggFieldsFilterMap.get($aggItem.field) } } )
+  #else
+    $util.error(\\"Unauthorized to run aggregation on field: \${aggItem.field}\\", \\"Unauthorized\\")
+  #end
+  #if( $nonKeywordFields.contains($aggItem.field) )
+    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"$aggItem.field\\" }}} }))
+  #else
+    $util.qr($aggregateValues.put(\\"$aggItem.name\\", { \\"filter\\": $aggFilter, \\"aggs\\": { \\"$aggItem.name\\": { \\"$aggItem.type\\": { \\"field\\": \\"\${aggItem.field}.keyword\\" }}} }))
+  #end
+#end
+#if( !$util.isNullOrEmpty($ctx.stash.authFilter) )
+  #set( $filter = $ctx.stash.authFilter )
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = {
+  \\"bool\\": {
+      \\"must\\":     [$ctx.stash.authFilter, $util.parseJson($util.transform.toElasticsearchQueryDSL($args.filter))]
+  }
+} )
+  #end
+#else
+  #if( !$util.isNullOrEmpty($args.filter) )
+    #set( $filter = $util.parseJson($util.transform.toElasticsearchQueryDSL($args.filter)) )
+  #end
+#end
+#if( $util.isNullOrEmpty($filter) )
+  #set( $filter = {
+  \\"match_all\\": {}
+} )
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"operation\\": \\"GET\\",
+  \\"path\\": \\"$indexPath\\",
+  \\"params\\": {
+      \\"body\\":     {
+                #if( $context.args.nextToken )\\"search_after\\": $util.base64Decode($args.nextToken), #end
+                #if( $context.args.from )\\"from\\": $args.from, #end
+                \\"size\\": #if( $args.limit ) $args.limit #else 100 #end,
+                \\"sort\\": $sortValues,
+                \\"version\\": true,
+                \\"query\\": $util.toJson($filter),
+                \\"aggs\\": $util.toJson($aggregateValues)
+                }
+  }
+}"
+`;
+
+exports[`Test SearchableModelTransformer with datastore enabled vtl 2`] = `
+"#set( $es_items = [] )
+#set( $aggregateValues = [] )
+#foreach( $entry in $context.result.hits.hits )
+  #if( !$foreach.hasNext )
+    #set( $nextToken = $util.base64Encode($util.toJson($entry.sort)) )
+  #end
+  #set( $row = $entry.get(\\"_source\\") )
+  $util.qr($row.put(\\"_version\\", $entry.get(\\"_version\\")))
+  $util.qr($es_items.add($row))
+#end
+#foreach( $aggItem in $context.result.aggregations.keySet() )
+  #set( $aggResult = {} )
+  #set( $aggResultValue = {} )
+  #set( $currentAggItem = $ctx.result.aggregations.get($aggItem) )
+  $util.qr($aggResult.put(\\"name\\", $aggItem))
+  #if( !$util.isNullOrEmpty($currentAggItem) )
+    #if( !$util.isNullOrEmpty($currentAggItem.get($aggItem).buckets) )
+      $util.qr($aggResultValue.put(\\"__typename\\", \\"SearchableAggregateBucketResult\\"))
+      $util.qr($aggResultValue.put(\\"buckets\\", $currentAggItem.get($aggItem).buckets))
+    #end
+    #if( !$util.isNullOrEmpty($currentAggItem.get($aggItem).value) )
+      $util.qr($aggResultValue.put(\\"__typename\\", \\"SearchableAggregateScalarResult\\"))
+      $util.qr($aggResultValue.put(\\"value\\", $currentAggItem.get($aggItem).value))
+    #end
+  #end
+  $util.qr($aggResult.put(\\"result\\", $aggResultValue))
+  $util.qr($aggregateValues.add($aggResult))
+#end
+$util.toJson({
+  \\"items\\": $es_items,
+  \\"total\\": $ctx.result.hits.total.value,
+  \\"nextToken\\": $nextToken,
+  \\"aggregateItems\\": $aggregateValues
+})"
+`;
+
 exports[`Test SearchableModelTransformer with multiple model searchable directives 1`] = `
 "
 type Post {

--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -156,7 +156,10 @@ export class SearchableModelTransformer extends TransformerPluginBase {
           ),
           `${typeName}.${def.fieldName}.req.vtl`,
         ),
-        MappingTemplate.s3MappingTemplateFromString(responseTemplate(false), `${typeName}.${def.fieldName}.res.vtl`),
+        MappingTemplate.s3MappingTemplateFromString(
+          responseTemplate(context.isProjectUsingDataStore()),
+          `${typeName}.${def.fieldName}.res.vtl`
+        ),
       );
       resolver.addToSlot(
         'postAuth',


### PR DESCRIPTION
#### Description of changes

When datastore is enabled, opensearch must add the `_version` to the response type.

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-cli/issues/9632

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
