### PR TITLE
chore: use dns for installing cli binary

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -10,7 +10,7 @@ import axios from 'axios';
 import rimraf from 'rimraf';
 import { name, version } from './package.json';
 
-const BINARY_LOCATION = 'https://d2bkhsss993doa.cloudfront.net';
+const BINARY_LOCATION = 'https://package.cli.amplify.aws';
 
 const pipeline = util.promisify(stream.pipeline);
 


### PR DESCRIPTION
This pr updates our binary install location from a cloud front distribution to cleaner and more flexible DNS: https://package.cli.amplify.aws