### PR TITLE
fix(amplify-category-analytics): ensure pinpoint permissions are created

### DIFF
--- a/packages/amplify-category-analytics/src/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
+++ b/packages/amplify-category-analytics/src/provider-utils/awscloudformation/cloudformation-templates/pinpoint-cloudformation-template.json
@@ -276,7 +276,6 @@
     },
     "CognitoUnauthPolicy": {
       "Type": "AWS::IAM::Policy",
-      "Condition": "ShouldCreatePinpointApp",
       "Properties": {
         "PolicyName": { "Ref": "unauthPolicyName" },
         "Roles": [{ "Ref": "unauthRoleName" }],
@@ -328,7 +327,6 @@
     },
     "CognitoAuthPolicy": {
       "Type": "AWS::IAM::Policy",
-      "Condition": "ShouldCreatePinpointApp",
       "Properties": {
         "PolicyName": { "Ref": "authPolicyName" },
         "Roles": [{ "Ref": "authRoleName" }],


### PR DESCRIPTION
#### Description of changes

When an AppId is provided the analytics module is not responsible for creating the pinpoint
resource. There is a condition named ```ShouldCreatePinpointApp``` to check for this.

The auth and unAuth roles had this permission specified, which is unnecessary as the resources
within them already have an if which outputs different values based on this condition.

#### Issue #, if available

#### Description of how you validated changes

My app was failing to be able to UpdateEndpoint before I made these changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
