### PR TITLE
Revert "Revert "chore: wrap getTransformerFactory behind a single API (#10373)" (#10390)"

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/directive-definitions.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/directive-definitions.ts
@@ -5,22 +5,23 @@ import {
   $TSContext,
 } from 'amplify-cli-core';
 import { print } from 'graphql';
-import { getTransformerFactoryV1, getTransformerFactoryV2 } from './transformer-factory';
+import { getTransformerFactory } from './transformer-factory';
 import { getTransformerVersion } from './transformer-version';
 
 /**
  * Return the set of directive definitions for the project, includes both appsync and amplify supported directives.
  * This will return the relevant set determined by whether or not the customer is using GQL transformer v1 or 2 in their project.
  */
-export async function getDirectiveDefinitions(context: $TSContext, resourceDir: string): Promise<string> {
+export const getDirectiveDefinitions = async (context: $TSContext, resourceDir: string): Promise<string> => {
   const transformerVersion = await getTransformerVersion(context);
+  const transformer = await getTransformerFactory(context, resourceDir);
   const transformList = transformerVersion === 2
-    ? await getTransformerFactoryV2(resourceDir)({ addSearchableTransformer: true, authConfig: {} })
-    : await getTransformerFactoryV1(context, resourceDir)(true);
+    ? await transformer({ addSearchableTransformer: true, authConfig: {} })
+    : await transformer(true);
 
   const transformDirectives = transformList
     .map(transformPluginInst => [transformPluginInst.directive, ...transformPluginInst.typeDefinitions].map(node => print(node)).join('\n'))
     .join('\n');
 
   return [getAppSyncServiceExtraDirectives(), transformDirectives].join('\n');
-}
+};

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/transformer-factory.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer-factory/transformer-factory.ts
@@ -3,8 +3,8 @@ import { DefaultValueTransformer as DefaultValueTransformerV2 } from '@aws-ampli
 import { FunctionTransformer as FunctionTransformerV2 } from '@aws-amplify/graphql-function-transformer';
 import { HttpTransformer as HttpTransformerV2 } from '@aws-amplify/graphql-http-transformer';
 import {
-    IndexTransformer as IndexTransformerV2,
-    PrimaryKeyTransformer as PrimaryKeyTransformerV2,
+  IndexTransformer as IndexTransformerV2,
+  PrimaryKeyTransformer as PrimaryKeyTransformerV2,
 } from '@aws-amplify/graphql-index-transformer';
 import { MapsToTransformer as MapsToTransformerV2 } from '@aws-amplify/graphql-maps-to-transformer';
 import { ModelTransformer as ModelTransformerV2 } from '@aws-amplify/graphql-model-transformer';
@@ -26,25 +26,26 @@ import { FunctionTransformer as FunctionTransformerV1 } from 'graphql-function-t
 import { HttpTransformer as HttpTransformerV1 } from 'graphql-http-transformer';
 import { PredictionsTransformer as PredictionsTransformerV1 } from 'graphql-predictions-transformer';
 import { KeyTransformer as KeyTransformerV1 } from 'graphql-key-transformer';
-import { isAmplifyAdminApp } from '../utils/admin-helpers';
 import {
   $TSAny,
   $TSContext,
   pathManager,
   stateManager,
 } from 'amplify-cli-core';
-import { ProviderName as providerName } from '../constants';
 import { printer } from 'amplify-prompts';
 import {
-    loadProject,
-    readTransformerConfiguration,
-    TRANSFORM_CONFIG_FILE_NAME,
-    ITransformer,
-    TransformConfig,
+  loadProject,
+  readTransformerConfiguration,
+  TRANSFORM_CONFIG_FILE_NAME,
+  ITransformer,
+  TransformConfig,
 } from 'graphql-transformer-core';
 import importFrom from 'import-from';
 import importGlobal from 'import-global';
 import path from 'path';
+import { ProviderName as providerName } from '../constants';
+import { isAmplifyAdminApp } from '../utils/admin-helpers';
+import { getTransformerVersion } from './transformer-version';
 
 type TransformerFactoryArgs = {
     addSearchableTransformer: boolean;
@@ -54,7 +55,21 @@ type TransformerFactoryArgs = {
     identityPoolId?: string;
   };
 
-export const getTransformerFactoryV2 = (
+/**
+ * Return the graphql transformer factory based on the projects current transformer version.
+ */
+export const getTransformerFactory = async (
+  context: $TSContext,
+  resourceDir: string,
+  authConfig?: $TSAny,
+): Promise<(options: $TSAny) => Promise<(TransformerPluginProviderV2 | ITransformer)[]>> => {
+  const transformerVersion = await getTransformerVersion(context);
+  return transformerVersion === 2
+    ? getTransformerFactoryV2(resourceDir)
+    : getTransformerFactoryV1(resourceDir, authConfig);
+};
+
+const getTransformerFactoryV2 = (
   resourceDir: string,
 ): (options: TransformerFactoryArgs) => Promise<TransformerPluginProviderV2[]> => async (options?: TransformerFactoryArgs) => {
   const modelTransformer = new ModelTransformerV2();
@@ -111,7 +126,7 @@ export const getTransformerFactoryV2 = (
   return transformerList;
 };
 
-export function getTransformerFactoryV1(context: $TSContext, resourceDir: string, authConfig?: $TSAny) {
+function getTransformerFactoryV1(resourceDir: string, authConfig?: $TSAny) {
   return async (addSearchableTransformer: boolean, storageConfig?: $TSAny) => {
     const transformerList: ITransformer[] = [
       // TODO: Removing until further discussion. `getTransformerOptions(project, '@model')`

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v1.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v1.ts
@@ -33,7 +33,7 @@ import {
 import { hashDirectory } from '../upload-appsync-files';
 import { exitOnNextTick } from 'amplify-cli-core';
 import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
-import { getTransformerFactoryV1 } from '../graphql-transformer-factory/transformer-factory';
+import { getTransformerFactory } from '../graphql-transformer-factory/transformer-factory';
 import { searchablePushChecks } from './api-utils';
 
 const apiCategory = 'api';
@@ -361,7 +361,7 @@ export async function transformGraphQLSchemaV1(context, options) {
 
   await transformerVersionCheck(context, resourceDir, previouslyDeployedBackendDir, resourcesToBeUpdated, directiveMap.directives);
 
-  const transformerListFactory = getTransformerFactoryV1(context, resourceDir, authConfig);
+  const transformerListFactory = await getTransformerFactory(context, resourceDir, authConfig);
 
   let searchableTransformerFlag = false;
 

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v2.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema-v2.ts
@@ -23,11 +23,17 @@ import {
 import { printer } from 'amplify-prompts';
 import fs from 'fs-extra';
 import { ResourceConstants } from 'graphql-transformer-common';
-import { DiffRule, getSanityCheckRules, loadProject, ProjectRule, sanityCheckProject } from 'graphql-transformer-core';
+import {
+  DiffRule,
+  getSanityCheckRules,
+  loadProject,
+  ProjectRule,
+  sanityCheckProject,
+} from 'graphql-transformer-core';
 import _ from 'lodash';
 import path from 'path';
 import { destructiveUpdatesFlag, ProviderName } from '../constants';
-import { getTransformerFactoryV2 } from '../graphql-transformer-factory/transformer-factory';
+import { getTransformerFactory } from '../graphql-transformer-factory/transformer-factory';
 import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
 /* eslint-disable-next-line import/no-cycle */
 import { searchablePushChecks } from './api-utils';
@@ -227,7 +233,7 @@ export const transformGraphQLSchemaV2 = async (context: $TSContext, options): Pr
 
   searchablePushChecks(context, directiveMap.types, parameters[ResourceConstants.PARAMETERS.AppSyncApiName]);
 
-  const transformerListFactory = getTransformerFactoryV2(resourceDir);
+  const transformerListFactory = await getTransformerFactory(context, resourceDir);
 
   if (sandboxModeEnabled && options.promptApiKeyCreation) {
     const apiKeyConfig = await showSandboxModePrompts(context);

--- a/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-transformer/transform-graphql-schema.ts
@@ -1,19 +1,19 @@
-import { DeploymentResources as DeploymentResourcesV2 } from "@aws-amplify/graphql-transformer-core";
-import { DeploymentResources as DeploymentResourcesV1 } from "graphql-transformer-core";
-import { $TSAny, $TSContext } from "amplify-cli-core";
-import { getTransformerVersion } from "../graphql-transformer-factory/transformer-version";
-import { transformGraphQLSchemaV1 } from "./transform-graphql-schema-v1";
-import { transformGraphQLSchemaV2 } from "./transform-graphql-schema-v2";
+import { DeploymentResources as DeploymentResourcesV2 } from '@aws-amplify/graphql-transformer-core';
+import { DeploymentResources as DeploymentResourcesV1 } from 'graphql-transformer-core';
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { getTransformerVersion } from '../graphql-transformer-factory/transformer-version';
+import { transformGraphQLSchemaV1 } from './transform-graphql-schema-v1';
+import { transformGraphQLSchemaV2 } from './transform-graphql-schema-v2';
 
 /**
  * Determine which transformer version is in effect, and execute the appropriate transformation.
  */
-export async function transformGraphQLSchema(
+export const transformGraphQLSchema = async (
   context: $TSContext,
-  options: $TSAny
-): Promise<DeploymentResourcesV2 | DeploymentResourcesV1 | undefined> {
+  options: $TSAny,
+): Promise<DeploymentResourcesV2 | DeploymentResourcesV1 | undefined> => {
   const transformerVersion = await getTransformerVersion(context);
   return transformerVersion === 2
     ? transformGraphQLSchemaV2(context, options)
     : transformGraphQLSchemaV1(context, options);
-}
+};


### PR DESCRIPTION
This reverts commit c2629f6ac6aba05d205e6a3622a8cfa9f8c2d0bf.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
