### PR TITLE
feat: support search with colon delimited claim

### DIFF
--- a/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
+++ b/packages/amplify-graphql-auth-transformer/src/__tests__/searchable-auth.test.ts
@@ -37,7 +37,7 @@ const expectMultiple = (
   });
 };
 
-test('auth logic is enabled on owner/static rules in es request', () => {
+test('auth logic is enabled on owner/static rules in os request', () => {
   const validSchema = `
         type Comment @model
             @searchable
@@ -64,9 +64,6 @@ test('auth logic is enabled on owner/static rules in es request', () => {
   const out = transformer.transform(validSchema);
   // expect response resolver to contain auth logic for owner rule
   expect(out).toBeDefined();
-  expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
-    '#set( $ownerClaim0 = "$ownerClaim0::$currentClaim1" )',
-  );
   expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
     '$util.qr($ownerClaimsList0.add($ownerClaim0))',
   );
@@ -130,7 +127,7 @@ test('auth logic is enabled for iam/apiKey auth rules', () => {
 });
 
 describe('identity flag feature flag disabled', () => {
-  test('auth logic is enabled on owner/static rules in es request', () => {
+  test('auth logic is enabled on owner/static rules in os request', () => {
     const validSchema = `
           type Comment @model
               @searchable
@@ -160,9 +157,6 @@ describe('identity flag feature flag disabled', () => {
     const out = transformer.transform(validSchema);
     // expect response resolver to contain auth logic for owner rule
     expect(out).toBeDefined();
-    expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
-      '#set( $ownerClaim0 = "$ownerClaim0::$currentClaim1" )',
-    );
     expect(out.resolvers['Query.searchComments.auth.1.req.vtl']).toContain(
       '$util.qr($ownerClaimsList0.add($ownerClaim0))',
     );

--- a/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
+++ b/packages/amplify-graphql-auth-transformer/src/resolvers/search.ts
@@ -22,7 +22,14 @@ import {
 } from 'graphql-mapping-template';
 import { NONE_VALUE } from 'graphql-transformer-common';
 import {
-  getIdentityClaimExp, getOwnerClaim, emptyPayload, setHasAuthExpression, iamCheck, iamAdminRoleCheckExpression,
+  getIdentityClaimExp,
+  getOwnerClaim,
+  emptyPayload,
+  setHasAuthExpression,
+  iamCheck,
+  iamAdminRoleCheckExpression,
+  generateOwnerClaimExpression,
+  generateOwnerClaimListExpression,
 } from './helpers';
 import {
   COGNITO_AUTH_TYPE,
@@ -165,20 +172,46 @@ const generateAuthFilter = (
     const entityIsList = fieldIsList(fields, role.entity);
     const roleKey = entityIsList ? role.entity : `${role.entity}.keyword`;
     if (role.strategy === 'owner') {
-      filterExpression.push(
-        set(
-          ref(`owner${idx}`),
-          obj({
-            terms_set: obj({
-              [roleKey]: obj({
-                terms: list([getOwnerClaim(role.claim!)]),
-                minimum_should_match_script: obj({ source: str('1') }),
+      const claims = role.claim!.split(':');
+      const hasMultiClaims = claims.length > 1
+        && role.claim! !== 'cognito:username'
+        && claims[0] !== 'custom';
+
+      if (hasMultiClaims) {
+        filterExpression.push(
+          generateOwnerClaimExpression(role.claim!, `ownerClaim${idx}`),
+          generateOwnerClaimListExpression(role.claim!, idx),
+          qref(methodCall(ref(`ownerClaimsList${idx}.add`), ref(`ownerClaim${idx}`))),
+          set(
+            ref(`owner${idx}`),
+            obj({
+              terms_set: obj({
+                [roleKey]: obj({
+                  terms: ref(`ownerClaimsList${idx}`),
+                  minimum_should_match_script: obj({ source: str('1') }),
+                }),
               }),
             }),
-          }),
-        ),
-      );
+          ),
+        );
+      } else {
+        filterExpression.push(
+          set(
+            ref(`owner${idx}`),
+            obj({
+              terms_set: obj({
+                [roleKey]: obj({
+                  terms: list([getOwnerClaim(role.claim!)]),
+                  minimum_should_match_script: obj({ source: str('1') }),
+                }),
+              }),
+            }),
+          ),
+        );
+      }
+
       authFilter.push(ref(`owner${idx}`));
+
       if (role.allowedFields) {
         role.allowedFields.forEach(field => {
           if (!allowedAggFields.includes(field)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Pulls in support for query requests and search with colon delimited claim to handle both `<username>` claim and `<sub>::<username>` claim. Built on top of https://github.com/aws-amplify/amplify-cli/pull/10196.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
