### PR TITLE
fix: fixes preSignup trigger naming

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
@@ -2,6 +2,7 @@ import { AmplifyAuthCognitoStack } from '../../../../provider-utils/awscloudform
 import { AuthStackSynthesizer } from '../../../../provider-utils/awscloudformation/auth-stack-builder/stack-synthesizer';
 import * as cdk from '@aws-cdk/core';
 import * as iam from '@aws-cdk/aws-iam';
+import { CognitoStackOptions } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/cognito-user-input-types';
 
 describe('generateCognitoStackResources', () => {
   it('adds correct custom oauth lambda dependencies', () => {
@@ -24,5 +25,91 @@ describe('generateCognitoStackResources', () => {
         "HostedUIProvidersCustomResourceInputs",
       ]
     `);
+  });
+
+  it('adds correct preSignUp  lambda config and permissions', () => {
+    const testApp = new cdk.App();
+    const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoPreSignUpTriggerTest', { synthesizer: new AuthStackSynthesizer() });
+    const props : CognitoStackOptions = {
+        "identityPoolName": "issue96802f106de3_identitypool_2f106de3",
+        "allowUnauthenticatedIdentities": false,
+        "resourceNameTruncated": "issue92f106de3",
+        "userPoolName": "issue96802f106de3_userpool_2f106de3",
+        "autoVerifiedAttributes": [
+          "email"
+        ],
+        "mfaConfiguration": "OFF",
+        "mfaTypes": [
+          "SMS Text Message"
+        ],
+        "smsAuthenticationMessage": "Your authentication code is {####}",
+        "smsVerificationMessage": "Your verification code is {####}",
+        "emailVerificationSubject": "Your verification code",
+        "emailVerificationMessage": "Your verification code is {####}",
+        "passwordPolicyMinLength": 8,
+        "passwordPolicyCharacters": [],
+        "requiredAttributes": [
+          "email"
+        ],
+        "aliasAttributes": [],
+        "userpoolClientGenerateSecret": false,
+        "userpoolClientRefreshTokenValidity": 30,
+        "userpoolClientWriteAttributes": [
+          "email"
+        ],
+        "userpoolClientReadAttributes": [
+          "email"
+        ],
+        "userpoolClientLambdaRole": "issue92f106de3_userpoolclient_lambda_role",
+        "userpoolClientSetAttributes": false,
+        "sharedId": "2f106de3",
+        "resourceName": "issue96802f106de32f106de3",
+        "authSelections": "identityPoolAndUserPool",
+        "useDefault": "manual",
+        "thirdPartyAuth": false,
+        "userPoolGroups": false,
+        "adminQueries": false,
+        "triggers": {
+          "PreSignup": [
+            "custom"
+          ]
+        },
+        "hostedUI": false,
+        "userPoolGroupList": [],
+        "serviceName": "Cognito",
+        "usernameCaseSensitive": false,
+        "useEnabledMfas": true,
+        "authRoleArn": {
+          "Fn::GetAtt": [
+            "AuthRole",
+            "Arn"
+          ]
+        },
+        "unauthRoleArn": {
+          "Fn::GetAtt": [
+            "UnauthRole",
+            "Arn"
+          ]
+        },
+        "breakCircularDependency": false,
+        "dependsOn": [
+          {
+            "category": "function",
+            "resourceName": "issue96802f106de32f106de3PreSignup",
+            "attributes": [
+              "Arn",
+              "Name"
+            ]
+          }
+        ],
+        "permissions": [],
+        "authTriggerConnections": [
+          {triggerType: "PreSignUp",lambdaFunctionName: "issue96802f106de32f106de3PreSignup"}
+        ],
+        "authProviders": [],
+      }
+    cognitoStack.generateCognitoStackResources(props);
+    expect(cognitoStack.userPool!.lambdaConfig).toHaveProperty('preSignUp');
+    expect(cognitoStack.lambdaConfigPermissions).toHaveProperty('UserPoolPreSignupLambdaInvokePermission');
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -28,7 +28,7 @@ const LambdaTriggersKeys = [
   'PostAuthentication',
   'PostConfirmation',
   'PreAuthentication',
-  'PreSignUp',
+  'PreSignup',
   'PreTokenGeneration',
   'VerifyAuthChallengeResponse',
 ];
@@ -349,10 +349,10 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
               preAuthentication: cdk.Fn.ref(`function${props.resourceName}${'PreAuthentication'}Arn`),
             };
           }
-          if (trigger.resourceName.includes('PreSignUp')) {
+          if (trigger.resourceName.includes('PreSignup')) {
             this.userPool!.lambdaConfig = {
               ...this.userPool!.lambdaConfig,
-              preSignUp: cdk.Fn.ref(`function${props.resourceName}${'PreSignUp'}Arn`),
+              preSignUp: cdk.Fn.ref(`function${props.resourceName}${'PreSignup'}Arn`),
             };
           }
           if (trigger.resourceName.includes('PreTokenGeneration')) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- PreSignUp naming bug fix 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #9680

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested
- added unit test checks for permissions

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
