### PR TITLE
chore: parallelize account and resource cleanup for e2e testing

### DIFF
--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -72,8 +72,8 @@ export const getBucketKeys = async (params: S3.ListObjectsRequest) => {
   }
 };
 
-export const deleteS3Bucket = async (bucket: string) => {
-  const s3 = new S3();
+export const deleteS3Bucket = async (bucket: string, providedS3Client: S3 | undefined = undefined) => {
+  const s3 = providedS3Client ? providedS3Client : new S3();
   let continuationToken: Required<Pick<S3.ListObjectVersionsOutput, 'KeyMarker' | 'VersionIdMarker'>> = undefined;
   const objectKeyAndVersion = <S3.ObjectIdentifier[]>[];
   let truncated = false;

--- a/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
@@ -20,7 +20,7 @@ const PROJECT_NAME = 'authTest';
 const defaultSettings = {
   name: PROJECT_NAME,
 };
-describe('zero config auth ', () => {
+describe('zero config auth', () => {
   let projRoot: string;
   beforeEach(async () => {
     projRoot = await createNewProjectDir('zero-config-auth');

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -24,13 +24,15 @@ const { prePushCfnTemplateModifier } = require('./pre-push-cfn-processor/pre-pus
 const logger = fileLogger('attach-backend');
 const { configurePermissionsBoundaryForInit } = require('./permissions-boundary/permissions-boundary');
 const { uploadHooksDirectory } = require('./utils/hooks-manager');
+import { v4 as uuid } from 'uuid';
+
 export async function run(context) {
   await configurationManager.init(context);
   if (!context.exeInfo || context.exeInfo.isNewEnv) {
     context.exeInfo = context.exeInfo || {};
     const { projectName } = context.exeInfo.projectConfig;
     const initTemplateFilePath = path.join(__dirname, '..', 'resources', 'rootStackTemplate.json');
-    const timeStamp = `${moment().format('Hmmss')}`;
+    const timeStamp = process.env.CIRCLECI ? uuid().substring(0, 5) : `${moment().format('Hmmss')}`;
     const { envName = '' } = context.exeInfo.localEnvInfo;
     let stackName = normalizeStackName(`amplify-${projectName}-${envName}-${timeStamp}`);
     const awsConfigInfo = await configurationManager.getAwsConfig(context);


### PR DESCRIPTION
#### Description of changes
- duplicates changes from api category repo for parallelizing e2e resources cleanup job
- PR: https://github.com/aws-amplify/amplify-category-api/pull/478
- adds milliseconds to stackName in circleCI env in order to avoid `bucket already exists` issue in the e2e tests

#### Description of how you validated changes
- executed locally the cleanup script

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
