### PR TITLE
fix(graphql): hasMany on model with (queries: null) generate correct scalar filter type

### DIFF
--- a/packages/amplify-graphql-relational-transformer/src/schema.ts
+++ b/packages/amplify-graphql-relational-transformer/src/schema.ts
@@ -355,10 +355,10 @@ function makeModelXFilterInputObject(
       const isList = isListType(field.type);
       let filterTypeName = baseType;
 
-      if (isScalar(field.type) || isList) {
-        filterTypeName = isList
-          ? ModelResourceIDs.ModelFilterListInputTypeName(baseType, true)
-          : ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, false);
+      if (isScalar(field.type)) {
+        filterTypeName = ModelResourceIDs.ModelScalarFilterInputTypeName(baseType, false);
+      } else if (isList) {
+        filterTypeName = ModelResourceIDs.ModelFilterListInputTypeName(baseType, true);
       }
 
       return {

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/RelationalTransformers.e2e.test.ts
@@ -118,6 +118,14 @@ type Course @model {
   title: String!
   students: [Student] @manyToMany(relationName: "Enrollment")
 }
+
+type Foo @model {
+  bars: [Bar] @hasMany
+}
+
+type Bar @model(queries: null) {
+  strings: [String]
+}
 `;
   let out;
   try {


### PR DESCRIPTION
#### Description of changes

hasMany directive on a model with queries: null generate incorrect filter input for Scalar list type, this PR will fix that behavior.

```graphql
type Foo @model {
  bars: [Bar] @hasMany
}

type Bar @model(queries: null) {
  strings: [String]
}
```

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-cli/issues/9737

#### Description of how you validated changes
- yarn test
- manual test (create api with the provided schema and amplify push)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
