### PR TITLE
fix: remove prompt from rds headless pull

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
@@ -1,9 +1,11 @@
-import { $TSContext, $TSObject, exitOnNextTick, ResourceCredentialsNotFoundError, ResourceDoesNotExistError } from 'amplify-cli-core';
+import { $TSContext, $TSObject, exitOnNextTick, ResourceCredentialsNotFoundError, ResourceDoesNotExistError, pathManager } from 'amplify-cli-core';
 import { printer, prompter } from 'amplify-prompts';
 import chalk from 'chalk';
 import { DataApiParams } from 'graphql-relational-schema-transformer';
 import ora from 'ora';
+import fs from 'fs-extra';
 
+const cfnRootStackFileName = 'root-cloudformation-stack.json';
 const spinner = ora('');
 const category = 'api';
 const providerName = 'awscloudformation';
@@ -42,8 +44,14 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
 
   const { inputs, availableRegions } = datasourceMetadata;
 
+  // FIXME: We should NOT be treating CloudFormation templates as inputs to prompts! This a temporary exception while we move team-provider-info to a service.
+  const cfnJson = fs.readJSONSync(`${pathManager.getCurrentCloudRootStackDirPath(pathManager.findProjectRoot())}/${cfnRootStackFileName}`);
+  const cfnJsonParameters = cfnJson?.Resources[`api${appSyncApi}`]?.Properties?.Parameters || {};
+  let selectedRegion = cfnJsonParameters.rdsRegion;
   // Region Question
-  const selectedRegion = await promptWalkthroughQuestion(inputs, 0, availableRegions);
+  if (!selectedRegion) {
+    selectedRegion = await promptWalkthroughQuestion(inputs, 0, availableRegions);
+  }
 
   const AWS = await getAwsClient(context, 'list');
 
@@ -53,13 +61,23 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
   });
 
   // RDS Cluster Question
-  const { selectedClusterArn, clusterResourceId } = await selectCluster(context, inputs, AWS);
+  let selectedClusterArn = cfnJsonParameters.rdsClusterIdentifier
+  let clusterResourceId = getClusterResourceIdFromArn(selectedClusterArn, AWS);
+  if (!selectedClusterArn || !clusterResourceId) {
+    ({ selectedClusterArn, clusterResourceId } = await selectCluster(context, inputs, AWS));
+  }
 
   // Secret Store Question
-  const selectedSecretArn = await getSecretStoreArn(context, inputs, clusterResourceId, AWS);
+  let selectedSecretArn = cfnJsonParameters.rdsSecretStoreArn;
+  if (!selectedSecretArn) {
+    selectedSecretArn = await getSecretStoreArn(context, inputs, clusterResourceId, AWS);
+  }
 
   // Database Name Question
-  const selectedDatabase = await selectDatabase(context, inputs, selectedClusterArn, selectedSecretArn, AWS);
+  let selectedDatabase = cfnJsonParameters.rdsDatabaseName;
+  if (!selectedDatabase) {
+    selectedDatabase = await selectDatabase(context, inputs, selectedClusterArn, selectedSecretArn, AWS);
+  }
 
   return {
     region: selectedRegion,
@@ -68,6 +86,18 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
     databaseName: selectedDatabase,
     resourceName: appSyncApi,
   };
+}
+
+async function getClusterResourceIdFromArn(arn: string|undefined, AWS) {
+  if (!arn) {
+    return;
+  }
+
+  const RDS = new AWS.RDS();
+  const describeDBClustersResult = await RDS.describeDBClusters().promise();
+  const rawClusters = describeDBClustersResult.DBClusters;
+  const identifiedCluster = rawClusters.find(cluster => cluster.DBClusterArn === arn);
+  return identifiedCluster.DBClusterIdentifier;
 }
 
 /**
@@ -242,8 +272,7 @@ async function promptWalkthroughQuestion(inputs, questionNumber, choicesList) {
       message: inputs[questionNumber].question,
       choices: choicesList,
     };
-  const answer = await prompter.pick(question.message, choicesList)
-  return answer[inputs[questionNumber].key];
+  return await prompter.pick(question.message, choicesList)
 }
 
 async function getAwsClient(context: $TSContext, action: string) {

--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-rds-walkthrough.ts
@@ -62,7 +62,7 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
 
   // RDS Cluster Question
   let selectedClusterArn = cfnJsonParameters.rdsClusterIdentifier
-  let clusterResourceId = getClusterResourceIdFromArn(selectedClusterArn, AWS);
+  let clusterResourceId = getRdsClusterResourceIdFromArn(selectedClusterArn, AWS);
   if (!selectedClusterArn || !clusterResourceId) {
     ({ selectedClusterArn, clusterResourceId } = await selectCluster(context, inputs, AWS));
   }
@@ -88,7 +88,8 @@ export async function serviceWalkthrough(context: $TSContext, datasourceMetadata
   };
 }
 
-async function getClusterResourceIdFromArn(arn: string|undefined, AWS) {
+async function getRdsClusterResourceIdFromArn(arn: string|undefined, AWS) {
+  // If the arn was not already existing in cloudformation template, return undefined to prompt for input.
   if (!arn) {
     return;
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
+    "skipLibCheck": true,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently, there is a bug for applications using RDS-backed apis with Studio / headless CI environments:

```
amplify init
amplify add api
amplify api add-graphql-datasource # using instructions from https://docs.amplify.aws/cli-legacy/graphql-transformer/relational/
amplify push 
amplify pull # prompts/fails if headless args are set 
```

The root cause of the issue is the RDS metadata is stored in team-provider-info.json, which is not available on `amplify pull` from an empty workspace.

This PR implements a bit of a ~~hack~~ creative solution that reads the necessary values from pulled cloud formation templates when available instead of prompting.

This can be removed when team-provider-info is moved to a service.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- manually created rds app and pulled it headlessly. failed without the change, succeeded with the change.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
