### PR TITLE
docs: ✏️ Provide useful default event structure for APIG fns

### DIFF
--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/event.json
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/event.json
@@ -1,5 +1,11 @@
 {
-  "key1": "value1",
-  "key2": "value2",
-  "key3": "value3"
+  "httpMethod": "POST",
+  "path": "/item",
+  "queryStringParameters": {
+    "limit": "10"
+  },
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": "{\"msg\":\"Hello from the event.json body\"}"
 }

--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/serverless/event.json
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/serverless/event.json
@@ -1,5 +1,11 @@
 {
-  "key1": "value1",
-  "key2": "value2",
-  "key3": "value3"
+  "httpMethod": "POST",
+  "path": "/item",
+  "queryStringParameters": {
+    "limit": "10"
+  },
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": "{\"msg\":\"Hello from the event.json body\"}"
 }


### PR DESCRIPTION
To be useful and perform correctly, the event.json structure needs to
conform to the Lambda proxy integration format.  The previous non-proxy
integration default is somewhat misleading.

It could be argued that even this update is slightly misleading since `queryStringParameters` would usually not be used with a `POST` event, but I thought it would be more helpful to include the most common parameters.


#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
