### PR TITLE
fix: disallow lists in @primaryKey and @index fields

### DIFF
--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-index-transformer.test.ts
@@ -124,6 +124,39 @@ test('throws if @index refers to itself', () => {
   }).toThrow(`@index field 'id' cannot reference itself.`);
 });
 
+test('throws if @index is specified on a list', () => {
+  const schema = `
+    type Test @model {
+      strings: [String]! @index(name: "GSI")
+      email: String
+    }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new IndexTransformer()],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow(`Index 'GSI' on type 'Test.strings' cannot be a non-scalar.`);
+});
+
+test('throws if @index sort key fields are a list', () => {
+  const schema = `
+    type Test @model {
+      id: ID! @index(name: "GSI", sortKeyFields: ["strings"])
+      strings: [String]!
+      email: String
+    }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new IndexTransformer()],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow(`The sort key of index 'GSI' on type 'Test.strings' cannot be a non-scalar.`);
+});
+
 test('@index with multiple sort keys adds a query field and GSI correctly', () => {
   const inputSchema = `
     type Test @model {

--- a/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
+++ b/packages/amplify-graphql-index-transformer/src/__tests__/amplify-graphql-primary-key-transformer.test.ts
@@ -140,6 +140,39 @@ test('throws if @primaryKey refers to itself', () => {
   }).toThrow(`@primaryKey field 'id' cannot reference itself.`);
 });
 
+test('throws if @primaryKey is specified on a list', () => {
+  const schema = `
+    type Test @model {
+      strings: [String]! @primaryKey
+      email: String
+    }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow(`The primary key on type 'Test.strings' cannot be a non-scalar.`);
+});
+
+test('throws if @primaryKey sort key fields are a list', () => {
+  const schema = `
+    type Test @model {
+      id: ID! @primaryKey(sortKeyFields: ["strings"])
+      strings: [String]!
+      email: String
+    }`;
+
+  const transformer = new GraphQLTransform({
+    transformers: [new ModelTransformer(), new PrimaryKeyTransformer()],
+  });
+
+  expect(() => {
+    transformer.transform(schema);
+  }).toThrow(`The primary key's sort key on type 'Test.strings' cannot be a non-scalar.`);
+});
+
 test('handles sortKeyFields being a string instead of an array', () => {
   const schema = `
     type NonScalar {

--- a/packages/amplify-graphql-index-transformer/src/graphql-index-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-index-transformer.ts
@@ -13,7 +13,7 @@ import {
   Kind,
   ObjectTypeDefinitionNode,
 } from 'graphql';
-import { isScalarOrEnum } from 'graphql-transformer-common';
+import { isListType, isScalarOrEnum } from 'graphql-transformer-common';
 import { appendSecondaryIndex, constructSyncVTL, updateResolversForIndex } from './resolvers';
 import { addKeyConditionInputs, ensureQueryField, updateMutationConditionInput } from './schema';
 import { IndexDirectiveConfiguration } from './types';
@@ -139,7 +139,7 @@ function validate(config: IndexDirectiveConfiguration, ctx: TransformerContextPr
 
   const enums = ctx.output.getTypeDefinitionsOfKind(Kind.ENUM_TYPE_DEFINITION) as EnumTypeDefinitionNode[];
 
-  if (!isScalarOrEnum(field.type, enums)) {
+  if (!isScalarOrEnum(field.type, enums) || isListType(field.type)) {
     throw new InvalidDirectiveError(`Index '${name}' on type '${object.name.value}.${field.name.value}' cannot be a non-scalar.`);
   }
 
@@ -152,7 +152,7 @@ function validate(config: IndexDirectiveConfiguration, ctx: TransformerContextPr
       );
     }
 
-    if (!isScalarOrEnum(sortField.type, enums)) {
+    if (!isScalarOrEnum(sortField.type, enums) || isListType(sortField.type)) {
       throw new InvalidDirectiveError(
         `The sort key of index '${name}' on type '${object.name.value}.${sortField.name.value}' cannot be a non-scalar.`,
       );

--- a/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
+++ b/packages/amplify-graphql-index-transformer/src/graphql-primary-key-transformer.ts
@@ -13,7 +13,7 @@ import {
   Kind,
   ObjectTypeDefinitionNode,
 } from 'graphql';
-import { isNonNullType, isScalarOrEnum } from 'graphql-transformer-common';
+import { isListType, isNonNullType, isScalarOrEnum } from 'graphql-transformer-common';
 import { constructSyncVTL, replaceDdbPrimaryKey, updateResolvers } from './resolvers';
 import {
   addKeyConditionInputs,
@@ -133,7 +133,7 @@ function validate(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerCont
 
   const enums = ctx.output.getTypeDefinitionsOfKind(Kind.ENUM_TYPE_DEFINITION) as EnumTypeDefinitionNode[];
 
-  if (!isScalarOrEnum(field.type, enums)) {
+  if (!isScalarOrEnum(field.type, enums) || isListType(field.type)) {
     throw new InvalidDirectiveError(`The primary key on type '${object.name.value}.${field.name.value}' cannot be a non-scalar.`);
   }
 
@@ -146,7 +146,7 @@ function validate(config: PrimaryKeyDirectiveConfiguration, ctx: TransformerCont
       );
     }
 
-    if (!isScalarOrEnum(sortField.type, enums)) {
+    if (!isScalarOrEnum(sortField.type, enums) || isListType(sortField.type)) {
       throw new InvalidDirectiveError(
         `The primary key's sort key on type '${object.name.value}.${sortField.name.value}' cannot be a non-scalar.`,
       );


### PR DESCRIPTION
This commit adds validation to @primaryKey and @index to disallow
lists for the fields used by these directives.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/5860