### PR TITLE
fix: aws-sdk to dev dependency for node crud template, bump versions

### DIFF
--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/package.json.ejs
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/package.json.ejs
@@ -5,12 +5,12 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.845.0",
     "aws-serverless-express": "^3.3.5",
-    "body-parser": "^1.17.1",
-    "express": "^4.15.2"
+    "body-parser": "^1.19.1",
+    "express": "^4.17.2"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.92"
+    "@types/aws-lambda": "^8.10.92",
+    "aws-sdk": "^2.1074.0"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Move `aws-sdk` to devDependencies because it's already included in the Lambda runtime, bump versions of express and body-parser to latest

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually setup REST API that integrated the CRUD lambda function template to modify DynamoDB with updated package.json.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
