### PR TITLE
fix: prevent crash when xdg-open is not available

### DIFF
--- a/packages/amplify-cli-core/src/utils/open.ts
+++ b/packages/amplify-cli-core/src/utils/open.ts
@@ -1,16 +1,21 @@
 import opn from 'open';
-import { isCI } from '..';
 import { ChildProcess } from 'child_process';
+import { isCI } from '..';
 
 /**
  * Helper function to Open stuff like URLs, files, executables. Cross-platform and opens only if its run in non-ci environmets
  * This is wrapper for https://github.com/sindresorhus/open
  * @param target The thing you want to open. Can be a URL, file, or executable.
- * @param options
+ * @param options opn.Options
  */
 export const open = (target: string, options: opn.Options): Promise<ChildProcess | void> => {
   if (isCI()) {
     return Promise.resolve();
   }
-  return opn(target, options);
+  try {
+    return opn(target, options);
+  } catch (e) {
+    console.warn(`Unable to open ${target}: ${(e as Error).message}`);
+    return Promise.resolve();
+  }
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR addresses an issue where pkg cli commands will fail when `xdg-open` is not available on a machine (such as during CI/CD or headless environments).

This can be reproduced using a Cloud9 ec2 instance:

```
wget https://github.com/aws-amplify/amplify-cli/releases/download/v7.6.26/amplify-pkg-linux.tgz
tar -xvzf amplify-pkg-linux.tgz
./amplify-pkg-linux configure
```

results in this error:

```
ec2-user:~/environment/amplify-cli (master) $ ./amplify-pkg-linux configure

Follow these steps to set up access to your AWS account:

Sign in to your AWS administrator account:
https://console.aws.amazon.com/
Press Enter to continue
2022-04-18T04:14:56.044Z - error: uncaughtException: spawn xdg-open ENOENT date=Mon Apr 18 2022 04:14:56 GMT+0000 (Coordinated Universal Time), pid=17888, uid=1000, gid=1000, cwd=/home/ec2-user/environment/amplify-cli, execPath=/home/ec2-user/environment/amplify-cli/amplify-pkg-linux, version=v12.22.7, argv=[/home/ec2-user/environment/amplify-cli/amplify-pkg-linux, /snapshot/node_modules/@aws-amplify/cli/bin/amplify, configure], rss=390303744, heapTotal=301809664, heapUsed=279318680, external=14024384, arrayBuffers=12447384, loadavg=[0.48, 1.14, 1.72], uptime=1447, trace=[column=19, file=internal/child_process.js, function=Process.ChildProcess._handle.onexit, line=268, method=onexit, native=false, column=16, file=internal/child_process.js, function=onErrorNT, line=470, method=null, native=false, column=21, file=internal/process/task_queues.js, function=processTicksAndRejections, line=84, method=null, native=false], stack=[Error: spawn xdg-open ENOENT,     at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19),     at onErrorNT (internal/child_process.js:470:16),     at processTicksAndRejections (internal/process/task_queues.js:84:21)]
```

This is not a new error, but it is more common to run into now since the pkg cli is used even via npm installations. Previously npm installations (such as via `npm i -g @aws-amplify/cli-internal`) do not crash in conditions where `xdg-open` is not available:

```
ec2-user:~/environment/amplify-cli (master) $ amplify configure
Follow these steps to set up access to your AWS account:

Sign in to your AWS administrator account:
https://console.aws.amazon.com/
Press Enter to continue
(node:24716) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/ec2-user/.nvm/versions/node/v16.14.2/lib/node_modules/@aws-amplify/cli-internal/node_modules/cloudform/package.json' of 'packages/cloudform/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)

Specify the AWS Region
? region:  (Use arrow keys)
❯ us-east-1 
  us-east-2 
  us-west-1 
  us-west-2 
  eu-north-1 
  eu-west-1 
  eu-west-2 
(Move up and down to reveal more choices)
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- ran on cloud9 with this change

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
