### PR TITLE
fix: oauth secret key fix removed when authProviders is empty

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -1,6 +1,6 @@
-import { AmplifyAuthTransform } from '../../../../provider-utils/awscloudformation/auth-stack-builder';
 import { $TSContext } from 'amplify-cli-core';
 import process from 'process';
+import { AmplifyAuthTransform } from '../../../../provider-utils/awscloudformation/auth-stack-builder';
 
 jest.mock('amplify-cli-core', () => ({
   ...(jest.requireActual('amplify-cli-core') as {}),
@@ -169,16 +169,12 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/get-app-id', () =>
   getAppId: jest.fn().mockReturnValue('mockAmplifyAppId'),
 }));
 
-jest.mock('../../../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state.ts', () => {
-  return {
-    AuthInputState: jest.fn().mockImplementation(() => {
-      return {
-        getCLIInputPayload: getCLIInputPayload_mock,
-        isCLIInputsValid: isCLIInputsValid_mock,
-      };
-    }),
-  };
-});
+jest.mock('../../../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state.ts', () => ({
+  AuthInputState: jest.fn().mockImplementation(() => ({
+    getCLIInputPayload: getCLIInputPayload_mock,
+    isCLIInputsValid: isCLIInputsValid_mock,
+  })),
+}));
 
 const mockPolicy1 = {
   policyName: 'AddToGroupCognito',
@@ -270,5 +266,20 @@ describe('Check Auth Template', () => {
     const authTransform = new AmplifyAuthTransform(resourceName);
     authTransform.validateCfnParameters(context_stub_typed, { requiredAttributes: ['email'] }, { requiredAttributes: ['email', 'phone_number'] });
     expect(process.exit).toBeCalledTimes(1);
+  });
+
+  it('should not include appId in tpi when auth providers not present', async () => {
+    const resourceName = 'mockResource';
+    getCLIInputPayload_mock.mockReturnValue({
+      cognitoConfig: {
+        ...inputPayload1.cognitoConfig,
+        authProvidersUserPool: [],
+        hostedUI: true,
+      },
+    });
+
+    const authTransform = new AmplifyAuthTransform(resourceName);
+    const mockTemplate = await authTransform.transform(context_stub_typed);
+    expect(mockTemplate?.Parameters?.oAuthSecretsPathAmplifyAppId).not.toBeDefined();
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -168,7 +168,7 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
       useEnabledMfas: FeatureFlags.getBoolean('auth.useenabledmfas'),
       dependsOn: [],
     };
-    if (this._cliInputs.cognitoConfig.hostedUI && this._cliInputs.cognitoConfig.authProvidersUserPool) {
+    if (this._cliInputs.cognitoConfig.hostedUI && !_.isEmpty(this._cliInputs.cognitoConfig.authProvidersUserPool)) {
       cognitoStackProps.oAuthSecretsPathAmplifyAppId = getAppId();
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- added empty checked to authProvidersUserPool array

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #10466

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- updated unit tests
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
