### PR TITLE
chore: add FF for primary key connection field attributes

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -637,6 +637,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'respectPrimaryKeyAttributesOnConnectionField',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: false,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [


### PR DESCRIPTION
#### Description of changes
- adds FF required for amplify-category-api package to change the logic around connection field attributes for primary keys

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
