### PR TITLE
fix: bump moment-timezone, and remove deprecated types dep

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "moment-jdateformatparser": "^1.2.1",
-    "moment-timezone": "0.5.27",
+    "moment-timezone": "0.5.34",
     "mqtt-connection": "4.0.0",
     "nanoid": "^3.3.1",
     "pino": "^6.13.0",
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.3",
-    "@types/moment-timezone": "0.5.12",
     "@types/node": "^12.12.6",
     "@types/pino": "^6.3.11",
     "@types/ws": "^7.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,13 +7204,6 @@
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/moment-timezone@0.5.12":
-  version "0.5.12"
-  resolved "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.12.tgz#0fb680c03db194fe8ff4551eaeb1eec8d3d80e9f"
-  integrity sha512-hnHH2+Efg2vExr/dSz+IX860nSiyk9Sk4pJF2EmS11lRpMcNXeB4KBW5xcgw2QPsb9amTXdsVNEe5IoJXiT0uw==
-  dependencies:
-    moment ">=2.14.0"
-
 "@types/node-fetch@^2.6.1":
   version "2.6.1"
   resolved "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
@@ -18018,14 +18011,14 @@ moment-jdateformatparser@^1.2.1:
   resolved "https://registry.npmjs.org/moment-jdateformatparser/-/moment-jdateformatparser-1.2.1.tgz#336c41ef7a6db8021d7ca086385a35fb8a648456"
   integrity sha512-lpUeQtMaxmpK+pPPHGWMnqzgsB/nunbAGPg72mzvRNbxxeQ2uBurdq9EJmvJtOiYB6k/4T9kuvQFbb+8Tirn4A==
 
-moment-timezone@0.5.27:
-  version "0.5.27"
-  resolved "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"
-  integrity sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==
+moment-timezone@0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@>=2.14.0, moment@^2.11.2, moment@^2.24.0, moment@^2.27.0:
+"moment@>= 2.9.0", moment@^2.11.2, moment@^2.24.0, moment@^2.27.0:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==


### PR DESCRIPTION
#### Description of changes
`moment-timezone@0.5.27`, and `@types/moment-timezone@0.5.12` have a mismatch which leads to the error `Property 'tz' does not exist on type 'Moment'`. This will be apparent if you build the package here outside the scope of the monorepo.

Bumping to a newer version of moment which bundles it's own types, and gets rid of this issue.

#### Issue #, if available
N/A

#### Description of how you validated changes
`yarn setup-dev && yarn test`

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
