### PR TITLE
fix(cli): spinner hiding prompt

### DIFF
--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "open": "^8.4.0",
+    "ora": "^4.0.3",
     "proxy-agent": "^5.0.0",
     "semver": "^7.3.5",
     "typescript-json-schema": "~0.52.0",

--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -31,6 +31,7 @@ export * from './category-interfaces';
 export * from './customPoliciesUtils';
 export * from './utils/doc-links';
 export * from './utils/gql-transformer-version';
+export * from './spinner';
 
 // Temporary types until we can finish full type definition across the whole CLI
 

--- a/packages/amplify-cli-core/src/spinner/index.ts
+++ b/packages/amplify-cli-core/src/spinner/index.ts
@@ -1,0 +1,2 @@
+import ora, { Ora } from 'ora';
+export const spinner : Ora = new (ora as any)();

--- a/packages/amplify-cli-core/src/spinner/index.ts
+++ b/packages/amplify-cli-core/src/spinner/index.ts
@@ -1,2 +1,3 @@
 import ora, { Ora } from 'ora';
+
 export const spinner : Ora = new (ora as any)();

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -1,10 +1,9 @@
-import { $TSAny, $TSContext, JSONUtilities, PathConstants, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, JSONUtilities, PathConstants, stateManager, spinner } from 'amplify-cli-core';
 import { ResourceExport } from './resource-package/resource-export';
 import { ResourceDefinition, StackIncludeDetails, StackParameters } from './resource-package/types';
 import * as path from 'path';
 import { printer, prompter } from 'amplify-prompts';
 import * as fs from 'fs-extra';
-import Ora from 'ora';
 const backup = 'backup';
 import _ from 'lodash';
 import rimraf from 'rimraf';
@@ -31,7 +30,6 @@ export async function run(context: $TSContext, resourceDefinition: $TSAny[], exp
     return;
   }
 
-  const spinner = Ora('Exporting...');
   spinner.start();
   try {
     const resourceExport = new ResourceExport(context, amplifyExportFolder);

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -7,6 +7,7 @@ import {
   readCFNTemplate,
   stateManager,
   writeCFNTemplate,
+  spinner,
 } from 'amplify-cli-core';
 import _ from 'lodash';
 import { legacyLayerMigration, prePushLambdaLayerPrompt } from '../lambdaLayerInvocations';
@@ -106,7 +107,9 @@ export abstract class ResourcePackager {
     )) {
       await legacyLayerMigration(this.context, lambdaLayerResource.resourceName);
     }
+    spinner.stop();
     await prePushLambdaLayerPrompt(this.context, resources);
+    spinner.start();
     return resources;
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The spinner interfered with the prompt in Lambda Layers when exporting it, this change creates a singleton by exporting it in the core
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
