### PR TITLE
fix(graphql): handle sandbox pull with no environment info

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/utils.ts
@@ -44,8 +44,16 @@ export const getIdentityPoolId = async (ctx: $TSContext): Promise<string | undef
 };
 
 export const getAdminRoles = async (ctx: $TSContext, apiResourceName: string | undefined): Promise<Array<string>> => {
-  const currentEnv = ctx.amplify.getEnvInfo().envName;
+  let currentEnv;
   const adminRoles = new Array<string>();
+
+  try {
+    currentEnv = ctx.amplify.getEnvInfo().envName;
+  } catch (err) {
+    // When there is no environment info, return [] - This is required for sandbox pull
+    return [];
+  }
+
   //admin ui roles
   try {
     const amplifyMeta = stateManager.getMeta();


### PR DESCRIPTION
Handle sandbox pull scenario with no environment info.

This fixes the below error.

```
$ amplify pull --sandboxId <app_id>
UndeterminedEnvironmentError: Current environment cannot be determined
Use 'amplify init' in the root of your app directory to initialize your project with Amplify
Successfully generated models. Generated models can be found in /Users/testuser/Projects/eager/src
```