### PR TITLE
Fix uibuilder e2e tests

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -23,7 +23,7 @@
     "aws-sdk": "2.1084.0"
   },
   "devDependencies": {
-    "@aws-amplify/codegen-ui": "*"
+    "@aws-amplify/codegen-ui": "2.1.0"
   },
   "jest": {
     "testRunner": "jest-circus/runner",

--- a/packages/amplify-util-uibuilder/src/commands/utils/createUiBuilderComponent.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/createUiBuilderComponent.ts
@@ -1,4 +1,4 @@
-import { StudioTemplateRendererManager, StudioTemplateRendererFactory, StudioTemplateRenderer, FrameworkOutputManager, RenderTextComponentResponse } from '@aws-amplify/codegen-ui-old';
+import { StudioTemplateRendererManager, StudioComponent, StudioTemplateRendererFactory, StudioTemplateRenderer, FrameworkOutputManager, RenderTextComponentResponse } from '@aws-amplify/codegen-ui-old';
 import {
   AmplifyRenderer,
   ReactThemeStudioTemplateRenderer,
@@ -20,16 +20,24 @@ const config = {
   renderTypeDeclarations: true,
 };
 
-const isUpdatedSchema = (schema: StudioComponentNew) => {
-  return schema.schemaVersion && schema.schemaVersion === '1.0'
-}
+const isUpdatedSchema = (schema: StudioComponent) => {
+  return (schema as unknown as StudioComponentNew).schemaVersion && (schema as unknown as StudioComponentNew).schemaVersion === '1.0';
+};
 
-export const createUiBuilderComponent = (context: $TSContext, schema: StudioComponentNew) => {
+export const createUiBuilderComponent = (context: $TSContext, schema: StudioComponent) => {
   if (isUpdatedSchema(schema)) {
-    return createUiBuilderComponentNew(context, schema);
+    return createUiBuilderComponentNew(context, schema as unknown as StudioComponentNew);
   }
   const uiBuilderComponentsPath = getUiBuilderComponentsPath(context);
-  const rendererFactory = new StudioTemplateRendererFactory((component: StudioComponentNew) => new AmplifyRenderer(component, config) as unknown as StudioTemplateRenderer<unknown, StudioComponentNew, FrameworkOutputManager<unknown>, RenderTextComponentResponse>);
+  const rendererFactory = new StudioTemplateRendererFactory(
+    (component: StudioComponent) =>
+      new AmplifyRenderer(component as StudioComponent, config) as unknown as StudioTemplateRenderer<
+        unknown,
+        StudioComponent,
+        FrameworkOutputManager<unknown>,
+        RenderTextComponentResponse
+      >,
+  );
 
   const outputPathDir = uiBuilderComponentsPath;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,6 @@
     "@aws-amplify/core" "4.3.11"
 
 "@aws-amplify/codegen-ui-new@npm:@aws-amplify/codegen-ui@2.1.0", "@aws-amplify/codegen-ui@2.1.0":
-  name "@aws-amplify/codegen-ui-new"
   version "2.1.0"
   resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.1.0.tgz#a75eaee407965ea34443e7a00c19115cba263d6a"
   integrity sha512-tWdYt4Vn8Y9CcYQ3eCGWQlPehna5SZATU9dus+t6cEcBQv+sFvBlM59N68B3SxOYAplPltSqdAJphHM+DFWIUQ==
@@ -109,7 +108,7 @@
     yup "^0.32.11"
 
 "@aws-amplify/codegen-ui-old@npm:@aws-amplify/codegen-ui@1.2.0", "@aws-amplify/codegen-ui@1.2.0":
-  name "@aws-amplify/codegen-ui-orig"
+  name "@aws-amplify/codegen-ui"
   version "1.2.0"
   resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-1.2.0.tgz#30b865eef7451d7cc8d1ae648f7d95638d9209f4"
   integrity sha512-UKULRKpQG8ABLNjEiLyGoR01PeDli90AbiX/z9RoyVntoyAqWIorYsZcvDh5kb5xhQySU/Rp9cKmZxbJqoxtcQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,7 @@
     "@aws-amplify/core" "4.3.11"
 
 "@aws-amplify/codegen-ui-new@npm:@aws-amplify/codegen-ui@2.1.0", "@aws-amplify/codegen-ui@2.1.0":
+  name "@aws-amplify/codegen-ui"
   version "2.1.0"
   resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.1.0.tgz#a75eaee407965ea34443e7a00c19115cba263d6a"
   integrity sha512-tWdYt4Vn8Y9CcYQ3eCGWQlPehna5SZATU9dus+t6cEcBQv+sFvBlM59N68B3SxOYAplPltSqdAJphHM+DFWIUQ==
@@ -135,13 +136,6 @@
     "@typescript/vfs" "~1.3.5"
     prettier "2.3.2"
     typescript "~4.4.4"
-
-"@aws-amplify/codegen-ui@*":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.1.2.tgz#2a278d4f0fc79a2328505b912aa3cf10d466507d"
-  integrity sha512-YdFS6McPyBBpBPDwPvcW1sww8rS0I6+djkCYkd9aorYXp/w5EWttJE/RFGDjsfTVK8Tfdts+o1JBH8rgNRrUiQ==
-  dependencies:
-    yup "^0.32.11"
 
 "@aws-amplify/core@4.3.11":
   version "4.3.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

A failing test is currently blocking the pipeline. This PR fixes the issue by correcting the node_modules path to codegen-ui that was causing the failure.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- e2e tests now pass
- ran uibuilder smoke tests on pkg-cli and amplify-dev

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
