### PR TITLE
fix: revert running amplify version on install

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
@@ -135,11 +135,6 @@ describe('run upgrade using packaged CLI', () => {
         "700",
       ]
     `);
-
-    expect(execaMock).toBeCalledWith(
-      `${path.join('homedir', 'bin', 'amplify')}`,
-      ['--version'], expect.anything(),
-    );
   });
 
   it('moves old binary to temp location before downloading on windows', async () => {

--- a/packages/amplify-cli/src/commands/upgrade.ts
+++ b/packages/amplify-cli/src/commands/upgrade.ts
@@ -11,8 +11,6 @@ import tar from 'tar-fs';
 import ProgressBar from 'progress';
 import { pipeline } from 'stream';
 import { promisify } from 'util';
-import ora from 'ora';
-import execa from 'execa';
 import { oldVersionPath } from '../utils/win-constants';
 
 const repoOwner = 'aws-amplify';
@@ -78,17 +76,6 @@ const upgradeCli = async (print, version: string) : Promise<void> => {
   await downloadPromise;
   await fs.move(extractedPath, binPath, { overwrite: true });
   await fs.chmod(binPath, '700');
-  // Load the new version of amplify-cli into memory to optimize subsequent runs and check if it runs without error.
-  const spinner:ora.Ora = ora('Validating downloaded Amplify CLI....');
-  spinner.start();
-  const { stderr } = await execa(binPath, ['--version'], { env: process.env, stdio: 'inherit' });
-  if (stderr) {
-    spinner.stop();
-    throw new Error(`Validation failed for Amplify CLI installed in ${binPath}`);
-  } else {
-    spinner.succeed('Validation succeeded');
-    spinner.stop();
-  }
 };
 
 const getLatestVersion = async (): Promise<string> => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->
Reverted code to check version on installation to resolve #10528 
#### Description of changes
Removed code and test to run amplify --version on the installed binary immediately. 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#10528 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
yarn test upgrade.pkg

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [*] PR description included
- [*] `yarn test` passes
- [*] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
