### PR TITLE
fix: prevent symlinks on nodejs package install

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -1,12 +1,14 @@
-import { getPackageManager } from 'amplify-cli-core';
+import { $TSObject, getPackageManager, JSONUtilities } from 'amplify-cli-core';
 import { BuildRequest, BuildResult, BuildType } from 'amplify-function-plugin-interface';
 import execa from 'execa';
 import * as fs from 'fs-extra';
 import glob from 'glob';
 import * as path from 'path';
 
-// copied from the existing build-resources.js file in amplify-cli with changes for new interface
-export async function buildResource(request: BuildRequest): Promise<BuildResult> {
+/**
+ * copied from the former build-resources.js file in amplify-cli with changes for new interface
+ */
+export const buildResource = async (request: BuildRequest): Promise<BuildResult> => {
   const resourceDir = request.service ? request.srcRoot : path.join(request.srcRoot, 'src');
 
   if (!request.lastBuildTimeStamp || isBuildStale(request.srcRoot, request.lastBuildTimeStamp, request.buildType, request.lastBuildType)) {
@@ -17,30 +19,27 @@ export async function buildResource(request: BuildRequest): Promise<BuildResult>
     return Promise.resolve({ rebuilt: true });
   }
   return Promise.resolve({ rebuilt: false });
-}
+};
 
-function runBuildScriptHook(resourceName: string, projectRoot: string) {
+const runBuildScriptHook = (resourceName: string, projectRoot: string): void => {
   const scriptName = `amplify:${resourceName}`;
   if (scriptExists(projectRoot, scriptName)) {
     runPackageManager(projectRoot, undefined, scriptName);
   }
-}
+};
 
-function scriptExists(projectRoot: string, scriptName: string) {
+const scriptExists = (projectRoot: string, scriptName: string): boolean => {
   const packageJsonPath = path.normalize(path.join(projectRoot, 'package.json'));
-  if (fs.existsSync(packageJsonPath)) {
-    const rootPackageJsonContents = require(packageJsonPath);
+  const rootPackageJsonContents = JSONUtilities.readJson<$TSObject>(packageJsonPath, { throwIfNotExist: false });
 
-    return rootPackageJsonContents.scripts && rootPackageJsonContents.scripts[scriptName];
-  }
-  return false;
-}
+  return !!rootPackageJsonContents?.scripts?.[scriptName];
+};
 
-function installDependencies(resourceDir: string, buildType: BuildType) {
+const installDependencies = (resourceDir: string, buildType: BuildType): void => {
   runPackageManager(resourceDir, buildType);
-}
+};
 
-function runPackageManager(cwd: string, buildType?: BuildType, scriptName?: string) {
+const runPackageManager = (cwd: string, buildType?: BuildType, scriptName?: string): void => {
   const packageManager = getPackageManager(cwd);
 
   if (packageManager === null) {
@@ -58,31 +57,31 @@ function runPackageManager(cwd: string, buildType?: BuildType, scriptName?: stri
       encoding: 'utf-8',
     });
   } catch (error) {
-    if ((error as any).code === 'ENOENT') {
+    if (error.code === 'ENOENT') {
       throw new Error(`Packaging lambda function failed. Could not find ${packageManager} executable in the PATH.`);
     } else if (error.stdout?.includes('YN0050: The --production option is deprecated')) {
-      throw new Error(`Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again.`);
+      throw new Error('Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again.');
     } else {
       throw new Error(`Packaging lambda function failed with the error \n${error.message}`);
     }
   }
-}
+};
 
-function toPackageManagerArgs(useYarn: boolean, buildType?: BuildType, scriptName?: string) {
+const toPackageManagerArgs = (useYarn: boolean, buildType?: BuildType, scriptName?: string): string[] => {
   if (scriptName) {
     return useYarn ? [scriptName] : ['run-script', scriptName];
   }
 
-  const args = useYarn ? [] : ['install'];
+  const args = useYarn ? ['--no-bin-links'] : ['install', '--no-bin-links'];
 
   if (buildType === BuildType.PROD) {
     args.push('--production');
   }
 
   return args;
-}
+};
 
-function isBuildStale(resourceDir: string, lastBuildTimeStamp: Date, buildType: BuildType, lastBuildType?: BuildType) {
+const isBuildStale = (resourceDir: string, lastBuildTimeStamp: Date, buildType: BuildType, lastBuildType?: BuildType): boolean => {
   const dirTime = new Date(fs.statSync(resourceDir).mtime);
   // If the last build type not matching we have to flag a stale build to force
   // a npm/yarn install. This way devDependencies will not be packaged when we
@@ -96,4 +95,4 @@ function isBuildStale(resourceDir: string, lastBuildTimeStamp: Date, buildType: 
     .filter(p => !p.includes('node_modules'))
     .find(file => new Date(fs.statSync(file).mtime) > lastBuildTimeStamp);
   return !!fileUpdatedAfterLastBuild;
-}
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add `--no-bin-links` flag to both yarn and npm install commands to prevent packaging issues for nodejs

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
