### PR TITLE
chore: add nightly trigger for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,24 @@
 version: 2.1
 
 jobs:
+  run-nightly_e2e_tests:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Run scheduled workflow
+          command: |
+            curl --location --request POST 'https://circleci.com/api/v2/project/gh/aws-amplify/amplify-cli/pipeline' \
+            --header 'Content-Type: application/json' \
+            -u "${CCI_CONTINUATION_TOKEN}:" \
+            --data-raw '{
+              "branch": "master",
+                "parameters": {
+                  "setup": true,
+                  "nightly_console_integration_tests": false,
+                  "e2e_resource_cleanup": false
+              }
+            }'
   run-nightly_console_integration_tests:
     docker:
       - image: cimg/base:stable
@@ -60,6 +78,16 @@ workflows:
                 - nightly-jobs
     jobs:
       - run-e2e_resource_cleanup
+  trigger_nightly_e2e_tests:
+    triggers:
+      - schedule:
+          cron: 0 14 * * *
+          filters:
+            branches:
+              only:
+                - nightly-jobs
+    jobs:
+      - run-nightly_e2e_tests
   run_on_push:
     jobs:
       - run-nightly_console_integration_tests:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds a nightly setup job that triggers e2e tests nightly. The new workflow triggers and API call to CI that will start the nightly e2e during after hours.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
