### PR TITLE
chore: revert to caret version of codegen dependencies after mv bump

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -51,7 +51,7 @@
     "amplify-category-xr": "3.2.26",
     "amplify-cli-core": "2.5.2",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.28.1",
+    "amplify-codegen": "^3.0.0",
     "amplify-console-hosting": "2.2.26",
     "amplify-container-hosting": "2.4.30",
     "amplify-dotnet-function-runtime-provider": "1.6.8",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -81,7 +81,7 @@
     "ajv": "^6.12.6",
     "amplify-cli-core": "2.5.2",
     "amplify-cli-logger": "1.1.0",
-    "amplify-codegen": "2.28.1",
+    "amplify-codegen": "^3.0.0",
     "amplify-prompts": "2.0.0",
     "amplify-util-import": "2.2.26",
     "archiver": "^5.3.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -30,7 +30,7 @@
     "amplify-appsync-simulator": "2.3.10",
     "amplify-category-function": "4.0.1",
     "amplify-cli-core": "2.5.2",
-    "amplify-codegen": "2.28.1",
+    "amplify-codegen": "^3.0.0",
     "amplify-dynamodb-simulator": "2.2.26",
     "amplify-provider-awscloudformation": "6.1.0",
     "amplify-storage-simulator": "1.6.6",


### PR DESCRIPTION
#### Description of changes
Now that each CLI release has a consistent dependency tree for all users, reverting our dependencies for codegen to use caret dependencies.

**N.B. - this is blocked until this change is released https://github.com/aws-amplify/amplify-codegen/pull/412, and the new major version is available on NPM.**

#### Issue #, if available
N/A

#### Description of how you validated changes
E2E Tests will validate once we have the new Codegen version released.

#### Checklist
- [X] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
