### PR TITLE
test: fix failing AWSURL unit tests on Node 16

### DIFF
--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSURL.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSURL.test.ts
@@ -15,7 +15,7 @@ describe('AWSURL parse', () => {
     function serialize() {
       scalars.AWSURL.parseValue('invalid-url');
     }
-    expect(serialize).toThrowErrorMatchingSnapshot();
+    expect(serialize).toThrowError('Invalid URL');
   });
 });
 
@@ -32,6 +32,6 @@ describe('AWSURL serialize', () => {
     function serialize() {
       scalars.AWSURL.serialize('invalid-url');
     }
-    expect(serialize).toThrowErrorMatchingSnapshot();
+    expect(serialize).toThrowError('Invalid URL');
   });
 });

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSURL.test.ts.snap
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/__snapshots__/AWSURL.test.ts.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`AWSURL parse Should reject an invalid URL 1`] = `"Invalid URL: invalid-url"`;
-
-exports[`AWSURL serialize Should reject an invalid URL 1`] = `"Invalid URL: invalid-url"`;


### PR DESCRIPTION
The message shown on `ERR_INVALID_URL` errors changed slightly in Node 16. This commit updates two `AWSURL` unit tests to pass across supported Node.js versions.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9703
