### PR TITLE
fix: use confirmContinue instead of yesOrNo behavior in conversion from inquirer to prompter

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/trigger-flow.ts
@@ -503,7 +503,7 @@ export const getTriggerEnvInputs = async (context, triggerPath, triggerKey, trig
             const prompterTypeMapping = {
               input: 'input',
               list: 'pick',
-              confirm: 'yesOrNo',
+              confirm: 'confirmContinue',
             }
             const prompterFunction = prompterTypeMapping[questions[j].question.type];
             const answer: any = await prompter[prompterFunction](questions[j].question.message);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

In 8.0.0, a change was released that replaced `inquirer` calls with our internal `prompter` library. In doing so, calls that were previously using `inquirer.confirm` were replaced with `prompter.yesOrNo`. This changed the behavior so that the prompter would respond to changes with the `--yes` flag with a yes, rather than default option (which could be no). 

This could cause unexpected code paths to be hit, which manifested in other unnecessary prompts appearing and unnecessary attempts to open programs (like browsers and code editors) emitting cryptic stack traces. These primarily manifested in CI/CD environments.

This change correctly replaces `inquirer.confirm` with `prompter.confirmContinue` instead of `prompter.yesOrNo`. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-cli/issues/10164

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- manual reproduction of customer issues
- e2e tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
