### PR TITLE
chore: fix amplify uninstall command

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -146,7 +146,9 @@ export class Binary {
 
     const [, , ...args] = process.argv;
     const result = spawnSync(this.binaryPath, args, { cwd: process.cwd(), stdio: 'inherit' });
-
+    if (args[0] === 'uninstall') {
+      spawnSync('npm', ['uninstall', '-g', '@aws-amplify/cli'], { cwd: process.cwd(), stdio: 'inherit' });
+    }
     process.exit(result.status as number);
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When v8.0.0 was released, the behavior for running `amplify uninstall` became... different. 

The `amplify uninstall` command was intended for users of the packaged CLI binary. It essentially causes the binary to self-destruct.

Previously, if amplify was installed via NPM, the cli would do nothing except emit a message instructing the caller to run `npm uninstall -g @aws-amplify/cli` instead of running `amplify uninstall`.

Now in NPM installations, since all cli commands are proxied to a packaged binary, run `amplify uninstall` causes the underlying binary to be destroyed. However, subsequent CLI commands will detect that the binary is missing and reinstall it.

```
npm i -g @aws-amplify/cli
amplify uninstall # success! amplify is removed
amplify version # One sec while I download the binary... OK version is 8.0.0
```

This pull request updates the node shim with special case logic for `amplify uninstall` that automatically also shells out a process to run `npm uninstall -g @aws-amplify/cli` on behalf of the caller.

```
npm i -g @aws-amplify/cli
amplify uninstall # success! amplify is removed
amplify version # Command not found!
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- tested locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
