### PR TITLE
fix: oauth amplify appId Issue

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.test.ts
@@ -281,5 +281,7 @@ describe('Check Auth Template', () => {
     const authTransform = new AmplifyAuthTransform(resourceName);
     const mockTemplate = await authTransform.transform(context_stub_typed);
     expect(mockTemplate?.Parameters?.oAuthSecretsPathAmplifyAppId).not.toBeDefined();
+    expect(mockTemplate?.Resources?.hostedUIProvidersCustomResourceInputs).not.toBeDefined();
+    expect(mockTemplate?.Resources?.hostedUIProvidersCustomResource).not.toBeDefined();
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -479,7 +479,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       if (props.hostedUIDomainName) {
         this.createHostedUICustomResource();
       }
-      if (props.hostedUIProviderMeta) {
+      if (props.hostedUIProviderMeta && props.hostedUI && !_.isEmpty(props.authProvidersUserPool)) {
         this.createHostedUIProviderCustomResource();
       }
       if (props.oAuthMetadata) {
@@ -885,7 +885,9 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
     });
 
     this.oAuthCustomResource.node.addDependency(this.hostedUICustomResourceInputs!.node!.defaultChild!);
-    this.oAuthCustomResource.node.addDependency(this.hostedUIProvidersCustomResourceInputs!.node!.defaultChild!);
+    if(this.hostedUIProvidersCustomResourceInputs){
+      this.oAuthCustomResource.node.addDependency(this.hostedUIProvidersCustomResourceInputs!.node!.defaultChild!);
+    }
 
     // userPool client lambda policy
     /**

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.js
@@ -580,7 +580,7 @@ async function handleUpdates(context, coreAnswers) {
     parseOAuthMetaData(context.updatingAuth);
   }
 
-  if (context.updatingAuth && context.updatingAuth.authProvidersUserPool) {
+  if (context.updatingAuth && !_.isEmpty(context.updatingAuth.authProvidersUserPool && context.updatingAuth.hostedUI)) {
     const { resourceName, authProvidersUserPool, hostedUIProviderMeta } = context.updatingAuth;
     const oAuthSecretKey = await syncOAuthSecretsToCloud(context, resourceName);
     /* eslint-disable */

--- a/packages/amplify-e2e-tests/src/__tests__/auth_4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_4.test.ts
@@ -13,7 +13,6 @@ import {
   updateAuthWithoutCustomTrigger,
   updateAuthRemoveRecaptchaTrigger,
   updateAuthSignInSignOutUrl,
-,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
@@ -52,7 +51,7 @@ describe('amplify updating auth...', () => {
     await addAuthWithSignInSignOutUrl(projRoot, settings);
     await amplifyPushAuth(projRoot);
     await updateAuthSignInSignOutUrl(projRoot, settings);
-    await expect(amplifyPushAuth(projRoot, true)).resolves.not.toThrowError();
+    await amplifyPushAuth(projRoot);
   });
 
   it('...should init a project and add auth with a custom trigger, and then update to remove the custom js while leaving the other js', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/auth_4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_4.test.ts
@@ -6,16 +6,14 @@ import {
   deleteProject,
   amplifyPushAuth,
   addFeatureFlag,
-} from 'amplify-e2e-core';
-import {
+
   addAuthWithRecaptchaTrigger,
   addAuthWithCustomTrigger,
   addAuthWithSignInSignOutUrl,
   updateAuthWithoutCustomTrigger,
   updateAuthRemoveRecaptchaTrigger,
   updateAuthSignInSignOutUrl,
-} from 'amplify-e2e-core';
-import {
+,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
@@ -52,7 +50,9 @@ describe('amplify updating auth...', () => {
     };
     await initAndroidProjectWithProfile(projRoot, { ...defaultsSettings, disableAmplifyAppCreation: false });
     await addAuthWithSignInSignOutUrl(projRoot, settings);
+    await amplifyPushAuth(projRoot);
     await updateAuthSignInSignOutUrl(projRoot, settings);
+    await expect(amplifyPushAuth(projRoot, true)).resolves.not.toThrowError();
   });
 
   it('...should init a project and add auth with a custom trigger, and then update to remove the custom js while leaving the other js', async () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Checks for authProviders to be an empty array instead of defined

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #10466

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested
- Updated an e2e test case for the same
- updated unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
