### PR TITLE
fix(graphql): resolve model codegen issue on first push for datastore enabled api

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/resource-status-data.ts
@@ -459,7 +459,7 @@ async function isBackendDirModifiedSinceLastPush(resourceName, category, lastPus
   const localBackendDir = path.normalize(path.join(pathManager.getBackendDirPath(), category, resourceName));
   const cloudBackendDir = path.normalize(path.join(pathManager.getCurrentCloudBackendDirPath(), category, resourceName));
 
-  if (!fs.existsSync(localBackendDir)) {
+  if (!fs.existsSync(localBackendDir) || !fs.existsSync(cloudBackendDir)) {
     return false;
   }
 


### PR DESCRIPTION
#### Description of changes

Currently model codegen fails for datastore enabled api on first push, this change is intended to fix it.
The tests will be added to the data package once this goes live.

#### Description of how you validated changes
- yarn test
- manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
