### PR TITLE
style: allow string template literals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,9 @@ module.exports = {
 
     // Disables double quote error when using single quotes within string for readability
     // https://eslint.org/docs/rules/quotes#avoidescape
-    'quotes': ['error', 'single', { 'avoidEscape': true }],
+    // Allows String template literals like `foo`
+    // https://eslint.org/docs/rules/quotes#allowtemplateliterals
+    'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
 
     // Typescript rules
     // Extends recommended rules here: https://www.npmjs.com/package/@typescript-eslint/eslint-plugin


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Allow template literals because the `avoidEscape: true` option does not account for string templates, and then ends up automatically converting \`'foo' bar\` =>  '\\'foo\\' bar'

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
