### PR TITLE
fix(amplify-graphql-transformer-core): fixes VTL template error with \n (#9206)

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -266,7 +266,7 @@ export class TransformerResolver implements TransformerResolverProvider {
     if (authModes.includes(AuthorizationType.IAM)) {
       const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
       const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
-      initResolver += dedent`\n
+      initResolver += dedent`
       $util.qr($ctx.stash.put("authRole", "arn:aws:sts::${
         Stack.of(context.stackManager.rootStack).account
       }:assumed-role/${authRoleParameter}/CognitoIdentityCredentials"))

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -265,7 +265,8 @@ export class TransformerResolver implements TransformerResolverProvider {
     );
     if (authModes.includes(AuthorizationType.IAM)) {
       const authRoleParameter = (context.stackManager.getParameter(IAM_AUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
-      const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
+			const unauthRoleParameter = (context.stackManager.getParameter(IAM_UNAUTH_ROLE_PARAMETER) as CfnParameter).valueAsString;
+			initResolver += '\n'
       initResolver += dedent`
       $util.qr($ctx.stash.put("authRole", "arn:aws:sts::${
         Stack.of(context.stackManager.rootStack).account


### PR DESCRIPTION
#### Description of changes

Removed the line break `\n` which is breaking the template being read.

#### Issue #9206 

#### Description of how you validated changes

- Manual testing
- `yarn test` passes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
