### PR TITLE
fix: move searchable parameters to api stack V2

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/graphql-searchable-transformer.ts
@@ -91,7 +91,7 @@ export class SearchableModelTransformer extends TransformerPluginBase {
     stack.templateOptions.description = 'An auto-generated nested stack for searchable.';
     stack.templateOptions.templateFormatVersion = '2010-09-09';
 
-    const parameterMap = createParametersInStack(stack);
+    const parameterMap = createParametersInStack(context.stackManager.rootStack);
 
     const domain = createSearchableDomain(stack, parameterMap, context.api.apiId);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The parameters for OpenSearch should be created in the API stack since they're not easily set in the child stack. Brings us back into alignment with docs.

A related docs PR to switch from elastic to opensearch: https://github.com/aws-amplify/docs/pull/4066

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#9728

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Created an application and validated that I could set the searchable instance type

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
