### PR TITLE
fix(graphql-auth-transformer): fix relational map key schema lookup when using LSI

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -7,6 +7,8 @@ import {
   IAM_AUTH_ROLE_PARAMETER,
   IAM_UNAUTH_ROLE_PARAMETER,
   TransformerResolver,
+  getTable,
+  getKeySchema,
 } from '@aws-amplify/graphql-transformer-core';
 import {
   DataSourceProvider,
@@ -53,7 +55,6 @@ import {
   getStackForField,
   NONE_DS,
   hasRelationalDirective,
-  getTable,
   getPartitionKey,
   getRelationalPrimaryMap,
   getReadRolesForField,
@@ -501,9 +502,7 @@ Static group authorization should perform as expected.`,
     const table = getTable(ctx, def);
     try {
       if (indexName) {
-        primaryFields = table.globalSecondaryIndexes
-          .find((gsi: any) => gsi.indexName === indexName)
-          .keySchema.map((att: any) => att.attributeName);
+        primaryFields = getKeySchema(table, indexName).map((att: any) => att.attributeName);
       } else {
         primaryFields = table.keySchema.map((att: any) => att.attributeName);
         partitionKey = getPartitionKey(table.keySchema);

--- a/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/schema.ts
@@ -1,18 +1,11 @@
 import { ModelDirectiveConfiguration, SubscriptionLevel } from '@aws-amplify/graphql-model-transformer';
-import {
-  DirectiveWrapper,
-  getKeySchema,
-  getTable,
-  InvalidDirectiveError,
-  TransformerContractError,
-} from '@aws-amplify/graphql-transformer-core';
+import { DirectiveWrapper, getKeySchema, getTable, InvalidDirectiveError } from '@aws-amplify/graphql-transformer-core';
 import {
   QueryFieldType,
   MutationFieldType,
   TransformerTransformSchemaStepContextProvider,
   TransformerContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
 import { ObjectTypeDefinitionNode, FieldDefinitionNode, DirectiveNode, NamedTypeNode } from 'graphql';
 import {
   blankObjectExtension,
@@ -22,7 +15,6 @@ import {
   isListType,
   makeInputValueDefinition,
   makeNamedType,
-  ModelResourceIDs,
   plurality,
   toCamelCase,
   toUpper,

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -1,7 +1,7 @@
 import { ModelTransformer } from '@aws-amplify/graphql-model-transformer';
 import { ConflictHandlerType, GraphQLTransform, SyncConfig, validateModelSchema } from '@aws-amplify/graphql-transformer-core';
 import { expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
-import { Kind, parse } from 'graphql';
+import { parse } from 'graphql';
 import { IndexTransformer, PrimaryKeyTransformer } from '..';
 
 test('throws if @index is used in a non-@model type', () => {

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -1,4 +1,4 @@
-import { MappingTemplate } from '@aws-amplify/graphql-transformer-core';
+import { getKeySchema, getTable, MappingTemplate } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
 import { Table } from '@aws-cdk/aws-dynamodb';
@@ -308,24 +308,6 @@ function makeExpression(keySchema: any[], connectionAttributes: string[]): Objec
       ':partitionKey': ref(`util.dynamodb.toDynamoDB($context.source.${connectionAttributes[0]})`),
     }),
   });
-}
-
-function getTable(ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode): Table {
-  const ddbDataSource = ctx.dataSources.get(object) as DynamoDbDataSource;
-  const tableName = ModelResourceIDs.ModelTableResourceID(object.name.value);
-  const table = ddbDataSource.ds.stack.node.findChild(tableName) as Table;
-
-  assert(table);
-  return table;
-}
-
-function getKeySchema(table: any, indexName?: string): any {
-  return (
-    (
-      table.globalSecondaryIndexes.find((gsi: any) => gsi.indexName === indexName) ??
-      table.localSecondaryIndexes.find((gsi: any) => gsi.indexName === indexName)
-    )?.keySchema ?? table.keySchema
-  );
 }
 
 function condenseRangeKey(fields: string[]): string {

--- a/packages/amplify-graphql-relational-transformer/src/resolvers.ts
+++ b/packages/amplify-graphql-relational-transformer/src/resolvers.ts
@@ -1,7 +1,5 @@
 import { getKeySchema, getTable, MappingTemplate } from '@aws-amplify/graphql-transformer-core';
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
-import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
-import { Table } from '@aws-cdk/aws-dynamodb';
 import * as cdk from '@aws-cdk/core';
 import assert from 'assert';
 import { ObjectTypeDefinitionNode } from 'graphql';

--- a/packages/amplify-graphql-transformer-core/src/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/index.ts
@@ -15,6 +15,8 @@ export {
   TransformerProjectConfig,
 } from './config/index';
 export {
+  getTable,
+  getKeySchema,
   collectDirectives,
   collectDirectivesByTypeNames,
   DirectiveWrapper,

--- a/packages/amplify-graphql-transformer-core/src/utils/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { DirectiveWrapper } from './directive-wrapper';
 export { collectDirectives, collectDirectivesByTypeNames } from './type-map-utils';
 export { stripDirectives } from './strip-directives';
+export { getTable, getKeySchema } from './schema-utils';
 export { DEFAULT_SCHEMA_DEFINITION } from './defaultSchema';
 export { IAM_AUTH_ROLE_PARAMETER, IAM_UNAUTH_ROLE_PARAMETER } from './authType';

--- a/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
@@ -1,0 +1,24 @@
+import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
+import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
+import { Table } from '@aws-cdk/aws-dynamodb';
+import assert from 'assert';
+import { ObjectTypeDefinitionNode } from 'graphql';
+import { ModelResourceIDs } from 'graphql-transformer-common';
+
+export function getKeySchema(table: any, indexName?: string): any {
+  return (
+    (
+      table.globalSecondaryIndexes.find((gsi: any) => gsi.indexName === indexName) ??
+      table.localSecondaryIndexes.find((gsi: any) => gsi.indexName === indexName)
+    )?.keySchema ?? table.keySchema
+  );
+}
+
+export function getTable(ctx: TransformerContextProvider, object: ObjectTypeDefinitionNode): any {
+  const ddbDataSource = ctx.dataSources.get(object) as DynamoDbDataSource;
+  const tableName = ModelResourceIDs.ModelTableResourceID(object.name.value);
+  const table = ddbDataSource.ds.stack.node.findChild(tableName) as Table;
+
+  assert(table);
+  return table;
+}

--- a/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
+++ b/packages/amplify-graphql-transformer-core/src/utils/schema-utils.ts
@@ -1,7 +1,7 @@
 import { TransformerContextProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import { DynamoDbDataSource } from '@aws-cdk/aws-appsync';
 import { Table } from '@aws-cdk/aws-dynamodb';
-import assert from 'assert';
+import * as assert from 'assert';
 import { ObjectTypeDefinitionNode } from 'graphql';
 import { ModelResourceIDs } from 'graphql-transformer-common';
 
@@ -19,6 +19,6 @@ export function getTable(ctx: TransformerContextProvider, object: ObjectTypeDefi
   const tableName = ModelResourceIDs.ModelTableResourceID(object.name.value);
   const table = ddbDataSource.ds.stack.node.findChild(tableName) as Table;
 
-  assert(table);
+  assert.ok(table);
   return table;
 }


### PR DESCRIPTION
#### Description of changes
- fix key schema lookup when using @auth with LSI

#### Issue [#9573](https://github.com/aws-amplify/amplify-cli/issues/9573), [#9292](https://github.com/aws-amplify/amplify-cli/issues/9292)

#### Description of how you validated changes
- manual deploy using customer schema and validated that succeeded
- added new unit tests
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
