### PR TITLE
chore: alias appsync provider methods, and rename to graphql

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
+++ b/packages/amplify-category-api/src/provider-utils/awscloudformation/service-walkthroughs/appSync-walkthrough.ts
@@ -537,7 +537,7 @@ async function displayApiInformation(context: $TSContext, resource: $TSObject, p
 
 async function displayAuthMode(context: $TSContext, resource: $TSObject, authMode: string) {
   if (authMode === 'API_KEY' && resource.output.GraphQLAPIKeyOutput) {
-    let { apiKeys } = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getAppSyncApiKeys', {
+    let { apiKeys } = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getGraphQLApiKeys', {
       apiId: resource.output.GraphQLAPIIdOutput,
     });
     let apiKeyExpires = apiKeys.find(key => key.id == resource.output.GraphQLAPIKeyOutput)?.expires;

--- a/packages/amplify-provider-awscloudformation/src/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/src/utility-functions.js
@@ -272,8 +272,14 @@ module.exports = {
       throw err;
     }
   },
+  /**
+   * @deprecated Use getGraphQLAPIs instead
+   */
   getAppSyncAPIs: context => {
-    const log = logger('getAppSyncAPIs.appSyncModel.appSync.listGraphqlApis', { maxResults: 25 });
+    return this.getGraphQLAPIs(context);
+  },
+  getGraphQLAPIs: context => {
+    const log = logger('getGraphQLAPIs.appSyncModel.appSync.listGraphqlApis', { maxResults: 25 });
 
     return new AppSync(context)
       .then(result => {
@@ -365,12 +371,18 @@ module.exports = {
         throw ex;
       });
   },
+  /**
+   * @deprecated Use getGraphQLApiKeys instead
+   */
   getAppSyncApiKeys: (context, options) => {
+    return this.getGraphQLApiKeys(context, options);
+  },
+  getGraphQLApiKeys: (context, options) => {
     const awsOptions = {};
     if (options.region) {
       awsOptions.region = options.region;
     }
-    const log = logger('getAppSyncApiKeys.appSync.listApiKeys', [
+    const log = logger('getGraphQLApiKeys.appSync.listApiKeys', [
       {
         apiId: options.apiId,
       },


### PR DESCRIPTION
#### Description of changes
Rename some of the `AppSync` named methods in the provider, and leave aliased methods in place for backwards compatibility until clients are migrated off.

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran unit tests, remaining tests will run in the pipeline.

#### Checklist
- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
