### PR TITLE
fix: improve error message on custom policies validation failure

### DIFF
--- a/packages/amplify-cli-core/src/customPoliciesUtils.ts
+++ b/packages/amplify-cli-core/src/customPoliciesUtils.ts
@@ -3,7 +3,7 @@ import { pathManager, stateManager } from './state-manager';
 import Ajv from 'ajv';
 import { EOL } from 'os';
 import * as _ from 'lodash';
-import { printer } from 'amplify-prompts';
+import { formatter, printer } from 'amplify-prompts';
 import { JSONUtilities } from './jsonUtilities';
 import { CustomPoliciesFormatError } from './errors';
 
@@ -103,14 +103,13 @@ function validateCustomPolicies(data: CustomIAMPolicies, categoryName: string, r
   const validatePolicy = ajv.compile(CustomIAMPoliciesSchema);
   const valid = validatePolicy(data);
   if (!valid) {
-    let errorMessage = `Invalid custom IAM policies in the ${resourceName} ${categoryName}.\n
-    Edit <project-dir>/amplify/backend/function/${resourceName}/custom-policies.json to fix
-    Learn more about custom IAM policies for ${categoryName}: https://docs.amplify.aws/cli/function/#access-existing-aws-resource-from-lambda-function\n`;
-    if (validatePolicy && validatePolicy.errors) {
-      errorMessage += validatePolicy.errors?.map((error: Ajv.ErrorObject) => error.message).join(EOL);
-    }
-
-    throw new CustomPoliciesFormatError(errorMessage);
+    printer.error(`${resourceName} ${categoryName} custom-policies.json failed validation:`);
+    formatter.list((validatePolicy?.errors || []).map(err => `${err.dataPath} ${err.message}`));
+    throw new CustomPoliciesFormatError(`
+      Invalid custom IAM policies for ${resourceName} ${categoryName}.
+      See details above and fix errors in <project-dir>/amplify/backend/${categoryName}/${resourceName}/custom-policies.json.
+      Learn more about custom IAM policies: https://docs.amplify.aws/cli/function/#access-existing-aws-resource-from-lambda-function
+    `);
   }
 
   for (const customPolicy of data) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Improve error message when custom-policies.json validation fails. The message will now include the path with the failure message.
#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/9861
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested manually. Message used to look like:
```
✖ An error occurred when pushing the resources to the cloud
🛑 An error occurred during the push operation: Invalid custom IAM policies in the envvartest function.

    Edit <project-dir>/amplify/backend/function/envvartest/custom-policies.json to fix
    Learn more about custom IAM policies for function: https://docs.amplify.aws/cli/function/#access-existing-aws-resource-from-lambda-function
should be array
```
and now looks like:
```
🛑 envvartest function custom-policies.json failed validation:
- [0].Resource should be array
✖ An error occurred when pushing the resources to the cloud
🛑 An error occurred during the push operation: 
      Invalid custom IAM policies for envvartest function.
      See details above and fix errors in <project-dir>/amplify/backend/function/envvartest/custom-policies.json.
      Learn more about custom IAM policies: https://docs.amplify.aws/cli/function/#access-existing-aws-resource-from-lam
```
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
