### PR TITLE
ci: use large CCI hosts

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -20,7 +20,7 @@ executors:
     docker:
       - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
-    resource_class: medium
+    resource_class: large
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux
@@ -423,7 +423,7 @@ jobs:
 
   integration_test:
     working_directory: ~/repo
-    resource_class: medium
+    resource_class: large
     docker:
       - image: cypress/base:14.17.0
         environment:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I'm seeing e2e test hosts intermittently running out of memory (see example: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/6860/workflows/e647898f-ad82-46fe-95e2-0735b3310940/jobs/178939). This PR bumps our resource class so that this doesn't happen.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
