### PR TITLE
fix: set secretsPathAmplfiyAppId on initEnv when function has secrets

### DIFF
--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -163,7 +163,7 @@ export async function initEnv(context) {
       }
 
       // if the function has secrets, set the appId key in team-provider-info
-      if (!!getLocalFunctionSecretNames(resourceName, { fromCurrentCloudBackend: true }).length) {
+      if (getLocalFunctionSecretNames(resourceName, { fromCurrentCloudBackend: true }).length > 0) {
         _.set(teamProviderInfo, [envName, 'categories', categoryName, resourceName, secretsPathAmplifyAppIdKey], getAppId());
       }
     });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When pulling or checking out a new environment that had a function with secrets configured, the `secretsPathAmplifyAppId` parameter was not being populated in `team-provider-info.json`. This causes push failures when the parameter cannot be resolved.

The fix updates the function category initEnv logic to copy the appId from `amplify-meta.json` into the correct location in `team-provider-info.json` on init env. This follows the same patter for updating the s3 bucket and key for the function zip asset.

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/8513
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit test and manually verified that pulling a project into a new directory and then pushing works.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
