### PR TITLE
fix(amplify-util-mock): Change exposed attr to reference correct attr

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -254,7 +254,7 @@ export function appSyncFunctionHandler(resourceName, resource, cfnContext: Cloud
   const dataSourceName = parseValue(properties.DataSourceName, cfnContext);
   return {
     ref: `arn:aws:appsync:us-east-1:123456789012:apis/graphqlapiid/functions/${resource.Properties.Name}`,
-    cfnExposedAttributes: { DataSourceName: 'dataSourceName', FunctionArn: 'Ref', FunctionId: 'name', Name: 'name' },
+    cfnExposedAttributes: { DataSourceName: 'dataSourceName', FunctionArn: 'ref', FunctionId: 'name', Name: 'name' },
     name: resource.Properties.Name,
     dataSourceName,
     requestMappingTemplateLocation: requestMappingTemplateLocation,

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
@@ -1,0 +1,24 @@
+import { appSyncFunctionHandler } from '../../../CFNParser/resource-processors/appsync';
+import { CloudFormationResource } from '../../../CFNParser/stack/types';
+import { CloudFormationParseContext } from '../../../CFNParser/types';
+
+describe('appSyncFunctionHandler', () => {
+  it('maps exposed attributes to properties that exist', () => {
+    const resource: CloudFormationResource = {
+      Type: 'AWS::AppSync::FunctionConfiguration',
+      Properties: {
+        Name: 'dummyFunction',
+        DataSourceName: 'dummyDataSource',
+      },
+    };
+    const cfnContext: CloudFormationParseContext = {
+      params: {},
+      conditions: {},
+      resources: {},
+      exports: {},
+    };
+    const processedResource = appSyncFunctionHandler('', resource, cfnContext);
+    const exposedAttribute = processedResource.cfnExposedAttributes.FunctionArn;
+    expect(processedResource[exposedAttribute]).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Changes the field name provided by the FunctionArn exposed attribute for processed appsync function resources so that it references the correct property.

Previously, the exposed attribute pointed to the 'Ref' field which did not exist. It should point to the 'ref' field. This was causing 'amplify mock api' to fail if the resource's FunctionArn was referenced later on in the template.

I've also updated a related test file to fix a broken test case and lint errors.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
No existing issue.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added a unit test to verify that the property referenced by FunctionArn is defined in the resource.
I've also made this change in my local development environment where I came upon this issue.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
