### PR TITLE
fix(amplify-category-custom): validate that the project has been initialized

### DIFF
--- a/packages/amplify-category-custom/src/index.ts
+++ b/packages/amplify-category-custom/src/index.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, IAmplifyResource, pathManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, IAmplifyResource, stateManager } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
 import { buildCustomResources } from './utils/build-custom-resources';
@@ -18,7 +18,11 @@ export async function executeAmplifyCommand(context: $TSContext) {
 
   const commandModule = await import(commandPath);
 
-  pathManager.getAmplifyMetaFilePath();
+  // Check if project has been initialized
+  if (!stateManager.metaFileExists()) {
+    printer.error('Could not find the amplfiy-meta.json file. Make sure your project is initialized in the cloud.');
+    return;
+  }
 
   await commandModule.run(context);
 }

--- a/packages/amplify-category-custom/src/index.ts
+++ b/packages/amplify-category-custom/src/index.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, IAmplifyResource } from 'amplify-cli-core';
+import { $TSAny, $TSContext, IAmplifyResource, pathManager } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
 import { buildCustomResources } from './utils/build-custom-resources';
@@ -17,6 +17,8 @@ export async function executeAmplifyCommand(context: $TSContext) {
   }
 
   const commandModule = await import(commandPath);
+
+  pathManager.getAmplifyMetaFilePath();
 
   await commandModule.run(context);
 }


### PR DESCRIPTION
#### Description of changes

Get meta file to validate that the project has been initialized before running the command

#### Issue #, if available

Closes #8920 

#### Description of how you validated changes

It uses the `pathManager` to validate that the meta file exist, if it doesn't then the it will throw a `NotInitializedError` before trying to run the command. This applies for every command in the `custom` category.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
