### PR TITLE
fix: allow api updates without migration

### DIFF
--- a/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
+++ b/packages/amplify-category-api/src/__tests__/provider-utils/awscloudformation/cfn-api-artifact-handler.test.ts
@@ -260,6 +260,7 @@ describe('update artifacts', () => {
   it('updates correct cli-inputs', async () => {
     updateRequestStub.serviceModification.additionalAuthTypes = [{ mode: 'AWS_IAM' }, { mode: 'API_KEY' }];
     jest.spyOn(AppsyncApiInputState.prototype, 'saveCLIInputPayload');
+    jest.spyOn(AppsyncApiInputState.prototype, 'cliInputFileExists').mockReturnValueOnce(true);
     jest.spyOn(AppsyncApiInputState.prototype, 'getCLIInputPayload').mockReturnValue({
       serviceConfiguration: {
         apiName: 'testApiName',

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -240,10 +240,7 @@ export const executeAmplifyHeadlessCommand = async (context: $TSContext, headles
       break;
     case 'update':
       const resourceName = await getAppSyncApiResourceName(context);
-      if (!(await checkAppsyncApiResourceMigration(context, resourceName, true))) {
-        printer.error('Update operations only work on migrated projects. Run "amplify update api" and opt for migration.');
-        exitOnNextTick(0);
-      }
+      await checkAppsyncApiResourceMigration(context, resourceName, true);
       await getCfnApiArtifactHandler(context).updateArtifacts(await validateUpdateApiRequest(headlessPayload));
       break;
     default:

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -300,7 +300,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
 
   /**
    * If the resource is migrated, updates cli-inputs.json with the specified updates
-   * If not migrated, this method is a noop (but still retusn the schema path)
+   * If not migrated, this method is a noop (but still returns the schema path)
    * @param updates The updates to apply
    * @param apiName The api name
    * @returns The gqlSchemaPath

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/cfn-api-artifact-handler.ts
@@ -110,12 +110,12 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
     }
     const resourceDir = this.getResourceDir(apiName);
     // update appsync cli-inputs
-    const appsyncCLIInputs = await this.updateAppsyncCLIInputs(updates, apiName);
+    const gqlSchemaPath = await this.updateAppsyncCLIInputs(updates, apiName);
     if (updates.transformSchema) {
-      this.writeSchema(appsyncCLIInputs.serviceConfiguration.gqlSchemaPath, updates.transformSchema);
+      this.writeSchema(gqlSchemaPath, updates.transformSchema);
     }
     if (updates.conflictResolution) {
-      updates.conflictResolution = await this.createResolverResources(appsyncCLIInputs.serviceConfiguration.conflictResolution);
+      updates.conflictResolution = await this.createResolverResources(updates.conflictResolution);
       await writeResolverConfig(updates.conflictResolution, resourceDir);
     }
 
@@ -298,13 +298,24 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
     return appsyncCLIInputs;
   };
 
-  private updateAppsyncCLIInputs = async (updates: AppSyncServiceModification, apiName: string) => {
+  /**
+   * If the resource is migrated, updates cli-inputs.json with the specified updates
+   * If not migrated, this method is a noop (but still retusn the schema path)
+   * @param updates The updates to apply
+   * @param apiName The api name
+   * @returns The gqlSchemaPath
+   */
+  private updateAppsyncCLIInputs = async (updates: AppSyncServiceModification, apiName: string): Promise<string> => {
     const cliState = new AppsyncApiInputState(apiName);
+    const gqlSchemaPath = path.join(this.getResourceDir(apiName), gqlSchemaFilename);
+    if (!cliState.cliInputFileExists()) {
+      return gqlSchemaPath;
+    }
     const prevAppsyncInputs = cliState.getCLIInputPayload();
 
     const appsyncInputs: AppSyncCLIInputs = prevAppsyncInputs;
     if (!_.isEmpty(appsyncInputs.serviceConfiguration)) {
-      appsyncInputs.serviceConfiguration.gqlSchemaPath = path.join(this.getResourceDir(apiName), gqlSchemaFilename);
+      appsyncInputs.serviceConfiguration.gqlSchemaPath = gqlSchemaPath;
     }
     if (updates.conflictResolution) {
       appsyncInputs.serviceConfiguration.conflictResolution = updates.conflictResolution;
@@ -316,7 +327,7 @@ class CfnApiArtifactHandler implements ApiArtifactHandler {
       appsyncInputs.serviceConfiguration.additionalAuthTypes = updates.additionalAuthTypes;
     }
     await cliState.saveCLIInputPayload(appsyncInputs);
-    return appsyncInputs;
+    return gqlSchemaPath;
   };
 }
 

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -463,10 +463,7 @@ export const updateWalkthrough = async (context: $TSContext): Promise<UpdateApiR
   }
 
   // migrate API project
-  if (!(await checkAppsyncApiResourceMigration(context, resourceName, true))) {
-    printer.error('Update operations only work on migrated projects. Run "amplify update api" and opt for migration.');
-    exitOnNextTick(0);
-  }
+  await checkAppsyncApiResourceMigration(context, resourceName, true);
 
   // Get models
   const project = await readProjectConfiguration(resourceDir);

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -1,7 +1,16 @@
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
-import { addFeatureFlag, checkIfBucketExists, ExecutionContext, getCLIPath, getProjectMeta, nspawn as spawn, setTransformerVersionFlag, updateSchema } from '..';
+import {
+  addFeatureFlag,
+  checkIfBucketExists,
+  ExecutionContext,
+  getCLIPath,
+  getProjectMeta,
+  nspawn as spawn,
+  setTransformerVersionFlag,
+  updateSchema,
+} from '..';
 import { multiSelect, singleSelect } from '../utils/selectors';
 import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
@@ -280,12 +289,13 @@ export function updateApiSchema(cwd: string, projectName: string, schemaName: st
   updateSchema(cwd, projectName, schemaText);
 }
 
-export function updateApiWithMultiAuth(cwd: string, settings: any) {
+export function updateApiWithMultiAuth(cwd: string, settings?: { testingWithLatestCodebase?: boolean; doMigrate?: boolean }) {
   return new Promise<void>((resolve, reject) => {
     const testingWithLatestCodebase = settings?.testingWithLatestCodebase ?? false;
     const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true });
     chain.wait('Select from one of the below mentioned services:').sendCarriageReturn();
-    if (testingWithLatestCodebase === true) {
+    const doMigrate = settings?.doMigrate || testingWithLatestCodebase;
+    if (doMigrate) {
       chain.wait('Do you want to migrate api resource').sendConfirmYes();
     }
     chain
@@ -883,4 +893,4 @@ export async function validateRestApiMeta(projRoot: string, meta?: any) {
     seenAtLeastOneFunc = true;
   }
   expect(seenAtLeastOneFunc).toBe(true);
-};
+}

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -294,9 +294,14 @@ export function updateApiWithMultiAuth(cwd: string, settings?: { testingWithLate
     const testingWithLatestCodebase = settings?.testingWithLatestCodebase ?? false;
     const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true });
     chain.wait('Select from one of the below mentioned services:').sendCarriageReturn();
-    const doMigrate = settings?.doMigrate || testingWithLatestCodebase;
-    if (doMigrate) {
-      chain.wait('Do you want to migrate api resource').sendConfirmYes();
+    const doMigrate = settings?.doMigrate ?? testingWithLatestCodebase;
+    if (testingWithLatestCodebase) {
+      chain.wait('Do you want to migrate api resource');
+      if (doMigrate) {
+        chain.sendConfirmYes();
+      } else {
+        chain.sendConfirmNo();
+      }
     }
     chain
       .wait(/.*Select a setting to edit.*/)

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -139,6 +139,10 @@ function setParameters(projRoot: string, category: string, resourceName: string,
   JSONUtilities.writeJson(parametersPath, parameters);
 }
 
+export function cliInputsExists(projRoot: string, category: string, resourceName: string): boolean {
+  return fs.existsSync(getCLIInputsPath(projRoot, category, resourceName));
+}
+
 export function getCLIInputs(projRoot: string, category: string, resourceName: string): any {
   const parametersPath = getCLIInputsPath(projRoot, category, resourceName);
   return JSONUtilities.parse(fs.readFileSync(parametersPath, 'utf8'));

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
@@ -7,7 +7,6 @@ import {
   deleteProjectDir,
   getAppSyncApi,
   getCLIInputs,
-  getProjectConfig,
   getProjectMeta,
   getProjectSchema,
   getSchemaPath,
@@ -46,6 +45,56 @@ describe('api migration update test', () => {
     await amplifyPush(projRoot);
     // update and push with codebase
     await updateApiWithMultiAuth(projRoot, { testingWithLatestCodebase: true });
+    // cli-inputs should exist
+    expect(getCLIInputs(projRoot, 'api', 'simplemodelmultiauth')).toBeDefined();
+    await amplifyPushUpdate(projRoot, undefined, true, true);
+
+    const meta = getProjectMeta(projRoot);
+    const { output } = meta.api.simplemodelmultiauth;
+    const { GraphQLAPIIdOutput, GraphQLAPIEndpointOutput, GraphQLAPIKeyOutput } = output;
+    const { graphqlApi } = await getAppSyncApi(GraphQLAPIIdOutput, meta.providers.awscloudformation.Region);
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.authenticationType).toEqual('API_KEY');
+    expect(graphqlApi.additionalAuthenticationProviders).toHaveLength(3);
+    expect(graphqlApi.additionalAuthenticationProviders).toHaveLength(3);
+
+    const cognito = graphqlApi.additionalAuthenticationProviders.filter(a => a.authenticationType === 'AMAZON_COGNITO_USER_POOLS')[0];
+
+    expect(cognito).toBeDefined();
+    expect(cognito.userPoolConfig).toBeDefined();
+
+    const iam = graphqlApi.additionalAuthenticationProviders.filter(a => a.authenticationType === 'AWS_IAM')[0];
+
+    expect(iam).toBeDefined();
+
+    const oidc = graphqlApi.additionalAuthenticationProviders.filter(a => a.authenticationType === 'OPENID_CONNECT')[0];
+
+    expect(oidc).toBeDefined();
+    expect(oidc.openIDConnectConfig).toBeDefined();
+    expect(oidc.openIDConnectConfig.issuer).toEqual('https://facebook.com/');
+    expect(oidc.openIDConnectConfig.clientId).toEqual('clientId');
+    expect(oidc.openIDConnectConfig.iatTTL).toEqual(1000);
+    expect(oidc.openIDConnectConfig.authTTL).toEqual(2000);
+
+    expect(GraphQLAPIIdOutput).toBeDefined();
+    expect(GraphQLAPIEndpointOutput).toBeDefined();
+    expect(GraphQLAPIKeyOutput).toBeDefined();
+
+    expect(graphqlApi).toBeDefined();
+    expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
+  });
+
+  // This test is the same as the one above except the api is NOT migrated on update.
+  // This checks that new versions of the CLI can still update non-migrated APIs
+  it('allows api updates without api migration', async () => {
+    // init and add api with installed CLI
+    await initJSProjectWithProfile(projRoot, { name: 'simplemodelmultiauth' });
+    await addApiWithoutSchemaOldDx(projRoot);
+    await updateApiSchema(projRoot, 'simplemodelmultiauth', 'simple_model.graphql');
+    await amplifyPush(projRoot);
+    // update and push with codebase
+    await updateApiWithMultiAuth(projRoot, { testingWithLatestCodebase: true, doMigrate: false });
     // cli-inputs should exist
     expect(getCLIInputs(projRoot, 'api', 'simplemodelmultiauth')).toBeDefined();
     await amplifyPushUpdate(projRoot, undefined, true, true);

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/api-migration.test.ts
@@ -2,6 +2,7 @@ import {
   addHeadlessApi,
   amplifyPush,
   amplifyPushUpdate,
+  cliInputsExists,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
@@ -95,8 +96,8 @@ describe('api migration update test', () => {
     await amplifyPush(projRoot);
     // update and push with codebase
     await updateApiWithMultiAuth(projRoot, { testingWithLatestCodebase: true, doMigrate: false });
-    // cli-inputs should exist
-    expect(getCLIInputs(projRoot, 'api', 'simplemodelmultiauth')).toBeDefined();
+    // cli-inputs should not exist
+    expect(cliInputsExists(projRoot, 'api', 'simplemodelmultiauth')).toBe(false);
     await amplifyPushUpdate(projRoot, undefined, true, true);
 
     const meta = getProjectMeta(projRoot);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When extensibility was implemented, api updates were blocked unless the resource was migrated. This change allows updates to the resource without requiring an update

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/9675
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manually verified and added a migration e2e test
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
