### PR TITLE
fix(category-geo): Two new map styles were add

### DIFF
--- a/packages/amplify-category-geo/src/__tests__/service-utils/mapParams.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/mapParams.test.ts
@@ -7,7 +7,9 @@ describe('map style construction works as expected', () => {
         "VectorEsriTopographic",
         "VectorEsriDarkGrayCanvas",
         "VectorEsriLightGrayCanvas",
-        "VectorHereBerlin"
+        "VectorHereBerlin",
+        "VectorHereExplore",
+        "VectorHereExploreTruck"
     ];
 
     it('parses various supported map styles', () => {

--- a/packages/amplify-category-geo/src/service-utils/mapParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapParams.ts
@@ -23,8 +23,10 @@ export enum EsriMapStyleType {
  * The type of Map styles for HERE data provider
  */
  export enum HereMapStyleType {
-    Berlin = "Berlin"
-}
+   Berlin = "Berlin",
+   Explore = "Explore",
+   ExploreTruck = "ExploreTruck"
+ }
 
 export type MapStyleType = EsriMapStyleType | HereMapStyleType;
 
@@ -38,6 +40,8 @@ export enum MapStyle {
     VectorEsriDarkGrayCanvas = "VectorEsriDarkGrayCanvas",
     VectorEsriLightGrayCanvas = "VectorEsriLightGrayCanvas",
     VectorHereBerlin = "VectorHereBerlin",
+    VectorHereExplore = "VectorHereExplore",
+    VectorHereExploreTruck = "VectorHereExploreTruck"
 }
 
 /**
@@ -60,9 +64,6 @@ export const convertToCompleteMapParams = (partial: Partial<MapParameters>): Map
  * Constructs the Amazon Location Map Style from available map parameters
  */
 export const getGeoMapStyle = (dataProvider: DataProvider, mapStyleType: MapStyleType) => {
-    if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.Berlin) {
-        return MapStyle.VectorHereBerlin;
-    }
     return `Vector${dataProvider}${mapStyleType}`;
 };
 
@@ -83,6 +84,10 @@ export const getMapStyleComponents = (mapStyle: string): Pick<MapParameters, 'da
             return { dataProvider: DataProvider.Esri, mapStyleType: EsriMapStyleType.Topographic };
         case MapStyle.VectorHereBerlin:
             return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.Berlin };
+        case MapStyle.VectorHereExplore:
+            return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.Explore };
+        case MapStyle.VectorHereExploreTruck:
+            return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.ExploreTruck };
         default:
             throw new Error(`Invalid map style ${mapStyle}`);
     }

--- a/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
@@ -60,7 +60,7 @@ export const mapNameWalkthrough = async (context: any): Promise<Partial<MapParam
 };
 
 export const mapAdvancedWalkthrough = async (context: $TSContext, parameters: Partial<MapParameters>): Promise<Partial<MapParameters>> => {
-    const advancedSettingOptions: string[] = ['Map style & Map data provider (default: Streets provided by Esri)'];
+    const advancedSettingOptions: string[] = ["Map style & Map data provider (default: Explore provided by Here)"];
     printer.info('Available advanced settings:');
     formatter.list(advancedSettingOptions);
     printer.blankLine();
@@ -70,8 +70,8 @@ export const mapAdvancedWalkthrough = async (context: $TSContext, parameters: Pa
         parameters = merge(parameters, await mapStyleWalkthrough(parameters));
     }
     else {
-        parameters.dataProvider = DataProvider.Esri;
-        parameters.mapStyleType = EsriMapStyleType.Streets;
+        parameters.dataProvider = DataProvider.Here;
+        parameters.mapStyleType = EsriMapStyleType.Explore;
     }
 
     return parameters;
@@ -81,13 +81,15 @@ export const mapStyleWalkthrough = async (parameters: Partial<MapParameters>): P
     const mapStyleChoices = [
         { name: 'Streets (data provided by Esri)', value: MapStyle.VectorEsriStreets },
         { name: 'Berlin (data provided by HERE)', value: MapStyle.VectorHereBerlin },
+        { name: 'Explore (data provided by HERE)', value: MapStyle.VectorHereExplore },
+        { name: 'ExploreTruck (data provided by HERE)', value: MapStyle.VectorHereExploreTruck },
         { name: 'Topographic (data provided by Esri)', value: MapStyle.VectorEsriTopographic },
         { name: 'Navigation (data provided by Esri)', value: MapStyle.VectorEsriNavigation },
         { name: 'LightGrayCanvas (data provided by Esri)', value: MapStyle.VectorEsriLightGrayCanvas },
         { name: 'DarkGrayCanvas (data provided by Esri)', value: MapStyle.VectorEsriDarkGrayCanvas }
     ];
     const mapStyleDefault = parameters.dataProvider && parameters.mapStyleType ?
-        getGeoMapStyle(parameters.dataProvider, parameters.mapStyleType) : 'VectorEsriStreets';
+        getGeoMapStyle(parameters.dataProvider, parameters.mapStyleType) : 'VectorHereExplore';
 
     const mapStyleDefaultIndex = mapStyleChoices.findIndex(item => item.value === mapStyleDefault);
     const mapStyleInput = await prompter.pick<'one', string>(

--- a/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
@@ -91,7 +91,9 @@
                 "VectorEsriNavigation",
                 "VectorEsriStreets",
                 "VectorEsriTopographic",
-                "VectorHereBerlin"
+                "VectorHereBerlin",
+                "VectorHereExplore",
+                "VectorHereExploreTruck"
             ],
             "type": "string"
         }

--- a/packages/amplify-headless-interface/src/interface/geo/add.ts
+++ b/packages/amplify-headless-interface/src/interface/geo/add.ts
@@ -70,4 +70,6 @@ export enum AccessType {
   VectorEsriDarkGrayCanvas = "VectorEsriDarkGrayCanvas",
   VectorEsriLightGrayCanvas = "VectorEsriLightGrayCanvas",
   VectorHereBerlin = "VectorHereBerlin",
+  VectorHereExplore = "VectorHereExplore",
+  VectorHereExploreTruck = "VectorHereExploreTruck"
 }


### PR DESCRIPTION
#### Description of changes

- Two new map styles were added.
  - "VectorHereExplore"
  - "VectorHereExploreTruck"
- The default map style has been changed to "VectorHereExplore", a standard map that is supported worldwide.
- I turned off lint as there were many changes to the existing code.

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
