### PR TITLE
ci: use renamed files in tarballs

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -571,9 +571,9 @@ jobs:
             mv amplify-pkg-macos-x64 amplify-pkg-macos
             mv amplify-pkg-linux-x64 amplify-pkg-linux
             mv amplify-pkg-win-x64.exe amplify-pkg-win.exe
-            tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos-x64
-            tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux-x64
-            tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win-x64.exe
+            tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos
+            tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux
+            tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win.exe
       - run:
           name: Publish Amplify CLI GitHub prerelease
           command: |


### PR DESCRIPTION
this pr updates our ci GitHub prerelease step to use the properly renamed files in our tarballs