### PR TITLE
ci: use legacy binary names for github releases

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -568,6 +568,9 @@ jobs:
           name: Compress binaries
           command: |
             cd out
+            mv amplify-pkg-macos-x64 amplify-pkg-macos
+            mv amplify-pkg-linux-x64 amplify-pkg-linux
+            mv amplify-pkg-win-x64.exe amplify-pkg-win.exe
             tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos-x64
             tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux-x64
             tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win-x64.exe


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR removes the `-x64` suffix from binary names (introduced when `arm64` support was added) for GitHub releases to support curl installation script.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
