### PR TITLE
fix: add HostedUIProvider dependency to OAuth Custom Lambda

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -1545,6 +1545,7 @@ exports.handler = (event, context, callback) => {
     "OAuthCustomResource": Object {
       "DependsOn": Array [
         "HostedUICustomResourceInputs",
+        "HostedUIProvidersCustomResourceInputs",
       ],
       "Properties": Object {
         "Code": Object {

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
@@ -1,0 +1,28 @@
+import { AmplifyAuthCognitoStack } from '../../../../provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder';
+import { AuthStackSynthesizer } from '../../../../provider-utils/awscloudformation/auth-stack-builder/stack-synthesizer';
+import * as cdk from '@aws-cdk/core';
+import * as iam from '@aws-cdk/aws-iam';
+
+describe('generateCognitoStackResources', () => {
+  it('adds correct custom oauth lambda dependencies', () => {
+    const testApp = new cdk.App();
+    const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'testCognitoStack', { synthesizer: new AuthStackSynthesizer() });
+    cognitoStack.userPoolClientRole = new iam.CfnRole(cognitoStack, 'testRole', {
+      assumeRolePolicyDocument: 'test policy document',
+    });
+    cognitoStack.createHostedUICustomResource();
+    cognitoStack.createHostedUIProviderCustomResource();
+    cognitoStack.createOAuthCustomResource();
+    expect(cognitoStack.oAuthCustomResource).toBeDefined();
+    expect(
+      cognitoStack
+        .oAuthCustomResource!.node!.dependencies!.map((dep: any) => dep.target.logicalId)
+        .map(logicalIdToken => /testCognitoStack\.([^\.]+)\.Default/.exec(logicalIdToken)![1]),
+    ).toMatchInlineSnapshot(`
+      Array [
+        "HostedUICustomResourceInputs",
+        "HostedUIProvidersCustomResourceInputs",
+      ]
+    `);
+  });
+});

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -461,13 +461,13 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
 
       this.createUserPoolClientCustomResource(props);
       if (props.hostedUIDomainName) {
-        this.createHostedUICustomResource(props);
+        this.createHostedUICustomResource();
       }
       if (props.hostedUIProviderMeta) {
-        this.createHostedUIProviderCustomResource(props);
+        this.createHostedUIProviderCustomResource();
       }
       if (props.oAuthMetadata) {
-        this.createOAuthCustomResource(props);
+        this.createOAuthCustomResource();
       }
       if (!props.useEnabledMfas && props.mfaConfiguration != 'OFF') {
         this.createMFACustomResource(props);
@@ -653,7 +653,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
     this.userPoolClientInputs.node.addDependency(this.userPoolClientLogPolicy);
   }
 
-  createHostedUICustomResource(props: CognitoStackOptions) {
+  createHostedUICustomResource() {
     // lambda function
     this.hostedUICustomResource = new lambda.CfnFunction(this, 'HostedUICustomResource', {
       code: {
@@ -731,7 +731,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
     this.hostedUICustomResourceInputs.node.addDependency(this.hostedUICustomResourceLogPolicy);
   }
 
-  createHostedUIProviderCustomResource(props: CognitoStackOptions) {
+  createHostedUIProviderCustomResource() {
     // lambda function
     this.hostedUIProvidersCustomResource = new lambda.CfnFunction(this, 'HostedUIProvidersCustomResource', {
       code: {
@@ -811,7 +811,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
     this.hostedUIProvidersCustomResourceInputs.node.addDependency(this.hostedUIProvidersCustomResourceLogPolicy);
   }
 
-  createOAuthCustomResource(props: CognitoStackOptions) {
+  createOAuthCustomResource() {
     // lambda function
     this.oAuthCustomResource = new lambda.CfnFunction(this, 'OAuthCustomResource', {
       code: {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -822,8 +822,9 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs12.x',
       timeout: 300,
     });
-    //TODO
+
     this.oAuthCustomResource.node.addDependency(this.hostedUICustomResourceInputs!.node!.defaultChild!);
+    this.oAuthCustomResource.node.addDependency(this.hostedUIProvidersCustomResourceInputs!.node!.defaultChild!);
 
     // userPool client lambda policy
     /**

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -15,7 +15,7 @@ import {
   $TSAny,
 } from 'amplify-cli-core';
 import { AmplifyAuthCognitoStack } from './auth-cognito-stack-builder';
-import { AuthStackSythesizer } from './stack-synthesizer';
+import { AuthStackSynthesizer } from './stack-synthesizer';
 import * as cdk from '@aws-cdk/core';
 import { AuthInputState } from '../auth-inputs-manager/auth-input-state';
 import { CognitoStackOptions, AuthTriggerConnection, AuthTriggerPermissions } from '../service-walkthrough-types/cognito-user-input-types';
@@ -34,13 +34,13 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
   private _category: string;
   private _service: string;
   private _authTemplateObj: AmplifyAuthCognitoStack; // Props to modify Root stack data
-  private _synthesizer: AuthStackSythesizer;
+  private _synthesizer: AuthStackSynthesizer;
   private _cliInputs: CognitoCLIInputs;
   private _cognitoStackProps: CognitoStackOptions;
 
   constructor(resourceName: string) {
     super(resourceName);
-    this._synthesizer = new AuthStackSythesizer();
+    this._synthesizer = new AuthStackSynthesizer();
     this._app = new cdk.App();
     this._category = AmplifyCategories.AUTH;
     this._service = AmplifySupportedService.COGNITO;

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/stack-synthesizer.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/stack-synthesizer.ts
@@ -3,7 +3,7 @@ import { Template } from 'cloudform-types';
 import { AmplifyAuthCognitoStack } from './auth-cognito-stack-builder';
 import { AmplifyUserPoolGroupStack, AmplifyUserPoolGroupStackOutputs } from './auth-user-pool-group-stack-builder';
 
-export class AuthStackSythesizer extends LegacyStackSynthesizer {
+export class AuthStackSynthesizer extends LegacyStackSynthesizer {
   private readonly stacks: Map<string, Stack> = new Map();
   private static readonly stackAssets: Map<string, Template> = new Map();
 
@@ -25,11 +25,11 @@ export class AuthStackSythesizer extends LegacyStackSynthesizer {
   }
 
   setStackAsset(templateName: string, template: string): void {
-    AuthStackSythesizer.stackAssets.set(templateName, JSON.parse(template));
+    AuthStackSynthesizer.stackAssets.set(templateName, JSON.parse(template));
   }
 
   collectStacks(): Map<string, Template> {
-    return new Map(AuthStackSythesizer.stackAssets.entries());
+    return new Map(AuthStackSynthesizer.stackAssets.entries());
   }
 
   addStack(stack: Stack) {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -12,7 +12,7 @@ import {
   AmplifyCategoryTransform,
   $TSAny,
 } from 'amplify-cli-core';
-import { AuthStackSythesizer } from './stack-synthesizer';
+import { AuthStackSynthesizer } from './stack-synthesizer';
 import * as cdk from '@aws-cdk/core';
 import { AuthInputState } from '../auth-inputs-manager/auth-input-state';
 import * as path from 'path';
@@ -39,8 +39,8 @@ export type AmplifyUserPoolGroupStackOptions = {
 export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
   private _app: cdk.App;
   private _userPoolGroupTemplateObj: AmplifyUserPoolGroupStack; // Props to modify Root stack data
-  private _synthesizer: AuthStackSythesizer;
-  private _synthesizerOutputs: AuthStackSythesizer;
+  private _synthesizer: AuthStackSynthesizer;
+  private _synthesizerOutputs: AuthStackSynthesizer;
   private __userPoolGroupTemplateObjOutputs: AmplifyUserPoolGroupStackOutputs;
   private _authResourceName: string;
   private _category: string;
@@ -52,8 +52,8 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
     super(resourceName);
     this._authResourceName = resourceName;
     this._resourceName = 'userPoolGroups';
-    this._synthesizer = new AuthStackSythesizer();
-    this._synthesizerOutputs = new AuthStackSythesizer();
+    this._synthesizer = new AuthStackSynthesizer();
+    this._synthesizerOutputs = new AuthStackSynthesizer();
     this._app = new cdk.App();
     this._category = AmplifyCategories.AUTH;
     this._service = AmplifySupportedService.COGNITOUSERPOOLGROUPS;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds a dependency from the oAuthCustomResource to the hostedUIProvidersCustomResource. The lack of this dependency caused push failures when updating oAuth config with a new provider as the new provider was not added before attempting to update the provider config.

Also removed some unused method parameters and fixed a class name typo.

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/7388
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified and added a unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
