### PR TITLE
chore(version): bump up conflicting beta packages

### DIFF
--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/amplify-category-auth",
-  "version": "2.5.0",
+  "version": "2.7.1",
   "description": "amplify-cli authentication plugin",
   "repository": {
     "type": "git",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-category-api": "1.2.10",
-    "@aws-amplify/amplify-category-auth": "2.5.0",
+    "@aws-amplify/amplify-category-auth": "2.7.1",
     "@aws-amplify/amplify-category-custom": "2.3.18",
     "@aws-amplify/amplify-category-storage": "3.1.15",
     "@aws-amplify/amplify-util-uibuilder": "1.2.11",
@@ -65,7 +65,7 @@
     "amplify-java-function-runtime-provider": "2.2.19",
     "amplify-java-function-template-provider": "1.5.12",
     "amplify-nodejs-function-runtime-provider": "2.2.19",
-    "amplify-nodejs-function-template-provider": "2.3.0",
+    "amplify-nodejs-function-template-provider": "2.3.3",
     "amplify-prompts": "1.6.3",
     "amplify-provider-awscloudformation": "5.9.5",
     "amplify-python-function-runtime-provider": "2.2.19",

--- a/packages/amplify-nodejs-function-template-provider/package.json
+++ b/packages/amplify-nodejs-function-template-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-nodejs-function-template-provider",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "description": "Node JS templates supplied by the Amplify Team",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump up the conflicting beta package versions.

- @aws-amplify/amplify-category-auth@2.5.1-beta.0 tag already exists
- amplify-nodejs-function-template-provider@2.3.1-beta.0 is already published to npm