### PR TITLE
fix(amplify-category-geo): trigger update auth flow to add cognito user group, add e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/categories/geo.ts
+++ b/packages/amplify-e2e-core/src/categories/geo.ts
@@ -44,11 +44,6 @@ export function addMapWithDefault(cwd: string, settings: GeoConfig = {}): Promis
       .wait('Who can access this Map?')
       .sendCarriageReturn();
 
-    if (config.isFirstGeoResource === true) {
-      chain.wait('Are you tracking commercial assets for your business in your app?').sendCarriageReturn();
-      chain.wait('Successfully set RequestBasedUsage pricing plan for your Geo resources.');
-    }
-
     chain.wait('Do you want to configure advanced settings?').sendConfirmNo();
 
     if (config.isAdditional === true) {
@@ -85,11 +80,6 @@ export function addPlaceIndexWithDefault(cwd: string, settings: GeoConfig = {}):
       .wait('Who can access this Search Index?')
       .sendCarriageReturn();
 
-    if (config.isFirstGeoResource === true) {
-      chain.wait('Are you tracking commercial assets for your business in your app?').sendConfirmNo();
-      chain.wait('Successfully set RequestBasedUsage pricing plan for your Geo resources.');
-    }
-
     chain.wait('Do you want to configure advanced settings?').sendConfirmNo();
     if (config.isAdditional === true) {
       chain.wait(defaultSearchIndexQuestion);
@@ -113,7 +103,7 @@ export function addPlaceIndexWithDefault(cwd: string, settings: GeoConfig = {}):
  * Add geofence collection with default values. Assume auth and cognito group are configured
  * @param cwd command directory
  */
- export function addGeofenceCollectionWithDefault(cwd: string, settings: GeoConfig = {}): Promise<void> {
+ export function addGeofenceCollectionWithDefault(cwd: string, groupName: string, settings: GeoConfig = {}): Promise<void> {
   const config = { ...defaultGeoConfig, ...settings };
   return new Promise((resolve, reject) => {
     const chain = spawn(getCLIPath(), ['geo', 'add'], { cwd, stripColors: true })
@@ -122,11 +112,11 @@ export function addPlaceIndexWithDefault(cwd: string, settings: GeoConfig = {}):
       .sendCarriageReturn()
       .wait('Provide a name for the Geofence Collection:')
       .sendLine(config.resourceName)
-      .wait('What kind of access do you want')
+      .wait('Select one or more cognito groups to give access:')
+      .sendCarriageReturn()
+      .wait(`What kind of access do you want for ${groupName} users? Select ALL that apply:`)
       .sendCtrlA()
       .sendCarriageReturn()
-      .wait('Are you tracking or directing commercial assets for your business in your app?')
-      .sendCarriageReturn();
 
     if (config.isAdditional === true) {
       chain.wait(defaultGeofenceCollectionQuestion);
@@ -283,6 +273,63 @@ export function updateSecondPlaceIndexAsDefault(cwd: string): Promise<void> {
 }
 
 /**
+ * Update an existing geofence collection with given settings. Assume auth is already configured
+ * @param cwd command directory
+ */
+ export function updateGeofenceCollectionWithDefault(cwd: string, groupName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['geo', 'update'], { cwd, stripColors: true })
+      .wait('Select which capability you want to update:')
+      .sendKeyDown(2)
+      .sendCarriageReturn()
+      .wait('Select the geofence collection you want to update')
+      .sendCarriageReturn()
+      .wait('Select one or more cognito groups to give access:')
+      .sendCarriageReturn()
+      .wait(`What kind of access do you want for ${groupName} users? Select ALL that apply:`)
+      .sendCarriageReturn()
+      .wait(defaultGeofenceCollectionQuestion)
+      .sendConfirmYes()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject();
+        }
+      });
+  });
+}
+
+/**
+ * Update the second geofence collection as default. Assume auth is already configured and two geofence collections added with first default
+ * @param cwd command directory
+ */
+export function updateSecondGeofenceCollectionAsDefault(cwd: string, groupName: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['geo', 'update'], { cwd, stripColors: true })
+      .wait('Select which capability you want to update:')
+      .sendKeyDown(2)
+      .sendCarriageReturn()
+      .wait('Select the geofence collection you want to update')
+      .sendKeyDown()
+      .sendCarriageReturn()
+      .wait('Select one or more cognito groups to give access:')
+      .sendCarriageReturn()
+      .wait(`What kind of access do you want for ${groupName} users? Select ALL that apply:`)
+      .sendCarriageReturn()
+      .wait(defaultGeofenceCollectionQuestion)
+      .sendConfirmYes()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject();
+        }
+      });
+  });
+}
+
+/**
  * Remove an existing map. Assume auth is already configured
  * @param cwd command directory
  */
@@ -379,6 +426,57 @@ export function removeFirstDefaultPlaceIndex(cwd: string): Promise<void> {
       });
   });
 }
+
+/**
+ * Remove an existing geofence collection. Assume auth is already configured
+ * @param cwd command directory
+ */
+ export function removeGeofenceCollection(cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['geo', 'remove'], { cwd, stripColors: true })
+      .wait('Select which capability you want to remove:')
+      .sendKeyDown(2)
+      .sendCarriageReturn()
+      .wait('Select the geofence collection you want to remove')
+      .sendCarriageReturn()
+      .wait('Are you sure you want to delete the resource?')
+      .sendConfirmYes()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject();
+        }
+      });
+  });
+}
+
+/**
+ * Remove an existing default geofence collection. Assume auth is already configured and two geofence collections added with first default
+ * @param cwd command directory
+ */
+export function removeFirstDefaultGeofenceCollection(cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['geo', 'remove'], { cwd, stripColors: true })
+      .wait('Select which capability you want to remove:')
+      .sendKeyDown(2)
+      .sendCarriageReturn()
+      .wait('Select the geofence collection you want to remove')
+      .sendCarriageReturn()
+      .wait('Are you sure you want to delete the resource?')
+      .sendConfirmYes()
+      .wait('Select the geofence collection you want to set as default:')
+      .sendCarriageReturn()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject();
+        }
+      });
+  });
+}
+
 
 /**
  * Get Geo configuration from aws-exports

--- a/packages/amplify-e2e-tests/src/__tests__/geo-add.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-add.test.ts
@@ -12,6 +12,9 @@ import {
   getPlaceIndex,
   generateRandomShortId,
   getGeoJSConfiguration,
+  updateAuthAddUserGroups,
+  addGeofenceCollectionWithDefault,
+  getGeofenceCollection
 } from 'amplify-e2e-core';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -70,6 +73,26 @@ describe('amplify geo add', () => {
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 
+  it('init a project with default auth config and add the geofence collection resource', async () => {
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin');
+    await amplifyPushWithoutCodegen(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    expect(meta.geo).toBeDefined();
+    const collectionId = _.findKey(meta.geo, ['service', 'GeofenceCollection']);
+    const collectionName = meta.geo[collectionId].output.Name;
+    const region = meta.geo[collectionId].output.Region;
+    const collection = await getGeofenceCollection(collectionName, region);
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(collection.CollectionName).toBeDefined();
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collectionName);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.default).toEqual(collectionName);
+    expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
+  });
+
   it('init a project with default auth config and add two map resources with the second set to default', async () => {
     const map1Id = `map${generateRandomShortId()}`;
     const map2Id = `map${generateRandomShortId()}`;
@@ -125,6 +148,36 @@ describe('amplify geo add', () => {
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index1Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index2Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.default).toEqual(index2Name);
+    expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
+  });
+
+  it('init a project with default auth config and add two geofence collection resources with the second set to default', async () => {
+    const collection1Id = `geofencecollection${generateRandomShortId()}`;
+    const collection2Id = `geofencecollection${generateRandomShortId()}`;
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection1Id });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection2Id, isAdditional: true });
+    await amplifyPushWithoutCodegen(projRoot);
+
+    // check amplify meta file
+    const meta = getProjectMeta(projRoot);
+    expect(meta.geo[collection1Id].isDefault).toBe(false);
+    expect(meta.geo[collection2Id].isDefault).toBe(true);
+    // check if resource is provisioned in cloud
+    const region = meta.geo[collection1Id].output.Region;
+    const collection1Name = meta.geo[collection1Id].output.Name;
+    const collection2Name = meta.geo[collection2Id].output.Name;
+    const collection1 = await getGeofenceCollection(collection1Name, region);
+    const collection2 = await getGeofenceCollection(collection2Name, region);
+    expect(collection1.CollectionName).toBeDefined();
+    expect(collection2.CollectionName).toBeDefined();
+    // check aws export file
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collection1Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collection2Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.default).toEqual(collection2Name);
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/geo-populate.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-populate.test.ts
@@ -22,7 +22,7 @@ describe('amplify geo populate', () => {
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await updateAuthAddUserGroups(projRoot, ['admin']);
-    await addGeofenceCollectionWithDefault(projRoot);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin');
   });
 
   afterAll(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/geo-remove.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-remove.test.ts
@@ -15,6 +15,11 @@ import {
   removeFirstDefaultPlaceIndex,
   generateResourceIdsInOrder,
   getGeoJSConfiguration,
+  updateAuthAddUserGroups,
+  addGeofenceCollectionWithDefault,
+  getGeofenceCollection,
+  removeGeofenceCollection,
+  removeFirstDefaultGeofenceCollection
 } from 'amplify-e2e-core';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -64,6 +69,24 @@ describe('amplify geo remove', () => {
     await amplifyPushUpdate(projRoot);
     const newMeta = getProjectMeta(projRoot);
     expect(newMeta.geo[placeIndexId]).toBeUndefined();
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(awsExport.geo).toBeUndefined();
+  });
+
+  it('init a project with default auth config and the geofence collection resource, then remove the geofence collection', async () => {
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin');
+    await amplifyPushWithoutCodegen(projRoot);
+
+    const oldMeta = getProjectMeta(projRoot);
+    const collectionId = Object.keys(oldMeta.geo).filter(key => oldMeta.geo[key].service === 'GeofenceCollection')[0];
+    //remove geofence collection
+    await removeGeofenceCollection(projRoot);
+    await amplifyPushUpdate(projRoot);
+    const newMeta = getProjectMeta(projRoot);
+    expect(newMeta.geo[collectionId]).toBeUndefined();
     const awsExport: any = getAWSExports(projRoot).default;
     expect(awsExport.geo).toBeUndefined();
   });
@@ -119,6 +142,35 @@ describe('amplify geo remove', () => {
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index2Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.items).not.toContain(index1Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.default).toEqual(index2Name);
+    expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
+  });
+
+  it('init a project with default auth config and multiple geofence collection resources, then remove the default geofence collection', async () => {
+    const [collection1Id, collection2Id, collection3Id] = generateResourceIdsInOrder(3);
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection1Id });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection2Id, isAdditional: true, isDefault: false });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection3Id, isAdditional: true, isDefault: false });
+    await amplifyPushWithoutCodegen(projRoot);
+    const oldMeta = getProjectMeta(projRoot);
+    expect(oldMeta.geo[collection1Id].isDefault).toBe(true);
+    expect(oldMeta.geo[collection2Id].isDefault).toBe(false);
+    const collection1Name = oldMeta.geo[collection1Id].output.Name;
+    const collection2Name = oldMeta.geo[collection2Id].output.Name;
+    const region = oldMeta.geo[collection1Id].output.Region;
+
+    //remove geofence collection
+    await removeFirstDefaultGeofenceCollection(projRoot);
+    await amplifyPushUpdate(projRoot);
+    const newMeta = getProjectMeta(projRoot);
+    expect(newMeta.geo[collection1Id]).toBeUndefined();
+    expect(newMeta.geo[collection2Id].isDefault).toBe(true);
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collection2Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).not.toContain(collection1Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.default).toEqual(collection2Name);
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/geo-update.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/geo-update.test.ts
@@ -16,6 +16,11 @@ import {
   updateSecondPlaceIndexAsDefault,
   generateResourceIdsInOrder,
   getGeoJSConfiguration,
+  updateAuthAddUserGroups,
+  addGeofenceCollectionWithDefault,
+  getGeofenceCollection,
+  updateGeofenceCollectionWithDefault,
+  updateSecondGeofenceCollectionAsDefault
 } from 'amplify-e2e-core';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -77,6 +82,27 @@ describe('amplify geo update', () => {
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 
+  it('init a project with default auth config, add the geofence collection resource and update the auth config', async () => {
+    const [collection1Id, collection2Id] = generateResourceIdsInOrder(2);
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection1Id });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection2Id, isAdditional: true, isDefault: false });
+    await updateGeofenceCollectionWithDefault(projRoot, 'admin');
+    await amplifyPushWithoutCodegen(projRoot);
+
+    const meta = getProjectMeta(projRoot);
+    const collectionName = meta.geo[collection1Id].output.Name;
+    const region = meta.geo[collection1Id].output.Region;
+    const collection = await getGeofenceCollection(collectionName, region);
+    expect(collection.CollectionName).toBeDefined();
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collectionName);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.default).toEqual(collectionName);
+    expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
+  });
+
   it('init a project with default auth config, add multiple map resources and update the default map', async () => {
     const [map1Id, map2Id, map3Id] = generateResourceIdsInOrder(3);
     await initJSProjectWithProfile(projRoot, {});
@@ -134,6 +160,37 @@ describe('amplify geo update', () => {
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index1Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.items).toContain(index2Name);
     expect(getGeoJSConfiguration(awsExport).search_indices.default).toEqual(index2Name);
+    expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
+  });
+
+  it('init a project with default auth config, add multiple geofence collection resources and update the default collection', async () => {
+    const [collection1Id, collection2Id, collection3Id] = generateResourceIdsInOrder(3);
+    await initJSProjectWithProfile(projRoot, {});
+    await addAuthWithDefault(projRoot);
+    await updateAuthAddUserGroups(projRoot, ['admin']);
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection1Id });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection2Id, isAdditional: true, isDefault: false });
+    await addGeofenceCollectionWithDefault(projRoot, 'admin', { resourceName: collection3Id, isAdditional: true, isDefault: false });
+    await updateSecondGeofenceCollectionAsDefault(projRoot, 'admin');
+    await amplifyPushWithoutCodegen(projRoot);
+
+    //check amplify meta file
+    const meta = getProjectMeta(projRoot);
+    expect(meta.geo[collection1Id].isDefault).toBe(false);
+    expect(meta.geo[collection2Id].isDefault).toBe(true);
+    //check if resource is provisioned in cloud
+    const region = meta.geo[collection1Id].output.Region;
+    const collection1Name = meta.geo[collection1Id].output.Name;
+    const collection2Name = meta.geo[collection2Id].output.Name;
+    const collection1 = await getGeofenceCollection(collection1Name, region);
+    const collection2 = await getGeofenceCollection(collection2Name, region);
+    expect(collection1.CollectionName).toBeDefined();
+    expect(collection2.CollectionName).toBeDefined();
+    //check aws export file
+    const awsExport: any = getAWSExports(projRoot).default;
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collection1Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.items).toContain(collection2Name);
+    expect(getGeoJSConfiguration(awsExport).geofenceCollections.default).toEqual(collection2Name);
     expect(getGeoJSConfiguration(awsExport).region).toEqual(region);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Adds redirect to `update auth` flow from the flow to add `Geofencing` capability. This helps developers who are getting started with Amplify CLI to easily get setup with their Geofence Collection resource in a single flow without needing them to terminate the `add geo` flow, trigger `update auth` then re-run `add geo`.
- Selects the only cognito group present in the project as default during setting the access permissions for a Geofence Collection resource. Since this is related to permissions, we want to be careful and require the developer to hit `enter` confirming that the selected group is the one he wants to use.
- Added e2e tests for Geofencing capability which includes `add, update and remove` commands.


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit and e2e tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
