### PR TITLE
fix: opensearch instance type check during push

### DIFF
--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/graphql-push-schema-checks.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/graphql-push-schema-checks.test.ts
@@ -57,6 +57,26 @@ describe('graphql schema checks', () => {
     );
   });
 
+  it('should warn users if they use not recommended elastic search instance with overrides', async () => {
+    stateManagerMock.getTeamProviderInfo.mockReturnValue({
+      test: {
+        categories: {
+          api: {
+            test_api_name: {
+              ElasticSearchInstanceType: 't2.small.elasticsearch',
+            },
+          },
+        },
+      },
+    });
+    contextMock.amplify.getEnvInfo.mockReturnValue({ envName: 'test' });
+    const map = { Post: ['model', 'searchable'] };
+    await searchablePushChecks(contextMock, map, 'test_api_name');
+    expect(printerMock.warn).lastCalledWith(
+      'Your instance type for OpenSearch is t2.small.elasticsearch, you may experience performance issues or data loss. Consider reconfiguring with the instructions here mockDocsLink',
+    );
+  });
+
   it('should NOT warn users if they use recommended open search instance', async () => {
     stateManagerMock.getTeamProviderInfo.mockReturnValue({
       test: {
@@ -64,6 +84,24 @@ describe('graphql schema checks', () => {
           api: {
             test_api_name: {
               OpenSearchInstanceType: 't2.medium.elasticsearch',
+            },
+          },
+        },
+      },
+    });
+    contextMock.amplify.getEnvInfo.mockReturnValue({ envName: 'test' });
+    const map = { Post: ['model', 'searchable'] };
+    await searchablePushChecks(contextMock, map, 'test_api_name');
+    expect(printerMock.warn).not.toBeCalled();
+  });
+
+  it('should NOT warn users if they use recommended elastic search instance', async () => {
+    stateManagerMock.getTeamProviderInfo.mockReturnValue({
+      test: {
+        categories: {
+          api: {
+            test_api_name: {
+              ElasticSearchInstanceType: 't2.medium.elasticsearch',
             },
           },
         },
@@ -91,6 +129,33 @@ describe('graphql schema checks', () => {
           api: {
             test_api_name: {
               OpenSearchInstanceType: 't2.medium.elasticsearch',
+            },
+          },
+        },
+      },
+    });
+    contextMock.amplify.getEnvInfo.mockReturnValue({ envName: 'prod' });
+    const map = { Post: ['model', 'searchable'] };
+    await searchablePushChecks(contextMock, map, 'test_api_name');
+    expect(printerMock.warn).not.toBeCalled();
+  });
+
+  it('should NOT warn users if they use recommended elastic search instance on the environment', async () => {
+    stateManagerMock.getTeamProviderInfo.mockReturnValue({
+      dev: {
+        categories: {
+          api: {
+            test_api_name: {
+              ElasticSearchInstanceType: 't2.small.elasticsearch',
+            },
+          },
+        },
+      },
+      prod: {
+        categories: {
+          api: {
+            test_api_name: {
+              ElasticSearchInstanceType: 't2.medium.elasticsearch',
             },
           },
         },

--- a/packages/amplify-category-api/src/__tests__/graphql-transformer/graphql-push-schema-checks.test.ts
+++ b/packages/amplify-category-api/src/__tests__/graphql-transformer/graphql-push-schema-checks.test.ts
@@ -1,4 +1,4 @@
-import { stateManager, getGraphQLTransformerOpenSearchProductionDocLink, getTransformerVersion } from 'amplify-cli-core';
+import { stateManager, getGraphQLTransformerOpenSearchProductionDocLink, ApiCategoryFacade } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { searchablePushChecks } from '../../graphql-transformer/api-utils';
 
@@ -7,7 +7,7 @@ jest.mock('amplify-prompts');
 
 const printerMock = printer as jest.Mocked<typeof printer>;
 const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
-const getTransformerVersionMock = getTransformerVersion as jest.MockedFunction<typeof getTransformerVersion>
+const getTransformerVersionMock = ApiCategoryFacade.getTransformerVersion as jest.MockedFunction<typeof ApiCategoryFacade.getTransformerVersion>
 const getGraphQLTransformerOpenSearchProductionDocLinkMock = getGraphQLTransformerOpenSearchProductionDocLink as jest.MockedFunction<
   typeof getGraphQLTransformerOpenSearchProductionDocLink
 >;

--- a/packages/amplify-category-api/src/graphql-transformer/api-utils.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/api-utils.ts
@@ -8,9 +8,10 @@ export async function searchablePushChecks(context, map, apiName): Promise<void>
     if (searchableModelTypes.length) {
       const currEnv = context.amplify.getEnvInfo().envName;
       const teamProviderInfo = stateManager.getTeamProviderInfo();
+      const version = await getTransformerVersion(context);
       const instanceType = _.get(
         teamProviderInfo,
-        [currEnv, 'categories', 'api', apiName, ResourceConstants.PARAMETERS.ElasticsearchInstanceType],
+        [currEnv, 'categories', 'api', apiName, version === 2 ? ResourceConstants.PARAMETERS.OpenSearchInstanceType : ResourceConstants.PARAMETERS.ElasticsearchInstanceType],
         't2.small.elasticsearch',
       );
       if (instanceType === 't2.small.elasticsearch' || instanceType === 't3.small.elasticsearch') {

--- a/packages/amplify-category-api/src/graphql-transformer/api-utils.ts
+++ b/packages/amplify-category-api/src/graphql-transformer/api-utils.ts
@@ -8,12 +8,11 @@ export async function searchablePushChecks(context, map, apiName): Promise<void>
     if (searchableModelTypes.length) {
       const currEnv = context.amplify.getEnvInfo().envName;
       const teamProviderInfo = stateManager.getTeamProviderInfo();
-      const version = await getTransformerVersion(context);
-      const instanceType = _.get(
-        teamProviderInfo,
-        [currEnv, 'categories', 'api', apiName, version === 2 ? ResourceConstants.PARAMETERS.OpenSearchInstanceType : ResourceConstants.PARAMETERS.ElasticsearchInstanceType],
-        't2.small.elasticsearch',
-      );
+      const getInstanceType = (instanceTypeParam: string) => _.get(teamProviderInfo, [currEnv, 'categories', 'api', apiName, instanceTypeParam]);
+      const instanceType = 
+        getInstanceType(ResourceConstants.PARAMETERS.OpenSearchInstanceType) ??
+        getInstanceType(ResourceConstants.PARAMETERS.ElasticsearchInstanceType) ??
+        't2.small.elasticsearch';
       if (instanceType === 't2.small.elasticsearch' || instanceType === 't3.small.elasticsearch') {
         const version = await ApiCategoryFacade.getTransformerVersion(context);
         const docLink = getGraphQLTransformerOpenSearchProductionDocLink(version);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use `OpenSearchInstanceType` for transformer v2 pre push check. `ElasticSearchInstanceType` will be checked afterwards when OS is not found
#### Issue #, if available
fix #10362 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
