### PR TITLE
fix: add pipeline parameters from api call to generated config

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -5,6 +5,17 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 
+parameters:
+  nightly_console_integration_tests:
+    type: boolean
+    default: false
+  e2e_resource_cleanup:
+    type: boolean
+    default: false
+  setup:
+    type: boolean
+    default: true
+
 executors:
   w: &windows-e2e-executor
     machine:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds the nightly pipeline parameters to the base config to use when setting up the nightly e2e tests. This is to fix this type of error: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/8776/workflows/9a23a616-050f-4ed0-9cad-1e2ba3d0e7f7/jobs/261559
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
