### PR TITLE
fix(graphql): handle gsi change iterative update of delta sync table exists on root template

### DIFF
--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -32,6 +32,7 @@
   "decrypt",
   "defs",
   "dict",
+  "diffable",
   "dotenv",
   "durations",
   "dynamodb",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
@@ -20,7 +20,7 @@ export const getDiffedProject = (
   });
 
   const currentProj = addTableToRoot ? makeProjWithTableOnRoot(table1) : makeProj('Post', table1);
-  const nextProj = addTableToRoot ? makeProjWithTableOnRoot(table1) : makeProj('Post', table2);
+  const nextProj = addTableToRoot ? makeProjWithTableOnRoot(table2) : makeProj('Post', table2);
 
   const diffedValue = getDiffs(currentProj, nextProj);
   return { current: currentProj, next: nextProj, diff: diffedValue };

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
@@ -1,12 +1,17 @@
-import * as gsiTestHelper from './gsi-test-helpers';
 import { diff as getDiffs } from 'deep-diff';
 import { DynamoDB } from 'cloudform';
+import { $TSAny } from 'amplify-cli-core';
+import * as gsiTestHelper from './gsi-test-helpers';
 import { DiffableProject } from '../../graphql-resource-manager/utils';
 
+/**
+ * Get a test Diffable project
+ */
 export const getDiffedProject = (
   currentGSI: gsiTestHelper.GSIDefinition[] | undefined,
   nextGSI: gsiTestHelper.GSIDefinition[] | undefined,
-) => {
+  addTableToRoot = false,
+): $TSAny => {
   const table1 = gsiTestHelper.makeTableWithGSI({
     gsis: currentGSI,
   });
@@ -14,22 +19,36 @@ export const getDiffedProject = (
     gsis: nextGSI,
   });
 
-  const currentProj = makeProj('Post', table1);
-  const nextProj = makeProj('Post', table2);
+  const currentProj = addTableToRoot ? makeProjWithTableOnRoot(table1) : makeProj('Post', table1);
+  const nextProj = addTableToRoot ? makeProjWithTableOnRoot(table1) : makeProj('Post', table2);
 
   const diffedValue = getDiffs(currentProj, nextProj);
   return { current: currentProj, next: nextProj, diff: diffedValue };
 };
 
-export const makeProj = (stackName: string, table: DynamoDB.Table): DiffableProject => {
-  return {
-    root: {},
-    stacks: {
-      [stackName]: {
-        Resources: {
-          [`${table.Properties.TableName || 'MyTable'}Table`]: table,
-        },
+/**
+ *  Makes a project with given table on a child stack
+ */
+export const makeProj = (stackName: string, table: DynamoDB.Table): DiffableProject => ({
+  root: {},
+  stacks: {
+    [stackName]: {
+      Resources: {
+        [`${table.Properties.TableName || 'MyTable'}Table`]: table,
       },
     },
-  };
-};
+  },
+});
+
+/**
+ * Makes a project with given table on the root stack
+ */
+export const makeProjWithTableOnRoot = (table: DynamoDB.Table): DiffableProject => ({
+  root: {
+    Resources: {
+      [`${table.Properties.TableName || 'MyTable'}Table`]: table,
+    },
+  },
+  stacks: {
+  },
+});

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -257,6 +257,10 @@ export class GraphQLResourceManager {
       const changeSteps = getGSIDiffs(gsiChange.currentTable, gsiChange.nextTable);
       const { stackName } = gsiChange;
       const { tableName } = gsiChange;
+      if (stackName === ROOT_LEVEL) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       for (const changeStep of changeSteps) {
         const ddbResource = this.templateState.getLatest(stackName) || this.getStack(stackName, currentState);
         let gsiRecord;

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -1,11 +1,5 @@
 import { $TSContext, JSONUtilities, pathManager } from 'amplify-cli-core';
-import { DeploymentOp, DeploymentStep, DEPLOYMENT_META } from '../iterative-deployment';
-import { DiffChanges, DiffableProject, getGQLDiff } from './utils';
 import { DynamoDB, Template } from 'cloudform-types';
-import { GSIChange, getGSIDiffs } from './gsi-diff-helpers';
-import { GSIRecord, TemplateState, getPreviousDeploymentRecord, getTableNames } from '../utils/amplify-resource-state-utils';
-import { ROOT_APPSYNC_S3_KEY, hashDirectory } from '../upload-appsync-files';
-import { addGSI, getGSIDetails, removeGSI } from './dynamodb-gsi-helpers';
 import {
   cantAddAndRemoveGSIAtSameTimeRule,
   cantBatchMutateGSIAtUpdateTimeRule,
@@ -13,14 +7,27 @@ import {
   cantHaveMoreThan500ResourcesRule,
   sanityCheckDiffs,
 } from 'graphql-transformer-core';
-
 import { CloudFormation } from 'aws-sdk';
 import { Diff } from 'deep-diff';
 import _ from 'lodash';
-import { loadConfiguration } from '../configuration-manager';
 import fs from 'fs-extra';
 import path from 'path';
+import { DeploymentOp, DeploymentStep, DEPLOYMENT_META } from '../iterative-deployment';
+import { DiffChanges, DiffableProject, getGQLDiff } from './utils';
+import { GSIChange, getGSIDiffs } from './gsi-diff-helpers';
+import {
+  GSIRecord, TemplateState, getPreviousDeploymentRecord, getTableNames,
+} from '../utils/amplify-resource-state-utils';
+import { ROOT_APPSYNC_S3_KEY, hashDirectory } from '../upload-appsync-files';
+import { addGSI, getGSIDetails, removeGSI } from './dynamodb-gsi-helpers';
 
+import { loadConfiguration } from '../configuration-manager';
+
+const ROOT_LEVEL = 'root';
+
+/**
+ * Type for GQLResourceManagerProps
+ */
 export type GQLResourceManagerProps = {
   cfnClient: CloudFormation;
   resourceMeta?: ResourceMeta;
@@ -29,6 +36,9 @@ export type GQLResourceManagerProps = {
   rebuildAllTables?: boolean;
 };
 
+/**
+ * Type for ResourceMeta
+ */
 export type ResourceMeta = {
   category: string;
   providerPlugin: string;
@@ -45,33 +55,38 @@ export type ResourceMeta = {
 };
 
 // TODO: Add unit testing
+/**
+ * Type for GraphQLResourceManager
+ */
 export class GraphQLResourceManager {
-  static serviceName: string = 'AppSync';
-  static categoryName: string = 'api';
+  static serviceName = 'AppSync';
+  static categoryName = 'api';
   private cfnClient: CloudFormation;
   private resourceMeta: ResourceMeta;
   private cloudBackendApiProjectRoot: string;
   private backendApiProjectRoot: string;
   private templateState: TemplateState;
-  private rebuildAllTables: boolean = false; // indicates that all underlying model tables should be rebuilt
+  private rebuildAllTables = false; // indicates that all underlying model tables should be rebuilt
 
-  public static createInstance = async (context: $TSContext, gqlResource: any, StackId: string, rebuildAllTables: boolean = false) => {
-    try {
-      const cred = await loadConfiguration(context);
-      const cfn = new CloudFormation(cred);
-      const apiStack = await cfn
-        .describeStackResources({ StackName: StackId, LogicalResourceId: gqlResource.providerMetadata.logicalId })
-        .promise();
-      return new GraphQLResourceManager({
-        cfnClient: cfn,
-        resourceMeta: { ...gqlResource, stackId: apiStack.StackResources[0].PhysicalResourceId },
-        backendDir: pathManager.getBackendDirPath(),
-        cloudBackendDir: pathManager.getCurrentCloudBackendDirPath(),
-        rebuildAllTables,
-      });
-    } catch (err) {
-      throw err;
-    }
+  public static createInstance = async (
+    context: $TSContext,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    gqlResource: any,
+    StackId: string,
+    rebuildAllTables = false,
+  ): Promise<GraphQLResourceManager> => {
+    const cred = await loadConfiguration(context);
+    const cfn = new CloudFormation(cred);
+    const apiStack = await cfn
+      .describeStackResources({ StackName: StackId, LogicalResourceId: gqlResource.providerMetadata.logicalId })
+      .promise();
+    return new GraphQLResourceManager({
+      cfnClient: cfn,
+      resourceMeta: { ...gqlResource, stackId: apiStack.StackResources[0].PhysicalResourceId },
+      backendDir: pathManager.getBackendDirPath(),
+      cloudBackendDir: pathManager.getCurrentCloudBackendDirPath(),
+      rebuildAllTables,
+    });
   };
 
   constructor(props: GQLResourceManagerProps) {
@@ -110,6 +125,7 @@ export class GraphQLResourceManager {
       this.gsiManagement(gqlDiff.diff, gqlDiff.current, gqlDiff.next);
     }
     this.tableRecreationManagement(gqlDiff.current);
+    // eslint-disable-next-line no-return-await
     return await this.getDeploymentSteps();
   };
 
@@ -133,7 +149,7 @@ export class GraphQLResourceManager {
     // copy the last deployment state as current state
     let previousStepPath = cloudBuildDir;
     let previousStep: DeploymentOp = await this.getCurrentlyDeployedStackStep();
-    let previousMetaKey = previousStep.previousMetaKey;
+    let { previousMetaKey } = previousStep;
 
     while (!this.templateState.isEmpty()) {
       const stepNumber = count.toString().padStart(2, '0');
@@ -154,10 +170,10 @@ export class GraphQLResourceManager {
       const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
       const deploymentStep: DeploymentOp = {
         stackTemplatePathOrUrl: `${deploymentRootKey}/cloudformation-template.json`,
-        previousMetaKey: previousMetaKey,
+        previousMetaKey,
         parameters: { ...parameters, S3DeploymentRootKey: deploymentRootKey },
         stackName: this.resourceMeta.stackId,
-        tableNames: tableNames,
+        tableNames,
         capabilities,
         // clientRequestToken: `${buildHash}-step-${stepNumber}`,
       };
@@ -179,7 +195,7 @@ export class GraphQLResourceManager {
   };
 
   /**
-   * get a copy of last deployed API nested stack to rollback to incase deployment fails
+   * get a copy of last deployed API nested stack to rollback to in case deployment fails
    */
   public getCurrentlyDeployedStackStep = async (): Promise<DeploymentOp> => {
     const cloudBuildDir = path.join(this.cloudBackendApiProjectRoot, 'build');
@@ -218,15 +234,13 @@ export class GraphQLResourceManager {
     return `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states`;
   };
 
-  private gsiManagement = (diffs: DiffChanges<DiffableProject>, currentState: DiffableProject, nextState: DiffableProject) => {
-    const gsiChanges = _.filter(diffs, diff => {
-      return diff.path.includes('GlobalSecondaryIndexes');
-    });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private gsiManagement = (diffs: DiffChanges<DiffableProject>, currentState: DiffableProject, nextState: DiffableProject): any => {
+    const gsiChanges = _.filter(diffs, diff => diff.path.includes('GlobalSecondaryIndexes'));
 
     const tableWithGSIChanges = _.uniqBy(gsiChanges, diff => diff.path?.slice(0, 3).join('/')).map(gsiChange => {
-      const tableName = gsiChange.path[3] as string;
-
-      const stackName = gsiChange.path[1].split('.')[0] as string;
+      const tableName = (gsiChange.path[0] === ROOT_LEVEL ? gsiChange.path[2] : gsiChange.path[3]) as string;
+      const stackName = (gsiChange.path[0] === ROOT_LEVEL ? ROOT_LEVEL : gsiChange.path[1].split('.')[0]) as string;
 
       const currentTable = this.getTable(gsiChange, currentState);
       const nextTable = this.getTable(gsiChange, nextState);
@@ -241,8 +255,8 @@ export class GraphQLResourceManager {
 
     for (const gsiChange of tableWithGSIChanges) {
       const changeSteps = getGSIDiffs(gsiChange.currentTable, gsiChange.nextTable);
-      const stackName = gsiChange.stackName;
-      const tableName = gsiChange.tableName;
+      const { stackName } = gsiChange;
+      const { tableName } = gsiChange;
       for (const changeStep of changeSteps) {
         const ddbResource = this.templateState.getLatest(stackName) || this.getStack(stackName, currentState);
         let gsiRecord;
@@ -278,16 +292,18 @@ export class GraphQLResourceManager {
       const ddbStack = this.getStack(tableMeta.stackName, currentState);
       this.dropTemplateResources(ddbStack);
 
-      // clear any other states created by GSI updates as dropping and recreating supercedes those changes
+      // clear any other states created by GSI updates as dropping and recreating supersedes those changes
       this.clearTemplateState(tableMeta.stackName);
       this.templateState.add(tableMeta.stackName, JSONUtilities.stringify(ddbStack));
     });
   };
 
-  getTablesBeingReplaced = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getTablesBeingReplaced = (): any => {
     const gqlDiff = getGQLDiff(this.backendApiProjectRoot, this.cloudBackendApiProjectRoot);
     const [diffs, currentState] = [gqlDiff.diff, gqlDiff.current];
-    const getTablesRequiringReplacement = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getTablesRequiringReplacement = (): any => {
       if (!diffs) {
         return [];
       }
@@ -295,8 +311,7 @@ export class GraphQLResourceManager {
         diffs
           // diff.path looks like [ "stacks", "ModelName.json", "Resources", "TableName", "Properties", "KeySchema", 0, "AttributeName"]
           .filter(
-            diff =>
-              (diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema') || diff.path.includes('LocalSecondaryIndexes'),
+            diff => (diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema') || diff.path.includes('LocalSecondaryIndexes'),
           ) // filter diffs with changes that require replacement
           .map(diff => ({
             // extract table name and stack name from diff path
@@ -305,21 +320,27 @@ export class GraphQLResourceManager {
           })),
       ) as { tableName: string; stackName: string }[];
     };
-    const getAllTables = () =>
-      Object.entries(currentState.stacks)
-        .map(([name, template]) => ({
-          tableName: this.getTableNameFromTemplate(template),
-          stackName: path.basename(name, '.json'),
-        }))
-        .filter(meta => !!meta.tableName);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getAllTables = (): any => Object.entries(currentState.stacks)
+      .map(([name, template]) => ({
+        tableName: this.getTableNameFromTemplate(template),
+        stackName: path.basename(name, '.json'),
+      }))
+      .filter(meta => !!meta.tableName);
     return this.rebuildAllTables ? getAllTables() : getTablesRequiringReplacement();
   };
 
   private getTable = (gsiChange: Diff<any, any>, proj: DiffableProject): DynamoDB.Table => {
+    if (gsiChange.path[0] === ROOT_LEVEL) {
+      return proj.root.Resources[gsiChange.path[2]] as DynamoDB.Table;
+    }
     return proj.stacks[gsiChange.path[1]].Resources[gsiChange.path[3]] as DynamoDB.Table;
-  };
+  }
 
-  private getStack(stackName: string, proj: DiffableProject): Template {
+  private getStack = (stackName: string, proj: DiffableProject): Template => {
+    if (stackName === ROOT_LEVEL) {
+      return proj.root;
+    }
     return proj.stacks[`${stackName}.json`];
   }
 
@@ -348,11 +369,13 @@ export class GraphQLResourceManager {
     }
   };
 
-  private getTableNameFromTemplate = (template: Template): string | undefined =>
-    Object.entries(template?.Resources || {}).find(([_, resource]) => resource.Type === 'AWS::DynamoDB::Table')?.[0];
+  private getTableNameFromTemplate = (template: Template): string | undefined => Object.entries(template?.Resources || {}).find(([_, resource]) => resource.Type === 'AWS::DynamoDB::Table')?.[0];
 }
 
 // https://stackoverflow.com/questions/39419170/how-do-i-check-that-a-switch-block-is-exhaustive-in-typescript
+/**
+ * assertUnreachable - Throws unhandled type error
+ */
 export const assertUnreachable = (_: never): never => {
   throw new Error('Default case should never reach');
 };


### PR DESCRIPTION
#### Description of changes

To improve the performance of delta table, data team is working on changing the structure of the delta sync table. This change adds a new GSI on the delta table and this resource definition exists on the api root template.

Amplify deploys the GSI changes iteratively but the current implementation doesn't handle the GSI change if the table exist on the root template. This fix will handle the GSI changes found on the root template of the api.

The tests will be added to the data package along with the delta table gsi change.

#### Description of how you validated changes
- manual test
- yarn test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
