### PR TITLE
fix: remove accidental space from amplify path

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -107,7 +107,7 @@ export class Binary {
       fs.mkdirSync(this.installDirectory, { recursive: true });
     }
 
-    const amplifyExecutableName = os.type() === 'Windows_NT' ? 'amplify.exe' : ' amplify';
+    const amplifyExecutableName = os.type() === 'Windows_NT' ? 'amplify.exe' : 'amplify';
     this.binaryPath = path.join(this.installDirectory, amplifyExecutableName);
   }
 


### PR DESCRIPTION
There is an accidental space in the amplify binary path. this pr removes it.