### PR TITLE
chore: prevent cold pkg start by warming binary immediately after installation

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -133,6 +133,7 @@ export class Binary {
         }),
       );
       console.log('amplify has been installed!');
+      spawnSync(this.binaryPath, ['version'], { cwd: process.cwd(), stdio: 'inherit' });
     } catch (e) {
       error(`Error fetching release: ${e.message}`);
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The first invocation of the `amplify` binary takes several seconds on Mac and Windows OSs. This commit moves the first invocation into the postinstall script so that the customer's manual CLI invocation feels snappy.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
