### PR TITLE
fix(cli): fix notification logic when API resource directory doesn't exist

### DIFF
--- a/packages/amplify-cli/src/__tests__/push-notifications.test.ts
+++ b/packages/amplify-cli/src/__tests__/push-notifications.test.ts
@@ -1,0 +1,53 @@
+import { notifyFieldAuthSecurityChange, notifySecurityEnhancement } from '../extensions/amplify-helpers/auth-notifications';
+import { $TSContext, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
+
+jest.mock('amplify-cli-core');
+
+const contextMock = {
+  amplify: {},
+  parameters: {
+    first: 'resourceName',
+  },
+} as unknown as $TSContext;
+
+describe('push notifications', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('notifyFieldAuthSecurityChange should exit without fail when there is not api resource directory', () => {
+    (<any>FeatureFlags.getBoolean).mockReturnValue(true);
+    (<any>pathManager.getResourceDirectoryPath).mockReturnValue('path-to-non-existing-resource-directory');
+    (<any>stateManager.getMeta).mockReturnValue({
+      api: {
+        'test-api-dev': {
+          service: 'AppSync',
+          output: {
+            name: 'test-api-dev',
+          },
+        },
+      },
+    });
+    (<any>FeatureFlags.ensureFeatureFlag).mockImplementation(() => {});
+    notifyFieldAuthSecurityChange(contextMock);
+    expect(<any>FeatureFlags.ensureFeatureFlag).toHaveBeenCalledWith('graphqltransformer', 'showfieldauthnotification');
+  });
+
+  it('notifySecurityEnhancement should exit without fail when there is not api resource directory', () => {
+    (<any>FeatureFlags.getBoolean).mockReturnValue(true);
+    (<any>pathManager.getResourceDirectoryPath).mockReturnValue('path-to-non-existing-resource-directory');
+    (<any>stateManager.getMeta).mockReturnValue({
+      api: {
+        'test-api-dev': {
+          service: 'AppSync',
+          output: {
+            name: 'test-api-dev',
+          },
+        },
+      },
+    });
+    (<any>FeatureFlags.ensureFeatureFlag).mockImplementation(() => {});
+    notifySecurityEnhancement(contextMock);
+    expect(<any>FeatureFlags.ensureFeatureFlag).toHaveBeenCalledWith('graphqltransformer', 'securityEnhancementNotification');
+  });
+});

--- a/packages/amplify-cli/src/extensions/amplify-helpers/auth-notifications.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/auth-notifications.ts
@@ -39,6 +39,12 @@ export async function notifyFieldAuthSecurityChange(context: $TSContext): Promis
 
   const apiName = apiNames[0];
   const apiResourceDir = pathManager.getResourceDirectoryPath(projectPath, 'api', apiName);
+
+  if (!fs.existsSync(apiResourceDir)) {
+    await setNotificationFlag(projectPath, flagName, false);
+    return;
+  }
+
   const project = await readProjectConfiguration(apiResourceDir);
   const directiveMap = collectDirectivesByType(project.schema);
   const doc: DocumentNode = parse(project.schema);
@@ -157,6 +163,12 @@ export async function notifySecurityEnhancement(context) {
     const apiName = apiNames[0];
 
     const apiResourceDir = pathManager.getResourceDirectoryPath(projectPath, 'api', apiName);
+
+    if (!fs.existsSync(apiResourceDir)) {
+      await setNotificationFlag(projectPath, 'securityEnhancementNotification', false);
+      return;
+    }
+
     const project = await readProjectConfiguration(apiResourceDir);
 
     const directiveMap = collectDirectivesByTypeNames(project.schema);


### PR DESCRIPTION
#### Description of changes
- fix notification logic when API resource directory doesn't exist, for example when api is added with `amplify codegen add --apiId {apiId}`

#### Issue #9721

#### Description of how you validated changes
- manual testing 
-- `amplify init` (remove `securityEnhancementNotification` or init with an older API)
-- `amplify codegen add --apiId {apiId}`
-- `amplify push`
- `yarn test` 
- unit tests added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
