### PR TITLE
Revert "fix: update s3 bucket policies to adhere to best practices"

### DIFF
--- a/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
+++ b/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
@@ -23,68 +23,13 @@
       "Properties": {
         "BucketName": {
           "Ref": "DeploymentBucketName"
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true
-        }
-      }
-    },
-    "DeploymentBucketBlockHTTP": {
-      "Type": "AWS::S3::BucketPolicy",
-      "Properties": {
-        "Bucket": {
-          "Ref": "DeploymentBucketName"
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "DeploymentBucketName"
-                      },
-                      "/*"
-                    ]
-                  ]
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "DeploymentBucketName"
-                      }
-                    ]
-                  ]
-                }
-              ],
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": false
-                }
-              }
-            }
-          ]
         }
       }
     },
     "AuthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName": {
-          "Ref": "AuthRoleName"
-        },
+        "RoleName": { "Ref": "AuthRoleName" },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -103,9 +48,7 @@
     "UnauthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName": {
-          "Ref": "UnauthRoleName"
-        },
+        "RoleName": { "Ref": "UnauthRoleName" },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -125,73 +68,43 @@
   "Outputs": {
     "Region": {
       "Description": "CloudFormation provider root stack Region",
-      "Value": {
-        "Ref": "AWS::Region"
-      },
+      "Value": { "Ref": "AWS::Region" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-Region"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-Region" }
       }
     },
     "StackName": {
       "Description": "CloudFormation provider root stack ID",
-      "Value": {
-        "Ref": "AWS::StackName"
-      },
+      "Value": { "Ref": "AWS::StackName" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-StackName"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-StackName" }
       }
     },
     "StackId": {
       "Description": "CloudFormation provider root stack name",
-      "Value": {
-        "Ref": "AWS::StackId"
-      },
+      "Value": { "Ref": "AWS::StackId" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-StackId"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-StackId" }
       }
     },
     "DeploymentBucketName": {
       "Description": "CloudFormation provider root stack deployment bucket name",
-      "Value": {
-        "Ref": "DeploymentBucketName"
-      },
+      "Value": { "Ref": "DeploymentBucketName" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-DeploymentBucketName"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-DeploymentBucketName" }
       }
     },
     "AuthRoleArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "AuthRole",
-          "Arn"
-        ]
-      }
+      "Value": { "Fn::GetAtt": ["AuthRole", "Arn"] }
     },
     "UnauthRoleArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "UnauthRole",
-          "Arn"
-        ]
-      }
+      "Value": { "Fn::GetAtt": ["UnauthRole", "Arn"] }
     },
     "AuthRoleName": {
-      "Value": {
-        "Ref": "AuthRole"
-      }
+      "Value": { "Ref": "AuthRole" }
     },
     "UnauthRoleName": {
-      "Value": {
-        "Ref": "UnauthRole"
-      }
+      "Value": { "Ref": "UnauthRole" }
     }
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -100,62 +100,9 @@ Object {
         "BucketName": Object {
           "Ref": "DeploymentBucketName",
         },
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
-    },
-    "DeploymentBucketBlockHTTP": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "DeploymentBucketName",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:*",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:SecureTransport": false,
-                },
-              },
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "UnauthRole": Object {
       "Properties": Object {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -121,62 +121,9 @@ Object {
         "BucketName": Object {
           "Ref": "DeploymentBucketName",
         },
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
-    },
-    "DeploymentBucketBlockHTTP": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "DeploymentBucketName",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:*",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:SecureTransport": false,
-                },
-              },
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
     },
     "UnauthRole": Object {
       "Properties": Object {


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#10272

This PR requires a `s3:PutPublicAccessBlock` on the Amplify Role

CREATE_FAILED      DeploymentBucket AWS::S3::Bucket Sat Apr 23 2022 07:24:10 GMT+0000 (Coordinated Universal Time) API: 
s3:PutPublicAccessBlock Access Denied 