### PR TITLE
fix: add ff for connection field attributes change

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -631,6 +631,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'respectPrimaryKeyAttributesOnConnectionField',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: false,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [


### PR DESCRIPTION
#### Description of changes
- adds feature flag to control PK data type and naming convention

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
