### PR TITLE
Fix references to `getGraphQLApiKeys` and `getGraphQLAPIs` functions

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/src/utility-functions.js
@@ -276,7 +276,7 @@ module.exports = {
    * @deprecated Use getGraphQLAPIs instead
    */
   getAppSyncAPIs: context => {
-    return this.getGraphQLAPIs(context);
+    return module.exports.getGraphQLAPIs(context);
   },
   getGraphQLAPIs: context => {
     const log = logger('getGraphQLAPIs.appSyncModel.appSync.listGraphqlApis', { maxResults: 25 });
@@ -375,7 +375,7 @@ module.exports = {
    * @deprecated Use getGraphQLApiKeys instead
    */
   getAppSyncApiKeys: (context, options) => {
-    return this.getGraphQLApiKeys(context, options);
+    return module.exports.getGraphQLApiKeys(context, options);
   },
   getGraphQLApiKeys: (context, options) => {
     const awsOptions = {};


### PR DESCRIPTION
#### Description of changes

Fix function references for `getGraphQLApiKeys` and `getGraphQLAPIs` by replacing `this` with `module.exports`.

#### Issue #, if available
Fixes aws-amplify/amplify-category-api#38

#### Description of how you validated changes
I ran `amplify add codegen --apiId API_ID` in my project and the command completed successfully, whereas it was previously falling with the error: `this.getGraphQLApiKeys is not a function`.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
