### PR TITLE
chore: fix nohoist of amplify-codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "packages/*"
     ],
     "nohoist": [
-      "@aws-amplify/cli/amplify-codegen"
+      "@aws-amplify/cli-internal/amplify-codegen"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

`amplify-dev` was showing a warning:

```
➜  amplify-dev init
The following official plugins are missing or inactive:
    codegen: util | amplify-codegen@2.28.1
Note: It is recommended to run this command from the root of your app directory
```

This is because the `@aws-amplify/cli` package was renamed to `@aws-amplify/cli-internal` so the nohoist reference also needed to be changed.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Cloned `master` branch, `yarn setup-dev` and `amplify-dev init` shows the error.
Cloned this branch, `yarn setup-dev` and `amplify-dev init` does not show the error.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
