### PR TITLE
fix: map headless auth pw recovery to auto-verified attrs

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/__snapshots__/auth-request-adaptor.test.ts.snap
@@ -34,6 +34,42 @@ Object {
 }
 `;
 
+exports[`get add auth request adaptor translates request with autoVerifiedAttributes 1`] = `
+Object {
+  "adminQueries": false,
+  "adminQueryGroup": undefined,
+  "aliasAttributes": Array [],
+  "authProviders": Array [],
+  "authSelections": "userPoolOnly",
+  "autoVerifiedAttributes": Array [
+    "email",
+    "phone_number",
+  ],
+  "emailVerificationMessage": "test email verificaiton message {####}",
+  "emailVerificationSubject": "test email verification subject",
+  "identityPoolName": undefined,
+  "mfaConfiguration": "OFF",
+  "requiredAttributes": Array [
+    "email",
+  ],
+  "resourceName": "myTestAuth",
+  "serviceName": "Cognito",
+  "smsVerificationMessage": "test sms verification message {####}",
+  "thirdPartyAuth": false,
+  "updateFlow": "manual",
+  "useDefault": "manual",
+  "userPoolGroupList": Array [],
+  "userPoolGroups": false,
+  "userPoolName": undefined,
+  "usernameAttributes": Array [
+    "email",
+  ],
+  "userpoolClientReadAttributes": Array [],
+  "userpoolClientRefreshTokenValidity": undefined,
+  "userpoolClientWriteAttributes": Array [],
+}
+`;
+
 exports[`get add auth request adaptor translates request without aliasAttributes 1`] = `
 Object {
   "adminQueries": false,

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-request-adaptor.test.ts
@@ -18,7 +18,7 @@ describe('get add auth request adaptor', () => {
   describe('valid translations', () => {
     it('translates request with minimal user pool config only', () => {
       const addAuthRequest: AddAuthRequest = {
-        version: 1,
+        version: 2,
         resourceName: 'myTestAuth',
         serviceConfiguration: {
           serviceName: 'Cognito',
@@ -36,7 +36,7 @@ describe('get add auth request adaptor', () => {
   it('translates request with aliasAttributes', () => {
     FeatureFlags.getBoolean = () => true;
     const addAuthRequest: AddAuthRequest = {
-      version: 1,
+      version: 2,
       resourceName: 'myTestAuth',
       serviceConfiguration: {
         serviceName: 'Cognito',
@@ -58,7 +58,7 @@ describe('get add auth request adaptor', () => {
   it('translates request without aliasAttributes', () => {
     FeatureFlags.getBoolean = () => true;
     const addAuthRequest: AddAuthRequest = {
-      version: 1,
+      version: 2,
       resourceName: 'myTestAuth',
       serviceConfiguration: {
         serviceName: 'Cognito',
@@ -77,13 +77,42 @@ describe('get add auth request adaptor', () => {
 
     expect(getAddAuthRequestAdaptor('javascript')(addAuthRequest)).toMatchSnapshot();
   });
+
+  it('translates request with autoVerifiedAttributes', () => {
+    FeatureFlags.getBoolean = () => true;
+    const addAuthRequest: AddAuthRequest = {
+      version: 2,
+      resourceName: 'myTestAuth',
+      serviceConfiguration: {
+        serviceName: 'Cognito',
+        includeIdentityPool: false,
+        userPoolConfiguration: {
+          signinMethod: CognitoUserPoolSigninMethod.EMAIL,
+          requiredSignupAttributes: [CognitoUserProperty.EMAIL],
+          autoVerifiedAttributes: [
+            {
+              type: 'EMAIL',
+              verificationMessage: 'test email verificaiton message {####}',
+              verificationSubject: 'test email verification subject',
+            },
+            {
+              type: 'PHONE_NUMBER',
+              verificationMessage: 'test sms verification message {####}',
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getAddAuthRequestAdaptor('javascript')(addAuthRequest)).toMatchSnapshot();
+  });
 });
 
 describe('get update auth request adaptor', () => {
   describe('valid translations', () => {
     it('translates empty oAuth config into hostedUI: false', () => {
       const updateAuthRequest: UpdateAuthRequest = {
-        version: 1,
+        version: 2,
         serviceModification: {
           serviceName: 'Cognito',
           userPoolModification: {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types/cognito-user-input-types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthrough-types/cognito-user-input-types.ts
@@ -32,7 +32,7 @@ export type ServiceQuestionHeadlessResult = ServiceQuestionsBaseResult &
   SocialProviderResult &
   IdentityPoolResult &
   PasswordPolicyResult &
-  PasswordRecoveryResult &
+  AutoVerifiedAttributesResult &
   MfaResult &
   AdminQueriesResult &
   Triggers;
@@ -102,7 +102,7 @@ export interface IdentityPoolResult {
   audiences?: string[];
 }
 
-export interface PasswordRecoveryResult {
+export interface AutoVerifiedAttributesResult {
   emailVerificationMessage?: string;
   emailVerificationSubject?: string;
   smsVerificationMessage?: string;

--- a/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_5.test.ts
@@ -6,28 +6,11 @@ import {
   updateHeadlessAuth,
   removeHeadlessAuth,
   getCloudBackendConfig,
-  headlessAuthImport,
 } from 'amplify-e2e-core';
 import { addAuthWithDefault, getBackendAmplifyMeta } from 'amplify-e2e-core';
 import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool, getMFAConfiguration } from 'amplify-e2e-core';
-import {
-  AddAuthRequest,
-  CognitoUserPoolSigninMethod,
-  CognitoPasswordRecoveryConfiguration,
-  CognitoUserProperty,
-  ImportAuthRequest,
-  UpdateAuthRequest,
-} from 'amplify-headless-interface';
+import { AddAuthRequest, CognitoUserPoolSigninMethod, CognitoUserProperty, UpdateAuthRequest } from 'amplify-headless-interface';
 import _ from 'lodash';
-import {
-  expectAuthProjectDetailsMatch,
-  expectLocalAndCloudMetaFilesMatching,
-  expectLocalTeamInfoHasNoCategories,
-  expectNoAuthInMeta,
-  getAuthProjectDetails,
-  removeImportedAuthWithDefault,
-  setupOgProjectWithAuth,
-} from '../import-helpers';
 
 const PROJECT_NAME = 'authTest';
 const defaultsSettings = {
@@ -46,7 +29,7 @@ describe('headless auth', () => {
   });
   it('adds auth resource', async () => {
     const addAuthRequest: AddAuthRequest = {
-      version: 1,
+      version: 2,
       resourceName: 'myAuthResource',
       serviceConfiguration: {
         serviceName: 'Cognito',
@@ -68,7 +51,7 @@ describe('headless auth', () => {
   });
   it('adds auth resource with TOTP only', async () => {
     const addAuthRequest: AddAuthRequest = {
-      version: 1,
+      version: 2,
       resourceName: 'myAuthResource',
       serviceConfiguration: {
         serviceName: 'Cognito',
@@ -105,7 +88,7 @@ describe('headless auth', () => {
 
   it('adds auth resource with TOTP only but enable SMS through signUp Attributes', async () => {
     const addAuthRequest: AddAuthRequest = {
-      version: 1,
+      version: 2,
       resourceName: 'myAuthResource',
       serviceConfiguration: {
         serviceName: 'Cognito',
@@ -136,7 +119,8 @@ describe('headless auth', () => {
   });
 
   it('adds auth resource with TOTP only but enables SMS through password recovery', async () => {
-    const addAuthRequest: AddAuthRequest = {
+    // AddAuthRequest v1
+    const addAuthRequest: any = {
       version: 1,
       resourceName: 'myAuthResource',
       serviceConfiguration: {
@@ -173,7 +157,7 @@ describe('headless auth', () => {
 
   it('updates existing auth resource', async () => {
     const updateAuthRequest: UpdateAuthRequest = {
-      version: 1,
+      version: 2,
       serviceModification: {
         serviceName: 'Cognito',
         userPoolModification: {

--- a/packages/amplify-e2e-tests/src/__tests__/auth_7.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_7.test.ts
@@ -1,5 +1,11 @@
-import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, headlessAuthImport } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import {
+  initJSProjectWithProfile,
+  deleteProject,
+  amplifyPushAuth,
+  headlessAuthImport,
+  createNewProjectDir,
+  deleteProjectDir
+} from 'amplify-e2e-core';
 import { ImportAuthRequest } from 'amplify-headless-interface';
 import _ from 'lodash';
 import {

--- a/packages/amplify-e2e-tests/src/__tests__/auth_7.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_7.test.ts
@@ -1,22 +1,6 @@
-import {
-  initJSProjectWithProfile,
-  deleteProject,
-  amplifyPushAuth,
-  addHeadlessAuth,
-  updateHeadlessAuth,
-  removeHeadlessAuth,
-  getCloudBackendConfig,
-  headlessAuthImport,
-} from 'amplify-e2e-core';
-import { addAuthWithDefault, getBackendAmplifyMeta } from 'amplify-e2e-core';
-import { createNewProjectDir, deleteProjectDir, getProjectMeta, getUserPool } from 'amplify-e2e-core';
-import {
-  AddAuthRequest,
-  CognitoUserPoolSigninMethod,
-  CognitoUserProperty,
-  ImportAuthRequest,
-  UpdateAuthRequest,
-} from 'amplify-headless-interface';
+import { initJSProjectWithProfile, deleteProject, amplifyPushAuth, headlessAuthImport } from 'amplify-e2e-core';
+import { createNewProjectDir, deleteProjectDir } from 'amplify-e2e-core';
+import { ImportAuthRequest } from 'amplify-headless-interface';
 import _ from 'lodash';
 import {
   expectAuthProjectDetailsMatch,
@@ -45,7 +29,7 @@ describe('headless auth', () => {
   });
 
   describe(' import', () => {
-    let ogProjectSettings: {name: string};
+    let ogProjectSettings: { name: string };
     let ogProjectRoot: string;
 
     beforeEach(async () => {

--- a/packages/amplify-headless-interface/schemas/auth/1/AddAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/1/AddAuthRequest.schema.json
@@ -139,7 +139,7 @@
                     ]
                 },
                 "passwordRecovery": {
-                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 intead. If defined, specifies password recovery configiuration. Default is email recovery.",
+                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 instead. If defined, specifies password recovery configuration. Default is email recovery.",
                     "anyOf": [
                         {
                             "$ref": "#/definitions/CognitoEmailPasswordRecoveryConfiguration"

--- a/packages/amplify-headless-interface/schemas/auth/1/AddAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/1/AddAuthRequest.schema.json
@@ -139,7 +139,7 @@
                     ]
                 },
                 "passwordRecovery": {
-                    "description": "If defined, specifies password recovery configiuration. Default is email recovery.",
+                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 intead. If defined, specifies password recovery configiuration. Default is email recovery.",
                     "anyOf": [
                         {
                             "$ref": "#/definitions/CognitoEmailPasswordRecoveryConfiguration"

--- a/packages/amplify-headless-interface/schemas/auth/1/UpdateAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/1/UpdateAuthRequest.schema.json
@@ -99,7 +99,7 @@
                     "description": "If defined, specifies password constraint configuration. Default is minimum length of 8 characters."
                 },
                 "passwordRecovery": {
-                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 intead. If defined, specifies password recovery configiuration. Default is email recovery.",
+                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 instead. If defined, specifies password recovery configuration. Default is email recovery.",
                     "anyOf": [
                         {
                             "$ref": "#/definitions/CognitoEmailPasswordRecoveryConfiguration"

--- a/packages/amplify-headless-interface/schemas/auth/2/AddAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/2/AddAuthRequest.schema.json
@@ -1,19 +1,25 @@
 {
-    "description": "Defines the payload expected by `amplify update auth --headless`",
+    "description": "Defines acceptable payloads to amplify add auth --headless.",
     "type": "object",
     "properties": {
         "version": {
+            "description": "The schema version.",
             "type": "number",
             "enum": [
-                1
+                2
             ]
         },
-        "serviceModification": {
+        "resourceName": {
+            "description": "A name for the auth resource.",
+            "type": "string"
+        },
+        "serviceConfiguration": {
+            "description": "The configuration that defines the auth resource.",
             "anyOf": [
                 {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/BaseCognitoServiceModification"
+                            "$ref": "#/definitions/BaseCognitoServiceConfiguration"
                         },
                         {
                             "$ref": "#/definitions/NoCognitoIdentityPool"
@@ -23,10 +29,10 @@
                 {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/BaseCognitoServiceModification"
+                            "$ref": "#/definitions/BaseCognitoServiceConfiguration"
                         },
                         {
-                            "$ref": "#/definitions/ModifyCognitoIdentityPool"
+                            "$ref": "#/definitions/CognitoIdentityPool"
                         }
                     ]
                 }
@@ -34,44 +40,82 @@
         }
     },
     "required": [
-        "serviceModification",
+        "resourceName",
+        "serviceConfiguration",
         "version"
     ],
     "definitions": {
-        "BaseCognitoServiceModification": {
+        "BaseCognitoServiceConfiguration": {
+            "description": "Configuration that applies to all Cognito configuration.",
             "type": "object",
             "properties": {
                 "serviceName": {
+                    "description": "The name of the service providing the resource.",
                     "type": "string",
                     "enum": [
                         "Cognito"
                     ]
                 },
-                "userPoolModification": {
-                    "description": "A subset of properties from CognitoUserPoolConfiguration that can be modified.\n\nEach field will overwrite the entire previous configuration of that field, but omitted fields will not be removed.\nFor example, adding auth with\n\n{\n   readAttributes: ['EMAIL', 'NAME', 'PHONE_NUMBER'],\n   passwordPolicy: {\n     minimumLength: 10,\n     additionalConstraints: [\n       REQUIRE_LOWERCASE, REQUIRE_UPPERCASE\n     ]\n   }\n}\n\nand then updating auth with\n\n{\n   passwordPolicy: {\n     minimumLength: 8\n   }\n}\n\nwill overwrite the entire passwordPolicy (removing the lowercase and uppercase constraints)\nbut will leave the readAttributes unaffected.\n\nHowever, the oAuth field is treated slightly differently:\n   Omitting the oAuth field entirely will leave oAuth configuration unchanged.\n   Setting oAuth to {} (an empty object) will remove oAuth from the auth resource.\n   Including a non-empty oAuth configuration will overwrite the previous oAuth configuration.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\">"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "oAuth": {
-                                    "$ref": "#/definitions/Partial<CognitoOAuthConfiguration>"
-                                }
-                            }
-                        }
-                    ]
+                "userPoolConfiguration": {
+                    "$ref": "#/definitions/CognitoUserPoolConfiguration",
+                    "description": "The Cognito user pool configuration."
                 }
             },
             "required": [
                 "serviceName",
-                "userPoolModification"
+                "userPoolConfiguration"
             ]
         },
-        "Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\">": {
+        "CognitoUserPoolConfiguration": {
+            "description": "Cognito configuration exposed by Amplify.",
             "type": "object",
             "properties": {
+                "signinMethod": {
+                    "$ref": "#/definitions/CognitoUserPoolSigninMethod",
+                    "description": "How users will signin to their account."
+                },
+                "requiredSignupAttributes": {
+                    "description": "Account attributes that must be specified to sign up.",
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                            "ADDRESS",
+                            "BIRTHDATE",
+                            "EMAIL",
+                            "FAMILY_NAME",
+                            "GENDER",
+                            "GIVEN_NAME",
+                            "LOCALE",
+                            "MIDDLE_NAME",
+                            "NAME",
+                            "NICKNAME",
+                            "PHONE_NUMBER",
+                            "PICTURE",
+                            "PREFERRED_USERNAME",
+                            "PROFILE",
+                            "UPDATED_AT",
+                            "WEBSITE",
+                            "ZONE_INFO"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "aliasAttributes": {
+                    "description": "Alias attributes that can be used for sign-up/sign-in",
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                            "EMAIL",
+                            "PHONE_NUMBER",
+                            "PREFERRED_USERNAME"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "userPoolName": {
+                    "description": "The name of the user pool. If not specified, a unique string will be generated.",
+                    "type": "string"
+                },
                 "userPoolGroups": {
                     "description": "User pool groups to create within the user pool. If not specified, no groups are created.",
                     "type": "array",
@@ -97,17 +141,6 @@
                 "passwordPolicy": {
                     "$ref": "#/definitions/CognitoPasswordPolicy",
                     "description": "If defined, specifies password constraint configuration. Default is minimum length of 8 characters."
-                },
-                "passwordRecovery": {
-                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 intead. If defined, specifies password recovery configiuration. Default is email recovery.",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/CognitoEmailPasswordRecoveryConfiguration"
-                        },
-                        {
-                            "$ref": "#/definitions/CognitoSMSPasswordRecoveryConfiguration"
-                        }
-                    ]
                 },
                 "refreshTokenPeriod": {
                     "description": "Defines how long refresh tokens are valid in days. Default is 30 days.",
@@ -166,8 +199,39 @@
                         ],
                         "type": "string"
                     }
+                },
+                "oAuth": {
+                    "$ref": "#/definitions/CognitoOAuthConfiguration",
+                    "description": "If defined, specified oAuth configuration will be applied to the user pool."
+                },
+                "autoVerifiedAttributes": {
+                    "description": "Defines user attributes that will be automatically verified upon account creation.",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CognitoAutoVerifyPhoneNumberConfiguration"
+                            },
+                            {
+                                "$ref": "#/definitions/CognitoAutoVerifyEmailConfiguration"
+                            }
+                        ]
+                    }
                 }
-            }
+            },
+            "required": [
+                "requiredSignupAttributes",
+                "signinMethod"
+            ]
+        },
+        "CognitoUserPoolSigninMethod": {
+            "enum": [
+                "EMAIL",
+                "EMAIL_AND_PHONE_NUMBER",
+                "PHONE_NUMBER",
+                "USERNAME"
+            ],
+            "type": "string"
         },
         "CognitoUserPoolGroup": {
             "description": "Defines a Cognito user pool group.",
@@ -280,50 +344,8 @@
                 }
             }
         },
-        "CognitoEmailPasswordRecoveryConfiguration": {
-            "description": "Defines the email that will be sent to users to recover their password.",
-            "type": "object",
-            "properties": {
-                "deliveryMethod": {
-                    "type": "string",
-                    "enum": [
-                        "EMAIL"
-                    ]
-                },
-                "emailMessage": {
-                    "type": "string"
-                },
-                "emailSubject": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "deliveryMethod",
-                "emailMessage",
-                "emailSubject"
-            ]
-        },
-        "CognitoSMSPasswordRecoveryConfiguration": {
-            "description": "Defines the SMS message that will be send to users to recover their password",
-            "type": "object",
-            "properties": {
-                "deliveryMethod": {
-                    "type": "string",
-                    "enum": [
-                        "SMS"
-                    ]
-                },
-                "smsMessage": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "deliveryMethod",
-                "smsMessage"
-            ]
-        },
-        "Partial<CognitoOAuthConfiguration>": {
-            "description": "Make all properties in T optional",
+        "CognitoOAuthConfiguration": {
+            "description": "Cognito OAuth configuration exposed by Amplify",
             "type": "object",
             "properties": {
                 "domainPrefix": {
@@ -370,6 +392,7 @@
                     "description": "If defined, users will be able to login with the specified social providers.",
                     "type": "array",
                     "items": {
+                        "description": "Defines a Cognito oAuth social provider",
                         "anyOf": [
                             {
                                 "$ref": "#/definitions/SocialProviderConfig"
@@ -380,7 +403,13 @@
                         ]
                     }
                 }
-            }
+            },
+            "required": [
+                "oAuthGrantType",
+                "oAuthScopes",
+                "redirectSigninURIs",
+                "redirectSignoutURIs"
+            ]
         },
         "SocialProviderConfig": {
             "description": "Defines a Cognito oAuth social provider",
@@ -444,6 +473,43 @@
                 "teamId"
             ]
         },
+        "CognitoAutoVerifyPhoneNumberConfiguration": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "PHONE_NUMBER"
+                    ]
+                },
+                "verificationMessage": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "CognitoAutoVerifyEmailConfiguration": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "EMAIL"
+                    ]
+                },
+                "verificationMessage": {
+                    "type": "string"
+                },
+                "verifiectionSubject": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
         "NoCognitoIdentityPool": {
             "description": "Specifies that the Cognito configuration should not include an identity pool.",
             "type": "object",
@@ -460,27 +526,33 @@
                 "includeIdentityPool"
             ]
         },
-        "ModifyCognitoIdentityPool": {
+        "CognitoIdentityPool": {
+            "description": "Specifies that the Cognito configuration includes an identity pool configuration.",
             "type": "object",
             "properties": {
                 "includeIdentityPool": {
+                    "description": "Indicates an identity pool should be configured.",
                     "type": "boolean",
                     "enum": [
                         true
                     ]
                 },
-                "identityPoolModification": {
-                    "$ref": "#/definitions/Pick<CognitoIdentityPoolConfiguration,\"unauthenticatedLogin\"|\"identitySocialFederation\">"
+                "identityPoolConfiguration": {
+                    "$ref": "#/definitions/CognitoIdentityPoolConfiguration",
+                    "description": "The identity pool configuration. If not specified, defaults are applied."
                 }
             },
             "required": [
-                "identityPoolModification",
                 "includeIdentityPool"
             ]
         },
-        "Pick<CognitoIdentityPoolConfiguration,\"unauthenticatedLogin\"|\"identitySocialFederation\">": {
+        "CognitoIdentityPoolConfiguration": {
             "type": "object",
             "properties": {
+                "identityPoolName": {
+                    "description": "If not specified, a random string is generated.",
+                    "type": "string"
+                },
                 "unauthenticatedLogin": {
                     "description": "Allow guest login or not. Default is false.",
                     "type": "boolean"

--- a/packages/amplify-headless-interface/schemas/auth/2/UpdateAuthRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/auth/2/UpdateAuthRequest.schema.json
@@ -5,7 +5,7 @@
         "version": {
             "type": "number",
             "enum": [
-                1
+                2
             ]
         },
         "serviceModification": {
@@ -48,10 +48,10 @@
                     ]
                 },
                 "userPoolModification": {
-                    "description": "A subset of properties from CognitoUserPoolConfiguration that can be modified.\n\nEach field will overwrite the entire previous configuration of that field, but omitted fields will not be removed.\nFor example, adding auth with\n\n{\n   readAttributes: ['EMAIL', 'NAME', 'PHONE_NUMBER'],\n   passwordPolicy: {\n     minimumLength: 10,\n     additionalConstraints: [\n       REQUIRE_LOWERCASE, REQUIRE_UPPERCASE\n     ]\n   }\n}\n\nand then updating auth with\n\n{\n   passwordPolicy: {\n     minimumLength: 8\n   }\n}\n\nwill overwrite the entire passwordPolicy (removing the lowercase and uppercase constraints)\nbut will leave the readAttributes unaffected.\n\nHowever, the oAuth field is treated slightly differently:\n   Omitting the oAuth field entirely will leave oAuth configuration unchanged.\n   Setting oAuth to {} (an empty object) will remove oAuth from the auth resource.\n   Including a non-empty oAuth configuration will overwrite the previous oAuth configuration.",
+                    "description": "A subset of properties from CognitoUserPoolConfiguration that can be modified.\n\nEach field will overwrite the entire previous configuration of that field, but omitted fields will not be removed.\nFor example, adding auth with\n\n{\n  readAttributes: ['EMAIL', 'NAME', 'PHONE_NUMBER'],\n  passwordPolicy: {\n    minimumLength: 10,\n    additionalConstraints: [\n      REQUIRE_LOWERCASE, REQUIRE_UPPERCASE\n    ]\n  }\n}\n\nand then updating auth with\n\n{\n  passwordPolicy: {\n    minimumLength: 8\n  }\n}\n\nwill overwrite the entire passwordPolicy (removing the lowercase and uppercase constraints)\nbut will leave the readAttributes unaffected.\n\nHowever, the oAuth field is treated slightly differently:\n  Omitting the oAuth field entirely will leave oAuth configuration unchanged.\n  Setting oAuth to {} (an empty object) will remove oAuth from the auth resource.\n  Including a non-empty oAuth configuration will overwrite the previous oAuth configuration.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\">"
+                            "$ref": "#/definitions/Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"autoVerifiedAttributes\">"
                         },
                         {
                             "type": "object",
@@ -69,7 +69,7 @@
                 "userPoolModification"
             ]
         },
-        "Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"passwordRecovery\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\">": {
+        "Pick<CognitoUserPoolConfiguration,\"userPoolGroups\"|\"adminQueries\"|\"mfa\"|\"passwordPolicy\"|\"refreshTokenPeriod\"|\"readAttributes\"|\"writeAttributes\"|\"autoVerifiedAttributes\">": {
             "type": "object",
             "properties": {
                 "userPoolGroups": {
@@ -97,17 +97,6 @@
                 "passwordPolicy": {
                     "$ref": "#/definitions/CognitoPasswordPolicy",
                     "description": "If defined, specifies password constraint configuration. Default is minimum length of 8 characters."
-                },
-                "passwordRecovery": {
-                    "description": "DEPRECATED. Use autoVerifiedAttributes in headless schema version 2 intead. If defined, specifies password recovery configiuration. Default is email recovery.",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/CognitoEmailPasswordRecoveryConfiguration"
-                        },
-                        {
-                            "$ref": "#/definitions/CognitoSMSPasswordRecoveryConfiguration"
-                        }
-                    ]
                 },
                 "refreshTokenPeriod": {
                     "description": "Defines how long refresh tokens are valid in days. Default is 30 days.",
@@ -165,6 +154,20 @@
                             "ZONE_INFO"
                         ],
                         "type": "string"
+                    }
+                },
+                "autoVerifiedAttributes": {
+                    "description": "Defines user attributes that will be automatically verified upon account creation.",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/CognitoAutoVerifyPhoneNumberConfiguration"
+                            },
+                            {
+                                "$ref": "#/definitions/CognitoAutoVerifyEmailConfiguration"
+                            }
+                        ]
                     }
                 }
             }
@@ -280,50 +283,44 @@
                 }
             }
         },
-        "CognitoEmailPasswordRecoveryConfiguration": {
-            "description": "Defines the email that will be sent to users to recover their password.",
+        "CognitoAutoVerifyPhoneNumberConfiguration": {
             "type": "object",
             "properties": {
-                "deliveryMethod": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "PHONE_NUMBER"
+                    ]
+                },
+                "verificationMessage": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "CognitoAutoVerifyEmailConfiguration": {
+            "type": "object",
+            "properties": {
+                "type": {
                     "type": "string",
                     "enum": [
                         "EMAIL"
                     ]
                 },
-                "emailMessage": {
+                "verificationMessage": {
                     "type": "string"
                 },
-                "emailSubject": {
+                "verifiectionSubject": {
                     "type": "string"
                 }
             },
             "required": [
-                "deliveryMethod",
-                "emailMessage",
-                "emailSubject"
-            ]
-        },
-        "CognitoSMSPasswordRecoveryConfiguration": {
-            "description": "Defines the SMS message that will be send to users to recover their password",
-            "type": "object",
-            "properties": {
-                "deliveryMethod": {
-                    "type": "string",
-                    "enum": [
-                        "SMS"
-                    ]
-                },
-                "smsMessage": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "deliveryMethod",
-                "smsMessage"
+                "type"
             ]
         },
         "Partial<CognitoOAuthConfiguration>": {
-            "description": "Make all properties in T optional",
             "type": "object",
             "properties": {
                 "domainPrefix": {
@@ -370,6 +367,7 @@
                     "description": "If defined, users will be able to login with the specified social providers.",
                     "type": "array",
                     "items": {
+                        "description": "Defines a Cognito oAuth social provider",
                         "anyOf": [
                             {
                                 "$ref": "#/definitions/SocialProviderConfig"
@@ -470,7 +468,7 @@
                     ]
                 },
                 "identityPoolModification": {
-                    "$ref": "#/definitions/Pick<CognitoIdentityPoolConfiguration,\"unauthenticatedLogin\"|\"identitySocialFederation\">"
+                    "$ref": "#/definitions/CognitoIdentityPoolModification"
                 }
             },
             "required": [
@@ -478,7 +476,7 @@
                 "includeIdentityPool"
             ]
         },
-        "Pick<CognitoIdentityPoolConfiguration,\"unauthenticatedLogin\"|\"identitySocialFederation\">": {
+        "CognitoIdentityPoolModification": {
             "type": "object",
             "properties": {
                 "unauthenticatedLogin": {

--- a/packages/amplify-headless-interface/src/interface/auth/add.ts
+++ b/packages/amplify-headless-interface/src/interface/auth/add.ts
@@ -5,7 +5,7 @@ export interface AddAuthRequest {
   /**
    * The schema version.
    */
-  version: 1;
+  version: 2;
   /**
    * A name for the auth resource.
    */
@@ -118,10 +118,6 @@ export interface CognitoUserPoolConfiguration {
    */
   mfa?: CognitoMFAConfiguration;
   /**
-   * If defined, specifies password recovery configiuration. Default is email recovery.
-   */
-  passwordRecovery?: CognitoPasswordRecoveryConfiguration;
-  /**
    * If defined, specifies password constraint configuration. Default is minimum length of 8 characters.
    */
   passwordPolicy?: CognitoPasswordPolicy;
@@ -141,6 +137,25 @@ export interface CognitoUserPoolConfiguration {
    * If defined, specified oAuth configuration will be applied to the user pool.
    */
   oAuth?: CognitoOAuthConfiguration;
+  /**
+   * Defines user attributes that will be automatically verified upon account creation.
+   */
+  autoVerifiedAttributes?: CognitoAutoVerifiedAttributesConfiguration;
+}
+
+export type CognitoAutoVerifiedAttributesConfiguration = Array<
+  CognitoAutoVerifyEmailConfiguration | CognitoAutoVerifyPhoneNumberConfiguration
+>;
+
+export interface CognitoAutoVerifyPhoneNumberConfiguration {
+  type: 'PHONE_NUMBER';
+  verificationMessage?: string;
+}
+
+export interface CognitoAutoVerifyEmailConfiguration {
+  type: 'EMAIL';
+  verificationMessage?: string;
+  verificationSubject?: string;
 }
 
 /**
@@ -223,25 +238,6 @@ export type CognitoSocialProviderConfiguration = SocialProviderConfig | SignInWi
 export interface CognitoPasswordPolicy {
   minimumLength?: number;
   additionalConstraints?: CognitoPasswordConstraint[];
-}
-
-export type CognitoPasswordRecoveryConfiguration = CognitoEmailPasswordRecoveryConfiguration | CognitoSMSPasswordRecoveryConfiguration;
-
-/**
- * Defines the email that will be sent to users to recover their password.
- */
-export interface CognitoEmailPasswordRecoveryConfiguration {
-  deliveryMethod: 'EMAIL';
-  emailMessage: string;
-  emailSubject: string;
-}
-
-/**
- * Defines the SMS message that will be send to users to recover their password
- */
-export interface CognitoSMSPasswordRecoveryConfiguration {
-  deliveryMethod: 'SMS';
-  smsMessage: string;
 }
 
 export type CognitoMFAConfiguration = CognitoMFAOff | CognitoMFASettings;

--- a/packages/amplify-headless-interface/src/interface/auth/update.ts
+++ b/packages/amplify-headless-interface/src/interface/auth/update.ts
@@ -4,7 +4,7 @@ import { CognitoUserPoolConfiguration, CognitoIdentityPoolConfiguration, NoCogni
  * Defines the payload expected by `amplify update auth --headless`
  */
 export interface UpdateAuthRequest {
-  version: 1;
+  version: 2;
   serviceModification: CognitoServiceModification;
 }
 
@@ -58,9 +58,9 @@ export type CognitoUserPoolModification = Pick<
   | 'adminQueries'
   | 'mfa'
   | 'passwordPolicy'
-  | 'passwordRecovery'
   | 'refreshTokenPeriod'
   | 'readAttributes'
   | 'writeAttributes'
+  | 'autoVerifiedAttributes'
 > & { oAuth?: Partial<CognitoOAuthConfiguration> };
 export type CognitoIdentityPoolModification = Pick<CognitoIdentityPoolConfiguration, 'unauthenticatedLogin' | 'identitySocialFederation'>;

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/auth-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/auth-migration.test.ts
@@ -156,7 +156,7 @@ describe('amplify auth migration', () => {
 
   it('updates existing auth resource', async () => {
     const updateAuthRequest: UpdateAuthRequest = {
-      version: 1,
+      version: 2,
       serviceModification: {
         serviceName: 'Cognito',
         userPoolModification: {

--- a/packages/amplify-util-headless-input/src/__tests__/authVersionUpgrades.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/authVersionUpgrades.ts
@@ -1,0 +1,138 @@
+import { v1toV2Upgrade } from '../authVersionUpgrades';
+
+describe('v1toV2Upgrade', () => {
+  it('bumps payload version to 2', () => {
+    expect(v1toV2Upgrade({ version: 1 }).version).toBe(2);
+  });
+
+  it('maps email pwRecovery in service config to autoVerifiedAttributes', () => {
+    const payload = {
+      version: 1,
+      serviceConfiguration: {
+        userPoolConfiguration: {
+          passwordRecovery: {
+            deliveryMethod: 'EMAIL',
+            emailMessage: 'test email message',
+            emailSubject: 'test email subject',
+          },
+        },
+      },
+    };
+    const result = v1toV2Upgrade(payload);
+    expect(result).toEqual({
+      version: 2,
+      serviceConfiguration: {
+        userPoolConfiguration: {
+          autoVerifiedAttributes: [
+            {
+              type: 'EMAIL',
+              verificationMessage: 'test email message',
+              verificationSubject: 'test email subject',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('maps sms pwRecovery in service config to autoVerifiedAttributes', () => {
+    const payload = {
+      version: 1,
+      serviceConfiguration: {
+        userPoolConfiguration: {
+          passwordRecovery: {
+            deliveryMethod: 'SMS',
+            smsMessage: 'test sms message',
+          },
+        },
+      },
+    };
+    const result = v1toV2Upgrade(payload);
+    expect(result).toEqual({
+      version: 2,
+      serviceConfiguration: {
+        userPoolConfiguration: {
+          autoVerifiedAttributes: [
+            {
+              type: 'PHONE_NUMBER',
+              verificationMessage: 'test sms message',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('maps email pwRecovery in service modification to autoVerifiedAttributes', () => {
+    const payload = {
+      version: 1,
+      serviceModification: {
+        userPoolModification: {
+          passwordRecovery: {
+            deliveryMethod: 'EMAIL',
+            emailMessage: 'test email message',
+            emailSubject: 'test email subject',
+          },
+        },
+      },
+    };
+    const result = v1toV2Upgrade(payload);
+    expect(result).toEqual({
+      version: 2,
+      serviceModification: {
+        userPoolModification: {
+          autoVerifiedAttributes: [
+            {
+              type: 'EMAIL',
+              verificationMessage: 'test email message',
+              verificationSubject: 'test email subject',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('maps sms pwRecovery in service modification to autoVerifiedAttributes', () => {
+    const payload = {
+      version: 1,
+      serviceModification: {
+        userPoolModification: {
+          passwordRecovery: {
+            deliveryMethod: 'SMS',
+            smsMessage: 'test sms message',
+          },
+        },
+      },
+    };
+    const result = v1toV2Upgrade(payload);
+    expect(result).toEqual({
+      version: 2,
+      serviceModification: {
+        userPoolModification: {
+          autoVerifiedAttributes: [
+            {
+              type: 'PHONE_NUMBER',
+              verificationMessage: 'test sms message',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('bumps version with no other changes when service config does not contian pwRecovery', () => {
+    const payload = {
+      version: 1,
+      serviceModification: {
+        userPoolModification: {
+          passwordPolicy: {
+            test: 'test',
+          },
+        },
+      },
+    };
+    const result = v1toV2Upgrade(payload);
+    expect(result).toEqual({ ...payload, version: 2 });
+  });
+});

--- a/packages/amplify-util-headless-input/src/__tests__/upgradePipeline.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/upgradePipeline.test.ts
@@ -1,0 +1,20 @@
+import { authUpgradePipeline } from '../upgradePipelines';
+
+describe('authUpgradePipeline', () => {
+  it('throws error when version is not supported', () => {
+    expect(() => authUpgradePipeline(0)).toThrowErrorMatchingInlineSnapshot(
+      `"Headless auth upgrade pipeline encountered unknown schema version 0"`,
+    );
+    expect(() => authUpgradePipeline(3)).toThrowErrorMatchingInlineSnapshot(
+      `"Headless auth upgrade pipeline encountered unknown schema version 3"`,
+    );
+  });
+
+  it('returns upgrade function for version 1', () => {
+    expect(authUpgradePipeline(1).length).toBe(1);
+  });
+
+  it('returns noop when version is 2', () => {
+    expect(authUpgradePipeline(2).length).toBe(0);
+  });
+});

--- a/packages/amplify-util-headless-input/src/authVersionUpgrades.ts
+++ b/packages/amplify-util-headless-input/src/authVersionUpgrades.ts
@@ -1,0 +1,36 @@
+/**
+ * In auth v2 payloads, passwordRecovery is removed and replaced with autoVerifiedAttributes
+ * Password recovery was mistakenly included in the original version and was internally mapped to autoVerifiedAttributes.
+ * This upgrade function maps the passwordRecovery config (if present) to the new autoVerifiedAttributes config
+ * @param payload A v1 addAuth or updateAuth headless payload
+ * @returns A v2 addAuth or updateAuth headless payload
+ */
+export const v1toV2Upgrade = (payload: any) => {
+  payload.version = 2;
+  const userPoolConfig = payload?.serviceConfiguration?.userPoolConfiguration || payload?.serviceModification?.userPoolModification;
+  const pwRecoveryConfig = userPoolConfig?.passwordRecovery;
+  if (!pwRecoveryConfig) {
+    return payload;
+  }
+  // payload has pwRecoveryConfig
+  switch (pwRecoveryConfig.deliveryMethod) {
+    case 'EMAIL':
+      userPoolConfig.autoVerifiedAttributes = [
+        {
+          type: 'EMAIL',
+          verificationMessage: pwRecoveryConfig.emailMessage,
+          verificationSubject: pwRecoveryConfig.emailSubject,
+        },
+      ];
+      break;
+    case 'SMS':
+      userPoolConfig.autoVerifiedAttributes = [
+        {
+          type: 'PHONE_NUMBER',
+          verificationMessage: pwRecoveryConfig.smsMessage,
+        },
+      ];
+  }
+  delete userPoolConfig.passwordRecovery;
+  return payload;
+};

--- a/packages/amplify-util-headless-input/src/index.ts
+++ b/packages/amplify-util-headless-input/src/index.ts
@@ -9,7 +9,7 @@ import {
   UpdateAuthRequest,
   UpdateStorageRequest,
   AddGeoRequest,
-  UpdateGeoRequest
+  UpdateGeoRequest,
 } from 'amplify-headless-interface';
 import { HeadlessInputValidator } from './HeadlessInputValidator';
 import {
@@ -23,9 +23,9 @@ import {
   updateAuthRequestSchemaSupplier,
   updateStorageRequestSchemaSupplier,
   addGeoRequestSchemaSupplier,
-  updateGeoRequestSchemaSupplier
+  updateGeoRequestSchemaSupplier,
 } from './schemaSuppliers';
-import { noopUpgradePipeline } from './upgradePipelines';
+import { authUpgradePipeline, noopUpgradePipeline } from './upgradePipelines';
 
 /* API */
 export const validateAddApiRequest = (raw: string) => {
@@ -38,11 +38,11 @@ export const validateUpdateApiRequest = (raw: string) => {
 
 /* Auth */
 export const validateAddAuthRequest = (raw: string) => {
-  return new HeadlessInputValidator(addAuthRequestSchemaSupplier, noopUpgradePipeline).validate<AddAuthRequest>(raw);
+  return new HeadlessInputValidator(addAuthRequestSchemaSupplier, authUpgradePipeline).validate<AddAuthRequest>(raw);
 };
 
 export const validateUpdateAuthRequest = (raw: string) => {
-  return new HeadlessInputValidator(updateAuthRequestSchemaSupplier, noopUpgradePipeline).validate<UpdateAuthRequest>(raw);
+  return new HeadlessInputValidator(updateAuthRequestSchemaSupplier, authUpgradePipeline).validate<UpdateAuthRequest>(raw);
 };
 
 export const validateImportAuthRequest = (raw: string) => {

--- a/packages/amplify-util-headless-input/src/upgradePipelines.ts
+++ b/packages/amplify-util-headless-input/src/upgradePipelines.ts
@@ -5,6 +5,18 @@
  * Once there are multiple versions of a schema, we will need to implement a conversion pipeline for it here.
  */
 
+import { v1toV2Upgrade } from './authVersionUpgrades';
 import { VersionUpgradePipeline } from './HeadlessInputValidator';
 
 export const noopUpgradePipeline: VersionUpgradePipeline = () => [];
+
+export const authUpgradePipeline: VersionUpgradePipeline = version => {
+  const minVersion = 1;
+  const maxVersion = 2;
+  if (version < minVersion || maxVersion < version) {
+    throw new Error(`Headless auth upgrade pipeline encountered unknown schema version ${version}`);
+  }
+
+  const upgradePipeline = [v1toV2Upgrade];
+  return upgradePipeline.slice(version - 1);
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
passwordRecovery options were mapped to autoVerified attributes in the v1 headless schema. the v2 schema instead specified autoVerifiedAttributes explicitly. Additionally, a translation function is added to map incoming v1 requests to the correct v2 request.

Related docs PR: https://github.com/aws-amplify/docs/pull/4046

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/9756
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually, added unit tests, updated e2e tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
