### PR TITLE
fix: remove exclusion of build directory on appsync upload

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const fs = require('fs');
 const fsext = require('fs-extra');
 const path = require('path');
@@ -230,9 +231,6 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
 async function hashDirectory(directory) {
   const options = {
     encoding: 'hex',
-    folders: {
-      exclude: ['build'],
-    },
   };
 
   const hashResult = await hashElement(directory, options);
@@ -245,3 +243,4 @@ module.exports = {
   uploadAppSyncFiles,
   hashDirectory,
 };
+/* eslint-enable */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Create API directory hash with the build directory. The intent is to detect changes in resolvers when the schema has not changed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
