### PR TITLE
Revert "chore: wrap getTransformerFactory behind a single API (#10373)"

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/transformer-factory.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/transformer-factory.ts
@@ -3,8 +3,8 @@ import { DefaultValueTransformer as DefaultValueTransformerV2 } from '@aws-ampli
 import { FunctionTransformer as FunctionTransformerV2 } from '@aws-amplify/graphql-function-transformer';
 import { HttpTransformer as HttpTransformerV2 } from '@aws-amplify/graphql-http-transformer';
 import {
-  IndexTransformer as IndexTransformerV2,
-  PrimaryKeyTransformer as PrimaryKeyTransformerV2,
+    IndexTransformer as IndexTransformerV2,
+    PrimaryKeyTransformer as PrimaryKeyTransformerV2,
 } from '@aws-amplify/graphql-index-transformer';
 import { MapsToTransformer as MapsToTransformerV2 } from '@aws-amplify/graphql-maps-to-transformer';
 import { ModelTransformer as ModelTransformerV2 } from '@aws-amplify/graphql-model-transformer';
@@ -26,26 +26,25 @@ import { FunctionTransformer as FunctionTransformerV1 } from 'graphql-function-t
 import { HttpTransformer as HttpTransformerV1 } from 'graphql-http-transformer';
 import { PredictionsTransformer as PredictionsTransformerV1 } from 'graphql-predictions-transformer';
 import { KeyTransformer as KeyTransformerV1 } from 'graphql-key-transformer';
+import { isAmplifyAdminApp } from '../utils/admin-helpers';
 import {
   $TSAny,
   $TSContext,
   pathManager,
   stateManager,
 } from 'amplify-cli-core';
+import { ProviderName as providerName } from '../constants';
 import { printer } from 'amplify-prompts';
 import {
-  loadProject,
-  readTransformerConfiguration,
-  TRANSFORM_CONFIG_FILE_NAME,
-  ITransformer,
-  TransformConfig,
+    loadProject,
+    readTransformerConfiguration,
+    TRANSFORM_CONFIG_FILE_NAME,
+    ITransformer,
+    TransformConfig,
 } from 'graphql-transformer-core';
 import importFrom from 'import-from';
 import importGlobal from 'import-global';
 import path from 'path';
-import { ProviderName as providerName } from '../constants';
-import { isAmplifyAdminApp } from '../utils/admin-helpers';
-import { getTransformerVersion } from './transformer-version';
 
 type TransformerFactoryArgs = {
     addSearchableTransformer: boolean;
@@ -55,21 +54,7 @@ type TransformerFactoryArgs = {
     identityPoolId?: string;
   };
 
-/**
- * Return the graphql transformer factory based on the projects current transformer version.
- */
-export const getTransformerFactory = async (
-  context: $TSContext,
-  resourceDir: string,
-  authConfig?: $TSAny,
-): Promise<(options: $TSAny) => Promise<(TransformerPluginProviderV2 | ITransformer)[]>> => {
-  const transformerVersion = await getTransformerVersion(context);
-  return transformerVersion === 2
-    ? getTransformerFactoryV2(resourceDir)
-    : getTransformerFactoryV1(resourceDir, authConfig);
-};
-
-const getTransformerFactoryV2 = (
+export const getTransformerFactoryV2 = (
   resourceDir: string,
 ): (options: TransformerFactoryArgs) => Promise<TransformerPluginProviderV2[]> => async (options?: TransformerFactoryArgs) => {
   const modelTransformer = new ModelTransformerV2();
@@ -126,7 +111,7 @@ const getTransformerFactoryV2 = (
   return transformerList;
 };
 
-function getTransformerFactoryV1(resourceDir: string, authConfig?: $TSAny) {
+export function getTransformerFactoryV1(context: $TSContext, resourceDir: string, authConfig?: $TSAny) {
   return async (addSearchableTransformer: boolean, storageConfig?: $TSAny) => {
     const transformerList: ITransformer[] = [
       // TODO: Removing until further discussion. `getTransformerOptions(project, '@model')`

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -33,7 +33,7 @@ import {
 import { hashDirectory } from '../upload-appsync-files';
 import { exitOnNextTick } from 'amplify-cli-core';
 import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
-import { getTransformerFactory } from '../graphql-transformer-factory/transformer-factory';
+import { getTransformerFactoryV1 } from '../graphql-transformer-factory/transformer-factory';
 import { searchablePushChecks } from './api-utils';
 
 const apiCategory = 'api';
@@ -361,7 +361,7 @@ export async function transformGraphQLSchemaV1(context, options) {
 
   await transformerVersionCheck(context, resourceDir, previouslyDeployedBackendDir, resourcesToBeUpdated, directiveMap.directives);
 
-  const transformerListFactory = await getTransformerFactory(context, resourceDir, authConfig);
+  const transformerListFactory = getTransformerFactoryV1(context, resourceDir, authConfig);
 
   let searchableTransformerFlag = false;
 

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -23,17 +23,11 @@ import {
 import { printer } from 'amplify-prompts';
 import fs from 'fs-extra';
 import { ResourceConstants } from 'graphql-transformer-common';
-import {
-  DiffRule,
-  getSanityCheckRules,
-  loadProject,
-  ProjectRule,
-  sanityCheckProject,
-} from 'graphql-transformer-core';
+import { DiffRule, getSanityCheckRules, loadProject, ProjectRule, sanityCheckProject } from 'graphql-transformer-core';
 import _ from 'lodash';
 import path from 'path';
 import { destructiveUpdatesFlag, ProviderName } from '../constants';
-import { getTransformerFactory } from '../graphql-transformer-factory/transformer-factory';
+import { getTransformerFactoryV2 } from '../graphql-transformer-factory/transformer-factory';
 import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
 /* eslint-disable-next-line import/no-cycle */
 import { searchablePushChecks } from './api-utils';
@@ -233,7 +227,7 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
 
   searchablePushChecks(context, directiveMap.types, parameters[ResourceConstants.PARAMETERS.AppSyncApiName]);
 
-  const transformerListFactory = await getTransformerFactory(context, resourceDir);
+  const transformerListFactory = getTransformerFactoryV2(resourceDir);
 
   if (sandboxModeEnabled && options.promptApiKeyCreation) {
     const apiKeyConfig = await showSandboxModePrompts(context);

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -1,19 +1,19 @@
-import { DeploymentResources as DeploymentResourcesV2 } from '@aws-amplify/graphql-transformer-core';
-import { DeploymentResources as DeploymentResourcesV1 } from 'graphql-transformer-core';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
-import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
-import { transformGraphQLSchemaV1 } from './transform-graphql-schema-v1';
-import { transformGraphQLSchemaV2 } from './transform-graphql-schema-v2';
+import { DeploymentResources as DeploymentResourcesV2 } from "@aws-amplify/graphql-transformer-core";
+import { DeploymentResources as DeploymentResourcesV1 } from "graphql-transformer-core";
+import { $TSAny, $TSContext } from "amplify-cli-core";
+import { getTransformerVersion } from "../graphql-transformer-factory/transformer-version";
+import { transformGraphQLSchemaV1 } from "./transform-graphql-schema-v1";
+import { transformGraphQLSchemaV2 } from "./transform-graphql-schema-v2";
 
 /**
  * Determine which transformer version is in effect, and execute the appropriate transformation.
  */
-export const transformGraphQLSchema = async (
+export async function transformGraphQLSchema(
   context: $TSContext,
-  options: $TSAny,
-): Promise<DeploymentResourcesV2 | DeploymentResourcesV1 | undefined> => {
+  options: $TSAny
+): Promise<DeploymentResourcesV2 | DeploymentResourcesV1 | undefined> {
   const transformerVersion = await getTransformerVersion(context);
   return transformerVersion === 2
     ? transformGraphQLSchemaV2(context, options)
     : transformGraphQLSchemaV1(context, options);
-};
+}


### PR DESCRIPTION
This reverts commit bff1ce505ea8c6483be05a9144e83a648f950897.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
