### PR TITLE
chore: bump aws-sdk version

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -29,7 +29,7 @@
     "@graphql-tools/schema": "^8.3.1",
     "@graphql-tools/utils": "^8.5.1",
     "amplify-velocity-template": "1.4.7",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "cors": "^2.8.5",
     "dataloader": "^2.0.0",

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockercompose-rest-express/express/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "axios": "^0.21.4",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/dockerfile-rest-express/package.json
@@ -9,7 +9,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-      "aws-sdk": "^2.1084.0",
+      "aws-sdk": "^2.1113.0",
       "body-parser": "^1.19.0",
       "express": "^4.17.1"
     }

--- a/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/package.json
+++ b/packages/amplify-category-api/resources/awscloudformation/container-templates/graphql-express/package.json
@@ -7,7 +7,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "aws-sdk": "^2.1084.0",
+        "aws-sdk": "^2.1113.0",
         "express": "^4.17.1",
         "express-graphql": "^0.11.0",
         "graphql": "^15.4.0"

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -33,7 +33,7 @@
     "amplify-util-headless-input": "1.9.3",
     "amplify-util-import": "2.2.26",
     "aws-cdk": "~1.124.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "change-case": "^4.1.1",
     "enquirer": "^2.3.6",

--- a/packages/amplify-category-auth/resources/adminAuth/admin-auth-package.json
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-auth-package.json
@@ -10,6 +10,6 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1084.0"
+    "aws-sdk": "^2.1113.0"
   }
 }

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -25,7 +25,7 @@
     "amplify-cli-core": "2.5.2",
     "amplify-function-plugin-interface": "1.9.4",
     "archiver": "^5.3.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "cloudform-types": "^4.2.0",
     "enquirer": "^2.3.6",

--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -32,7 +32,7 @@
     "amplify-headless-interface": "1.14.2",
     "amplify-prompts": "2.0.0",
     "amplify-util-headless-input": "1.9.3",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "folder-hash": "^4.0.2",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.3",

--- a/packages/amplify-category-predictions/package.json
+++ b/packages/amplify-category-predictions/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "amplify-cli-core": "2.5.2",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.3.3",

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -44,7 +44,7 @@
     "vm2": "^3.9.8"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "cloudform-types": "^4.2.0",
     "rimraf": "^3.0.2"
   },

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -72,7 +72,7 @@
     "amplify-python-function-template-provider": "1.3.15",
     "amplify-util-import": "2.2.26",
     "amplify-util-mock": "4.3.15",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "ci-info": "^2.0.0",
     "cli-table3": "^0.6.0",

--- a/packages/amplify-console-hosting/package.json
+++ b/packages/amplify-console-hosting/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "amplify-cli-core": "2.5.2",
     "archiver": "^5.3.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "chalk": "^4.1.1",
     "cli-table3": "^0.6.0",
     "execa": "^5.1.1",

--- a/packages/amplify-console-integration-tests/package.json
+++ b/packages/amplify-console-integration-tests/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@types/ini": "^1.3.30",
     "amplify-e2e-core": "3.1.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "amplify-cli-core": "2.5.2",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "detect-port": "^1.3.0",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -28,7 +28,7 @@
     "amplify-e2e-core": "3.1.0",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "circleci-api": "^4.1.4",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "amplify-e2e-core": "3.1.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/package.json.ejs
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/crud/package.json.ejs
@@ -11,6 +11,6 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92",
-    "aws-sdk": "^2.1084.0"
+    "aws-sdk": "^2.1113.0"
   }
 }

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -85,7 +85,7 @@
     "amplify-prompts": "2.0.0",
     "amplify-util-import": "2.2.26",
     "archiver": "^5.3.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "bottleneck": "2.19.5",
     "cfn-lint": "^1.9.7",
     "chalk": "^4.1.1",

--- a/packages/amplify-storage-simulator/package.json
+++ b/packages/amplify-storage-simulator/package.json
@@ -43,7 +43,7 @@
     "@types/serve-static": "^1.13.3",
     "@types/uuid": "^8.3.1",
     "@types/xml": "^1.0.4",
-    "aws-sdk": "^2.1084.0"
+    "aws-sdk": "^2.1113.0"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-util-import/package.json
+++ b/packages/amplify-util-import/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "amplify-cli-core": "2.5.2",
-    "aws-sdk": "^2.1084.0"
+    "aws-sdk": "^2.1113.0"
   },
   "devDependencies": {
     "@types/node": "^12.12.6"

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -65,7 +65,7 @@
     "amplify-function-plugin-interface": "1.9.4",
     "amplify-nodejs-function-runtime-provider": "2.2.26",
     "aws-appsync": "^2.0.2",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "aws-sdk-mock": "^5.6.2",
     "axios": "^0.26.0",
     "graphql-auth-transformer": "7.2.30",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -18,7 +18,7 @@
     "amplify-cli-core": "2.5.2",
     "amplify-prompts": "2.0.0",
     "amplify-provider-awscloudformation": "6.1.1",
-    "aws-sdk": "2.1113.0",
+    "aws-sdk": "^2.1113.0",
     "ora": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/graphql-relational-schema-transformer/package.json
+++ b/packages/graphql-relational-schema-transformer/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
-    "aws-sdk": "^2.1084.0"
+    "aws-sdk": "^2.1113.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/graphql-transformers-e2e-tests/package.json
+++ b/packages/graphql-transformers-e2e-tests/package.json
@@ -41,7 +41,7 @@
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-cdk": "~1.124.0",
-    "aws-sdk": "^2.1084.0",
+    "aws-sdk": "^2.1113.0",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",
     "graphql-auth-transformer": "7.2.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,21 +8931,6 @@ aws-sdk-mock@^5.6.2:
     sinon "^11.1.1"
     traverse "^0.6.6"
 
-aws-sdk@2.1113.0:
-  version "2.1113.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1113.0.tgz#78ce8b713048f3f72c6c55561cd0d70b4ac71da1"
-  integrity sha512-F+B+HFnKCVIOmErZ1jJ8YL4XxDSaUI9l3JskfpIrk0XdJVcIfyHgA4XUrTUda4z5TOy1Z7eWV2IXgEpVRM4xyw==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.16.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
-
 aws-sdk@2.518.0:
   version "2.518.0"
   resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.518.0.tgz#a0412cfcb41fd02e18d9e8b20c1dce356160fcc2"
@@ -8961,10 +8946,10 @@ aws-sdk@2.518.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.1084.0:
-  version "2.1086.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1086.0.tgz#49e782f8017d1962651061606b6ac0f901af8fe6"
-  integrity sha512-iQb9UpvaJphZSJrNccN8xA3rQBG7mg29Qvgt2VG4XnUM4cwD/i4+gJ3V/rSmM4rzAWZMbTk04lal+KBn7ByNyw==
+aws-sdk@^2.1113.0:
+  version "2.1117.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1117.0.tgz#9565fbf39caebd51c7822ab78fb3c07876e811d4"
+  integrity sha512-MBSEiLLlj8ULr8na118m44M2VvTlkyaw13J3rcHOlMSbuB2DpXBZTs2dJylFWv2szaOOSsUTo8vmc+pRJHC+Aw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
This PR updates our AWS SDK to ^2.814.0 