### PR TITLE
chore: fix syntax error in .eslintrc.js

### DIFF
--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -103,7 +103,7 @@
   "vscode",
   "xcode",
   "xamznone",
-  "yaml"
+  "yaml",
   "versioned",
   "yyyymmddhhmmss"
 ]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

syntax error occurs in .eslintrc.json because of the missing comma in json array, when execute eslint.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Run `yarn yarn lint-fix`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
