### PR TITLE
chore: remove the nightly workflow from build/test/deploy and add its own workflow

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -670,15 +670,99 @@ workflows:
             - e2e-test-context
           requires:
             - build
-
-  build_test_deploy:
+  nightly_e2e_tests:
     triggers:
       - schedule:
-          cron: '0 14 * * *'
+          cron: '0 12 * * *'
           filters:
             branches:
               only:
                 - master
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              os:
+                - l
+                - w
+      - lint:
+          requires:
+            - build
+      - test:
+          requires:
+            - build
+      - mock_e2e_tests:
+          requires:
+            - build
+      - graphql_e2e_tests:
+          context:
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - integration_test:
+          context:
+            - e2e-test-context
+          requires:
+            - build
+      - publish_to_local_registry:
+          requires:
+            - build
+      - build_pkg_binaries:
+          context:
+            - e2e-auth-credentials
+            - e2e-test-context
+            - amplify-s3-upload
+          requires:
+            - publish_to_local_registry
+      - amplify_sudo_install_test:
+          context: amplify-ecr-image-pull
+          requires:
+            - build_pkg_binaries
+      - amplify_e2e_tests_pkg:
+          context:
+            - cleanup-resources
+            - e2e-auth-credentials
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - amplify_migration_tests_v6:
+          context:
+            - e2e-auth-credentials
+            - cleanup-resources
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - amplify_migration_tests_v5:
+          context:
+            - e2e-auth-credentials
+            - cleanup-resources
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - amplify_migration_tests_non_multi_env_layers:
+          context:
+            - e2e-auth-credentials
+            - cleanup-resources
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - amplify_migration_tests_multi_env_layers:
+          context:
+            - e2e-auth-credentials
+            - cleanup-resources
+            - e2e-test-context
+          requires:
+            - build_pkg_binaries
+      - cleanup_resources_after_e2e_runs:
+          context:
+            - cleanup-resources
+            - e2e-test-context
+          requires:
+            - amplify_e2e_tests_pkg
+            - amplify_migration_tests_v6
+            - amplify_migration_tests_v5
+
+  build_test_deploy:
     jobs:
       - build:
           matrix:


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixes the broke master runs and creates a nightly workflow for running e2e test suite.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
