### PR TITLE
fix(graphql-auth-transformer): update resolver should allow if update operation is set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,6 +42,7 @@ module.exports = {
     '<rootDir>/packages/amplify-frontend-ios',
     '<rootDir>/packages/amplify-frontend-javascript',
     // '<rootDir>/packages/amplify-graphiql-explorer',
+    '<rootDir>/packages/amplify-graphql-auth-transformer',
     '<rootDir>/packages/amplify-graphql-function-transformer',
     '<rootDir>/packages/amplify-graphql-http-transformer',
     '<rootDir>/packages/amplify-graphql-index-transformer',

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/group-auth.test.ts
@@ -230,9 +230,6 @@ test('dynamic group auth generates authorized fields list correctly', () => {
             #if( !$groupAllowedFields0.isEmpty() || !$groupNullAllowedFields0.isEmpty() )
               $util.qr($allowedFields.addAll($groupAllowedFields0))
               $util.qr($nullAllowedFields.addAll($groupNullAllowedFields0))
-            #else
-              #set( $isAuthorized = true )
-              #break
             #end
           #end
         #end

--- a/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
+++ b/packages/amplify-graphql-auth-transformer/src/graphql-auth-transformer.ts
@@ -744,6 +744,8 @@ Static group authorization should perform as expected.`,
       const roleDefinition = this.roleMap.get(role)!;
       roleDefinition.allowedFields = allowedFields.length === fields.length ? [] : [...allowedFields, ...dataStoreFields];
       roleDefinition.nullAllowedFields = nullAllowedFields.length === fields.length ? [] : nullAllowedFields;
+      roleDefinition.areAllFieldsAllowed = allowedFields.length === fields.length;
+      roleDefinition.areAllFieldsNullAllowed = nullAllowedFields.length === fields.length;
       return roleDefinition;
     });
     const datasource = ctx.api.host.getDataSource(`${def.name.value}Table`) as DataSourceProvider;

--- a/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/utils/definitions.ts
@@ -53,6 +53,8 @@ export interface RoleDefinition {
   // specific to mutations
   allowedFields?: Array<string>;
   nullAllowedFields?: Array<string>;
+  areAllFieldsAllowed?: boolean;
+  areAllFieldsNullAllowed?: boolean;
 }
 
 export interface AuthDirective {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -782,12 +782,7 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
     #set( $ownerAllowedFields0 = [] )
     #set( $ownerNullAllowedFields0 = [] )
     #if( $ownerEntity0 == $ownerClaim0 )
-      #if( !$ownerAllowedFields0.isEmpty() || !$ownerNullAllowedFields0.isEmpty() )
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-        $util.qr($nullAllowedFields.addAll($ownerNullAllowedFields0))
-      #else
-        #set( $isAuthorized = true )
-      #end
+      #set( $isAuthorized = true )
     #end
   #end
 #end

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -426,6 +426,95 @@ describe('@model operations', () => {
     });
     expect(deleteResponseAsEditor.hadException).toEqual(false);
   });
+
+  test('explicit operations where update restricted', () => {
+    const validSchema = `
+      type Post @model @auth(rules: [
+        { allow: owner, operations: [create, read, delete] },
+        ]) {
+        id: ID
+        name: String
+        owner: String
+      }`;
+    const out = transformer.transform(validSchema);
+    expect(out).toBeDefined();
+    // load vtl templates
+    const createRequestTemplate = out.resolvers['Mutation.createPost.auth.1.req.vtl'];
+    const readRequestTemplate = out.resolvers['Query.listPosts.auth.1.req.vtl'];
+    const updateResponseTemplate = out.resolvers['Mutation.updatePost.auth.1.res.vtl'];
+    const deleteResponseTemplate = out.resolvers['Mutation.deletePost.auth.1.res.vtl'];
+
+    // run the create request as owner should fail if the input is different the signed in owner
+    const createRequestAsNonOwner = vtlTemplate.render(createRequestTemplate, {
+      context: createPostInput('user2'),
+      requestParameters: ownerRequest,
+    });
+    expect(createRequestAsNonOwner.hadException).toEqual(true);
+
+    const createRequestAsOwner = vtlTemplate.render(createRequestTemplate, {
+      context: createPostInput('user1'),
+      requestParameters: ownerRequest,
+    });
+    expect(createRequestAsOwner.hadException).toEqual(false);
+
+    // read should have filter
+    const readRequestAsOwner = vtlTemplate.render(readRequestTemplate, { context: {}, requestParameters: ownerRequest });
+    expect(readRequestAsOwner.stash.hasAuth).toEqual(true);
+    expect(readRequestAsOwner.stash.authFilter).toEqual(
+      expect.objectContaining({
+        or: [{ owner: { eq: 'user1' } }],
+      }),
+    );
+
+    // read should have filter
+    const readRequestAsNonOwner = vtlTemplate.render(readRequestTemplate, { context: {}, requestParameters: adminGroupRequest });
+    expect(readRequestAsNonOwner.stash.authFilter).toEqual(
+      expect.objectContaining({
+        or: [{ owner: { eq: 'user2' } }],
+      }),
+    );
+
+    // update should fail for owner
+    const ddbUpdateResult: AppSyncVTLContext = {
+      result: { id: '001', name: 'sample', owner: 'user1' },
+      arguments: {
+        input: {
+          id: '001',
+          name: 'sample',
+        },
+      },
+    };
+    const updateResponseAsOwner = vtlTemplate.render(updateResponseTemplate, {
+      context: ddbUpdateResult,
+      requestParameters: ownerRequest,
+    });
+    expect(updateResponseAsOwner.hadException).toEqual(true);
+
+    // update should fail for NON owner
+    const updateResponseAsNonOwner = vtlTemplate.render(updateResponseTemplate, {
+      context: ddbUpdateResult,
+      requestParameters: adminGroupRequest,
+    });
+    expect(updateResponseAsNonOwner.hadException).toEqual(true);
+
+    // delete should fail for non owner
+    const ddbDeleteResult: AppSyncVTLContext = {
+      result: { id: '001', name: 'sample', owner: 'user1' },
+    };
+    const deleteResponseAsNonOwner = vtlTemplate.render(deleteResponseTemplate, {
+      context: ddbDeleteResult,
+      requestParameters: adminGroupRequest,
+    });
+    expect(deleteResponseAsNonOwner.hadException).toEqual(true);
+
+    // delete should pass for owner
+    const deleteResponseAsOwner = vtlTemplate.render(deleteResponseTemplate, {
+      context: ddbDeleteResult,
+      requestParameters: ownerRequest,
+    });
+    expect(deleteResponseAsOwner.hadException).toEqual(false);
+    expect(deleteResponseAsOwner.stash.hasAuth).toEqual(true);
+  });
 });
 
 describe('@model field auth', () => {
@@ -582,7 +671,7 @@ describe('@model @primaryIndex @index auth', () => {
     const validSchema = `
     type FamilyMember @model @auth(rules: [
       { allow: owner, ownerField: "parent", operations: [read] },
-      { allow: owner, ownerField: "child", operations: [read] } 
+      { allow: owner, ownerField: "child", operations: [read] }
     ]){
       parent: ID! @primaryKey(sortKeyFields: ["child"]) @index(name: "byParent", queryField: "byParent")
       child: ID! @index(name: "byChild", queryField: "byChild")


### PR DESCRIPTION
#### Description of changes
- pass parameters into update resolver to properly identity when empty list refers to allow all

#### Description of how you validated changes
- manual testing
- `yarn test` passes
-  e2e passes
- unit test and e2e test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
