### PR TITLE
ci: upload gzipped pkg binaries

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -146,7 +146,6 @@ jobs:
             source .circleci/local_publish_helpers.sh
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
-            loginToLocalRegistry
             git config user.email not@used.com
             git config user.name "Doesnt Matter"
             setNpmTag
@@ -720,6 +719,7 @@ workflows:
                 - beta
                 - release
                 - /tagged-release\/.*/
+                - /tagged-release-without-e2e-tests\/.*/
                 - /run-e2e\/.*/
           requires:
             - build
@@ -870,6 +870,7 @@ workflows:
             - amplify_migration_tests_non_multi_env_layers
             - amplify_migration_tests_multi_env_layers
             - github_prerelease_install_sanity_check
+            - build_pkg_binaries
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
             source .circleci/local_publish_helpers.sh
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
-            loginToLocalRegistry
             git config user.email not@used.com
             git config user.name "Doesnt Matter"
             yarn publish-to-verdaccio

--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -88,6 +88,7 @@
   "totp",
   "tsconfig",
   "uibuilder",
+  "uint",
   "unauth",
   "updateamplify",
   "userpool",

--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -36,6 +36,8 @@
   "func",
   "globals",
   "graphql",
+  "gunzip",
+  "integtestFn",
   "homedir",
   "integtestFn",
   "iam",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "yarn-use-bash": "yarn config set script-shell /bin/bash",
     "verdaccio-start": "source .circleci/local_publish_helpers.sh && startLocalRegistry \"$(pwd)/.circleci/verdaccio.yaml\"",
     "verdaccio-clean": "rimraf ../verdaccio-cache",
-    "verdaccio-connect": "source .circleci/local_publish_helpers.sh && setNpmRegistryUrlToLocal && loginToLocalRegistry",
+    "verdaccio-connect": "source .circleci/local_publish_helpers.sh && setNpmRegistryUrlToLocal",
     "publish-to-verdaccio": "lerna publish --yes --no-commit-hooks --no-push --exact --dist-tag=latest --conventional-commits --no-git-tag-version --no-verify-access",
     "verdaccio-disconnect": "source .circleci/local_publish_helpers.sh && unsetNpmRegistryUrl",
     "verdaccio-stop": "kill -9 $(lsof -n -t -iTCP:4873 -sTCP:LISTEN) || true",

--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { spawnSync, execSync } from 'child_process';
 import util from 'util';
 import tar from 'tar-stream';
-import {createGunzip} from 'zlib';
+import { createGunzip } from 'zlib';
 import stream from 'stream';
 import os from 'os';
 import axios from 'axios';
@@ -107,10 +107,7 @@ export class Binary {
       fs.mkdirSync(this.installDirectory, { recursive: true });
     }
 
-    let amplifyExecutableName = 'amplify';
-    if (os.type() === 'Windows_NT') {
-      amplifyExecutableName = 'amplify.exe';
-    }
+    const amplifyExecutableName = os.type() === 'Windows_NT' ? 'amplify.exe' : ' amplify';
     this.binaryPath = path.join(this.installDirectory, amplifyExecutableName);
   }
 
@@ -161,17 +158,17 @@ export class Binary {
   private extract(): tar.Extract {
     const extract = tar.extract();
     const chunks: Uint8Array[] = [];
-    extract.on('entry', (header, s, next) => {
+    extract.on('entry', (header, extractStream, next) => {
       if (header.type === 'file') {
-        s.on('data', chunk => {
+        extractStream.on('data', chunk => {
           chunks.push(chunk);
         });
       }
-      s.on('end', () => {
+      extractStream.on('end', () => {
         next();
       });
 
-      s.resume();
+      extractStream.resume();
     });
     extract.on('finish', () => {
       if (chunks.length) {

--- a/packages/amplify-cli-npm/package.json
+++ b/packages/amplify-cli-npm/package.json
@@ -31,10 +31,12 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "tar-stream": "^2.2.0"
   },
   "devDependencies": {
     "@aws-amplify/cli-internal": "8.0.1",
+    "@types/tar": "^6.1.1",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2"
   }

--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/file-asset.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/file-asset.ts
@@ -20,8 +20,11 @@ export class FileAsset extends cdk.Construct implements cdk.IAsset {
     const rootStack = findRootStack(scope);
     const sythesizer = rootStack.synthesizer;
 
-    if (sythesizer instanceof TransformerStackSythesizer) {
-      sythesizer.setMappingTemplates(props.fileName, props.fileContent);
+    // Check the constructor name instead of using 'instanceof' because the latter does not work
+    // with copies of the class, which happens with custom transformers.
+    // See: https://github.com/aws-amplify/amplify-cli/issues/9362
+    if (sythesizer.constructor.name === TransformerStackSythesizer.name) {
+      (sythesizer as TransformerStackSythesizer).setMappingTemplates(props.fileName, props.fileContent);
       this.assetHash = crypto
         .createHash('sha256')
         .update(props.fileContent)
@@ -34,7 +37,7 @@ export class FileAsset extends cdk.Construct implements cdk.IAsset {
       this.httpUrl = asset.httpUrl;
       this.s3BucketName = asset.bucketName;
       this.s3ObjectKey = asset.objectKey;
-      this.s3Url = asset.s3ObjectUrl
+      this.s3Url = asset.s3ObjectUrl;
     } else {
       // TODO: handle a generic synthesizer by creating a asset in output path
       throw new Error('Template asset can be used only with TransformerStackSynthesizer');

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -385,10 +385,11 @@ export class TransformerResolver implements TransformerResolverProvider {
    * substitueSlotInfo
    */
   private substitueSlotInfo(template: MappingTemplateProvider, slotName: string, index: number) {
-    if (template instanceof S3MappingTemplate) {
-      template.substitueValues({
-        slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName,
-      });
+    // Check the constructor name instead of using 'instanceof' because the latter does not work
+    // with copies of the class, which happens with custom transformers.
+    // See: https://github.com/aws-amplify/amplify-cli/issues/9362
+    if (template.constructor.name === S3MappingTemplate.name) {
+      (template as S3MappingTemplate).substitueValues({ slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName });
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7393,6 +7393,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tar@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/@types/tar/-/tar-6.1.1.tgz#ab341ec1f149d7eb2a4f4ded56ff85f0d4fe7cb5"
+  integrity sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
+
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.2"
   resolved "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz#564fb2b2dc827147e937a75b639a05d17ce18b44"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Since shipping Amplify CLI 8.0.0, we're vending platform specific binaries downloaded as a post install script of `@aws-amplify/cli` npm package. 

This commit adds compression to the binaries to reduce network overhead of that download, speeding up install times, reducing variability caused by different network conditions, and overall limiting impact on bandwidth for CLI users. A ~72% improvement!

Linux: 696 MB to 197 MB
MacOS: 701 MB to 198 MB
Windows: 690 MB to 195 MB

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

* cloud-e2e: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e%2Fxss%2Fbinary-compression&filter=all
* tagged release: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=tagged-release-without-e2e-tests%2Fbinary-compression-2&filter=all

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
