### PR TITLE
feat: alias cloudfront package destination 

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -10,7 +10,7 @@ import axios from 'axios';
 import rimraf from 'rimraf';
 import { name, version } from './package.json';
 
-const BINARY_LOCATION = 'https://d2bkhsss993doa.cloudfront.net';
+const BINARY_LOCATION = 'https://package.cli.amplify.aws';
 
 const pipeline = util.promisify(stream.pipeline);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The PR replace the current raw cloudfront distribution with an aliased end point

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
