### PR TITLE
Update pkg cli names to use -x64 when needed

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -568,9 +568,9 @@ jobs:
           name: Compress binaries
           command: |
             cd out
-            tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos
-            tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux
-            tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win.exe
+            tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos-x64
+            tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux-x64
+            tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win-x64.exe
       - run:
           name: Publish Amplify CLI GitHub prerelease
           command: |
@@ -931,7 +931,7 @@ commands:
                 command: |
                   # rename the command to amplify
                   cd /home/circleci/repo/out
-                  cp amplify-pkg-win.exe amplify.exe
+                  cp amplify-pkg-win-x64.exe amplify.exe
             - run:
                 shell: powershell.exe
                 name: Move to CLI Binary to already existing PATH
@@ -974,7 +974,7 @@ commands:
             - run: yarn --cache-folder ~/.cache/yarn
             - run:
                 shell: powershell.exe
-                command: cp /home/circleci/repo/out/amplify-pkg-win.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe
+                command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe
   install_java:
     description: 'Install Java on Linux and Docker images'
     parameters:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -41,8 +41,8 @@ function uploadPkgCli {
     export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
 
-    aws --profile=s3-uploader s3 cp amplify-pkg-win.exe s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win-$(echo $hash).exe
-    aws --profile=s3-uploader s3 cp amplify-pkg-macos s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos-$(echo $hash)
+    aws --profile=s3-uploader s3 cp amplify-pkg-win-x64.exe s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win-$(echo $hash).exe
+    aws --profile=s3-uploader s3 cp amplify-pkg-macos-x64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos-$(echo $hash)
     aws --profile=s3-uploader s3 cp amplify-pkg-linux-arm64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-arm64-$(echo $hash)
     aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash)
     if [ -z "$NPM_TAG" ]; then
@@ -54,8 +54,8 @@ function uploadPkgCli {
         echo "Cannot overwrite existing file at s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64"
         exit 1
     fi
-    aws --profile=s3-uploader s3 cp amplify-pkg-win.exe s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win.exe
-    aws --profile=s3-uploader s3 cp amplify-pkg-macos s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos
+    aws --profile=s3-uploader s3 cp amplify-pkg-win-x64.exe s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win.exe
+    aws --profile=s3-uploader s3 cp amplify-pkg-macos-x64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos
     aws --profile=s3-uploader s3 cp amplify-pkg-linux-arm64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-arm64
     aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64 s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64
     cd ..


### PR DESCRIPTION
-x64 is now being generated in filenames by generatePkgCli, and needs to be referenced in CCI.