### PR TITLE
only install java once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN sudo apt-get install -y \
   groff \
   python \
   python-pip \
-  libpython-dev \
-  default-jdk
+  libpython-dev
 
 RUN sudo pip install awscli
 


### PR DESCRIPTION
Our e2e container docker file installs default-jdk (which is jdk8) as well as explicitly installing jdk 11. Only jdk 11 is needed.