### PR TITLE
chore: reduce time required to re-run amplify-cli after upgrade

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
@@ -1,24 +1,38 @@
+/* eslint-disable jest/no-interpolation-in-snapshots */
 import * as fs from 'fs-extra';
-import { run } from '../../commands/upgrade';
 import fetch, { Response } from 'node-fetch';
 import { $TSContext } from 'amplify-cli-core';
 import * as core from 'amplify-cli-core';
 import * as path from 'path';
+import execa from 'execa';
+import { run } from '../../commands/upgrade';
 import { windowsPathSerializer } from '../testUtils/snapshot-serializer';
 
 jest.mock('fs-extra');
-const fs_mock = fs as unknown as jest.Mocked<typeof fs>;
+const fsMock = fs as unknown as jest.Mocked<typeof fs>;
 
 jest.mock('node-fetch');
-const fetch_mock = fetch as jest.MockedFunction<typeof fetch>;
+const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
 
 jest.mock('util', () => ({
-  ...(jest.requireActual('util') as object),
+  ...(jest.requireActual('util') as Record<string, unknown>),
   promisify: jest.fn().mockReturnValue(() => () => {}),
 }));
 jest.mock('stream');
 
-const context_stub = {
+jest.mock('ora', () => () => ({
+  ...(jest.requireActual('ora') as Record<string, unknown>),
+  start: jest.fn(),
+  stop: jest.fn(),
+  succeed: jest.fn(),
+}));
+
+jest.mock('execa');
+const mockCLIVersion = '8.0.1';
+const execaMock = execa as jest.MockedFunction<typeof execa>;
+(execaMock as any).mockImplementation(async () => ({ stdout: mockCLIVersion }));
+
+const contextStub = {
   print: {
     success: jest.fn(),
     info: jest.fn(),
@@ -46,10 +60,10 @@ const mockStream = {
   pipe: jest.fn().mockImplementation(() => mockStream),
 };
 
-const core_mock = core as jest.Mocked<typeof core>;
-core_mock.pathManager.getHomeDotAmplifyDirPath = jest.fn().mockReturnValue('homedir');
+const coreMock = core as jest.Mocked<typeof core>;
+coreMock.pathManager.getHomeDotAmplifyDirPath = jest.fn().mockReturnValue('homedir');
 
-const context_stub_typed = context_stub as unknown as $TSContext;
+const contextStubTyped = contextStub as unknown as $TSContext;
 
 // save original process.platform
 const originalPlatform = process.platform;
@@ -65,7 +79,7 @@ describe('run upgrade using packaged CLI', () => {
 
   it('exits early if no new packaged version available', async () => {
     // setup
-    fetch_mock.mockResolvedValueOnce({
+    fetchMock.mockResolvedValueOnce({
       status: 200,
       json: jest.fn().mockResolvedValueOnce({
         tag_name: 'v1.0.0',
@@ -73,15 +87,15 @@ describe('run upgrade using packaged CLI', () => {
     } as unknown as Response);
 
     // test
-    await run(context_stub_typed);
+    await run(contextStubTyped);
 
     // validate
-    expect(context_stub.print.info.mock.calls[0][0]).toMatchInlineSnapshot(`"This is the latest Amplify CLI version."`);
+    expect(contextStub.print.info.mock.calls[0][0]).toMatchInlineSnapshot('"This is the latest Amplify CLI version."');
   });
 
   it('upgrades packaged CLI using GitHub releases', async () => {
     // setup
-    fetch_mock
+    fetchMock
       .mockResolvedValueOnce({
         status: 200,
         json: jest.fn().mockResolvedValueOnce({
@@ -102,10 +116,10 @@ describe('run upgrade using packaged CLI', () => {
     });
 
     // test
-    await run(context_stub_typed);
+    await run(contextStubTyped);
 
     // validate
-    expect(fs_mock.move.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(fsMock.move.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "${path.join('homedir', 'bin', 'amplify-pkg-linux')}",
         "${path.join('homedir', 'bin', 'amplify')}",
@@ -115,17 +129,22 @@ describe('run upgrade using packaged CLI', () => {
       ]
     `);
 
-    expect(fs_mock.chmod.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(fsMock.chmod.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "${path.join('homedir', 'bin', 'amplify')}",
         "700",
       ]
     `);
+
+    expect(execaMock).toBeCalledWith(
+      `${path.join('homedir', 'bin', 'amplify')}`,
+      ['--version'], expect.anything(),
+    );
   });
 
   it('moves old binary to temp location before downloading on windows', async () => {
     // setup
-    fetch_mock
+    fetchMock
       .mockResolvedValueOnce({
         status: 200,
         json: jest.fn().mockResolvedValueOnce({
@@ -139,8 +158,9 @@ describe('run upgrade using packaged CLI', () => {
         },
         body: mockStream,
       } as unknown as Response);
+
     let movedBinToTemp = false;
-    fs_mock.move
+    fsMock.move
       .mockImplementationOnce(async () => {
         movedBinToTemp = true;
       })
@@ -153,17 +173,20 @@ describe('run upgrade using packaged CLI', () => {
       value: 'win32',
     });
 
+    // override platform.exit
+    Object.defineProperty(process, 'exit', jest.fn);
+
     // test
-    await run(context_stub_typed);
+    await run(contextStubTyped);
 
     // validate
-    expect(fs_mock.move.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(fsMock.move.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "${path.join('homedir', 'bin', 'amplify.exe')}",
         "${path.join('homedir', 'bin', 'amplify-old.exe')}",
       ]
     `);
-    expect(fs_mock.move.mock.calls[1]).toMatchInlineSnapshot(`
+    expect(fsMock.move.mock.calls[1]).toMatchInlineSnapshot(`
       Array [
         "${path.join('homedir', 'bin', 'amplify-pkg-win.exe')}",
         "${path.join('homedir', 'bin', 'amplify.exe')}",
@@ -172,7 +195,7 @@ describe('run upgrade using packaged CLI', () => {
         },
       ]
     `);
-    expect(fs_mock.chmod.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(fsMock.chmod.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "${path.join('homedir', 'bin', 'amplify.exe')}",
         "700",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Spawn amplify cli after upgrade to allow the kernel to load process into memory. This resolves the cold-start problem for CLI post `amplify upgrade`.
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
1. update code to disable checks for dev-mode or version-check
2.`amplify upgrade`
3. validate that CLI is executed and the version of the latest amplify cli is displayed on the screen. 
4. `time amplify --version`

Repeat the above process with an upgrade from an older version of the CLI.







#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
