### PR TITLE
fix: validate that the app limit has not been reached

### DIFF
--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -75,6 +75,15 @@ export async function onSuccess(context: $TSContext) {
   if (!context.parameters.options.app) {
     printWelcomeMessage(context);
   }
+
+  const appId = currentAmplifyMeta?.providers?.awscloudformation?.AmplifyAppId;
+  
+  if (!appId) {
+    context.print.warning('You have reached your app limit:');
+    context.print.info('For more information on Amplify Service Quotas, see:');
+    context.print.info('https://docs.aws.amazon.com/general/latest/gr/amplify.html');
+    context.print.info('');
+  }
 }
 
 function generateLocalRuntimeFiles(context: $TSContext) {


### PR DESCRIPTION
#### Description of changes
Validate that the app limit has not been reached by checking the meta file and print a warning it it
has been reached

#### Issue #, if available
Closes #10063

#### Description of how you validated changes
Reached the app limit and got the expected warning. Then, deleted an app in the cloud and created a new project, the warning was not printed as expected.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
