### PR TITLE
fix: explicitly assign buffer to node.global

### DIFF
--- a/packages/amplify-graphiql-explorer/config/webpack.config.js
+++ b/packages/amplify-graphiql-explorer/config/webpack.config.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 const fs = require('fs');
 const path = require('path');
@@ -567,6 +567,9 @@ module.exports = function (webpackEnv) {
       ].filter(Boolean),
     },
     plugins: [
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+      }),
       new webpack.ProvidePlugin({
         process: 'process/browser',
       }),

--- a/packages/amplify-graphiql-explorer/public/index.html
+++ b/packages/amplify-graphiql-explorer/public/index.html
@@ -1,16 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <script>
+    var global = global || window;
+  </script>
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -19,12 +23,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Amplify GraphiQL Explorer</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>Amplify GraphiQL Explorer</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -34,5 +39,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
After a discussion with @josefaidt , the Initial change which explicitly initialized global.buffer in `polyfills.ts` has been removed and the `buffer` library is now imported through a webpack.config plugin. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
10304
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
amplify mock does not correctly render GraphiQL explorer and Cognito fails OIDC token generation with the error
"Error: Error when generating OIDC token: Buffer is not defined". 
The change explicitly defines global ( if missing on platforms ) and assigns buffer to global .
Test:
```
amplify add api   (graphql + cognito user pools + iam auth)
amplify mock 
```
and Update graphql schema 
```
type Todo
  @model
  @auth(rules: [{ allow: public }, { allow: private, provider: iam }]) {
  id: ID!
  name: String!
  description: String
}
```
GraphiQL UI works fine.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [*] PR description included
- [*] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
