### PR TITLE
fix(amplify-category-auth): ensure owner is set when there is @auth owner directive

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/api_2.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/api_2.test.ts.snap
@@ -10,25 +10,23 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.unauthorized()
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"content\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #if( $ownerClaim0 == $ownerEntity0 )
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"content\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #if( $ownerClaim0 == $ownerEntity0 )
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
-    #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
-      $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #end
+  #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
+    $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
   #end
 #end
@@ -61,25 +59,23 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 $util.unauthorized()
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"content\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #if( $ownerClaim0 == $ownerEntity0 )
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"content\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #if( $ownerClaim0 == $ownerEntity0 )
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
-    #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
-      $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #end
+  #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
+    $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
   #end
 #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/amplify-admin-auth.test.ts.snap
@@ -150,12 +150,10 @@ exports[`admin roles should be return the field name inside field resolvers 1`] 
 $util.unauthorized()
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )
@@ -195,25 +193,23 @@ $util.unauthorized()
       #end
     #end
   #end
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"name\\",\\"description\\",\\"secretValue\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #if( $ownerClaim0 == $ownerEntity0 )
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"name\\",\\"description\\",\\"secretValue\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #if( $ownerClaim0 == $ownerEntity0 )
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
-    #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
-      $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #end
+  #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
+    $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
   #end
 #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/field-auth-argument.test.ts.snap
@@ -7,12 +7,10 @@ exports[`does not generate field resolvers when private rule takes precedence ov
 $util.unauthorized()
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )
@@ -46,12 +44,10 @@ exports[`generates field resolver for other provider rules even if private remov
   #end
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )
@@ -137,12 +133,10 @@ exports[`subscription disabled and userPools configured with non-nullable (requi
 "## [Start] Field Authorization Steps. **
 #set( $isAuthorized = false )
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )
@@ -178,12 +172,10 @@ exports[`subscription disabled and userPools configured with nullable fields top
 "## [Start] Field Authorization Steps. **
 #set( $isAuthorized = false )
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/__snapshots__/owner-auth.test.ts.snap
@@ -7,28 +7,26 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
 #set( $isAuthorized = false )
 #set( $allowedFields = [] )
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.editors, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"title\\",\\"editors\\",\\"createdAt\\",\\"updatedAt\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #foreach( $allowedOwner in $ownerEntity0 )
-      #if( $allowedOwner == $ownerClaim0 )
-        #if( $isAuthorizedOnAllFields0 )
-          #set( $isAuthorized = true )
-          #break
-        #else
-          $util.qr($allowedFields.addAll($ownerAllowedFields0))
-        #end
-      #end
-    #end
-    #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"editors\\") )
-      $util.qr($ctx.args.input.put(\\"editors\\", [$ownerClaim0]))
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.editors, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"title\\",\\"editors\\",\\"createdAt\\",\\"updatedAt\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #foreach( $allowedOwner in $ownerEntity0 )
+    #if( $allowedOwner == $ownerClaim0 )
       #if( $isAuthorizedOnAllFields0 )
         #set( $isAuthorized = true )
+        #break
       #else
         $util.qr($allowedFields.addAll($ownerAllowedFields0))
       #end
+    #end
+  #end
+  #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"editors\\") )
+    $util.qr($ctx.args.input.put(\\"editors\\", [$ownerClaim0]))
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
   #end
 #end

--- a/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/field-auth-argument.test.ts
@@ -174,12 +174,10 @@ describe('subscription disabled and userPools configured', () => {
 
         expect(out.resolvers['Student.ssn.req.vtl']).toMatchSnapshot();
         expect(out.resolvers['Student.ssn.req.vtl']).toContain(`#if( $util.authType() == "User Pool Authorization" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end`);
       });
@@ -259,12 +257,10 @@ describe('subscription disabled and userPools configured', () => {
 
         expect(out.resolvers['Student.ssn.req.vtl']).toMatchSnapshot();
         expect(out.resolvers['Student.ssn.req.vtl']).toContain(`#if( $util.authType() == "User Pool Authorization" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.source.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get("username"), $util.defaultIfNull($ctx.identity.claims.get("cognito:username"), "___xamznone____")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end`);
       });

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/field.ts
@@ -50,23 +50,20 @@ const generateDynamicAuthReadExpression = (roles: Array<RoleDefinition>, fields:
     const entityIsList = fieldIsList(fields, role.entity!);
     if (role.strategy === 'owner') {
       ownerExpressions.push(
-        iff(
-          not(ref(IS_AUTHORIZED_FLAG)),
-          compoundExpression([
-            set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.source.${role.entity!}`), nul())),
-            set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
-            ...(entityIsList
-              ? [
-                  forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
-                    iff(
-                      equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
-                      compoundExpression([set(ref(IS_AUTHORIZED_FLAG), bool(true)), raw('#break')]),
-                    ),
-                  ]),
-                ]
-              : [iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true)))]),
-          ]),
-        ),
+        compoundExpression([
+          set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.source.${role.entity!}`), nul())),
+          set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
+          ...(entityIsList
+            ? [
+                forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
+                  iff(
+                    equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
+                    compoundExpression([set(ref(IS_AUTHORIZED_FLAG), bool(true)), raw('#break')]),
+                  ),
+                ]),
+              ]
+            : [iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true)))]),
+        ]),
       );
     }
     if (role.strategy === 'groups') {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.create.ts
@@ -163,43 +163,40 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>, fields: ReadonlyArr
     const entityIsList = fieldIsList(fields, role.entity!);
     if (role.strategy === 'owner') {
       ownerExpression.push(
-        iff(
-          not(ref(IS_AUTHORIZED_FLAG)),
-          compoundExpression([
-            set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.args.input.${role.entity!}`), nul())),
-            set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
-            set(ref(`ownerAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
-            set(ref(`isAuthorizedOnAllFields${idx}`), bool(role.areAllFieldsAllowed)),
-            ...(entityIsList
-              ? [
-                  forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
-                    iff(
-                      equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
-                      addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`, true),
-                    ),
-                  ]),
-                ]
-              : [
+        compoundExpression([
+          set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.args.input.${role.entity!}`), nul())),
+          set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
+          set(ref(`ownerAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
+          set(ref(`isAuthorizedOnAllFields${idx}`), bool(role.areAllFieldsAllowed)),
+          ...(entityIsList
+            ? [
+                forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
                   iff(
-                    equals(ref(`ownerClaim${idx}`), ref(`ownerEntity${idx}`)),
-                    addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
+                    equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
+                    addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`, true),
                   ),
                 ]),
-            iff(
-              and([ref(`util.isNull($ownerEntity${idx})`), not(methodCall(ref('ctx.args.input.containsKey'), str(role.entity!)))]),
-              compoundExpression([
-                qref(
-                  methodCall(
-                    ref('ctx.args.input.put'),
-                    str(role.entity!),
-                    entityIsList ? list([ref(`ownerClaim${idx}`)]) : ref(`ownerClaim${idx}`),
-                  ),
+              ]
+            : [
+                iff(
+                  equals(ref(`ownerClaim${idx}`), ref(`ownerEntity${idx}`)),
+                  addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
                 ),
-                addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
               ]),
-            ),
-          ]),
-        ),
+          iff(
+            and([ref(`util.isNull($ownerEntity${idx})`), not(methodCall(ref('ctx.args.input.containsKey'), str(role.entity!)))]),
+            compoundExpression([
+              qref(
+                methodCall(
+                  ref('ctx.args.input.put'),
+                  str(role.entity!),
+                  entityIsList ? list([ref(`ownerClaim${idx}`)]) : ref(`ownerClaim${idx}`),
+                ),
+              ),
+              addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
+            ]),
+          ),
+        ]),
       );
     }
     if (role.strategy === 'groups') {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.delete.ts
@@ -120,20 +120,17 @@ const dynamicGroupRoleExpression = (roles: Array<RoleDefinition>, fields: Readon
     const entityIsList = fieldIsList(fields, role.entity!);
     if (role.strategy === 'owner') {
       ownerExpression.push(
-        iff(
-          not(ref(IS_AUTHORIZED_FLAG)),
-          compoundExpression([
-            set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.result.${role.entity!}`), nul())),
-            set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
-            ...(entityIsList
-              ? [
-                  forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
-                    iff(equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true))),
-                  ]),
-                ]
-              : [iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true)))]),
-          ]),
-        ),
+        compoundExpression([
+          set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.result.${role.entity!}`), nul())),
+          set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
+          ...(entityIsList
+            ? [
+                forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
+                  iff(equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true))),
+                ]),
+              ]
+            : [iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true)))]),
+        ]),
       );
     }
     if (role.strategy === 'groups') {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/mutation.update.ts
@@ -177,39 +177,36 @@ const dynamicGroupRoleExpression = (roles: Array<RoleDefinition>, fields: Readon
     const entityIsList = fieldIsList(fields, role.entity!);
     if (role.strategy === 'owner') {
       ownerExpression.push(
-        iff(
-          not(ref(IS_AUTHORIZED_FLAG)),
-          compoundExpression([
-            set(
-              ref(`ownerEntity${idx}`),
-              methodCall(ref('util.defaultIfNull'), ref(`ctx.result.${role.entity!}`), entityIsList ? list([]) : nul()),
-            ),
-            set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
-            set(ref(`ownerAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
-            set(ref(`ownerNullAllowedFields${idx}`), raw(JSON.stringify(role.nullAllowedFields))),
-            set(ref(`isAuthorizedOnAllFields${idx}`), bool(role.areAllFieldsAllowed && role.areAllFieldsNullAllowed)),
-            ...(entityIsList
-              ? [
-                  forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
-                    iff(
-                      equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
-                      addAllowedFieldsIfElse(
-                        `ownerAllowedFields${idx}`,
-                        `ownerNullAllowedFields${idx}`,
-                        `isAuthorizedOnAllFields${idx}`,
-                        true,
-                      ),
-                    ),
-                  ]),
-                ]
-              : [
+        compoundExpression([
+          set(
+            ref(`ownerEntity${idx}`),
+            methodCall(ref('util.defaultIfNull'), ref(`ctx.result.${role.entity!}`), entityIsList ? list([]) : nul()),
+          ),
+          set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
+          set(ref(`ownerAllowedFields${idx}`), raw(JSON.stringify(role.allowedFields))),
+          set(ref(`ownerNullAllowedFields${idx}`), raw(JSON.stringify(role.nullAllowedFields))),
+          set(ref(`isAuthorizedOnAllFields${idx}`), bool(role.areAllFieldsAllowed && role.areAllFieldsNullAllowed)),
+          ...(entityIsList
+            ? [
+                forEach(ref('allowedOwner'), ref(`ownerEntity${idx}`), [
                   iff(
-                    equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)),
-                    addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `ownerNullAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
+                    equals(ref('allowedOwner'), ref(`ownerClaim${idx}`)),
+                    addAllowedFieldsIfElse(
+                      `ownerAllowedFields${idx}`,
+                      `ownerNullAllowedFields${idx}`,
+                      `isAuthorizedOnAllFields${idx}`,
+                      true,
+                    ),
                   ),
                 ]),
-          ]),
-        ),
+              ]
+            : [
+                iff(
+                  equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)),
+                  addAllowedFieldsIfElse(`ownerAllowedFields${idx}`, `ownerNullAllowedFields${idx}`, `isAuthorizedOnAllFields${idx}`),
+                ),
+              ]),
+        ]),
       );
     }
     if (role.strategy === 'groups') {

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/subscriptions.ts
@@ -29,14 +29,11 @@ const dynamicRoleExpression = (roles: Array<RoleDefinition>): Array<Expression> 
   roles.forEach((role, idx) => {
     if (role.strategy === 'owner') {
       ownerExpression.push(
-        iff(
-          not(ref(IS_AUTHORIZED_FLAG)),
-          compoundExpression([
-            set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.args.${role.entity!}`), nul())),
-            set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
-            iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true))),
-          ]),
-        ),
+        compoundExpression([
+          set(ref(`ownerEntity${idx}`), methodCall(ref('util.defaultIfNull'), ref(`ctx.args.${role.entity!}`), nul())),
+          set(ref(`ownerClaim${idx}`), getOwnerClaim(role.claim!)),
+          iff(equals(ref(`ownerEntity${idx}`), ref(`ownerClaim${idx}`)), set(ref(IS_AUTHORIZED_FLAG), bool(true))),
+        ]),
       );
     }
   });

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/__snapshots__/amplify-graphql-many-to-many-transformer.test.ts.snap
@@ -559,25 +559,23 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #end
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #if( $ownerClaim0 == $ownerEntity0 )
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.args.input.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #if( $ownerClaim0 == $ownerEntity0 )
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
-    #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
-      $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-      #end
+  #end
+  #if( $util.isNull($ownerEntity0) && !$ctx.args.input.containsKey(\\"owner\\") )
+    $util.qr($ctx.args.input.put(\\"owner\\", $ownerClaim0))
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
     #end
   #end
 #end
@@ -643,12 +641,10 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #end
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.result.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #set( $isAuthorized = true )
-    #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.result.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #set( $isAuthorized = true )
   #end
 #end
 #if( !$isAuthorized )
@@ -777,19 +773,17 @@ $util.qr($ctx.stash.put(\\"hasAuth\\", true))
   #end
 #end
 #if( $util.authType() == \\"User Pool Authorization\\" )
-  #if( !$isAuthorized )
-    #set( $ownerEntity0 = $util.defaultIfNull($ctx.result.owner, null) )
-    #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
-    #set( $ownerAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
-    #set( $ownerNullAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
-    #set( $isAuthorizedOnAllFields0 = true )
-    #if( $ownerEntity0 == $ownerClaim0 )
-      #if( $isAuthorizedOnAllFields0 )
-        #set( $isAuthorized = true )
-      #else
-        $util.qr($allowedFields.addAll($ownerAllowedFields0))
-        $util.qr($nullAllowedFields.addAll($ownerNullAllowedFields0))
-      #end
+  #set( $ownerEntity0 = $util.defaultIfNull($ctx.result.owner, null) )
+  #set( $ownerClaim0 = $util.defaultIfNull($ctx.identity.claims.get(\\"username\\"), $util.defaultIfNull($ctx.identity.claims.get(\\"cognito:username\\"), \\"___xamznone____\\")) )
+  #set( $ownerAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
+  #set( $ownerNullAllowedFields0 = [\\"id\\",\\"fooID\\",\\"barID\\",\\"foo\\",\\"bar\\"] )
+  #set( $isAuthorizedOnAllFields0 = true )
+  #if( $ownerEntity0 == $ownerClaim0 )
+    #if( $isAuthorizedOnAllFields0 )
+      #set( $isAuthorized = true )
+    #else
+      $util.qr($allowedFields.addAll($ownerAllowedFields0))
+      $util.qr($nullAllowedFields.addAll($ownerNullAllowedFields0))
     #end
   #end
 #end

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/AuthV2Transformer.e2e.test.ts
@@ -2129,8 +2129,7 @@ describe('@model with @auth', () => {
     expect(ownedBy2.data.createAllThree).toBeTruthy();
     // set by input
     expect(ownedBy2.data.createAllThree.owner).toEqual('user2@test.com');
-    // not auto filled as the admin condition was met
-    expect(ownedBy2.data.createAllThree.editors).toBeNull();
+    expect(ownedBy2.data.createAllThree.editors).toEqual(['user1@test.com']);
     expect(ownedBy2.data.createAllThree.groups).toBeNull();
     expect(ownedBy2.data.createAllThree.alternativeGroup).toBeNull();
 

--- a/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
+++ b/packages/graphql-transformers-e2e-tests/src/__tests__/SearchableWithAuthV2.e2e.test.ts
@@ -141,7 +141,7 @@ beforeAll(async () => {
     downs: Int
     percentageUp: Float
     isPublished: Boolean
-    createdAt: AWSDateTime 
+    createdAt: AWSDateTime
     updatedAt: AWSDateTime
     owner: String
     groupsField: String
@@ -368,9 +368,7 @@ test('test Comments as user in writer group', async () => {
   });
   expect(writerResponse.data.searchComments).toBeDefined();
   expect(writerResponse.data.searchComments.items.length).toEqual(4);
-  // only ownerContent should have the owner name
-  // because the group permission was met we did not populate an owner field
-  // therefore there is no owner
+
   expect(writerResponse.data.searchComments.items).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -381,17 +379,17 @@ test('test Comments as user in writer group', async () => {
       expect.objectContaining({
         id: expect.any(String),
         content: 'content1',
-        owner: null,
+        owner: USERNAME2,
       }),
       expect.objectContaining({
         id: expect.any(String),
-        content: 'content1',
-        owner: null,
+        content: 'content2',
+        owner: USERNAME2,
       }),
       expect.objectContaining({
         id: expect.any(String),
         content: 'content3',
-        owner: null,
+        owner: USERNAME2,
       }),
     ]),
   );


### PR DESCRIPTION
#### Description of changes
- ensure owner is set when there is @auth owner directive

#### Issue [#9920](https://github.com/aws-amplify/amplify-cli/issues/9920)

#### Description of how you validated changes
- manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
