### PR TITLE
fix: improve instanceof checks to support custom transformers

### DIFF
--- a/packages/amplify-graphql-transformer-core/src/cdk-compat/file-asset.ts
+++ b/packages/amplify-graphql-transformer-core/src/cdk-compat/file-asset.ts
@@ -20,8 +20,11 @@ export class FileAsset extends cdk.Construct implements cdk.IAsset {
     const rootStack = findRootStack(scope);
     const sythesizer = rootStack.synthesizer;
 
-    if (sythesizer instanceof TransformerStackSythesizer) {
-      sythesizer.setMappingTemplates(props.fileName, props.fileContent);
+    // Check the constructor name instead of using 'instanceof' because the latter does not work
+    // with copies of the class, which happens with custom transformers.
+    // See: https://github.com/aws-amplify/amplify-cli/issues/9362
+    if (sythesizer.constructor.name === TransformerStackSythesizer.name) {
+      (sythesizer as TransformerStackSythesizer).setMappingTemplates(props.fileName, props.fileContent);
       this.assetHash = crypto
         .createHash('sha256')
         .update(props.fileContent)
@@ -34,7 +37,7 @@ export class FileAsset extends cdk.Construct implements cdk.IAsset {
       this.httpUrl = asset.httpUrl;
       this.s3BucketName = asset.bucketName;
       this.s3ObjectKey = asset.objectKey;
-      this.s3Url = asset.s3ObjectUrl
+      this.s3Url = asset.s3ObjectUrl;
     } else {
       // TODO: handle a generic synthesizer by creating a asset in output path
       throw new Error('Template asset can be used only with TransformerStackSynthesizer');

--- a/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
+++ b/packages/amplify-graphql-transformer-core/src/transformer-context/resolver.ts
@@ -385,10 +385,11 @@ export class TransformerResolver implements TransformerResolverProvider {
    * substitueSlotInfo
    */
   private substitueSlotInfo(template: MappingTemplateProvider, slotName: string, index: number) {
-    if (template instanceof S3MappingTemplate) {
-      template.substitueValues({
-        slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName,
-      });
+    // Check the constructor name instead of using 'instanceof' because the latter does not work
+    // with copies of the class, which happens with custom transformers.
+    // See: https://github.com/aws-amplify/amplify-cli/issues/9362
+    if (template.constructor.name === S3MappingTemplate.name) {
+      (template as S3MappingTemplate).substitueValues({ slotName, slotIndex: index, typeName: this.typeName, fieldName: this.fieldName });
     }
   }
 


### PR DESCRIPTION
This commit updates two `instanceof` checks to instead check
the constructor name. This is done to better support custom
transformers. Because custom transformers `import`/`require`
potentially different copies of the transformer modules,
the `instanceof` checks do not work. This required v2 custom
transformers to rely on `NODE_PATH` hacks and other
workarounds.

Fixes: https://github.com/aws-amplify/amplify-cli/issues/9362

Duplicates https://github.com/aws-amplify/amplify-cli/pull/9970 because @cjihrig's fork of amplify-cli no longer exists so the change cannot be rebased.