### PR TITLE
fix: build resource when adding new env

### DIFF
--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -68,10 +68,8 @@ async function add(context, skipNextSteps = false) {
 async function transformCategoryStack(context, resource) {
   if (resource.service === AmplifySupportedService.COGNITO) {
     if (canResourceBeTransformed(resource.resourceName)) {
-      generateAuthStackTemplate(context, resource.resourceName);
+      await generateAuthStackTemplate(context, resource.resourceName);
     }
-  } else if (resource.service === 'S3') {
-    // Not yet implemented
   }
 }
 

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -348,6 +348,39 @@ export function initNewEnvWithProfile(cwd: string, s: { envName: string }): Prom
   });
 }
 
+export function updatedInitNewEnvWithProfile(cwd: string, s: { envName: string }): Promise<void> {
+  addCircleCITags(cwd);
+
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['init'], {
+      cwd,
+      stripColors: true,
+      env: {
+        CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
+      },
+    })
+      .wait('Do you want to use an existing environment?')
+      .sendConfirmNo()
+      .wait('Enter a name for the environment')
+      .sendLine(s.envName)
+      .wait('Choose your default editor:')
+      .sendCarriageReturn()
+      .wait('Using default provider  awscloudformation')
+      .wait('Select the authentication method you want to use:')
+      .sendCarriageReturn()
+      .wait('Please choose the profile you want to use')
+      .sendCarriageReturn()
+      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
 export function amplifyInitSandbox(cwd: string, settings: {}): Promise<void> {
   const s = { ...defaultSettings, ...settings };
   let env;

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -355,9 +355,6 @@ export function updatedInitNewEnvWithProfile(cwd: string, s: { envName: string }
     spawn(getCLIPath(), ['init'], {
       cwd,
       stripColors: true,
-      env: {
-        CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
-      },
     })
       .wait('Do you want to use an existing environment?')
       .sendConfirmNo()

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -24,7 +24,7 @@ export * from './sleep';
 export * from './transformConfig';
 export * from './admin-ui';
 export * from './hooks';
-export * from './transformCurrentProjectToGitPulledProject';
+export * from './transform-current-project-to-git-pulled-project';
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -24,6 +24,7 @@ export * from './sleep';
 export * from './transformConfig';
 export * from './admin-ui';
 export * from './hooks';
+export * from './transformCurrentProjectToGitPulledProject';
 
 // run dotenv config to update env variable
 config();

--- a/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
+++ b/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
@@ -11,16 +11,22 @@ export const transformCurrentProjectToGitPulledProject = (projRoot: string) => {
   const gitIgnoreFilePath = pathManager.getGitIgnoreFilePath(projRoot);
   const regexrArray = fs.readFileSync(gitIgnoreFilePath, 'utf-8').split('\n');
   regexrArray.forEach(str => {
+    if (str.endsWith('/')) {
+      str = str.split('/')[0];
+    }
     const dirPath = glob.sync(str, {
       cwd: projRoot,
       absolute: true,
+      matchBase: true,
     });
     dirPath.forEach(file => {
-      if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
-        fs.removeSync(file);
-      } else {
-        fs.unlinkSync(file);
-      }
+      try {
+        if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
+          fs.removeSync(file);
+        } else {
+          fs.unlinkSync(file);
+        }
+      } catch (err) {}
     });
   });
 };

--- a/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
+++ b/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
@@ -21,10 +21,12 @@ export const transformCurrentProjectToGitPulledProject = (projRoot: string) => {
     });
     dirPath.forEach(file => {
       try {
-        if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
-          fs.removeSync(file);
-        } else {
-          fs.unlinkSync(file);
+        if (fs.existsSync(file)) {
+          if (fs.lstatSync(file).isDirectory()) {
+            fs.removeSync(file);
+          } else {
+            fs.unlinkSync(file);
+          }
         }
       } catch (err) {}
     });

--- a/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
+++ b/packages/amplify-e2e-core/src/utils/transform-current-project-to-git-pulled-project.ts
@@ -10,17 +10,17 @@ import glob from 'glob';
 export const transformCurrentProjectToGitPulledProject = (projRoot: string) => {
   const gitIgnoreFilePath = pathManager.getGitIgnoreFilePath(projRoot);
   const regexrArray = fs.readFileSync(gitIgnoreFilePath, 'utf-8').split('\n');
-  //const dir =  fs.readdirSync(projRoot);
-  const dir = glob.sync('**/*', {
-    cwd: projRoot,
-    absolute: true,
-  });
-
   regexrArray.forEach(str => {
-    let regex;
-    try {
-      regex = new RegExp(str);
-      dir.filter(file => regex.test(file)).map(file => fs.unlinkSync(projRoot + file));
-    } catch (e) {}
+    const dirPath = glob.sync(str, {
+      cwd: projRoot,
+      absolute: true,
+    });
+    dirPath.forEach(file => {
+      if (fs.existsSync(file) && fs.lstatSync(file).isDirectory()) {
+        fs.removeSync(file);
+      } else {
+        fs.unlinkSync(file);
+      }
+    });
   });
 };

--- a/packages/amplify-e2e-core/src/utils/transformCurrentProjectToGitPulledProject.ts
+++ b/packages/amplify-e2e-core/src/utils/transformCurrentProjectToGitPulledProject.ts
@@ -1,0 +1,26 @@
+import { pathManager } from 'amplify-cli-core';
+import * as fs from 'fs-extra';
+import glob from 'glob';
+
+/**
+ *
+ * @param projRoot : string
+ * deleting files matching .gitignore regex
+ */
+export const transformCurrentProjectToGitPulledProject = (projRoot: string) => {
+  const gitIgnoreFilePath = pathManager.getGitIgnoreFilePath(projRoot);
+  const regexrArray = fs.readFileSync(gitIgnoreFilePath, 'utf-8').split('\n');
+  //const dir =  fs.readdirSync(projRoot);
+  const dir = glob.sync('**/*', {
+    cwd: projRoot,
+    absolute: true,
+  });
+
+  regexrArray.forEach(str => {
+    let regex;
+    try {
+      regex = new RegExp(str);
+      dir.filter(file => regex.test(file)).map(file => fs.unlinkSync(projRoot + file));
+    } catch (e) {}
+  });
+};

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -1,5 +1,18 @@
+import { category } from '@aws-amplify/amplify-category-auth';
+import {
+  addAuthWithDefault,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getBackendAmplifyMeta,
+  getParameters,
+  getTeamProviderInfo,
+  initJSProjectWithProfile,
+  initNewEnvWithProfile,
+  transformCurrentProjectToGitPulledProject,
+} from 'amplify-e2e-core';
 import * as specialCaseInit from '../init-special-cases';
-import { createNewProjectDir, getBackendAmplifyMeta, deleteProject, deleteProjectDir } from 'amplify-e2e-core';
 
 describe('amplify init', () => {
   let projRoot: string;
@@ -20,5 +33,30 @@ describe('amplify init', () => {
     expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
     expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
     expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
+  });
+
+  it.only('test init on a git pulled project', async () => {
+    const envName = 'dev';
+    const resourceName = 'authConsoleTest';
+    await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
+    await addAuthWithDefault(projRoot, {});
+    await amplifyPushAuth(projRoot);
+    let teamInfo = getTeamProviderInfo(projRoot);
+    expect(teamInfo).toBeDefined();
+    let appId = teamInfo[envName].awscloudformation.AmplifyAppId;
+    let stackName = teamInfo[envName].awscloudformation.StackName;
+    expect(stackName).toBeDefined();
+    expect(appId).toBeDefined();
+    expect(teamInfo[envName].categories.auth).toBeDefined();
+    /**
+     * simulate git clone by deleteing files based on .gitignore
+     */
+    transformCurrentProjectToGitPulledProject(projRoot);
+
+    // to not crash
+    expect(await initNewEnvWithProfile(projRoot, { envName })).not.toThrow();
+
+    // check parameters.json exists
+    expect(getParameters(projRoot, category, resourceName)).not.toThrow();
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -9,8 +9,8 @@ import {
   getParameters,
   getTeamProviderInfo,
   initJSProjectWithProfile,
-  initNewEnvWithProfile,
   transformCurrentProjectToGitPulledProject,
+  updatedInitNewEnvWithProfile,
 } from 'amplify-e2e-core';
 import * as specialCaseInit from '../init-special-cases';
 
@@ -21,8 +21,8 @@ describe('amplify init', () => {
   });
 
   afterEach(async () => {
-    await deleteProject(projRoot);
-    deleteProjectDir(projRoot);
+    // await deleteProject(projRoot);
+    // deleteProjectDir(projRoot);
   });
 
   it('init without credential files and no new user set up', async () => {
@@ -35,7 +35,7 @@ describe('amplify init', () => {
     expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
   });
 
-  it('test init on a git pulled project', async () => {
+  it.only('test init on a git pulled project', async () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
@@ -54,7 +54,7 @@ describe('amplify init', () => {
     transformCurrentProjectToGitPulledProject(projRoot);
 
     // to not crash
-    expect(await initNewEnvWithProfile(projRoot, { envName })).not.toThrow();
+    expect(await updatedInitNewEnvWithProfile(projRoot, { envName })).not.toThrow();
 
     // check parameters.json exists
     expect(getParameters(projRoot, category, resourceName)).not.toThrow();

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -35,7 +35,7 @@ describe('amplify init', () => {
     expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
   });
 
-  it.only('test init on a git pulled project', async () => {
+  it('test init on a git pulled project', async () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });

--- a/packages/amplify-provider-awscloudformation/src/initialize-env.ts
+++ b/packages/amplify-provider-awscloudformation/src/initialize-env.ts
@@ -13,6 +13,8 @@ import { pullHooks } from './utils/hooks-manager';
 import { buildOverridesEnabledResources } from './build-override-enabled-resources';
 
 export async function run(context: $TSContext, providerMetadata: $TSMeta) {
+  await buildOverridesEnabledResources(context);
+
   if (context.exeInfo && context.exeInfo.isNewEnv) {
     return context;
   }
@@ -115,6 +117,4 @@ export async function run(context: $TSContext, providerMetadata: $TSMeta) {
   if (hasMigratedResources) {
     stateManager.setCurrentMeta(undefined, amplifyMeta);
   }
-
-  await buildOverridesEnabledResources(context);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Build resource first when adding a new env locally when project is git pulled
- Add missing await
- Already approved PR e2e fix: https://github.com/aws-amplify/amplify-cli/pull/9847

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #9508, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested
- e2e test for same scenario

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
