### PR TITLE
fix: use standard endpoint syntax for CloudFrontDistribution

### DIFF
--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
@@ -107,7 +107,7 @@
           "HttpVersion": "http2",
           "Origins": [
             {
-              "DomainName": { "Fn::GetAtt": ["S3Bucket", "DomainName"] },
+              "DomainName": { "Fn::GetAtt": ["S3Bucket", "RegionalDomainName"] },
               "Id": "hostingS3Bucket",
               "S3OriginConfig": {
                 "OriginAccessIdentity": {


### PR DESCRIPTION
#### Description of changes

Always use the standard endpoint syntax to access buckets; Otherwise, the website will return AccessDenied for up to 24 hours after first deploying.

Refs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html

I have deployed 5-6 times in the last few days and 100% of the time I'm waiting at least an hour each time. Today I waited 5 hours and couldn't stand it so I had to manually change the origin to `s3.ap-northeast-1.amazonaws.com`. Do not use Legacy Endpoints.

#### Description of how you validated changes

I confirmed that the CloudFrontDistribution origin setting is RegionalDomainName in the AWS Console.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [X] Relevant documentation is changed or added (and PR referenced)
- [X] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

----

I got advice from `uncodable#9999` in the Amplify Discord Community.
