### PR TITLE
chore: ensure cli stays in sync with internal cli version

### DIFF
--- a/packages/amplify-cli-npm/package.json
+++ b/packages/amplify-cli-npm/package.json
@@ -34,6 +34,7 @@
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
+    "@aws-amplify/cli-internal": "8.0.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2"
   }


### PR DESCRIPTION
this pr adds a dev dependency to @aws-amplify/cli on @aws-amplify/cli-internal so that when the internal version updates, it propagates the version bump to the public package.