### PR TITLE
chore: block insecure traffic to deployment bucket

### DIFF
--- a/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
+++ b/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
@@ -23,12 +23,6 @@
       "Properties": {
         "BucketName": {
           "Ref": "DeploymentBucketName"
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true
         }
       }
     },

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -100,12 +100,6 @@ Object {
         "BucketName": Object {
           "Ref": "DeploymentBucketName",
         },
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -121,12 +121,6 @@ Object {
         "BucketName": Object {
           "Ref": "DeploymentBucketName",
         },
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -112,7 +112,6 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
     const bucketName = this._cfnParameterMap.get('DeploymentBucketName').valueAsString;
     this.deploymentBucket = new s3.CfnBucket(this, 'DeploymentBucket', {
       bucketName,
-      publicAccessBlockConfiguration: s3.BlockPublicAccess.BLOCK_ALL,
     });
 
     this.deploymentBucket.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
@@ -179,7 +178,7 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
   /**
    * Synthesizes the template into a JSON string
    */
-  public renderCloudFormationTemplate = (_: ISynthesisSession): string => JSON.stringify(this._toCloudFormation(), undefined, 2);
+  public renderCloudFormationTemplate = (__: ISynthesisSession): string => JSON.stringify(this._toCloudFormation(), undefined, 2);
 }
 
 /**
@@ -235,5 +234,5 @@ export class AmplifyRootStackOutputs extends cdk.Stack implements AmplifyRootSta
   }
 
   public renderCloudFormationTemplate =
-    (_: ISynthesisSession): string => JSON.stringify((this as $TSAny)._toCloudFormation(), undefined, 2);
+    (__: ISynthesisSession): string => JSON.stringify((this as $TSAny)._toCloudFormation(), undefined, 2);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Attaches a bucket policy that blocks all unencrypted traffic to the deployment bucket. This is to adhere to best practices for private buckets.

This partially reinstates the functionality that was reverted in [this PR](https://github.com/aws-amplify/amplify-cli/pull/10272). The BPA config is not added here because that requires updating the Amplify managed policy first

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
