### PR TITLE
fix: create same identifier for flow data and reporter

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/diagnose.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/diagnose.test.ts
@@ -12,7 +12,14 @@ import { Context } from '../../domain/context';
 jest.mock('uuid');
 jest.mock('amplify-cli-core');
 jest.mock('../../commands/helpers/collect-files');
-jest.mock('../../commands/helpers/encryption-helpers');
+jest.mock('../../commands/helpers/encryption-helpers', () => ({
+  createHashedIdentifier: jest.fn().mockReturnValue({
+    projectIdentifier: 'projectId',
+    projectEnvIdentifier: 'projectId',
+  }),
+  encryptBuffer: jest.fn().mockReturnValue('encryptedString'),
+  encryptKey: jest.fn().mockReturnValue('encryptedKey'),
+}));
 jest.mock('archiver');
 jest.mock('fs-extra');
 jest.mock('amplify-cli-logger', () => ({
@@ -21,19 +28,6 @@ jest.mock('amplify-cli-logger', () => ({
 }));
 
 jest.mock('path');
-jest.mock('crypto', () => ({
-  publicEncrypt: jest.fn().mockReturnValue(Buffer.from([])),
-  createHash: jest.fn().mockReturnValue({
-    update: jest.fn().mockReturnValue({
-      digest: jest.fn().mockReturnValue('projectId'),
-    }),
-  }),
-  randomBytes: jest.fn().mockReturnValue(Buffer.from('RandomBytes')),
-  /* eslint-disable spellcheck/spell-checker*/
-  pbkdf2Sync: jest.fn(),
-  createCipheriv: jest.fn(),
-  /* eslint-enable spellcheck/spell-checker*/
-}));
 jest.mock('node-fetch', () => jest.fn().mockReturnValue({ status: 200 }));
 
 const mockMeta = {

--- a/packages/amplify-cli/src/__tests__/flow-report.test.ts
+++ b/packages/amplify-cli/src/__tests__/flow-report.test.ts
@@ -1,154 +1,152 @@
-import { CLIFlowReport } from '../domain/amplify-usageData/FlowReport';
 import { stateManager } from 'amplify-cli-core';
 import {
-    AddS3ServiceConfiguration, AddStorageRequest,
-    ImportAuthRequest, CrudOperation, AddGeoRequest,
-    GeoServiceConfiguration, AccessType, MapStyle, AppSyncServiceConfiguration, AppSyncAPIKeyAuthType, AddApiRequest
+  AddS3ServiceConfiguration, AddStorageRequest,
+  ImportAuthRequest, CrudOperation, AddGeoRequest,
+  GeoServiceConfiguration, AccessType, MapStyle, AppSyncServiceConfiguration, AppSyncAPIKeyAuthType, AddApiRequest,
 } from 'amplify-headless-interface';
 import { v4 as uuid } from 'uuid';
 import { Redactor } from 'amplify-cli-logger';
-
-
+import crypto from 'crypto';
+import { CLIFlowReport } from '../domain/amplify-usageData/FlowReport';
 
 describe('Test FlowReport Logging', () => {
-    beforeAll(() => {
-    });
+  beforeAll(() => {
+  });
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
-    it('flow-log-interactive-payload: Interactive payload is available in payload', () => {
-        const flowReport = new CLIFlowReport();
-        flowReport.pushInteractiveFlow(mockInputs.interactivePrompt, mockInputs.interactiveValue);
-        expect(flowReport.optionFlowData[0].input).toContain(mockInputs.interactiveValue);
-    })
-    it('Project Identifiers are correctly formed', () => {
-        const flowReport = new CLIFlowReport();
-        flowReport.setIsHeadless(true);
-        flowReport.setVersion(mockInputs.version);
-        //Mock the state-manager functions
-        jest.mock('amplify-cli-core');
-        jest.spyOn(stateManager, 'getProjectName').mockReturnValue(mockInputs.projectName);
-        jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValueOnce(mockInputs.envName);
-        jest.spyOn(stateManager, 'getAppID').mockReturnValue(mockInputs.appID)
-        flowReport.assignProjectIdentifier();
-        expect(flowReport.projectEnvIdentifier).toEqual(`${mockInputs.projectName}${mockInputs.appID}${mockInputs.envName}`);
-        expect(flowReport.projectIdentifier).toEqual(`${mockInputs.projectName}${mockInputs.appID}`);
-        expect(flowReport.version).toEqual(mockInputs.version);
-    });
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+  it('flow-log-interactive-payload: Interactive payload is available in payload', () => {
+    const flowReport = new CLIFlowReport();
+    flowReport.pushInteractiveFlow(mockInputs.interactivePrompt, mockInputs.interactiveValue);
+    expect(flowReport.optionFlowData[0].input).toContain(mockInputs.interactiveValue);
+  });
+  it('Project Identifiers are correctly formed', () => {
+    const flowReport = new CLIFlowReport();
+    flowReport.setIsHeadless(true);
+    flowReport.setVersion(mockInputs.version);
+    // Mock the state-manager functions
+    jest.mock('amplify-cli-core');
+    jest.spyOn(stateManager, 'getProjectName').mockReturnValue(mockInputs.projectName);
+    jest.spyOn(stateManager, 'getCurrentEnvName').mockReturnValueOnce(mockInputs.envName);
+    jest.spyOn(stateManager, 'getAppID').mockReturnValue(mockInputs.appID);
+    flowReport.assignProjectIdentifier();
+    expect(flowReport.projectEnvIdentifier).toEqual('e5ea1967add3f4ce56bfd90b0a533fc0'); // value is always forward reproducible
+    expect(flowReport.projectIdentifier).toEqual('8c73d955105e310dcab5e091574f9df3'); // value is always forward reproducible
+    expect(flowReport.version).toEqual(mockInputs.version);
+  });
 
-    it('flow-log-headless-payload: (Auth) is redacted in flowReport', () => {
-        const input = getAuthHeadlessTestInput();
-        const inputString = JSON.stringify(input);
-        const flowReport = new CLIFlowReport();
-        flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('auth', 'add'));
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.identityPoolId);
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.webClientId);
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.nativeClientId);
-        const report = flowReport.getFlowReport();
-        expect(report.isHeadless).toEqual(true);
-        expect(report.input.plugin).toEqual('auth');
-        expect(report.input.command).toEqual('add');
-        expect(report.optionFlowData[0].input).toEqual(Redactor(inputString));
-    });
+  it('flow-log-headless-payload: (Auth) is redacted in flowReport', () => {
+    const input = getAuthHeadlessTestInput();
+    const inputString = JSON.stringify(input);
+    const flowReport = new CLIFlowReport();
+    flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('auth', 'add'));
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.identityPoolId);
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.webClientId);
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.nativeClientId);
+    const report = flowReport.getFlowReport();
+    expect(report.isHeadless).toEqual(true);
+    expect(report.input.plugin).toEqual('auth');
+    expect(report.input.command).toEqual('add');
+    expect(report.optionFlowData[0].input).toEqual(Redactor(inputString));
+  });
 
-    it('flow-log-headless-payload: (Storage S3) is redacted in flowReport', () => {
-        const input = getAddStorageS3HeadlessTestInput();
-        const inputString = JSON.stringify(input);
-        const flowReport = new CLIFlowReport();
-        flowReport.assignProjectIdentifier();
-        flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('storage', 'add'));
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.bucketName);
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.resourceName);
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.lambdaTrigger?.name as string);
-        expect(flowReport.optionFlowData[0].input).toContain(redactValue('bucketName', input.serviceConfiguration.bucketName));
-        expect(flowReport.optionFlowData[0].input).toContain(redactValue('resourceName', input.serviceConfiguration.resourceName));
-        expect(flowReport.optionFlowData[0].input).toContain(redactValue('name', input.serviceConfiguration.lambdaTrigger?.name as string));
+  it('flow-log-headless-payload: (Storage S3) is redacted in flowReport', () => {
+    const input = getAddStorageS3HeadlessTestInput();
+    const inputString = JSON.stringify(input);
+    const flowReport = new CLIFlowReport();
+    flowReport.assignProjectIdentifier();
+    flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('storage', 'add'));
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.bucketName);
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.resourceName);
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.lambdaTrigger?.name as string);
+    expect(flowReport.optionFlowData[0].input).toContain(redactValue('bucketName', input.serviceConfiguration.bucketName));
+    expect(flowReport.optionFlowData[0].input).toContain(redactValue('resourceName', input.serviceConfiguration.resourceName));
+    expect(flowReport.optionFlowData[0].input).toContain(redactValue('name', input.serviceConfiguration.lambdaTrigger?.name as string));
 
-        const report = flowReport.getFlowReport();
-        expect(report.isHeadless).toEqual(true);
-        expect(report.input.plugin).toEqual('storage');
-        expect(report.input.command).toEqual('add');
-        expect(report.optionFlowData[0].input).toEqual(Redactor(inputString));
-    });
+    const report = flowReport.getFlowReport();
+    expect(report.isHeadless).toEqual(true);
+    expect(report.input.plugin).toEqual('storage');
+    expect(report.input.command).toEqual('add');
+    expect(report.optionFlowData[0].input).toEqual(Redactor(inputString));
+  });
 
-    it('flow-log-headless-payload: (API GraphQL) headless-payload is redacted in flowReport', () => {
-        const input = getGraphQLHeadlessTestInput();
+  it('flow-log-headless-payload: (API GraphQL) headless-payload is redacted in flowReport', () => {
+    const input = getGraphQLHeadlessTestInput();
 
-        const inputString = JSON.stringify(input);
-        const flowReport = new CLIFlowReport();
-        flowReport.assignProjectIdentifier();
-        flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('api', 'add'));
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.apiName); //resource name redacted
-        expect(flowReport.optionFlowData[0].input).toContain(redactValue("apiName", input.serviceConfiguration.apiName));
-        const redactedInput = JSON.parse(flowReport.optionFlowData[0].input as unknown as string);
-        expect(redactedInput.serviceConfiguration.transformSchema).toEqual(input.serviceConfiguration.transformSchema);//transform schema must exist
-    });
+    const inputString = JSON.stringify(input);
+    const flowReport = new CLIFlowReport();
+    flowReport.assignProjectIdentifier();
+    flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('api', 'add'));
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.apiName); // resource name redacted
+    expect(flowReport.optionFlowData[0].input).toContain(redactValue('apiName', input.serviceConfiguration.apiName));
+    const redactedInput = JSON.parse(flowReport.optionFlowData[0].input as unknown as string);
+    expect(redactedInput.serviceConfiguration.transformSchema).toEqual(input.serviceConfiguration.transformSchema);// transform schema must exist
+  });
 
-    it('flow-log-headless-payload: (Geo) is redacted in flowReport', () => {
-        const input = getGeoHeadlessTestInput();
-        const inputString = JSON.stringify(input);
-        const redactedName = redactValue('name', input.serviceConfiguration.name);
-        const flowReport = new CLIFlowReport();
-        flowReport.assignProjectIdentifier();
-        flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('geo', 'add'));
-        expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.name); //resource name redacted
-        expect(flowReport.optionFlowData[0].input).toContain(redactedName); //resource name redacted
-        expect(flowReport.optionFlowData[0].input).toContain(input.serviceConfiguration.accessType);
-        expect(flowReport.optionFlowData[0].input).toContain(input.serviceConfiguration.mapStyle);
-        expect(flowReport.optionFlowData[0].input).toEqual(Redactor(inputString));
-    });
-
+  it('flow-log-headless-payload: (Geo) is redacted in flowReport', () => {
+    const input = getGeoHeadlessTestInput();
+    const inputString = JSON.stringify(input);
+    const redactedName = redactValue('name', input.serviceConfiguration.name);
+    const flowReport = new CLIFlowReport();
+    flowReport.assignProjectIdentifier();
+    flowReport.pushHeadlessFlow(inputString, mockInputs.headlessInput('geo', 'add'));
+    expect(flowReport.optionFlowData[0].input).not.toContain(input.serviceConfiguration.name); // resource name redacted
+    expect(flowReport.optionFlowData[0].input).toContain(redactedName); // resource name redacted
+    expect(flowReport.optionFlowData[0].input).toContain(input.serviceConfiguration.accessType);
+    expect(flowReport.optionFlowData[0].input).toContain(input.serviceConfiguration.mapStyle);
+    expect(flowReport.optionFlowData[0].input).toEqual(Redactor(inputString));
+  });
 });
 
 const redactValue = (key: string, value: unknown) => {
-    const retVal = JSON.parse(Redactor(JSON.stringify({ [key]: value })));
-    return retVal[key];
-}
+  const retVal = JSON.parse(Redactor(JSON.stringify({ [key]: value })));
+  return retVal[key];
+};
 
-/*** Helper functions and test data ***/
+/** * Helper functions and test data ***/
 const mockAddStorageInput: AddS3ServiceConfiguration = {
-    serviceName: 'S3',
-    permissions: {
-        auth: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ, CrudOperation.DELETE],
-        guest: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ],
-        groups: {
-            Admin: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ, CrudOperation.DELETE],
-            Guest: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ],
-            Reader: [CrudOperation.READ]
-        }
+  serviceName: 'S3',
+  permissions: {
+    auth: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ, CrudOperation.DELETE],
+    guest: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ],
+    groups: {
+      Admin: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ, CrudOperation.DELETE],
+      Guest: [CrudOperation.CREATE_AND_UPDATE, CrudOperation.READ],
+      Reader: [CrudOperation.READ],
     },
-    resourceName: 'testMockS3ResourceName',
-    bucketName: 'testMockS3BucketName',
-    lambdaTrigger: {
-        mode: 'new',
-        name: 'existingFunctionName'
-    },
-}
+  },
+  resourceName: 'testMockS3ResourceName',
+  bucketName: 'testMockS3BucketName',
+  lambdaTrigger: {
+    mode: 'new',
+    name: 'existingFunctionName',
+  },
+};
 
 const getShortId = (prefix: string) => {
-    const [shortId] = uuid().split('-');
-    const mapId = `${prefix}${shortId}`;
-    return mapId;
-}
+  const [shortId] = uuid().split('-');
+  const mapId = `${prefix}${shortId}`;
+  return mapId;
+};
 
 const mockAddGeoInput: GeoServiceConfiguration = {
-    serviceName: "Map",
-    name: getShortId('map'),
-    accessType: AccessType.AuthorizedUsers,
-    mapStyle: MapStyle.VectorEsriDarkGrayCanvas,
-    setAsDefault: true
-}
+  serviceName: 'Map',
+  name: getShortId('map'),
+  accessType: AccessType.AuthorizedUsers,
+  mapStyle: MapStyle.VectorEsriDarkGrayCanvas,
+  setAsDefault: true,
+};
 
 const appSyncAPIKeyAuthType: AppSyncAPIKeyAuthType = {
-    mode: 'API_KEY',
-    expirationTime: Math.floor((Date.now() / 1000) + 86400), //one day
-}
+  mode: 'API_KEY',
+  expirationTime: Math.floor((Date.now() / 1000) + 86400), // one day
+};
 
 const mockAddAPIInput: AppSyncServiceConfiguration = {
-    serviceName: 'AppSync',
-    apiName: "mockGQLAPIName",
-    transformSchema: 'type User @model(subscriptions: null)\
+  serviceName: 'AppSync',
+  apiName: 'mockGQLAPIName',
+  transformSchema: 'type User @model(subscriptions: null)\
                         @key(fields: ["userId"])\
                         @auth(rules: [\
                             { allow: owner, ownerField: "userId" }\
@@ -158,68 +156,66 @@ const mockAddAPIInput: AppSyncServiceConfiguration = {
                         createdAt: String\
                         updatedAt: String\
                         }',
-    defaultAuthType: appSyncAPIKeyAuthType
-}
+  defaultAuthType: appSyncAPIKeyAuthType,
+};
 
 const mockInputs = {
-    projectName: 'mockProjectName',
-    envName: 'dev',
-    appID: 'mockAppID',
-    Auth: {
-        USER_POOL_ID: 'user-pool-123',
-        IDENTITY_POOL_ID: 'identity-pool-123',
-        NATIVE_CLIENT_ID: 'native-app-client-123',
-        WEB_CLIENT_ID: 'web-app-client-123'
-    },
-    StorageS3: mockAddStorageInput,
-    Geo: mockAddGeoInput,
-    GraphQLAPI: mockAddAPIInput,
-    headlessInput: (feature, command) => ({
-        argv: [],
-        plugin: feature,
-        command: command
-    }),
-    interactivePrompt: "Enter resource name",
-    interactiveValue: "mockResourceID",
-    version: "1.0"
-}
+  projectName: 'mockProjectName',
+  envName: 'dev',
+  appID: 'mockAppID',
+  Auth: {
+    USER_POOL_ID: 'user-pool-123',
+    IDENTITY_POOL_ID: 'identity-pool-123',
+    NATIVE_CLIENT_ID: 'native-app-client-123',
+    WEB_CLIENT_ID: 'web-app-client-123',
+  },
+  StorageS3: mockAddStorageInput,
+  Geo: mockAddGeoInput,
+  GraphQLAPI: mockAddAPIInput,
+  headlessInput: (feature, command) => ({
+    argv: [],
+    plugin: feature,
+    command,
+  }),
+  interactivePrompt: 'Enter resource name',
+  interactiveValue: 'mockResourceID',
+  version: '1.0',
+};
 const getAuthHeadlessTestInput = () => {
-    const headlessPayload: ImportAuthRequest = {
-        version: 1,
-        userPoolId: mockInputs.Auth.USER_POOL_ID,
-        identityPoolId: mockInputs.Auth.IDENTITY_POOL_ID,
-        nativeClientId: mockInputs.Auth.NATIVE_CLIENT_ID,
-        webClientId: mockInputs.Auth.WEB_CLIENT_ID,
-    };
-    return headlessPayload;
-}
+  const headlessPayload: ImportAuthRequest = {
+    version: 1,
+    userPoolId: mockInputs.Auth.USER_POOL_ID,
+    identityPoolId: mockInputs.Auth.IDENTITY_POOL_ID,
+    nativeClientId: mockInputs.Auth.NATIVE_CLIENT_ID,
+    webClientId: mockInputs.Auth.WEB_CLIENT_ID,
+  };
+  return headlessPayload;
+};
 
 const getAddStorageS3HeadlessTestInput = () => {
-    const headlessPayload: AddStorageRequest = {
-        version: 1,
-        serviceConfiguration: mockInputs.StorageS3
-    };
-    return headlessPayload;
-}
+  const headlessPayload: AddStorageRequest = {
+    version: 1,
+    serviceConfiguration: mockInputs.StorageS3,
+  };
+  return headlessPayload;
+};
 
 const getGeoHeadlessTestInput = () => {
-    const headlessPayload: AddGeoRequest = {
-        version: 1,
-        serviceConfiguration: mockInputs.Geo
-    }
-    return headlessPayload;
-}
+  const headlessPayload: AddGeoRequest = {
+    version: 1,
+    serviceConfiguration: mockInputs.Geo,
+  };
+  return headlessPayload;
+};
 
 const getAPIHeadlessTestInput = () => {
 
-}
+};
 
 const getGraphQLHeadlessTestInput = () => {
-    const headlessPayload: AddApiRequest = {
-        version: 1,
-        serviceConfiguration: mockInputs.GraphQLAPI
-    }
-    return headlessPayload;
-
-}
-
+  const headlessPayload: AddApiRequest = {
+    version: 1,
+    serviceConfiguration: mockInputs.GraphQLAPI,
+  };
+  return headlessPayload;
+};

--- a/packages/amplify-cli/src/commands/diagnose.ts
+++ b/packages/amplify-cli/src/commands/diagnose.ts
@@ -91,7 +91,6 @@ const zipSend = async (context: Context, skipPrompts: boolean, error: Error | un
       printer.info(`Project Identifier: ${projectId}`);
       printer.blankLine();
     } catch (ex) {
-      console.log(ex);
       context.usageData.emitError(ex);
       spinner.fail();
     }
@@ -213,11 +212,7 @@ const hashedProjectIdentifiers = (): { projectIdentifier: string; projectEnvIden
   const projectConfig = stateManager.getProjectConfig();
   const envName = stateManager.getCurrentEnvName();
   const appId = getAppId();
-  const { projectIdentifier, projectEnvIdentifier } = createHashedIdentifier(projectConfig.projectName, appId, envName);
-  return {
-    projectIdentifier,
-    projectEnvIdentifier,
-  };
+  return createHashedIdentifier(projectConfig.projectName, appId, envName);
 };
 
 const getAppId = (): string => {

--- a/packages/amplify-cli/src/commands/helpers/encryption-helpers.ts
+++ b/packages/amplify-cli/src/commands/helpers/encryption-helpers.ts
@@ -43,3 +43,25 @@ export const encryptKey = async (key: string): Promise<string> => {
     oaepHash: 'sha256',
   }, Buffer.from(key)).toString('base64');
 };
+
+/**
+ * converts projectName, envName and appId to identifiers
+ * @param projectName the name of the project
+ * @param appId the Amplify app Id
+ * @param envName the current Environment name
+ * @returns
+ */
+export const createHashedIdentifier = (projectName: string, appId: string, envName: string | undefined): {
+  projectIdentifier: string,
+  projectEnvIdentifier: string,
+} => {
+  const projectIdentifier = crypto
+    .createHash('md5')
+    .update(`${projectName}-${appId}`)
+    .digest('hex');
+  const projectEnvIdentifier = crypto
+    .createHash('md5')
+    .update(`${projectName}-${appId}-${envName}`)
+    .digest('hex');
+  return { projectIdentifier, projectEnvIdentifier };
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Generate identical project identifier for flow data and reporter
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
