### PR TITLE
refactor: use a prefix matching for the claim in subscriptions

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/owner-auth.test.ts
@@ -93,13 +93,13 @@ test('owner field with subscriptions', () => {
 
   // expect logic in the resolvers to check for postOwner args as an allowed owner
   expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.postOwner.split(":")[0], null) )',
   );
 });
 
@@ -137,24 +137,24 @@ test('multiple owner rules with subscriptions', () => {
 
   // expect logic in the resolvers to check for owner args as an allowedOwner
   expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner, null) )',
+    '#set( $ownerEntity0 = $util.defaultIfNull($ctx.args.owner.split(":")[0], null) )',
   );
 
   // expect logic in the resolvers to check for editor args as an allowedOwner
   expect(out.resolvers['Subscription.onCreatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onUpdatePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor.split(":")[0], null) )',
   );
   expect(out.resolvers['Subscription.onDeletePost.auth.1.req.vtl']).toContain(
-    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor, null) )',
+    '#set( $ownerEntity1 = $util.defaultIfNull($ctx.args.editor.split(":")[0], null) )',
   );
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This makes subscription resolvers compatible with new default "sub:username" identity claim, and the resolvers are also backwards compatible with the old "username" default.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
