### PR TITLE
chore: explicitly declare some dependencies we're pulling implicitly today

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@commitlint/config-lerna-scopes": "^15.0.0",
     "@commitlint/cz-commitlint": "^15.0.0",
     "@commitlint/prompt": "^15.0.0",
+    "@types/glob": "^7.1.1",
     "@types/jest": "^26.0.20",
     "@types/js-yaml": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^4.14.2",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -45,6 +45,7 @@
     "yargs": "^15.1.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.149",
     "ts-node": "^8.10.2"
   },
   "jest": {

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -37,6 +37,7 @@
     "@aws-amplify/graphql-searchable-transformer": "0.13.4",
     "@aws-amplify/graphql-transformer-core": "0.16.2",
     "@aws-amplify/graphql-transformer-interfaces": "1.13.0",
+    "@aws-cdk/assert": "~1.124.0",
     "@aws-cdk/assets": "~1.124.0",
     "@aws-cdk/aws-apigatewayv2": "~1.124.0",
     "@aws-cdk/aws-autoscaling": "~1.124.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, some of the packages in the CLI repo have expectations around dependencies existing which they get transitively through lerna (i.e. I don't declare a dependency on `@types/lodash` but it exists in the root because at least 2 deps in the repo do depend on it). This makes a few of those explicit. These were identified while working through a workstream to separate graphql transformers into a new repo (which will be tracked separately).

#### Issue #, if available
N/A

#### Description of how you validated changes
Built and ran `yarn test` on the package.

After building, there were no changes to `yarn.lock` which is expected, since there should be no new or changed package version associated with this change, just ensuring that if we were to pull these repos apart, we maintain the right dep tree.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
