### PR TITLE
test: fix failing geo tests

### DIFF
--- a/packages/amplify-category-geo/src/service-stacks/mapStack.ts
+++ b/packages/amplify-category-geo/src/service-stacks/mapStack.ts
@@ -29,7 +29,7 @@ export class MapStack extends BaseStack {
     this.authResourceName = this.props.authResourceName;
     this.mapRegion = this.regionMapping.findInMap(cdk.Fn.ref('AWS::Region'), 'locationServiceRegion');
 
-    const inputParameters: string[] = this.props.groupPermissions.map(
+    const inputParameters: string[] = (this.props.groupPermissions || []).map(
       (group: string) => `authuserPoolGroups${group}GroupRole`
     );
     inputParameters.push(

--- a/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
+++ b/packages/amplify-category-geo/src/service-utils/resourceUtils.ts
@@ -224,7 +224,7 @@ export const getResourceDependencies = (groupNames: string[], authResourceName: 
       attributes: ['UserPoolId']
     }
   ];
-  if (groupNames.length > 0) {
+  if (groupNames && groupNames.length > 0) {
     dependsOnResources.push({
       category: authCategoryName,
       resourceName: 'userPoolGroups',

--- a/packages/amplify-e2e-core/src/categories/geo.ts
+++ b/packages/amplify-e2e-core/src/categories/geo.ts
@@ -99,7 +99,7 @@ export function addGeofenceCollectionWithDefault(cwd: string, groupNames: string
     .wait('Select one or more cognito groups to give access:')
     .sendCtrlA()
     .sendCarriageReturn();
-  
+
   for (const groupName of groupNames){
     chain.wait(`What kind of access do you want for ${groupName} users? Select ALL that apply:`)
       .sendCtrlA()
@@ -270,7 +270,7 @@ export function removeMap(cwd: string): Promise<void> {
     .wait('Select the Map you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .runAsync()
 }
 
@@ -285,7 +285,7 @@ export function removeFirstDefaultMap(cwd: string): Promise<void> {
     .wait('Select the Map you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .wait('Select the Map you want to set as default:')
     .sendCarriageReturn()
     .runAsync()
@@ -303,7 +303,7 @@ export function removePlaceIndex(cwd: string): Promise<void> {
     .wait('Select the search index you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .runAsync()
 }
 
@@ -319,7 +319,7 @@ export function removeFirstDefaultPlaceIndex(cwd: string): Promise<void> {
     .wait('Select the search index you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .wait('Select the search index you want to set as default:')
     .sendCarriageReturn()
     .runAsync()
@@ -337,7 +337,7 @@ export function removeFirstDefaultPlaceIndex(cwd: string): Promise<void> {
     .wait('Select the geofence collection you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .runAsync()
 }
 
@@ -353,7 +353,7 @@ export function removeFirstDefaultGeofenceCollection(cwd: string): Promise<void>
     .wait('Select the geofence collection you want to remove')
     .sendCarriageReturn()
     .wait('Are you sure you want to delete the resource?')
-    .sendYes()
+    .sendConfirmYes()
     .wait('Select the geofence collection you want to set as default:')
     .sendCarriageReturn()
     .runAsync()


### PR DESCRIPTION
This PR fixes two small issues causing e2e failures on [geo-remove](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/7694/workflows/41afd811-2421-4e31-ae3c-103e7144fccd/jobs/217351) and [geo-headless](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/7694/workflows/41afd811-2421-4e31-ae3c-103e7144fccd/jobs/217351) test suites. 