### PR TITLE
feat: use cloudfront to serve curl binaries

### DIFF
--- a/install
+++ b/install
@@ -48,12 +48,12 @@ REPO_NAME=amplify-cli
 
 if [[ -z "$version" ]]; then
   # if no version specified, look up the latest version
-  version=`curl -sL https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest | grep 'tag_name' | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?"`
+  version=$(curl -sL 'https://registry.npmjs.org/-/v1/search?text=@aws-amplify/cli&size=1' | jq -rc '.objects[0].package.version')
 fi
 
-BASE_NAME=amplify-pkg-$PLATFORM
+BASE_NAME=amplify-pkg-$PLATFORM-$ARCH
 TAR_NAME=${BASE_NAME}.tgz
-BINARY_URL=https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/$version/$TAR_NAME
+BINARY_URL=https://d2bkhsss993doa.cloudfront.net/$version/$TAR_NAME
 
 # Dowload binary
 BINARIES_DIR_PATH=$HOME/.amplify/bin


### PR DESCRIPTION
This PR updates [our curl install script](https://docs.amplify.aws/cli/start/install/):

```
curl -sL https://aws-amplify.github.io/amplify-cli/install | bash && $SHELL
```

for Mac and Linux to use CloudFront instead of GitHub releases. 

Labeling as WIP because I need to add support for this in the windows batch script and I need to support falling back to GitHub releases for older versions.

-----

EDIT: just tracking this thought - instead of adding support for falling back to GitHub releases, we should just upload historical releases to our S3 bucket.