### PR TITLE
feat(geo): add headless command for map remove

### DIFF
--- a/packages/amplify-category-geo/src/index.ts
+++ b/packages/amplify-category-geo/src/index.ts
@@ -8,7 +8,7 @@ import * as helpCommand from './commands/geo/help';
 import { getServicePermissionPolicies } from './service-utils/resourceUtils';
 import { ServiceName } from './service-utils/constants';
 import { printer } from 'amplify-prompts';
-import { addResourceHeadless, updateResourceHeadless } from './provider-controllers';
+import { addResourceHeadless, updateResourceHeadless, removeResourceHeadless } from './provider-controllers';
 
 export const executeAmplifyCommand = async (context: $TSContext) => {
   switch (context.input.command) {
@@ -75,6 +75,9 @@ export const getPermissionPolicies = (context: $TSContext, resourceOpsMapping: $
       break;
     case 'update':
       await updateResourceHeadless(context, headlessPayload);
+      break;
+    case 'remove':
+      await removeResourceHeadless(context, headlessPayload);
       break;
     default:
       printer.error(`Headless mode for ${context.input.command} geo is not implemented yet`);

--- a/packages/amplify-category-geo/src/provider-controllers/index.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/index.ts
@@ -3,11 +3,11 @@ import { ServiceName, provider } from '../service-utils/constants';
 import { $TSObject, open, stateManager } from 'amplify-cli-core';
 import { $TSContext } from 'amplify-cli-core';
 import { addPlaceIndexResource, updatePlaceIndexResource, removePlaceIndexResource } from './placeIndex';
-import { addMapResource, updateMapResource, removeMapResource, addMapResourceHeadless, updateMapResourceHeadless } from './map';
+import { addMapResource, updateMapResource, removeMapResource, addMapResourceHeadless, updateMapResourceHeadless, removeMapResourceHeadless } from './map';
 import { printer, prompter } from 'amplify-prompts';
 import { getServiceFriendlyName } from '../service-walkthroughs/resourceWalkthrough';
 import { TemplateMappings } from '../service-stacks/baseStack';
-import { validateAddGeoRequest, validateUpdateGeoRequest } from 'amplify-util-headless-input';
+import { validateAddGeoRequest, validateUpdateGeoRequest, validateRemoveGeoRequest } from 'amplify-util-headless-input';
 import { checkGeoResourceExists } from '../service-utils/resourceUtils';
 
 /**
@@ -163,6 +163,26 @@ export const updateResourceHeadless = async (
   switch (serviceName) {
     case ServiceName.Map:
       return updateMapResourceHeadless(context, serviceModification);
+    default:
+      throw badHeadlessServiceError(serviceName);
+  }
+};
+
+/**
+ * Entry point for headless command of removing an existing Geo resource
+ */
+ export const removeResourceHeadless = async (
+  context: $TSContext,
+  headlessPayload: string
+): Promise<string | undefined> => {
+  const { serviceRemoval } = await validateRemoveGeoRequest(headlessPayload);
+  const { serviceName, name } = serviceRemoval;
+  if (!await checkGeoResourceExists(name)) {
+    throw new Error(`Geo resource with name '${name}' does not exist.`)
+  }
+  switch (serviceName) {
+    case ServiceName.Map:
+      return removeMapResourceHeadless(context, serviceRemoval);
     default:
       throw badHeadlessServiceError(serviceName);
   }

--- a/packages/amplify-category-geo/src/provider-controllers/map.ts
+++ b/packages/amplify-category-geo/src/provider-controllers/map.ts
@@ -10,7 +10,7 @@ import { printer } from 'amplify-prompts';
 import { getMapStyleComponents } from '../service-utils/mapParams';
 import { GeoServiceConfiguration, GeoServiceModification, GeoServiceRemoval } from 'amplify-headless-interface';
 import { merge } from '../service-utils/resourceUtils';
-import { checkGeoResourceExists, updateDefaultResource } from '../service-utils/resourceUtils';
+import { updateDefaultResource } from '../service-utils/resourceUtils';
 
 export const addMapResource = async (
   context: $TSContext

--- a/packages/amplify-e2e-core/src/utils/headless.ts
+++ b/packages/amplify-e2e-core/src/utils/headless.ts
@@ -9,7 +9,8 @@ import {
   UpdateApiRequest,
   UpdateAuthRequest,
   UpdateStorageRequest,
-  UpdateGeoRequest
+  UpdateGeoRequest,
+  RemoveGeoRequest
 } from 'amplify-headless-interface';
 import execa, { ExecaChildProcess } from 'execa';
 import { getCLIPath } from '..';
@@ -78,6 +79,10 @@ export const updateHeadlessGeo = async (cwd: string, request: UpdateGeoRequest):
   return await executeHeadlessCommand(cwd, 'geo', 'update', request);
 }
 
+export const removeHeadlessGeo = async (cwd: string, request: RemoveGeoRequest): Promise<ExecaChildProcess<String>> => {
+  return await executeHeadlessCommand(cwd, 'geo', 'remove', request);
+}
+
 const headlessRemoveResource = async (cwd: string, category: string, resourceName: string): Promise<ExecaChildProcess<String>> => {
   return await execa(getCLIPath(), ['remove', category, resourceName, '--yes'], { cwd });
 };
@@ -110,4 +115,5 @@ type AnyHeadlessRequest =
   | RemoveStorageRequest
   | UpdateStorageRequest
   | AddGeoRequest
-  | UpdateGeoRequest;
+  | UpdateGeoRequest
+  | RemoveGeoRequest;

--- a/packages/amplify-headless-interface/schemas/geo/1/RemoveGeoRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/geo/1/RemoveGeoRequest.schema.json
@@ -1,0 +1,69 @@
+{
+    "description": "Defines the json object expected by `amplify remove geo --headless`",
+    "type": "object",
+    "properties": {
+        "version": {
+            "description": "The schema version.",
+            "type": "number",
+            "enum": [
+                1
+            ]
+        },
+        "serviceRemoval": {
+            "description": "The service configuration that will be interpreted by Amplify.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/BaseGeoServiceRemoval"
+                },
+                {
+                    "$ref": "#/definitions/MapRemoval"
+                }
+            ]
+        }
+    },
+    "required": [
+        "serviceRemoval",
+        "version"
+    ],
+    "definitions": {
+        "BaseGeoServiceRemoval": {
+            "description": "Configuration that applies to all geo service removal.",
+            "type": "object",
+            "properties": {
+                "serviceName": {
+                    "description": "The service name of the resource provider.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the map that will be removed.",
+                    "type": "string"
+                },
+                "newDefaultResourceName": {
+                    "description": "Optional param. The name of new default resource when the removed one is default",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "serviceName"
+            ]
+        },
+        "MapRemoval": {
+            "description": "Specifies configuration for map.",
+            "type": "object",
+            "properties": {
+                "serviceName": {
+                    "description": "The service name of the resource provider.",
+                    "type": "string",
+                    "enum": [
+                        "Map"
+                    ]
+                }
+            },
+            "required": [
+                "serviceName"
+            ]
+        }
+    },
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/amplify-headless-interface/scripts/generateSchemas.ts
+++ b/packages/amplify-headless-interface/scripts/generateSchemas.ts
@@ -57,6 +57,11 @@ const typeDefs: TypeDef[] = [
     typeName: 'UpdateGeoRequest',
     category: 'geo',
     relativeSourcePaths: ['add.ts', 'update.ts'].map(file => path.join('geo', file)),
+  },
+  {
+    typeName: 'RemoveGeoRequest',
+    category: 'geo',
+    relativeSourcePaths: [path.join('geo', 'remove.ts')],
   }
 ];
 

--- a/packages/amplify-headless-interface/src/index.ts
+++ b/packages/amplify-headless-interface/src/index.ts
@@ -6,3 +6,4 @@ export * from './interface/auth/import';
 export * from './interface/storage';
 export * from './interface/geo/add';
 export * from './interface/geo/update';
+export * from './interface/geo/remove';

--- a/packages/amplify-headless-interface/src/interface/geo/remove.ts
+++ b/packages/amplify-headless-interface/src/interface/geo/remove.ts
@@ -1,0 +1,44 @@
+/**
+ * Defines the json object expected by `amplify remove geo --headless`
+ */
+ export interface RemoveGeoRequest {
+  /**
+   * The schema version.
+   */
+  version: 1;
+  /**
+   * The service removal that will be interpreted by Amplify.
+   */
+  serviceRemoval: GeoServiceRemoval;
+}
+/**
+ * Defines the removed AWS Location Service parameters.
+ */
+ export type GeoServiceRemoval = BaseGeoServiceRemoval & MapRemoval;
+
+ /**
+  * Configuration that applies to all geo service removal.
+  */
+ export interface BaseGeoServiceRemoval {
+   /**
+    * The service name of the resource provider.
+    */
+   serviceName: string;
+   /**
+    * The name of the map that will be removed.
+    */
+   name: string;
+   /**
+    * Optional param. The name of new default resource when the removed one is default
+    */
+   newDefaultResourceName?: string;
+ }
+ /**
+  * Specifies configuration for map.
+  */
+ export interface MapRemoval {
+   /**
+    * The service name of the resource provider.
+    */
+   serviceName: "Map";
+ }

--- a/packages/amplify-util-headless-input/src/__tests__/assets/geo/remove/validRequest.map.json
+++ b/packages/amplify-util-headless-input/src/__tests__/assets/geo/remove/validRequest.map.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "serviceRemoval":{
+    "serviceName": "Map",
+    "name": "mymapname",
+    "newDefaultResourceName": "mynewdefaultmap"
+  }
+}

--- a/packages/amplify-util-headless-input/src/__tests__/geo/remove/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/remove/__snapshots__/index.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validate remove geo request returns valid payload for map 1`] = `
+Object {
+  "serviceRemoval": Object {
+    "name": "mymapname",
+    "newDefaultResourceName": "mynewdefaultmap",
+    "serviceName": "Map",
+  },
+  "version": 1,
+}
+`;

--- a/packages/amplify-util-headless-input/src/__tests__/geo/remove/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/remove/index.test.ts
@@ -1,0 +1,18 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { validateRemoveGeoRequest } from '../../../index';
+
+const assetRoot = path.resolve(path.join(__dirname, '..', '..', 'assets'));
+
+describe('validate remove geo request', () => {
+  it('returns valid payload for map', async () => {
+    const rawRequest = fs.readFileSync(path.join(assetRoot, 'geo', 'remove', 'validRequest.map.json'), 'utf8');
+    const result = await validateRemoveGeoRequest(rawRequest);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('rejects promise when invalid payload', async () => {
+    const resultPromise = validateRemoveGeoRequest('garbage');
+    expect(resultPromise).rejects.toBeTruthy();
+  });
+});

--- a/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { validateAddGeoRequest, validateUpdateGeoRequest } from '../../../index';
+import { validateUpdateGeoRequest } from '../../../index';
 
 const assetRoot = path.resolve(path.join(__dirname, '..', '..', 'assets'));
 

--- a/packages/amplify-util-headless-input/src/index.ts
+++ b/packages/amplify-util-headless-input/src/index.ts
@@ -10,6 +10,7 @@ import {
   UpdateStorageRequest,
   AddGeoRequest,
   UpdateGeoRequest,
+  RemoveGeoRequest
 } from 'amplify-headless-interface';
 import { HeadlessInputValidator } from './HeadlessInputValidator';
 import {
@@ -24,6 +25,7 @@ import {
   updateStorageRequestSchemaSupplier,
   addGeoRequestSchemaSupplier,
   updateGeoRequestSchemaSupplier,
+  removeGeoRequestSchemaSupplier
 } from './schemaSuppliers';
 import { authUpgradePipeline, noopUpgradePipeline } from './upgradePipelines';
 
@@ -73,4 +75,8 @@ export const validateAddGeoRequest = (raw: string) => {
 
 export const validateUpdateGeoRequest = (raw: string) => {
   return new HeadlessInputValidator(updateGeoRequestSchemaSupplier, noopUpgradePipeline).validate<UpdateGeoRequest>(raw);
+};
+
+export const validateRemoveGeoRequest = (raw: string) => {
+  return new HeadlessInputValidator(removeGeoRequestSchemaSupplier, noopUpgradePipeline).validate<RemoveGeoRequest>(raw);
 };

--- a/packages/amplify-util-headless-input/src/schemaSuppliers.ts
+++ b/packages/amplify-util-headless-input/src/schemaSuppliers.ts
@@ -44,6 +44,10 @@ export const updateGeoRequestSchemaSupplier: VersionedSchemaSupplier = version =
   return getSchema('UpdateGeoRequest', 'geo', version);
 }
 
+export const removeGeoRequestSchemaSupplier: VersionedSchemaSupplier = version => {
+  return getSchema('RemoveGeoRequest', 'geo', version);
+}
+
 const getSchema = async (type: string, category: string, version: number) => {
   try {
     return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add headless command for removing map in geo category, including

- Interface and schema definition for headless payload
- Headless entry point for remove in geo category
- Unit and e2e tests

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
