### PR TITLE
WIP: Adding preProcess support to V2 transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ packages/amplify-category-geo/lib/
 packages/amplify-e2e-tests/amplify-e2e-reports
 packages/amplify-console-integration-tests/lib
 packages/amplify-console-integration-tests/console-integration-reports
+packages/amplify-data-core/lib
+packages/amplify-data-interfaces/lib
 packages/amplify-migration-tests/amplify-migration-reports
 packages/amplify-migration-tests/lib
 packages/amplify-headless-interface/lib

--- a/packages/amplify-data-core/CHANGELOG.md
+++ b/packages/amplify-data-core/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.1.0 (2020-12-07)
+
+
+### Bug Fixes
+
+* fix winston error with 0 transports ([#5631](https://github.com/aws-amplify/amplify-cli/issues/5631)) ([4326ec6](https://github.com/aws-amplify/amplify-cli/commit/4326ec6cf2a62580cd2646241463d20d7b7fb062))
+* fixed core references ([#6069](https://github.com/aws-amplify/amplify-cli/issues/6069)) ([32446ac](https://github.com/aws-amplify/amplify-cli/commit/32446ac77a5064bee928544861b8a70fba556d51))
+
+
+### Features
+
+* Cloudformation logging ([#5195](https://github.com/aws-amplify/amplify-cli/issues/5195)) ([19b2165](https://github.com/aws-amplify/amplify-cli/commit/19b21651375848c0858328952852201da47b17bb))

--- a/packages/amplify-data-core/package.json
+++ b/packages/amplify-data-core/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "amplify-data-core",
+  "version": "1.1.0",
+  "description": "Amplify CLI Data Core Library",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "watch": "tsc -w",
+    "clean": "rimraf lib tsconfig.tsbuildinfo"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws-amplify/amplify-cli.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/aws-amplify/amplify-cli/issues"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/src/__tests__/.*|(\\.|/)test)\\.tsx?$",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/templates/"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true
+  },
+  "homepage": "https://github.com/aws-amplify/amplify-cli#readme",
+  "dependencies": {
+    "amplify-cli-core": "2.5.0",
+    "amplify-data-interfaces": "1.0.0",
+    "@aws-amplify/graphql-auth-transformer": "0.7.10",
+    "@aws-amplify/graphql-default-value-transformer": "0.5.18",
+    "@aws-amplify/graphql-function-transformer": "0.7.12",
+    "@aws-amplify/graphql-http-transformer": "0.8.12",
+    "@aws-amplify/graphql-index-transformer": "0.11.3",
+    "@aws-amplify/graphql-maps-to-transformer": "1.1.10",
+    "@aws-amplify/graphql-model-transformer": "0.13.3",
+    "@aws-amplify/graphql-predictions-transformer": "0.6.12",
+    "@aws-amplify/graphql-relational-transformer": "0.7.10",
+    "@aws-amplify/graphql-searchable-transformer": "0.13.5",
+    "@aws-amplify/graphql-transformer-core": "0.16.3",
+    "@aws-amplify/graphql-transformer-interfaces": "1.13.0",
+    "immer": "^9.0.12",
+    "fs-extra": "^10.0.1",
+    "graphql": "^16.3.0"
+  }
+}

--- a/packages/amplify-data-core/src/amplify-data-api.ts
+++ b/packages/amplify-data-core/src/amplify-data-api.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs-extra';
+import { DocumentNode, parse } from 'graphql';
+import path from 'path';
+
+import { AmplifyDataApiProvider } from '../../amplify-data-interfaces';
+import { GraphQLTransform } from '@aws-amplify/graphql-transformer-core';
+
+export class AmplifyDataApi implements AmplifyDataApiProvider {
+  private schema?: DocumentNode;
+
+  public constructor() {
+    this.schema = undefined;
+  }
+
+  public async readSchema(schemaPath: string): Promise<DocumentNode> {
+    if (this.schema) {
+      return this.schema;
+    }
+
+    const fileContentsList = new Array<Promise<Buffer>>();
+
+    const stats = fs.statSync(schemaPath);
+    if (stats.isDirectory()) {
+      fs.readdirSync(schemaPath).forEach(fileName => {
+        fileContentsList.push(fs.readFile(path.join(schemaPath, fileName)));
+      });
+    } else {
+      fileContentsList.push(fs.readFile(schemaPath));
+    }
+
+    const bufferList = await Promise.all(fileContentsList);
+    const fullSchema = bufferList.map(buff => buff.toString()).join('\n');
+    const parsedSchema = parse(fullSchema);/*
+    const transformer = {} as GraphQLTransform; // TODO: implement getTransformer();
+    const processedSchema = transformer.preProcess(parsedSchema);
+    this.schema = processedSchema;
+    return processedSchema;*/
+    return parsedSchema;
+  }
+}

--- a/packages/amplify-data-core/src/transformer-util/create-transformer.ts
+++ b/packages/amplify-data-core/src/transformer-util/create-transformer.ts
@@ -1,0 +1,10 @@
+import {
+  BelongsToTransformer,
+  HasManyTransformer,
+  HasOneTransformer,
+  ManyToManyTransformer,
+} from '@aws-amplify/graphql-relational-transformer';
+import {
+  getAppSyncServiceExtraDirectives,
+  GraphQLTransform,
+} from '@aws-amplify/graphql-transformer-core';

--- a/packages/amplify-data-core/tsconfig.json
+++ b/packages/amplify-data-core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+  },
+  "references": [
+    { "path": "../amplify-data-interfaces" },
+  ]
+}

--- a/packages/amplify-data-interfaces/CHANGELOG.md
+++ b/packages/amplify-data-interfaces/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 1.1.0 (2020-12-07)
+
+
+### Bug Fixes
+
+* fix winston error with 0 transports ([#5631](https://github.com/aws-amplify/amplify-cli/issues/5631)) ([4326ec6](https://github.com/aws-amplify/amplify-cli/commit/4326ec6cf2a62580cd2646241463d20d7b7fb062))
+* fixed core references ([#6069](https://github.com/aws-amplify/amplify-cli/issues/6069)) ([32446ac](https://github.com/aws-amplify/amplify-cli/commit/32446ac77a5064bee928544861b8a70fba556d51))
+
+
+### Features
+
+* Cloudformation logging ([#5195](https://github.com/aws-amplify/amplify-cli/issues/5195)) ([19b2165](https://github.com/aws-amplify/amplify-cli/commit/19b21651375848c0858328952852201da47b17bb))

--- a/packages/amplify-data-interfaces/package.json
+++ b/packages/amplify-data-interfaces/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "amplify-data-interfaces",
+  "version": "1.0.0",
+  "description": "Amplify CLI Data Interfaces",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "watch": "tsc -w",
+    "clean": "rimraf lib tsconfig.tsbuildinfo"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws-amplify/amplify-cli.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/aws-amplify/amplify-cli/issues"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/src/__tests__/.*|(\\.|/)test)\\.tsx?$",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/templates/"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "collectCoverage": true
+  },
+  "homepage": "https://github.com/aws-amplify/amplify-cli#readme",
+  "dependencies": {
+    "amplify-cli-core": "2.5.0",
+    "@aws-amplify/graphql-auth-transformer": "0.7.10",
+    "@aws-amplify/graphql-default-value-transformer": "0.5.18",
+    "@aws-amplify/graphql-function-transformer": "0.7.12",
+    "@aws-amplify/graphql-http-transformer": "0.8.12",
+    "@aws-amplify/graphql-index-transformer": "0.11.3",
+    "@aws-amplify/graphql-maps-to-transformer": "1.1.10",
+    "@aws-amplify/graphql-model-transformer": "0.13.3",
+    "@aws-amplify/graphql-predictions-transformer": "0.6.12",
+    "@aws-amplify/graphql-relational-transformer": "0.7.10",
+    "@aws-amplify/graphql-searchable-transformer": "0.13.5",
+    "@aws-amplify/graphql-transformer-core": "0.16.3",
+    "@aws-amplify/graphql-transformer-interfaces": "1.13.0",
+    "graphql": "^16.3.0"
+  }
+}

--- a/packages/amplify-data-interfaces/src/amplify-data-api-provider.ts
+++ b/packages/amplify-data-interfaces/src/amplify-data-api-provider.ts
@@ -1,0 +1,9 @@
+import { DocumentNode } from 'graphql';
+
+/**
+ * The AmplifyDataApiProvider serves as a definition for the API used for external interactions with the data layer
+ */
+export interface AmplifyDataApiProvider {
+  readSchema: (path: string) => Promise<DocumentNode>;
+  // getRemovedTables: (referencedTables: string[]) => string[];
+}

--- a/packages/amplify-data-interfaces/src/index.ts
+++ b/packages/amplify-data-interfaces/src/index.ts
@@ -1,0 +1,1 @@
+export { AmplifyDataApiProvider } from './amplify-data-api-provider';

--- a/packages/amplify-data-interfaces/tsconfig.json
+++ b/packages/amplify-data-interfaces/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src",
+  }
+}

--- a/packages/amplify-graphql-relational-transformer/package.json
+++ b/packages/amplify-graphql-relational-transformer/package.json
@@ -36,7 +36,8 @@
     "@aws-cdk/core": "~1.124.0",
     "graphql": "^14.5.8",
     "graphql-mapping-template": "4.20.3",
-    "graphql-transformer-common": "4.23.0"
+    "graphql-transformer-common": "4.23.0",
+    "immer": "^9.0.12"
   },
   "jest": {
     "transform": {

--- a/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
+++ b/packages/amplify-graphql-relational-transformer/src/__tests__/amplify-graphql-has-one-transformer.test.ts
@@ -467,7 +467,7 @@ test('recursive @hasOne relationships are supported if DataStore is enabled', ()
   validateModelSchema(schema);
 });
 
-describe('Pre Processing Tests', () => {
+describe('Pre Processing Has One Tests', () => {
   let transformer: GraphQLTransform;
   const hasGeneratedField = (doc: DocumentNode, objectType: string, fieldName: string): boolean => {
     let hasField = false;

--- a/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-belongs-to-transformer.ts
@@ -5,7 +5,14 @@ import {
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { DirectiveNode, FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import {
+  DirectiveNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+} from 'graphql';
 import { getBaseType, isListType } from 'graphql-transformer-common';
 import { makeGetItemConnectionWithKeyResolver } from './resolvers';
 import { ensureBelongsToConnectionField } from './schema';
@@ -19,6 +26,9 @@ import {
   validateModelDirective,
   validateRelatedModelDirective,
 } from './utils';
+import { TransformerPreProcessContextProvider } from '@aws-amplify/graphql-transformer-interfaces/lib/transformer-context/transformer-context-provider';
+import produce from 'immer';
+import { WritableDraft } from 'immer/dist/types/types-external';
 
 const directiveName = 'belongsTo';
 const directiveDefinition = `
@@ -49,6 +59,45 @@ export class BelongsToTransformer extends TransformerPluginBase {
     validate(args, context as TransformerContextProvider);
     this.directiveList.push(args);
   };
+
+  /** During the preProcess step, modify the document node and return it
+   * so that it represents any schema modifications the plugin needs
+   */
+  preProcess = (context: TransformerPreProcessContextProvider): DocumentNode => {
+    const resultDoc: DocumentNode = produce(context.inputDocument, draftDoc => {
+      const objectTypeMap = new Map<string, WritableDraft<ObjectTypeDefinitionNode | ObjectTypeExtensionNode>>(); // key: type name | value: object type node
+      // First iteration builds a map of the object types to reference for relation types
+      draftDoc?.definitions?.forEach(def => {
+        if (def.kind === 'ObjectTypeExtension' || def.kind === 'ObjectTypeDefinition') {
+          objectTypeMap.set(def.name.value, def);
+        }
+      });
+
+      draftDoc?.definitions?.forEach(def => {
+        if (def.kind === 'ObjectTypeExtension' || def.kind === 'ObjectTypeDefinition') {
+          def?.fields?.forEach(field => {
+            field?.directives?.forEach(dir => {
+              if (dir.name.value === directiveName) {
+                const relatedType = objectTypeMap.get(getBaseType(field.type));
+                if (relatedType) { // Validation is done in a different segment of the life cycle
+                  const relationTypeField = relatedType?.fields?.find(relatedField => {
+                    if (getBaseType(field.type) === def.name.value && relatedField?.directives?.some(
+                      relatedDir => relatedDir.name.value === 'hasOne' || relatedDir.name.value === 'hasMany',
+                    )) {
+                      return true;
+                    }
+                    return false;
+                  });
+                  const typeOfRelation = relationTypeField // WIP
+                }
+              }
+            });
+          });
+        }
+      });
+    });
+    return resultDoc;
+  }
 
   /**
    * During the prepare step, register any foreign keys that are renamed due to a model rename

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -6,7 +6,7 @@ import {
   TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
 import { isListType } from 'graphql-transformer-common';
-import { DirectiveNode, FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import { DirectiveNode, DocumentNode, FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
 import { makeQueryConnectionWithKeyResolver, updateTableForConnection } from './resolvers';
 import { ensureHasManyConnectionField, extendTypeWithConnection } from './schema';
 import { HasManyDirectiveConfiguration } from './types';
@@ -20,6 +20,8 @@ import {
   validateModelDirective,
   validateRelatedModelDirective,
 } from './utils';
+import { TransformerPreProcessContextProvider } from '@aws-amplify/graphql-transformer-interfaces/lib/transformer-context/transformer-context-provider';
+import produce from 'immer';
 
 const directiveName = 'hasMany';
 const defaultLimit = 100;
@@ -52,6 +54,16 @@ export class HasManyTransformer extends TransformerPluginBase {
     validate(args, context as TransformerContextProvider);
     this.directiveList.push(args);
   };
+
+  /** During the preProcess step, modify the document node and return it
+   * so that it represents any schema modifications the plugin needs
+   */
+  preProcess = (context: TransformerPreProcessContextProvider): DocumentNode => {
+    const resultDoc: DocumentNode = produce(context.inputDocument, draftDoc => {
+
+    });
+    return resultDoc;
+  }
 
   /**
    * During the prepare step, register any foreign keys that are renamed due to a model rename

--- a/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
+++ b/packages/amplify-graphql-relational-transformer/src/graphql-has-many-transformer.ts
@@ -5,13 +5,20 @@ import {
   TransformerSchemaVisitStepContextProvider,
   TransformerTransformSchemaStepContextProvider,
 } from '@aws-amplify/graphql-transformer-interfaces';
-import { isListType } from 'graphql-transformer-common';
-import { DirectiveNode, DocumentNode, FieldDefinitionNode, InterfaceTypeDefinitionNode, ObjectTypeDefinitionNode } from 'graphql';
+import { getBaseType, isListType, isNonNullType, makeField, makeNamedType, makeNonNullType } from 'graphql-transformer-common';
+import {
+  DirectiveNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  NamedTypeNode,
+  ObjectTypeDefinitionNode,
+} from 'graphql';
 import { makeQueryConnectionWithKeyResolver, updateTableForConnection } from './resolvers';
 import { ensureHasManyConnectionField, extendTypeWithConnection } from './schema';
 import { HasManyDirectiveConfiguration } from './types';
 import {
-  ensureFieldsArray,
+  ensureFieldsArray, getConnectionAttributeName,
   getFieldsNodes,
   getRelatedType,
   getRelatedTypeIndex,
@@ -22,6 +29,8 @@ import {
 } from './utils';
 import { TransformerPreProcessContextProvider } from '@aws-amplify/graphql-transformer-interfaces/lib/transformer-context/transformer-context-provider';
 import produce from 'immer';
+import { Field } from '@aws-cdk/aws-appsync';
+import { WritableDraft } from 'immer/dist/types/types-external';
 
 const directiveName = 'hasMany';
 const defaultLimit = 100;
@@ -60,7 +69,31 @@ export class HasManyTransformer extends TransformerPluginBase {
    */
   preProcess = (context: TransformerPreProcessContextProvider): DocumentNode => {
     const resultDoc: DocumentNode = produce(context.inputDocument, draftDoc => {
+      const connectingFieldsMap = new Map<string, WritableDraft<FieldDefinitionNode>>(); // key: type name | value: connecting field
+      // First iteration builds a map of the hasMany connecting fields that need to exist, second iteration ensures they exist
+      draftDoc?.definitions?.forEach(def => {
+        if (def.kind === 'ObjectTypeExtension' || def.kind === 'ObjectTypeDefinition') {
+          def?.fields?.forEach(field => {
+            field?.directives?.forEach(dir => {
+              if (dir.name.value === directiveName) {
+                const baseFieldType = getBaseType(field.type);
+                const connectionAttributeName = getConnectionAttributeName(def.name.value, field.name.value);
+                const newField = makeField(connectionAttributeName, [], isNonNullType(field.type) ? makeNonNullType(makeNamedType('ID')) : makeNamedType('ID'), []);
+                connectingFieldsMap.set(baseFieldType, newField as WritableDraft<FieldDefinitionNode>);
+              }
+            });
+          });
+        }
+      });
 
+      draftDoc?.definitions?.forEach(def => {
+        if ((def.kind === 'ObjectTypeDefinition' || def.kind === 'ObjectTypeExtension') && connectingFieldsMap.has(def.name.value)) {
+          const fieldToAdd = connectingFieldsMap.get(def.name.value);
+          if (def.fields && fieldToAdd && !def.fields.some(field => field.name.value === fieldToAdd.name.value)) {
+            def.fields.push(fieldToAdd);
+          }
+        }
+      });
     });
     return resultDoc;
   }

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-context/transformer-context-provider.ts
@@ -33,6 +33,11 @@ export interface TransformerContextProvider {
   getResolverConfig<ResolverConfig>(): ResolverConfig | undefined;
 }
 
+export type TransformerPreProcessContextProvider = Pick<
+  TransformerContextProvider,
+  'inputDocument' | 'featureFlags'
+>;
+
 export type TransformerBeforeStepContextProvider = Pick<
   TransformerContextProvider,
   'inputDocument' | 'featureFlags' | 'isProjectUsingDataStore' | 'getResolverConfig' | 'authConfig' | 'stackManager' | 'sandboxModeEnabled'

--- a/packages/amplify-graphql-transformer-interfaces/src/transformer-plugin-provider.ts
+++ b/packages/amplify-graphql-transformer-interfaces/src/transformer-plugin-provider.ts
@@ -18,7 +18,7 @@ import {
   TransformerPrepareStepContextProvider,
   TransformerSchemaVisitStepContextProvider,
   TransformerValidationStepContextProvider,
-  TransformerTransformSchemaStepContextProvider,
+  TransformerTransformSchemaStepContextProvider, TransformerPreProcessContextProvider,
 } from './transformer-context/transformer-context-provider';
 
 export enum TransformerPluginType {
@@ -35,6 +35,16 @@ export interface TransformerPluginProvider {
   readonly directive: DirectiveDefinitionNode;
 
   typeDefinitions: TypeDefinitionNode[];
+
+  /**
+   * A processing step executed prior to and separate from transformation.
+   * This method is used by plugins to make any necessary schema modifications
+   * before processing is done. This allows external sources to make necessary
+   * schema modifications without adding all the other transformation logic
+   * @param context the context provider with the document and feature flags
+   * @returns DocumentNode returns a modified GraphQL DocumentNode
+   */
+  preProcess?: (context: TransformerPreProcessContextProvider) => void;
 
   /**
    * An initializer that is called once at the beginning of a transformation.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This begins to add support for transformer plugins to modify schemas outside the transformation process. Enables codegen to hook into these changes directly and use them

This is only for the purpose of adding support in right now and does not hook into any active workflows

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
