### PR TITLE
chore: separate update from install steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM circleci/node:14
 RUN sudo npm install -g npm@7
 RUN npm -v
 WORKDIR /tmp
-RUN sudo apt-get update && sudo apt-get install -y \
+RUN sudo apt-get update
+RUN sudo apt-get install -y \
   xdg-utils \
   libatk-bridge2.0-0 \
   libgtk-3.0 \


### PR DESCRIPTION
this pr fixes an issue where the second half of the && update and install instruction isn't being executed. The update appears to have succeeded without incident though

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/7679/workflows/4b4b8234-154b-4502-b3c9-c276826b6d56/jobs/215203