### PR TITLE
fix: cause conflicts with Error type definition, rename to reason

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/errors/index.ts
+++ b/packages/amplify-graphql-transformer-core/src/errors/index.ts
@@ -76,17 +76,17 @@ export class TransformerContractError extends Error {
  */
 export class InvalidMigrationError extends Error {
   fix: string;
-  cause: string;
-  constructor(message: string, cause: string, fix: string) {
+  reason: string;
+  constructor(message: string, reason: string, fix: string) {
     super(message);
     Object.setPrototypeOf(this, InvalidMigrationError.prototype);
     this.name = 'InvalidMigrationError';
     this.fix = fix;
-    this.cause = cause;
+    this.reason = reason;
   }
 }
 InvalidMigrationError.prototype.toString = function () {
-  return `${this.message}\nCause: ${this.cause}\nHow to fix: ${this.fix}`;
+  return `${this.message}\nCause: ${this.reason}\nHow to fix: ${this.fix}`;
 };
 
 export class InvalidDirectiveError extends Error {

--- a/packages/graphql-transformer-core/src/errors.ts
+++ b/packages/graphql-transformer-core/src/errors.ts
@@ -95,19 +95,19 @@ export class DestructiveMigrationError extends Error {
  * Thrown by the sanity checker when a user is trying to make a migration that is known to not work.
  */
 export class InvalidMigrationError extends Error {
-  constructor(message: string, public cause: string, public fix: string) {
+  constructor(message: string, public reason: string, public fix: string) {
     super(message);
     Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InvalidMigrationError';
   }
-  toString = () => `${this.message}\nCause: ${this.cause}\nHow to fix: ${this.fix}`;
+  toString = () => `${this.message}\nCause: ${this.reason}\nHow to fix: ${this.fix}`;
 }
 
 export class InvalidGSIMigrationError extends InvalidMigrationError {
   fix: string;
-  cause: string;
-  constructor(message: string, cause: string, fix: string) {
-    super(message, cause, fix);
+  cause: Error;
+  constructor(message: string, reason: string, fix: string) {
+    super(message, reason, fix);
     this.name = 'InvalidGSIMigrationError';
   }
 }


### PR DESCRIPTION
#### Description of changes
Error expects the argument `cause` to be type `Error`. If you delete and reconstruct the yarn file these changes will cause compilation to fail. Renaming the field to `reason` to allow us to still leverage `toString` in the same way we are today.

#### Issue #, if available
N/A

#### Description of how you validated changes
`yarn setup-dev && yarn test`

#### Checklist

- [ ] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
