### PR TITLE
Fix deployment state cleanup

### DIFF
--- a/packages/amplify-cli-core/src/deploymentState.ts
+++ b/packages/amplify-cli-core/src/deploymentState.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export type DeploymentState = {
   version: '1';
   startedAt?: string;
@@ -34,15 +35,16 @@ export enum DeploymentStepStatus {
 }
 
 export interface IDeploymentStateManager {
-  startDeployment(steps: DeploymentStepState[]): Promise<boolean>;
-  failDeployment(): Promise<void>;
-  updateStatus(status: DeploymentStatus): Promise<void>;
-  updateCurrentStepStatus(status: DeploymentStepStatus): Promise<void>;
-  startCurrentStep(parameters?: StepStatusParameters): Promise<void>;
-  advanceStep(): Promise<void>;
-  startRollback(): Promise<void>;
+  startDeployment: (steps: DeploymentStepState[]) => Promise<boolean>;
+  failDeployment: () => Promise<void>;
+  updateStatus: (status: DeploymentStatus) => Promise<void>;
+  updateCurrentStepStatus: (status: DeploymentStepStatus) => Promise<void>;
+  startCurrentStep: (parameters?: StepStatusParameters) => Promise<void>;
+  advanceStep: () => Promise<void>;
+  startRollback: () => Promise<void>;
+  deleteDeploymentStateFile: () => Promise<void>;
 
-  isDeploymentInProgress(): boolean;
-  isDeploymentFinished(): boolean;
-  getStatus(): DeploymentState | undefined;
+  isDeploymentInProgress: () => boolean;
+  isDeploymentFinished: () => boolean;
+  getStatus: () => DeploymentState | undefined;
 }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -1,8 +1,29 @@
+/* eslint-disable spellcheck/spell-checker */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-prototype-builtins */
+/* eslint-disable consistent-return */
+/* eslint-disable jsdoc/require-description */
+/* eslint-disable no-else-return */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable spellcheck/spell-checker */
+/* eslint-disable no-return-await */
+/* eslint-disable arrow-parens */
+/* eslint-disable no-confusing-arrow */
+/* eslint-disable implicit-arrow-linebreak */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable import/order */
+/* eslint-disable import/first */
 import { $TSAny, $TSContext } from 'amplify-cli-core';
 
 import aws from './aws.js';
 import _ from 'lodash';
+
 const providerName = require('../constants').ProviderName;
+
 import { loadConfiguration } from '../configuration-manager';
 import fs from 'fs-extra';
 import ora from 'ora';
@@ -11,11 +32,15 @@ import { ListObjectVersionsOutput, ListObjectVersionsRequest, ObjectIdentifier }
 
 const minChunkSize = 5 * 1024 * 1024; // 5 MB https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3/ManagedUpload.html#minPartSize-property
 const { fileLogger } = require('../utils/aws-logger');
+
 const logger = fileLogger('aws-s3');
 
 // https://stackoverflow.com/questions/52703321/make-some-properties-optional-in-a-typescript-type
 type OptionalExceptFor<T, TRequired extends keyof T> = Partial<T> & Pick<T, TRequired>;
 
+/**
+ *
+ */
 export class S3 {
   private static instance: S3;
   private readonly context: $TSContext;
@@ -27,6 +52,9 @@ export class S3 {
     };
   };
 
+  /**
+   *
+   */
   static async getInstance(context: $TSContext, options = {}): Promise<S3> {
     if (!S3.instance) {
       let cred = {};
@@ -46,6 +74,9 @@ export class S3 {
     this.s3 = new aws.S3({ ...cred, ...options });
   }
 
+  /**
+   *
+   */
   private populateUploadState(): void {
     const projectDetails = this.context.amplify.getProjectDetails();
     const { envName } = this.context.amplify.getEnvInfo();
@@ -61,7 +92,10 @@ export class S3 {
     };
   }
 
-  private attatchBucketToParams(s3Params: $TSAny, envName?: string) {
+  /**
+   *
+   */
+  private attachBucketToParams(s3Params: $TSAny, envName?: string) {
     if (!s3Params.hasOwnProperty('Bucket')) {
       const projectDetails = this.context.amplify.getProjectDetails();
       if (!envName) envName = this.context.amplify.getEnvInfo().envName;
@@ -71,13 +105,16 @@ export class S3 {
     return s3Params;
   }
 
-  async uploadFile(s3Params: $TSAny, showSpinner: boolean = true) {
+  /**
+   *
+   */
+  async uploadFile(s3Params: $TSAny, showSpinner = true) {
     // envName and bucket does not change during execution, cache them into a class level
     // field.
     if (this.uploadState === undefined) {
       this.populateUploadState();
     }
-    let spinner = showSpinner ? ora('Uploading files...') : undefined;
+    const spinner = showSpinner ? ora('Uploading files...') : undefined;
 
     const augmentedS3Params = {
       ...s3Params,
@@ -88,8 +125,8 @@ export class S3 {
     try {
       showSpinner && spinner.start('Uploading files...');
       if (
-        (s3Params.Body instanceof fs.ReadStream && fs.statSync(s3Params.Body.path).size > minChunkSize) ||
-        (Buffer.isBuffer(s3Params.Body) && s3Params.Body.length > minChunkSize)
+        (s3Params.Body instanceof fs.ReadStream && fs.statSync(s3Params.Body.path).size > minChunkSize)
+        || (Buffer.isBuffer(s3Params.Body) && s3Params.Body.length > minChunkSize)
       ) {
         logger('uploadFile.s3.upload', [others])();
         uploadTask = this.s3.upload(augmentedS3Params);
@@ -110,8 +147,11 @@ export class S3 {
     }
   }
 
+  /**
+   *
+   */
   async getFile(s3Params: $TSAny, envName?: string) {
-    s3Params = this.attatchBucketToParams(s3Params, envName);
+    s3Params = this.attachBucketToParams(s3Params, envName);
     const log = logger('s3.getFile', [s3Params]);
     try {
       log();
@@ -123,7 +163,10 @@ export class S3 {
     }
   }
 
-  async createBucket(bucketName: string, throwIfExists: boolean = false): Promise<string | void> {
+  /**
+   *
+   */
+  async createBucket(bucketName: string, throwIfExists = false): Promise<string | void> {
     // Check if bucket exists;
     const params = {
       Bucket: bucketName,
@@ -145,6 +188,12 @@ export class S3 {
     }
   }
 
+  /**
+   * Get all the object versions of all objects in the S3 bucket
+   * @param bucketName - name of s3 bucekt
+   * @param options - list object versions output
+   * @returns Object list
+   */
   async getAllObjectVersions(
     bucketName: string,
     options: OptionalExceptFor<ListObjectVersionsOutput, 'KeyMarker' | 'VersionIdMarker'> = null,
@@ -168,12 +217,15 @@ export class S3 {
     return result;
   }
 
+  /**
+   *
+   */
   public async deleteDirectory(bucketName: string, dirPath: string): Promise<void> {
     logger('deleteDirectory.s3.getAllObjectVersions', [{ BucketName: bucketName }])();
     const allObjects = await this.getAllObjectVersions(bucketName, { Prefix: dirPath });
     const chunkedResult = _.chunk(allObjects, 1000);
     const chunkedResultLength = chunkedResult.length;
-    for (let idx = 0; idx < chunkedResultLength; idx++) {
+    for (let idx = 0; idx < chunkedResultLength; idx += 1) {
       logger(`deleteAllObjects.s3.deleteObjects (${idx} of ${chunkedResultLength})`, [{ Bucket: bucketName }])();
       await this.s3
         .deleteObjects({
@@ -186,12 +238,28 @@ export class S3 {
     }
   }
 
+  /**
+   * Delete the file provided as input
+   * @param bucketName S3 bucket name
+   * @param filePath Path to the file to be deleted
+   */
+  public async deleteObject(bucketName: string, filePath: string): Promise<void> {
+    logger('deleteObject.s3', [{ BucketName: bucketName, FilePath: filePath }])();
+    await this.s3.deleteObject({
+      Bucket: bucketName,
+      Key: filePath,
+    }).promise();
+  }
+
+  /**
+   *
+   */
   public async deleteAllObjects(bucketName: string): Promise<void> {
     logger('deleteAllObjects.s3.getAllObjectVersions', [{ BucketName: bucketName }])();
     const allObjects = await this.getAllObjectVersions(bucketName);
     const chunkedResult = _.chunk(allObjects, 1000);
     const chunkedResultLength = chunkedResult.length;
-    for (let idx = 0; idx < chunkedResultLength; idx++) {
+    for (let idx = 0; idx < chunkedResultLength; idx += 1) {
       logger(`deleteAllObjects.s3.deleteObjects (${idx} of ${chunkedResultLength})`, [{ Bucket: bucketName }])();
       await this.s3
         .deleteObjects({
@@ -204,6 +272,9 @@ export class S3 {
     }
   }
 
+  /**
+   *
+   */
   public async deleteS3Bucket(bucketName: string) {
     logger('deleteS3Bucket.s3.ifBucketExists', [{ BucketName: bucketName }])();
     if (await this.ifBucketExists(bucketName)) {
@@ -214,12 +285,18 @@ export class S3 {
     }
   }
 
+  /**
+   *
+   */
   public async emptyS3Bucket(bucketName: string) {
     if (await this.ifBucketExists(bucketName)) {
       await this.deleteAllObjects(bucketName);
     }
   }
 
+  /**
+   *
+   */
   public async ifBucketExists(bucketName: string) {
     try {
       logger('ifBucketExists.s3.headBucket', [{ BucketName: bucketName }])();

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -107,7 +107,7 @@ export class S3 {
    * @param showSpinner Flag, if true displays the spinner on the terminal. Must be set to false on headless.
    * @returns Promise<void>
    */
-  async uploadFile(s3Params: $TSAny, showSpinner = true):Promise<void|string> {
+  async uploadFile(s3Params: $TSAny, showSpinner = true):Promise<string> {
     // envName and bucket does not change during execution, cache them into a class level
     // field.
     if (this.uploadState === undefined) {

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
@@ -217,6 +217,9 @@ export class DeploymentStateManager implements IDeploymentStateManager {
     );
   };
 
+  /**
+ * Delete the deployment state file if it exists
+ */
   public deleteDeploymentStateFile = async (): Promise<void> => {
     await this.s3.deleteObject(this.deploymentBucketName, DeploymentStateManager.stateFileName);
   };

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1,3 +1,17 @@
+/* eslint-disable prefer-const */
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-return-await */
+/* eslint-disable consistent-return */
+/* eslint-disable jsdoc/require-description */
+/* eslint-disable no-continue */
+/* eslint-disable max-len */
+/* eslint-disable spellcheck/spell-checker */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable func-style */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable prefer-arrow/prefer-arrow-functions */
 import _ from 'lodash';
 import * as fs from 'fs-extra';
 import { EOL } from 'os';
@@ -22,6 +36,7 @@ import {
   Template,
 } from 'amplify-cli-core';
 import ora from 'ora';
+import { Fn } from 'cloudform-types';
 import { S3 } from './aws-utils/aws-s3';
 import Cloudformation from './aws-utils/aws-cfn';
 import { formUserAgentParam } from './aws-utils/user-agent';
@@ -38,8 +53,9 @@ import { loadResourceParameters } from './resourceParams';
 import { uploadAuthTriggerFiles } from './upload-auth-trigger-files';
 import archiver from './utils/archiver';
 import amplifyServiceManager from './amplify-service-manager';
-import { DeploymentManager, DeploymentStep, DeploymentOp, DeploymentStateManager, runIterativeRollback } from './iterative-deployment';
-import { Fn } from 'cloudform-types';
+import {
+  DeploymentManager, DeploymentStep, DeploymentOp, DeploymentStateManager, runIterativeRollback,
+} from './iterative-deployment';
 import { getGqlUpdatedResource } from './graphql-transformer/utils';
 import { isAmplifyAdminApp } from './utils/admin-helpers';
 import { fileLogger } from './utils/aws-logger';
@@ -79,7 +95,10 @@ const deploymentInProgressErrorMessage = (context: $TSContext) => {
   context.print.error('"amplify push --force" to re-deploy');
 };
 
-export async function run(context: $TSContext, resourceDefinition: $TSObject, rebuild: boolean = false) {
+/**
+ *
+ */
+export async function run(context: $TSContext, resourceDefinition: $TSObject, rebuild = false) {
   const deploymentStateManager = await DeploymentStateManager.createDeploymentStateManager(context);
   let iterativeDeploymentWasInvoked = false;
   let layerResources = [];
@@ -100,7 +119,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     } = context;
     let resources = !!context?.exeInfo?.forcePush || rebuild ? allResources : resourcesToBeCreated.concat(resourcesToBeUpdated);
 
-    layerResources = resources.filter(r => r.service === AmplifySupportedService.LAMBDA_LAYER);
+    layerResources = resources.filter((r: { service: string; }) => r.service === AmplifySupportedService.LAMBDA_LAYER);
 
     if (deploymentStateManager.isDeploymentInProgress() && !deploymentStateManager.isDeploymentFinished()) {
       if (context.exeInfo?.forcePush || context.exeInfo?.iterativeRollback) {
@@ -114,7 +133,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     await createEnvLevelConstructs(context);
 
     // removing dependent functions if @model{Table} is deleted
-    const apiResourceTobeUpdated = resourcesToBeUpdated.filter(resource => resource.service === 'AppSync');
+    const apiResourceTobeUpdated = resourcesToBeUpdated.filter((resource: { service: string; }) => resource.service === 'AppSync');
     if (apiResourceTobeUpdated.length) {
       const functionResourceToBeUpdated = await ensureValidFunctionModelDependencies(
         context,
@@ -123,7 +142,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
       );
       // filter updated function to replace with existing updated ones(in case of duplicates)
       if (functionResourceToBeUpdated !== undefined && functionResourceToBeUpdated.length > 0) {
-        resources = _.uniqBy(resources.concat(functionResourceToBeUpdated), `resourceName`);
+        resources = _.uniqBy(resources.concat(functionResourceToBeUpdated), 'resourceName');
       }
     }
 
@@ -142,10 +161,10 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
         context.print.info(`${consoleUrl}\n`);
 
         context.print.info(
-          `It may take a few moments for this to appear. If you have trouble with first time deployments, please try refreshing this page after a few moments and watch the CodeBuild Details for debugging information.`,
+          'It may take a few moments for this to appear. If you have trouble with first time deployments, please try refreshing this page after a few moments and watch the CodeBuild Details for debugging information.',
         );
 
-        if (resourcesToBeUpdated.find(res => res.resourceName === resource.resourceName)) {
+        if (resourcesToBeUpdated.find((res: { resourceName: any; }) => res.resourceName === resource.resourceName)) {
           resource.lastPackageTimeStamp = undefined;
           await context.amplify.updateamplifyMetaAfterResourceUpdate('api', resource.resourceName, 'lastPackageTimeStamp', undefined);
         }
@@ -164,8 +183,8 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
      * calling transform schema here to support old project with out overrides
      */
     await transformGraphQLSchema(context, {
-      handleMigration: opts => updateStackForAPIMigration(context, 'api', undefined, opts),
-      minify: options['minify'],
+      handleMigration: (opts: any) => updateStackForAPIMigration(context, 'api', undefined, opts),
+      minify: options.minify,
       promptApiKeyCreation: true,
     });
 
@@ -173,7 +192,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     await prepareBuildableResources(context, resources);
     await buildOverridesEnabledResources(context);
 
-    //Removed api transformation to generate resources befoe starting deploy/
+    // Removed api transformation to generate resources befoe starting deploy/
 
     // If there is a deployment already in progress we have to fail the push operation as another
     // push in between could lead non-recoverable stacks and files.
@@ -185,7 +204,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     let deploymentSteps: DeploymentStep[] = [];
 
     // location where the intermediate deployment steps are stored
-    let stateFolder: { local?: string; cloud?: string } = {};
+    const stateFolder: { local?: string; cloud?: string } = {};
 
     // Check if iterative updates are enabled or not and generate the required deployment steps if needed.
     if (FeatureFlags.getBoolean('graphQLTransformer.enableIterativeGSIUpdates')) {
@@ -233,13 +252,13 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
 
     // We do not need CloudFormation update if only syncable resources are the changes.
     if (
-      resourcesToBeCreated.length > 0 ||
-      resourcesToBeUpdated.length > 0 ||
-      resourcesToBeDeleted.length > 0 ||
-      tagsUpdated ||
-      rootStackUpdated ||
-      context.exeInfo.forcePush ||
-      rebuild
+      resourcesToBeCreated.length > 0
+      || resourcesToBeUpdated.length > 0
+      || resourcesToBeDeleted.length > 0
+      || tagsUpdated
+      || rootStackUpdated
+      || context.exeInfo.forcePush
+      || rebuild
     ) {
       // if there are deploymentSteps, need to do an iterative update
       if (deploymentSteps.length > 0) {
@@ -303,13 +322,14 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
         } catch (err) {
           if (err?.name === 'ValidationError' && err?.message === 'No updates are to be performed.') {
             return;
-          } else {
-            throw err;
           }
+          throw err;
         } finally {
           spinner.stop();
         }
       }
+      // Cleanup the deployment-state file
+      await deploymentStateManager.deleteDeploymentStateFile();
     }
 
     await postPushGraphQLCodegen(context);
@@ -350,7 +370,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     updatedAllResources = updatedAllResources.filter((resource: { service: string }) => resource.service === AmplifySupportedService.APIGW);
 
     for (let i = 0; i < updatedAllResources.length; i++) {
-      if (resources.findIndex(resource => resource.resourceName === updatedAllResources[i].resourceName) > -1) {
+      if (resources.findIndex((resource: { resourceName: any; }) => resource.resourceName === updatedAllResources[i].resourceName) > -1) {
         newAPIresources.push(updatedAllResources[i]);
       }
     }
@@ -385,8 +405,8 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
 
               for (const additionalAuthenticationProvider of additionalAuthenticationProviders) {
                 if (
-                  additionalAuthenticationProvider &&
-                  additionalAuthenticationProvider.authenticationType === 'AMAZON_COGNITO_USER_POOLS'
+                  additionalAuthenticationProvider
+                  && additionalAuthenticationProvider.authenticationType === 'AMAZON_COGNITO_USER_POOLS'
                 ) {
                   additionalAuthenticationProvider.userPoolConfig.userPoolId = userPoolId;
 
@@ -406,7 +426,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     await downloadAPIModels(context, newAPIresources);
 
     // remove emphemeral Lambda layer state
-    if (resources.concat(resourcesToBeDeleted).filter(r => r.service === AmplifySupportedService.LAMBDA_LAYER).length > 0) {
+    if (resources.concat(resourcesToBeDeleted).filter((r: { service: string; }) => r.service === AmplifySupportedService.LAMBDA_LAYER).length > 0) {
       await postPushLambdaLayerCleanup(context, resources, projectDetails.localEnvInfo.envName);
       await context.amplify.updateamplifyMetaAfterPush(resources);
     }
@@ -415,9 +435,9 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
     await storeCurrentCloudBackend(context);
     await amplifyServiceManager.storeArtifactsForAmplifyService(context);
 
-    //check for auth resources and remove deployment secret for push
+    // check for auth resources and remove deployment secret for push
     resources
-      .filter(resource => resource.category === 'auth' && resource.service === 'Cognito' && resource.providerPlugin === 'awscloudformation')
+      .filter((resource: { category: string; service: string; providerPlugin: string; }) => resource.category === 'auth' && resource.service === 'Cognito' && resource.providerPlugin === 'awscloudformation')
       .map(({ category, resourceName }) => context.amplify.removeDeploymentSecrets(context, category, resourceName));
 
     await adminModelgen(context, resources);
@@ -442,19 +462,24 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
 
 async function canAutoResolveGraphQLAuthError(message: string) {
   if (
-    message === `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.` ||
-    message ===
-      `@auth directive with 'userPools' provider found, but the project has no Cognito User Pools authentication provider configured.` ||
-    message === `@auth directive with 'oidc' provider found, but the project has no OPENID_CONNECT authentication provider configured.` ||
-    message === `@auth directive with 'apiKey' provider found, but the project has no API Key authentication provider configured.` ||
-    message === `@auth directive with 'function' provider found, but the project has no Lambda authentication provider configured.`
+    message === '@auth directive with \'iam\' provider found, but the project has no IAM authentication provider configured.'
+    || message
+      === '@auth directive with \'userPools\' provider found, but the project has no Cognito User Pools authentication provider configured.'
+    || message === '@auth directive with \'oidc\' provider found, but the project has no OPENID_CONNECT authentication provider configured.'
+    || message === '@auth directive with \'apiKey\' provider found, but the project has no API Key authentication provider configured.'
+    || message === '@auth directive with \'function\' provider found, but the project has no Lambda authentication provider configured.'
   ) {
     return true;
   }
 }
 
+/**
+ *
+ */
 export async function updateStackForAPIMigration(context: $TSContext, category: string, resourceName: string, options: $TSAny) {
-  const { resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources } = await context.amplify.getResourceStatus(
+  const {
+    resourcesToBeCreated, resourcesToBeUpdated, resourcesToBeDeleted, allResources,
+  } = await context.amplify.getResourceStatus(
     category,
     resourceName,
     providerName,
@@ -467,7 +492,7 @@ export async function updateStackForAPIMigration(context: $TSContext, category: 
 
   validateCfnTemplates(context, resources);
 
-  resources = allResources.filter(resource => resource.service === 'AppSync');
+  resources = allResources.filter((resource: { service: string; }) => resource.service === 'AppSync');
 
   await uploadAppSyncFiles(context, resources, allResources, {
     useDeprecatedParameters: isReverting,
@@ -525,6 +550,9 @@ export async function updateStackForAPIMigration(context: $TSContext, category: 
   }
 }
 
+/**
+ *
+ */
 export async function storeCurrentCloudBackend(context: $TSContext) {
   const zipFilename = '#current-cloud-backend.zip';
   const backendDir = pathManager.getBackendDirPath();
@@ -650,10 +678,9 @@ async function prepareResource(context: $TSContext, resource: $TSAny) {
   });
 
   if (cfnFiles.length !== 1) {
-    const errorMessage =
-      cfnFiles.length > 1
-        ? 'Only one CloudFormation template is allowed in the resource directory'
-        : 'CloudFormation template is missing in the resource directory';
+    const errorMessage = cfnFiles.length > 1
+      ? 'Only one CloudFormation template is allowed in the resource directory'
+      : 'CloudFormation template is missing in the resource directory';
     context.print.error(errorMessage);
     context.print.error(resourceDir);
 
@@ -766,6 +793,9 @@ function getAllUniqueCategories(resources: $TSObject[]): $TSObject[] {
   return [...categories];
 }
 
+/**
+ *
+ */
 export function getCfnFiles(category: string, resourceName: string, options?: glob.IOptions) {
   const backEndDir = pathManager.getBackendDirPath();
   const resourceDir = path.normalize(path.join(backEndDir, category, resourceName));
@@ -827,6 +857,9 @@ async function updateS3Templates(context: $TSContext, resourcesToBeUpdated: $TSA
   return Promise.all(promises);
 }
 
+/**
+ *
+ */
 export async function uploadTemplateToS3(
   context: $TSContext,
   filePath: string,
@@ -843,7 +876,7 @@ export async function uploadTemplateToS3(
   };
 
   const log = logger('uploadTemplateToS3.s3.uploadFile', [{ Key: s3Params.Key }]);
-  let projectBucket;
+  let projectBucket: string;
   try {
     projectBucket = await s3.uploadFile(s3Params, false);
   } catch (error) {
@@ -862,6 +895,9 @@ export async function uploadTemplateToS3(
   }
 }
 
+/**
+ *
+ */
 export async function formNestedStack(
   context: $TSContext,
   projectDetails: $TSObject,
@@ -869,9 +905,9 @@ export async function formNestedStack(
   resourceName?: string,
   serviceName?: string,
   skipEnv?: boolean,
-  useExistingMeta?: boolean
+  useExistingMeta?: boolean,
 ) {
-  let rootStack;
+  let rootStack: Template;
   // CFN transform for Root stack
   rootStack = await transformRootStack(context);
 
@@ -894,7 +930,7 @@ export async function formNestedStack(
   // update amplify meta with updated root stack Info
   if (Object.keys(metaToBeUpdated).length) {
     context.amplify.updateProvideramplifyMeta(providerName, metaToBeUpdated);
-    //update teamProviderInfo
+    // update teamProviderInfo
     const { envName } = context.amplify.getEnvInfo();
     const teamProviderInfo = stateManager.getTeamProviderInfo(projectPath);
     const tpiResourceParams: $TSAny = _.get(teamProviderInfo, [envName, 'awscloudformation'], {});
@@ -961,24 +997,24 @@ export async function formNestedStack(
     const cognitoResource = stateManager.getResourceFromMeta(amplifyMeta, 'auth', 'Cognito');
     const authRootStackResourceName = `auth${cognitoResource.resourceName}`;
 
-    stack.Properties.Parameters['userpoolId'] = {
+    (stack.Properties.Parameters as any).userpoolId = {
       'Fn::GetAtt': [authRootStackResourceName, 'Outputs.UserPoolId'],
     };
-    stack.Properties.Parameters['userpoolArn'] = {
+    (stack.Properties.Parameters as any).userpoolArn = {
       'Fn::GetAtt': [authRootStackResourceName, 'Outputs.UserPoolArn'],
     };
     stack.DependsOn.push(authRootStackResourceName);
 
-    const { dependsOn } = cognitoResource.resource as { dependsOn };
+    const { dependsOn } = cognitoResource.resource as { dependsOn: any };
 
-    dependsOn.forEach(resource => {
+    dependsOn.forEach((resource: { category: any; resourceName: any; attributes: any; }) => {
       const dependsOnStackName = `${resource.category}${resource.resourceName}`;
 
       stack.DependsOn.push(dependsOnStackName);
 
       const dependsOnAttributes = resource?.attributes;
 
-      dependsOnAttributes.forEach(attribute => {
+      dependsOnAttributes.forEach((attribute: any) => {
         const parameterKey = `${resource.category}${resource.resourceName}${attribute}`;
         const parameterValue = { 'Fn::GetAtt': [dependsOnStackName, `Outputs.${attribute}`] };
 
@@ -997,11 +1033,11 @@ export async function formNestedStack(
       },
     };
 
-    rootStack.Resources.DeploymentBucket.Properties['VersioningConfiguration'] = {
+    rootStack.Resources.DeploymentBucket.Properties.VersioningConfiguration = {
       Status: 'Enabled',
     };
 
-    rootStack.Resources.DeploymentBucket.Properties['LifecycleConfiguration'] = {
+    rootStack.Resources.DeploymentBucket.Properties.LifecycleConfiguration = {
       Rules: [
         {
           ExpirationInDays: 7,
@@ -1026,7 +1062,7 @@ export async function formNestedStack(
       }
 
       const resourceKey = category + resource;
-      let templateURL;
+      let templateURL: any;
 
       if (resourceDetails.providerPlugin) {
         const parameters = <$TSObject>loadResourceParameters(context, category, resource);
@@ -1037,7 +1073,7 @@ export async function formNestedStack(
               // If the depends on resource is an imported resource we cannot form GetAtt type reference
               // since there is no such thing. We have to read the output.{AttributeName} from the meta
               // and inject the value itself into the parameters block
-              let parameterValue;
+              let parameterValue: { 'Fn::GetAtt': any[]; };
 
               const dependentResource = _.get(amplifyMeta, [dependsOn[i].category, dependsOn[i].resourceName], undefined);
 
@@ -1087,11 +1123,11 @@ export async function formNestedStack(
         }
 
         if (
-          (category === AmplifyCategories.API || category === AmplifyCategories.HOSTING) &&
-          resourceDetails.service === ApiServiceNameElasticContainer
+          (category === AmplifyCategories.API || category === AmplifyCategories.HOSTING)
+          && resourceDetails.service === ApiServiceNameElasticContainer
         ) {
-          parameters['deploymentBucketName'] = Fn.Ref('DeploymentBucketName');
-          parameters['rootStackName'] = Fn.Ref('AWS::StackName');
+          parameters.deploymentBucketName = Fn.Ref('DeploymentBucketName');
+          parameters.rootStackName = Fn.Ref('AWS::StackName');
         }
 
         const currentEnv = context.amplify.getEnvInfo().envName;
@@ -1107,8 +1143,9 @@ export async function formNestedStack(
         // If auth is imported check the parameters section of the nested template
         // and if it has auth or unauth role arn or name or userpool id, then inject it from the
         // imported auth resource's properties
-        const { imported, userPoolId, authRoleArn, authRoleName, unauthRoleArn, unauthRoleName } =
-          context.amplify.getImportedAuthProperties(context);
+        const {
+          imported, userPoolId, authRoleArn, authRoleName, unauthRoleArn, unauthRoleName,
+        } = context.amplify.getImportedAuthProperties(context);
 
         if (category !== AmplifyCategories.AUTH && resourceDetails.service !== 'Cognito' && imported) {
           if (parameters.AuthCognitoUserPoolId) {
@@ -1175,12 +1212,15 @@ function updateIdPRolesInNestedStack(nestedStack: $TSAny, authResourceName: $TSA
 
 function isAuthTrigger(dependsOnResource: $TSObject) {
   return (
-    FeatureFlags.getBoolean('auth.breakCircularDependency') &&
-    dependsOnResource.category === 'function' &&
-    dependsOnResource.triggerProvider === 'Cognito'
+    FeatureFlags.getBoolean('auth.breakCircularDependency')
+    && dependsOnResource.category === 'function'
+    && dependsOnResource.triggerProvider === 'Cognito'
   );
 }
 
+/**
+ *
+ */
 export async function generateAndUploadRootStack(context: $TSContext, destinationPath: string, destinationS3Key: string) {
   const projectDetails = context.amplify.getProjectDetails();
   const nestedStack = await formNestedStack(context, projectDetails);

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-depth */
+/* eslint-disable max-lines-per-function */
 /* eslint-disable prefer-const */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-return-await */
@@ -164,7 +166,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSObject, re
           'It may take a few moments for this to appear. If you have trouble with first time deployments, please try refreshing this page after a few moments and watch the CodeBuild Details for debugging information.',
         );
 
-        if (resourcesToBeUpdated.find((res: { resourceName: any; }) => res.resourceName === resource.resourceName)) {
+        if (resourcesToBeUpdated.find((res: { resourceName: string; }) => res.resourceName === resource.resourceName)) {
           resource.lastPackageTimeStamp = undefined;
           await context.amplify.updateamplifyMetaAfterResourceUpdate('api', resource.resourceName, 'lastPackageTimeStamp', undefined);
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->
The deployment-state.json is created during "iterative updates" in GraphQL schema deployments. This file is not deleted after completion of the deployment.  Future iterative updates fail if the deployment-state.json file exists but is not in "IDLE" state. 

#### Description of changes
The fix deletes the deployment-state.json file after the completion of any deployment ( success or failure ) . 


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#9665 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manual tests:
1. Force iterative updates on a GraphQL schema.
2. Check deployment-state.json is getting created when deployment is in progress.
3. Validate that deployment-state.json is deleted after deployment concludes.

integration test:
schema-iterative-update-locking test succeeds

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [*] PR description included
- [*] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
