### PR TITLE
style: tweak a few lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,14 +75,16 @@ module.exports = {
     ],
     '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
     '@typescript-eslint/no-explicit-any': 'error',
-    // ESLint rule conflicts with the corresponding typescript rule
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'all' }],
     '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/method-signature-style': ['error', 'property'],
-    // ESLint rule conflicts with the corresponding typescript rule
+    
+    // Some ESLint rules conflict with the corresponding TS rule. These ESLint rules are turned off in favor of the corresponding TS rules
     'no-invalid-this': 'off',
     '@typescript-eslint/no-invalid-this': 'error',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'all' }],
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
 
     // Import Rules
     // Extends recommended rules here: https://github.com/import-js/eslint-plugin-import/blob/6c957e7df178d1b81d01cf219d62ba91b4e6d9e8/config/recommended.js
@@ -102,9 +104,14 @@ module.exports = {
       publicOnly: true,
       require: {
         ClassDeclaration: true,
-        MethodDefinition: true,
         ArrowFunctionExpression: true,
       },
+      contexts: [
+        'MethodDefinition:not([accessibility=/(private|protected)/]) > FunctionExpression', // Require JSDoc on public methods
+        'TSInterfaceDeclarationn',
+        'TSTypeAliasDeclaration',
+        'TSEnumDeclaration',
+      ],
       checkConstructors: false
     }],
     'jsdoc/require-description': ['error', { contexts: ['any'] }
@@ -130,7 +137,6 @@ module.exports = {
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     'max-classes-per-file': 'error',
     'no-lonely-if': 'error',
-    'no-shadow': 'error',
     'no-unneeded-ternary': 'error',
     'no-use-before-define': 'off',
     'consistent-return': 'error',
@@ -148,6 +154,12 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed'],
     'func-style': ['error', 'expression'],
     'prefer-arrow/prefer-arrow-functions': ['error', { disallowPrototype: true }],
+    'max-lines-per-function': ['error', {
+      max: 50,
+      skipBlankLines: true,
+      skipComments: true,
+    }],
+    'max-depth': ['error', 2],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,7 +82,7 @@ module.exports = {
     'no-invalid-this': 'off',
     '@typescript-eslint/no-invalid-this': 'error',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'all' }],
+    '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'all', argsIgnorePattern: '^_$' }],
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
 
@@ -108,7 +108,7 @@ module.exports = {
       },
       contexts: [
         'MethodDefinition:not([accessibility=/(private|protected)/]) > FunctionExpression', // Require JSDoc on public methods
-        'TSInterfaceDeclarationn',
+        'TSInterfaceDeclaration',
         'TSTypeAliasDeclaration',
         'TSEnumDeclaration',
       ],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Turns off `no-shadow` in favor of the corresponding TS rule
- Enforces a 50 line limit for functions (excluding comments and blank lines)
- Enforces a max statement depth of 2
- Enforces JSDoc for exported / public class methods, TS interfaces, types and enums

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
