### PR TITLE
fix(graphql): upgrade searchable streaming lambda python version

### DIFF
--- a/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
+++ b/packages/amplify-graphql-searchable-transformer/src/cdk/create-streaming-lambda.ts
@@ -30,7 +30,7 @@ export const createLambda = (
     'functions/' + OpenSearchStreamingLambdaFunctionLogicalID + '.zip',
     parameterMap.get(OpenSearchStreamingLambdaHandlerName)!.valueAsString,
     path.resolve(__dirname, '..', '..', 'lib', 'streaming-lambda.zip'),
-    Runtime.PYTHON_3_6,
+    Runtime.PYTHON_3_8,
     [
       LayerVersion.fromLayerVersionArn(
         stack,


### PR DESCRIPTION
#### Description of changes

Upgrade searchable streaming python lambda to runtime 3.8

#### Issue #, if available

Fixes https://github.com/aws-amplify/amplify-cli/issues/10242

#### Description of how you validated changes
- Manual test
- e2e test in local

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
