### PR TITLE
chore: update link to use https so that it is clickable from the CLI

### DIFF
--- a/packages/amplify-e2e-core/src/export/index.ts
+++ b/packages/amplify-e2e-core/src/export/index.ts
@@ -3,7 +3,7 @@ import { nspawn as spawn, getCLIPath } from '..';
 export function exportBackend(cwd: string, settings: { exportPath: string }): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['export', '--out', settings.exportPath], { cwd, stripColors: true })
-      .wait('For more information: docs.amplify.aws/cli/usage/export-to-cdk')
+      .wait('For more information: https://docs.amplify.aws/cli/usage/export-to-cdk')
       .sendEof()
       .run((err: Error) => {
         if (!err) {

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -66,7 +66,7 @@ export async function run(context: $TSContext, resourceDefinition: $TSAny[], exp
     printer.info(
       'Install the "Amplify Exported Backend" CDK Construct by running "npm i @aws-amplify/cdk-exported-backend" in your CDK app',
     );
-    printer.info('For more information: docs.amplify.aws/cli/usage/export-to-cdk');
+    printer.info('For more information: https://docs.amplify.aws/cli/usage/export-to-cdk');
     printer.blankLine();
   } catch (ex) {
     revertToBackup(amplifyExportFolder);


### PR DESCRIPTION
This PR updates the `docs.amplify.aws/cli/usage/export-to-cdk` url to use `https://` which makes it clickable from the CLI. It also matches the other links to the docs emitted by the CLI.