### PR TITLE
ci: reduce integration-test pipeline step flakiness

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -442,6 +442,7 @@ jobs:
             git clone $AUTH_CLONE_URL
             cd aws-amplify-cypress-auth
             yarn --cache-folder ~/.cache/yarn
+            yarn add cypress@6.8.0 --save
       - run: cd .circleci/ && chmod +x auth.sh
       - run: cd .circleci/ && chmod +x amplify_init.sh
       - run: cd .circleci/ && chmod +x amplify_init.exp
@@ -462,7 +463,6 @@ jobs:
           name: Run cypress tests for auth
           command: |
             cd ../aws-amplify-cypress-auth
-            yarn add cypress@6.8.0 --save
             cp ../repo/cypress.json .
             cp -R ../repo/cypress .
             yarn cypress run --spec $(find . -type f -name 'auth_spec*')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This change moves the installation of cypress to _before_ the react server has started. This is necessary because there is a race condition where the react development server is starting at the same time that yarn is mucking with `node_modules` contents. This can cause the react server to not start and the pipeline step to fail and require a retry.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
