### PR TITLE
ci: prevent timeouts on scan_artifacts job

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -43,6 +43,7 @@ clean_e2e_resources: &clean_e2e_resources
 
 scan_e2e_test_artifacts: &scan_e2e_test_artifacts
   name: Scan And Cleanup E2E Test Artifacts
+  no_output_timeout: 90m
   command: |
     if ! yarn ts-node .circleci/scan_artifacts.ts; then
       echo "Cleaning the repository"
@@ -106,7 +107,7 @@ jobs:
       - run:
           name: Collect code coverage
           command: yarn coverage
-  
+
   lint:
     <<: *linux-e2e-executor
     steps:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently, stages are failing in CI because the `scan_artifacts` step takes longer than 10 minutes. CCI kills the process after it takes up 10m without emitting any output.

This PR adds a progress indicator so that on call dev can see the progress and timeouts are prevented.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

N/A
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
