### PR TITLE
fix(amplify-util-mock): fn parameter shadowing lodash

### DIFF
--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -86,14 +86,14 @@ const getAmplifyMetaParams = (
 /**
  * Loads CFN parameters from the parameters.json file for the resource (if present)
  */
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const getParametersJsonParams = (_, resourceName: string): Record<string, string> => stateManager.getResourceParametersJson(undefined, 'function', resourceName, { throwIfNotExist: false }) ?? {};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getParametersJsonParams = (print, resourceName: string): Record<string, string> => stateManager.getResourceParametersJson(undefined, 'function', resourceName, { throwIfNotExist: false }) ?? {};
 
 /**
  * Loads CFN parameters for the resource in the team-provider-info.json file (if present)
  */
-// eslint-disable-next-line @typescript-eslint/no-shadow
-const getTeamProviderParams = (_, resourceName: string): Record<string, string> => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getTeamProviderParams = (print, resourceName: string): Record<string, string> => {
   const env = stateManager.getLocalEnvInfo().envName;
   return _.get(stateManager.getTeamProviderInfo(), [env, 'categories', 'function', resourceName], {});
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fix unused parameter `_` shadowing `lodash` and causing the error on `amplify mock function`: `_.get is not a function`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Failing e2e test: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/8554/workflows/2a064fa1-f90d-475c-a9ef-1600b686b548/jobs/254635
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
