### PR TITLE
fix: remove stray `undefined` message on `ctrl+c`

### DIFF
--- a/packages/amplify-category-storage/src/commands/storage/update.ts
+++ b/packages/amplify-category-storage/src/commands/storage/update.ts
@@ -27,7 +27,9 @@ export async function run(context: $TSContext) {
       }
     })
     .catch(async err => {
-      printer.info(err.stack);
+      if (err.stack){
+        printer.info(err.stack);
+      }
       printer.error('An error occurred when updating the storage resource');
 
       await context.usageData.emitError(err);

--- a/packages/amplify-category-storage/src/commands/storage/update.ts
+++ b/packages/amplify-category-storage/src/commands/storage/update.ts
@@ -27,7 +27,7 @@ export async function run(context: $TSContext) {
       }
     })
     .catch(async err => {
-      if (err.stack){
+      if (err.stack) {
         printer.info(err.stack);
       }
       printer.error('An error occurred when updating the storage resource');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
force ending `amplify update storage` does not print a stray undefined message
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Closes #9829

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran reproduction steps, `undefined` doesn't print anymore

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
