### PR TITLE
fix: use lib paths instead of src to reference submodule imports across data-cli split

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -21,7 +21,7 @@ import {
 } from '@aws-amplify/graphql-transformer-core';
 import { Template } from '@aws-amplify/graphql-transformer-core/lib/config/project-config';
 import { MapsToTransformer } from '@aws-amplify/graphql-maps-to-transformer';
-import { OverrideConfig } from '@aws-amplify/graphql-transformer-core/src/transformation/types';
+import { OverrideConfig } from '@aws-amplify/graphql-transformer-core/lib/transformation/types';
 import { AppSyncAuthConfiguration, TransformerPluginProvider } from '@aws-amplify/graphql-transformer-interfaces';
 import {
   $TSContext,

--- a/packages/graphql-elasticsearch-transformer/src/resources.ts
+++ b/packages/graphql-elasticsearch-transformer/src/resources.ts
@@ -24,7 +24,7 @@ import {
   methodCall,
 } from 'graphql-mapping-template';
 import { toUpper, plurality, graphqlName, ResourceConstants, ModelResourceIDs } from 'graphql-transformer-common';
-import { MappingParameters } from 'graphql-transformer-core/src/TransformerContext';
+import { MappingParameters } from 'graphql-transformer-core/lib/TransformerContext';
 
 export class ResourceFactory {
   public makeParams() {


### PR DESCRIPTION
#### Description of changes
While prepping to split the first round of data and cli packages, I realized we had a few places where we were importing locally from src, rather than from `lib` of the distributed package. This addresses the two issues I spotted. I was hoping to get a generalized solution and check in place using something like tslint/no-submodule-imports, but it looks like we aren't onboarded w/ tslint yet, and I couldn't get the eslint package no-internal-modules working quite as expected, so ended up just addressing these two.

#### Issue #, if available
N/A

#### Description of how you validated changes
Built and ran unit tests.

Current path imports (fails unless local)
* https://unpkg.com/@aws-amplify/graphql-transformer-core@0.16.2/src/transformation/types.d.ts
* https://unpkg.com/graphql-transformer-core@7.4.9/src/TransformerContext.d.ts

Updated path imports
* https://unpkg.com/@aws-amplify/graphql-transformer-core@0.16.2/lib/transformation/types.d.ts
* https://unpkg.com/graphql-transformer-core@7.4.9/lib/TransformerContext.d.ts

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
