### PR TITLE
fix(amplify-category-api): remove stack trace from printout for api

### DIFF
--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -224,6 +224,9 @@ export async function executeAmplifyCommand(context: $TSContext) {
   } catch (error) {
     if (error) {
       printer.error(error.message || error);
+      if(error.stack) {
+        printer.debug(error.stack);
+      }
       await context.usageData.emitError(error);
     }
     process.exitCode = 1;

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -224,7 +224,7 @@ export async function executeAmplifyCommand(context: $TSContext) {
   } catch (error) {
     if (error) {
       printer.error(error.message || error);
-      if(error.stack) {
+      if (error.stack) {
         printer.debug(error.stack);
       }
       await context.usageData.emitError(error);

--- a/packages/amplify-category-api/src/index.ts
+++ b/packages/amplify-category-api/src/index.ts
@@ -224,9 +224,6 @@ export async function executeAmplifyCommand(context: $TSContext) {
   } catch (error) {
     if (error) {
       printer.error(error.message || error);
-      if (error.stack) {
-        printer.info(error.stack);
-      }
       await context.usageData.emitError(error);
     }
     process.exitCode = 1;


### PR DESCRIPTION
We're barfing stack traces for many error conditions in the API category with an explicit print,
this is removing that

fix #9825

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Removes an explicit printout of the stack trace in the API category. An error was showing up in GQL transform in `push` and `gql-compile`, but push is just printing the error without the trace because it has separate logic. This brings the two into alignment

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#9825 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Triggered the error and saw it without stack trace on `gql-compile`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
