### PR TITLE
fix(amplify-category-function): add length validation for secret value

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.test.ts
@@ -1,0 +1,10 @@
+import { secretValueValidator } from '../../../../provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough';
+
+describe('Check not valid secret values', () => {
+  it('Empty value', () => {
+    expect(secretValueValidator()('')).toEqual('Secret value must be between 1 and 2048 characters long');
+  });
+  it('Value over 2048 characters', () => {
+    expect(secretValueValidator()('a'.repeat(2049))).toEqual('Secret value must be between 1 and 2048 characters long');
+  });
+});

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.test.ts
@@ -2,9 +2,9 @@ import { secretValueValidator } from '../../../../provider-utils/awscloudformati
 
 describe('Check not valid secret values', () => {
   it('Empty value', () => {
-    expect(secretValueValidator()('')).toEqual('Secret value must be between 1 and 2048 characters long');
+    expect(secretValueValidator('')).toEqual('Secret value must be between 1 and 2048 characters long');
   });
   it('Value over 2048 characters', () => {
-    expect(secretValueValidator()('a'.repeat(2049))).toEqual('Secret value must be between 1 and 2048 characters long');
+    expect(secretValueValidator('a'.repeat(2049))).toEqual('Secret value must be between 1 and 2048 characters long');
   });
 });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
@@ -176,7 +176,7 @@ const enterSecretName = async (invalidNames: string[]) =>
 
 const secretValueDefaultMessage = (secretName: string) => `Enter the value for ${secretName}:`;
 
-const secretValueValidator = () => (input?: string) => {
+export const secretValueValidator = () => (input?: string) => {
   if (!input || input.length === 0 || input.length > 2048) {
     return 'Secret value must be between 1 and 2048 characters long';
   }

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
@@ -176,7 +176,7 @@ const enterSecretName = async (invalidNames: string[]) =>
 
 const secretValueDefaultMessage = (secretName: string) => `Enter the value for ${secretName}:`;
 
-export const secretValueValidator = () => (input?: string) => {
+export const secretValueValidator = (input?: string) => {
   if (typeof input !== 'string' || input.length === 0 || input.length > 2048) {
     return 'Secret value must be between 1 and 2048 characters long';
   }
@@ -189,7 +189,7 @@ const enterSecretValue = async (message: string) =>
       type: 'password',
       name: 'secretValue',
       message,
-      validate: secretValueValidator(),
+      validate: secretValueValidator,
     })
   ).secretValue;
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
@@ -177,7 +177,7 @@ const enterSecretName = async (invalidNames: string[]) =>
 const secretValueDefaultMessage = (secretName: string) => `Enter the value for ${secretName}:`;
 
 export const secretValueValidator = () => (input?: string) => {
-  if (!input || input.length === 0 || input.length > 2048) {
+  if (typeof input !== 'string' || input.length === 0 || input.length > 2048) {
     return 'Secret value must be between 1 and 2048 characters long';
   }
   return true;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
@@ -176,12 +176,20 @@ const enterSecretName = async (invalidNames: string[]) =>
 
 const secretValueDefaultMessage = (secretName: string) => `Enter the value for ${secretName}:`;
 
+const secretValueValidator = () => (input?: string) => {
+  if (!input || input.length === 0 || input.length > 2048) {
+    return 'Secret value must be between 1 and 2048 characters long';
+  }
+  return true;
+};
+
 const enterSecretValue = async (message: string) =>
   (
     await inquirer.prompt<{ secretValue: string }>({
       type: 'password',
       name: 'secretValue',
       message,
+      validate: secretValueValidator(),
     })
   ).secretValue;
 


### PR DESCRIPTION
#### Description of changes
Validate that the secret value provided by the user has a length between 1 and 2048 characters

#### Issue #, if available
Closes #8304

#### Description of how you validated changes
The cli now doesn't allow you to continue until you have provided a valid secret value, similar to how the validation of the secret name works.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.