### PR TITLE
fix(test): check aws-exports on sandbox pull

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/init.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init.test.ts
@@ -51,6 +51,16 @@ describe('amplify init', () => {
     await amplifyInitSandbox(projRoot, {});
     const projectSchema = getProjectSchema(projRoot, 'amplifyDatasource');
     expect(projectSchema).toEqual(schemaBody.schema);
+    
+    const awsExportsPath = path.join(projRoot, 'src', 'aws-exports.js');
+    const modelsIndexPath = path.join(projRoot, 'src', 'models', 'index.js');
+    const modelsSchemaPath = path.join(projRoot, 'src', 'models', 'schema.js');
+    expect(
+      fs.existsSync(awsExportsPath) &&
+      fs.existsSync(modelsIndexPath) &&
+      fs.existsSync(modelsSchemaPath)
+    ).toBe(true);
+    
     await amplifyPush(projRoot);
   });
 


### PR DESCRIPTION
Update sandbox pull e2e test to validate aws-exports.js, models/index.js and models/schema.js files.