### PR TITLE
chore: add e2e tests for codegen add, both with and without apiId

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
@@ -23,12 +23,13 @@ describe('amplify codegen add', () => {
   });
 
   afterEach(async () => {
-    [projRoot, projRootExternalApi].forEach(async root => {
+    await Promise.all([projRoot, projRootExternalApi].map(async root => {
       if (existsSync(path.join(root, 'amplify', '#current-cloud-backend', 'amplify-meta.json'))) {
         await deleteProject(root);
       }
       deleteProjectDir(root);
-    });
+      return Promise.resolve();
+    }));
   });
 
   it('allows adding codegen to a project with api', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
@@ -1,0 +1,61 @@
+/* eslint-disable spellcheck/spell-checker */
+import {
+  addApiWithoutSchema,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+  getProjectMeta,
+  amplifyPush,
+  updateApiSchema,
+  createRandomName,
+} from 'amplify-e2e-core';
+import * as path from 'path';
+import { existsSync } from 'fs-extra';
+import { addCodegen } from '../../codegen/add';
+
+describe('amplify codegen add', () => {
+  let projRoot: string;
+  let projRootExternalApi: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('add_codegen');
+    projRootExternalApi = await createNewProjectDir('add_codegen_external_api');
+  });
+
+  afterEach(async () => {
+    [projRoot, projRootExternalApi].forEach(async root => {
+      if (existsSync(path.join(root, 'amplify', '#current-cloud-backend', 'amplify-meta.json'))) {
+        await deleteProject(root);
+      }
+      deleteProjectDir(root);
+    });
+  });
+
+  it('allows adding codegen to a project with api', async () => {
+    const projName = createRandomName();
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApiWithoutSchema(projRoot);
+    await updateApiSchema(projRoot, projName, 'simple_model.graphql');
+    await addCodegen(projRoot, {});
+  });
+
+  it('allows adding codegen to a project without an api using an api id', async () => {
+    // Set up project 1 with API
+    const proj1Name = createRandomName();
+    await initJSProjectWithProfile(projRoot, { name: proj1Name });
+    await addApiWithoutSchema(projRoot);
+    // await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
+    await updateApiSchema(projRoot, proj1Name, 'simple_model.graphql');
+    await amplifyPush(projRoot);
+
+    // Get API Id
+    const { GraphQLAPIIdOutput } = getProjectMeta(projRoot).api[proj1Name].output;
+    expect(GraphQLAPIIdOutput).toBeDefined();
+
+    // Setup Project 2
+    const proj2Name = createRandomName();
+    await initJSProjectWithProfile(projRootExternalApi, { name: proj2Name });
+    await addCodegen(projRootExternalApi, { apiId: GraphQLAPIIdOutput });
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
@@ -36,7 +36,7 @@ describe('amplify codegen add', () => {
     await initJSProjectWithProfile(projRoot, { name: projName });
     await addApiWithoutSchema(projRoot);
     await updateApiSchema(projRoot, projName, 'simple_model.graphql');
-    await addCodegen(projRoot, {});
+    await expect(addCodegen(projRoot, {})).resolves.not.toThrow();
   });
 
   it('allows adding codegen to a project without an api using an api id', async () => {
@@ -54,6 +54,6 @@ describe('amplify codegen add', () => {
     // Setup Project 2
     const proj2Name = createRandomName();
     await initJSProjectWithProfile(projRootExternalApi, { name: proj2Name });
-    await addCodegen(projRootExternalApi, { apiId: GraphQLAPIIdOutput });
+    await expect(addCodegen(projRootExternalApi, { apiId: GraphQLAPIIdOutput })).resolves.not.toThrow();
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/codegen/add_codegen.ts
@@ -1,4 +1,3 @@
-/* eslint-disable spellcheck/spell-checker */
 import {
   addApiWithoutSchema,
   createNewProjectDir,
@@ -45,7 +44,6 @@ describe('amplify codegen add', () => {
     const proj1Name = createRandomName();
     await initJSProjectWithProfile(projRoot, { name: proj1Name });
     await addApiWithoutSchema(projRoot);
-    // await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
     await updateApiSchema(projRoot, proj1Name, 'simple_model.graphql');
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -24,11 +24,11 @@ import {
   pinpointAppExist,
   pushToCloud,
 } from 'amplify-e2e-core';
+import * as fs from 'fs-extra';
+import _ from 'lodash';
 import { addEnvironment, checkoutEnvironment, removeEnvironment } from '../environment/env';
 import { addCodegen } from '../codegen/add';
-import * as fs from 'fs-extra';
 import { getAWSExportsPath } from '../aws-exports/awsExports';
-import _ from 'lodash';
 
 describe('amplify delete', () => {
   let projRoot: string;
@@ -105,7 +105,7 @@ describe('amplify delete', () => {
   });
 });
 
-async function testDeletion(projRoot: string, settings: { ios?: Boolean; android?: Boolean }) {
+async function testDeletion(projRoot: string, settings: { ios?: boolean; android?: boolean }) {
   const amplifyMeta = getProjectMeta(projRoot);
   const meta = amplifyMeta.providers.awscloudformation;
   const deploymentBucketName1 = meta.DeploymentBucketName;
@@ -138,13 +138,11 @@ async function testDeletion(projRoot: string, settings: { ios?: Boolean; android
 
 async function putFiles(bucket: string, count = 1001) {
   const s3 = new S3();
-  const s3Params = [...Array(count)].map((_, num) => {
-    return {
-      Bucket: bucket,
-      Body: 'dummy body',
-      Key: `${num}.txt`,
-    };
-  });
+  const s3Params = [...Array(count)].map((_, num) => ({
+    Bucket: bucket,
+    Body: 'dummy body',
+    Key: `${num}.txt`,
+  }));
   await Promise.all(s3Params.map(p => s3.putObject(p).promise()));
 }
 

--- a/packages/amplify-e2e-tests/src/codegen/add.ts
+++ b/packages/amplify-e2e-tests/src/codegen/add.ts
@@ -1,31 +1,44 @@
 import { nspawn as spawn, getCLIPath } from 'amplify-e2e-core';
 
-export function addCodegen(cwd: string, settings: any): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const run = spawn(getCLIPath(), ['codegen', 'add'], { cwd, stripColors: true });
-    if (!(settings.ios || settings.android)) {
-      run.wait('Choose the code generation language target').sendCarriageReturn();
-    }
+type AddCodegenSettings = {
+  ios?: boolean;
+  android?: boolean;
+  apiId?: string;
+};
+
+/**
+ * Execute a `codegen add` command for testing purposes.
+ * @param cwd working directory to execute the command in
+ * @param settings configuration settings for the command
+ */
+export const addCodegen = (cwd: string, settings: AddCodegenSettings): Promise<void> => new Promise((resolve, reject) => {
+  const commandParams = ['codegen', 'add'];
+  if (settings.apiId) {
+    commandParams.push('--apiId', settings.apiId);
+  }
+  const run = spawn(getCLIPath(), commandParams, { cwd, stripColors: true });
+  if (!(settings.ios || settings.android)) {
+    run.wait('Choose the code generation language target').sendCarriageReturn();
+  }
+  run
+    .wait('Enter the file name pattern of graphql queries, mutations and subscriptions')
+    .sendCarriageReturn()
+    .wait('Do you want to generate/update all possible GraphQL operations')
+    .sendConfirmYes()
+    .wait('Enter maximum statement depth [increase from default if your schema is deeply')
+    .sendCarriageReturn();
+  if (settings.ios) {
     run
-      .wait('Enter the file name pattern of graphql queries, mutations and subscriptions')
+      .wait('Enter the file name for the generated code')
       .sendCarriageReturn()
-      .wait('Do you want to generate/update all possible GraphQL operations')
-      .sendConfirmYes()
-      .wait('Enter maximum statement depth [increase from default if your schema is deeply')
+      .wait('Do you want to generate code for your newly created GraphQL API')
       .sendCarriageReturn();
-    if (settings.ios) {
-      run
-        .wait('Enter the file name for the generated code')
-        .sendCarriageReturn()
-        .wait('Do you want to generate code for your newly created GraphQL API')
-        .sendCarriageReturn();
+  }
+  run.run((err: Error) => {
+    if (!err) {
+      resolve();
+    } else {
+      reject(err);
     }
-    run.run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        reject(err);
-      }
-    });
   });
-}
+});


### PR DESCRIPTION
#### Description of changes
Adding a regression test for basic happy-case functionality from https://github.com/aws-amplify/amplify-category-api/issues/38 this issue. Verified that using CLI v8.1.0 will fail the second test here.

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/38

#### Description of how you validated changes
Ran test, and verified test failed for 8.1.0

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
