### PR TITLE
fix(container-api): upgrade flask version for the python api

### DIFF
--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/requirements.txt
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/python/requirements.txt
@@ -1,2 +1,1 @@
-Flask==1.1.2
-itsdangerous==2.0.1
+Flask==2.0.3


### PR DESCRIPTION
Upgrade flask version for the python api. This is required to fix the failing container api tests.