### PR TITLE
ci: retry failed e2e test in ci 

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -103,15 +103,7 @@ function retry {
     do
         echo "Attempting $@ with max retries $MAX_ATTEMPTS"
         setAwsAccountCredentials
-        if [ -f  $FAILED_TEST_REGEX_FILE ]; then
-            # read the content of failed tests
-            faileTests=$(<$FAILED_TEST_REGEX_FILE)
-            cmd="$@ -t \"$faileTests\""
-            eval ${cmd} && break
-        else
-            # is it is not exist then it will be printed
-            "$@" && break
-        fi
+        "$@" && break
         n=$[$n+1]
         FIRST_RUN=false
         echo "Attempt $n completed."

--- a/packages/amplify-e2e-core/failed-test-reporter.js
+++ b/packages/amplify-e2e-core/failed-test-reporter.js
@@ -1,0 +1,34 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+function escapeRegex(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+class FailedTestNameReporter {
+  constructor(globalConfig, options) {
+    this._globalConfig = globalConfig;
+    this._options = options;
+  }
+
+  onRunComplete(contexts, results) {
+    const failedTests = this.getFailedTestRegEx(results);
+    const result = failedTests.map(title => escapeRegex(title)).join('|');
+    const failedTestReportPath = this._options.reportPath || './amplify-e2e-reports/amplify-e2e-failed-test.txt';
+    fs.writeFileSync(path.resolve(failedTestReportPath), result);
+  }
+
+  getFailedTestRegEx(results) {
+    let failedTestNames = [];
+    if (results.testResults) {
+      for (let result of results.testResults) {
+        failedTestNames = [...failedTestNames, ...this.getFailedTestRegEx(result)];
+      }
+    } else if (results.status === 'failed') {
+      failedTestNames.push(results.title);
+    }
+
+    return failedTestNames;
+  }
+}
+
+module.exports = FailedTestNameReporter;

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -78,6 +78,12 @@
           "filename": "index.html",
           "expand": true
         }
+      ],
+      [
+        "amplify-e2e-core/failed-test-reporter",
+        {
+          "reportPath": "./amplify-e2e-reports/amplify-e2e-failed-test.txt"
+        }
       ]
     ],
     "moduleFileExtensions": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
E2E tests are flaky due to the resource constraint and cause the pipeline to fail frequently. When the tests fail, all the tests in that suite gets rerun instead of the ones that failed. This causes the retry to run longer and makes probability of already passed test failing possible. With this change, the retry will run only the failed tests when retrying to run them.

This is an example execution where the only the failed tests were re-run
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/6576/workflows/bb0bd11d-18c7-41ef-8e80-ca607a04ea40/jobs/165144/parallel-runs/0/steps/0-106

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
