### PR TITLE
Revert "chore: block insecure traffic to deployment bucket"

### DIFF
--- a/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
+++ b/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
@@ -26,59 +26,10 @@
         }
       }
     },
-    "DeploymentBucketBlockHTTP": {
-      "Type": "AWS::S3::BucketPolicy",
-      "Properties": {
-        "Bucket": {
-          "Ref": "DeploymentBucketName"
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "DeploymentBucketName"
-                      },
-                      "/*"
-                    ]
-                  ]
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:s3:::",
-                      {
-                        "Ref": "DeploymentBucketName"
-                      }
-                    ]
-                  ]
-                }
-              ],
-              "Condition": {
-                "Bool": {
-                  "aws:SecureTransport": false
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
     "AuthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName": {
-          "Ref": "AuthRoleName"
-        },
+        "RoleName": { "Ref": "AuthRoleName" },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -97,9 +48,7 @@
     "UnauthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName": {
-          "Ref": "UnauthRoleName"
-        },
+        "RoleName": { "Ref": "UnauthRoleName" },
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -119,73 +68,43 @@
   "Outputs": {
     "Region": {
       "Description": "CloudFormation provider root stack Region",
-      "Value": {
-        "Ref": "AWS::Region"
-      },
+      "Value": { "Ref": "AWS::Region" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-Region"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-Region" }
       }
     },
     "StackName": {
       "Description": "CloudFormation provider root stack ID",
-      "Value": {
-        "Ref": "AWS::StackName"
-      },
+      "Value": { "Ref": "AWS::StackName" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-StackName"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-StackName" }
       }
     },
     "StackId": {
       "Description": "CloudFormation provider root stack name",
-      "Value": {
-        "Ref": "AWS::StackId"
-      },
+      "Value": { "Ref": "AWS::StackId" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-StackId"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-StackId" }
       }
     },
     "DeploymentBucketName": {
       "Description": "CloudFormation provider root stack deployment bucket name",
-      "Value": {
-        "Ref": "DeploymentBucketName"
-      },
+      "Value": { "Ref": "DeploymentBucketName" },
       "Export": {
-        "Name": {
-          "Fn::Sub": "${AWS::StackName}-DeploymentBucketName"
-        }
+        "Name": { "Fn::Sub": "${AWS::StackName}-DeploymentBucketName" }
       }
     },
     "AuthRoleArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "AuthRole",
-          "Arn"
-        ]
-      }
+      "Value": { "Fn::GetAtt": ["AuthRole", "Arn"] }
     },
     "UnauthRoleArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "UnauthRole",
-          "Arn"
-        ]
-      }
+      "Value": { "Fn::GetAtt": ["UnauthRole", "Arn"] }
     },
     "AuthRoleName": {
-      "Value": {
-        "Ref": "AuthRole"
-      }
+      "Value": { "Ref": "AuthRole" }
     },
     "UnauthRoleName": {
-      "Value": {
-        "Ref": "UnauthRole"
-      }
+      "Value": { "Ref": "UnauthRole" }
     }
   }
 }

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -104,53 +104,6 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "DeploymentBucketBlockHTTP": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "DeploymentBucketName",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:*",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:SecureTransport": false,
-                },
-              },
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "UnauthRole": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -125,53 +125,6 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
-    "DeploymentBucketBlockHTTP": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "DeploymentBucketName",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:*",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:SecureTransport": false,
-                },
-              },
-              "Effect": "Deny",
-              "Principal": "*",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:aws:s3:::",
-                      Object {
-                        "Ref": "DeploymentBucketName",
-                      },
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "UnauthRole": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -1,24 +1,16 @@
-/* eslint-disable max-classes-per-file */
 import * as cdk from '@aws-cdk/core';
 import * as s3 from '@aws-cdk/aws-s3';
 import * as iam from '@aws-cdk/aws-iam';
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 import { IStackSynthesizer, ISynthesisSession } from '@aws-cdk/core';
-import { $TSAny } from 'amplify-cli-core';
 
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
 
-/**
- * Properties to the AmplifyRootStack constructor
- */
 export type AmplifyRootStackProps = {
   synthesizer: IStackSynthesizer;
 };
 
-/**
- * CDK construct for the environment root stack
- */
 export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTemplate {
   _scope: cdk.Construct;
   deploymentBucket: s3.CfnBucket;
@@ -34,11 +26,12 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
   }
 
   /**
-   * Add an output to the stack
+   *
+   * @param props :cdk.CfnOutputProps
+   * @param logicalId: : lodicalId of the Resource
    */
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void {
     try {
-      // eslint-disable-next-line no-new
       new cdk.CfnOutput(this, logicalId, props);
     } catch (error) {
       throw new Error(error);
@@ -46,11 +39,12 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
   }
 
   /**
-   * Add a mapping to the stack
+   *
+   * @param props
+   * @param logicalId
    */
   addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void {
     try {
-      // eslint-disable-next-line no-new
       new cdk.CfnMapping(this, logicalId, props);
     } catch (error) {
       throw new Error(error);
@@ -58,23 +52,24 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
   }
 
   /**
-   * Add a condition to the stack
+   *
+   * @param props
+   * @param logicalId
    */
   addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void {
     try {
-      // eslint-disable-next-line no-new
       new cdk.CfnCondition(this, logicalId, props);
     } catch (error) {
       throw new Error(error);
     }
   }
-
   /**
-   * Add a resource to the stack
+   *
+   * @param props
+   * @param logicalId
    */
   addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void {
     try {
-      // eslint-disable-next-line no-new
       new cdk.CfnResource(this, logicalId, props);
     } catch (error) {
       throw new Error(error);
@@ -82,7 +77,9 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
   }
 
   /**
-   * Add CFN parameter to root stack
+   *
+   * @param props
+   * @param logicalId
    */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
     try {
@@ -95,49 +92,20 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
     }
   }
 
-  /**
-   * Get CFN parameter by logical id
-   */
   getCfnParameter(logicalId: string): cdk.CfnParameter {
     if (this._cfnParameterMap.has(logicalId)) {
       return this._cfnParameterMap.get(logicalId);
+    } else {
+      throw new Error(`Cfn Parameter with LogicalId ${logicalId} doesnt exist`);
     }
-    throw new Error(`Cfn Parameter with LogicalId ${logicalId} doesn't exist`);
   }
 
-  /**
-   * Populates the root stack with default resources
-   */
-  async generateRootStackResources(): Promise<void> {
-    const bucketName = this._cfnParameterMap.get('DeploymentBucketName').valueAsString;
+  generateRootStackResources = async () => {
     this.deploymentBucket = new s3.CfnBucket(this, 'DeploymentBucket', {
-      bucketName,
+      bucketName: this._cfnParameterMap.get('DeploymentBucketName').valueAsString,
     });
 
     this.deploymentBucket.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
-
-    // eslint-disable-next-line no-new
-    new s3.CfnBucketPolicy(this, 'DeploymentBucketBlockHTTP', {
-      bucket: bucketName,
-      policyDocument: {
-        Statement: [
-          {
-            Action: 's3:*',
-            Effect: 'Deny',
-            Principal: '*',
-            Resource: [
-              `arn:aws:s3:::${bucketName}/*`,
-              `arn:aws:s3:::${bucketName}`,
-            ],
-            Condition: {
-              Bool: {
-                'aws:SecureTransport': false,
-              },
-            },
-          },
-        ],
-      },
-    });
 
     this.authRole = new iam.CfnRole(this, 'AuthRole', {
       roleName: this._cfnParameterMap.get('AuthRoleName').valueAsString,
@@ -172,67 +140,51 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
         ],
       },
     });
-  }
+  };
 
   // add Function for Custom Resource in Root stack
   /**
-   * Synthesizes the template into a JSON string
+   *
+   * @param _
+   * @returns
    */
-  public renderCloudFormationTemplate = (__: ISynthesisSession): string => JSON.stringify(this._toCloudFormation(), undefined, 2);
+  public renderCloudFormationTemplate = (_: ISynthesisSession): string => {
+    return JSON.stringify(this._toCloudFormation(), undefined, 2);
+  };
 }
 
 /**
- * Additional class to merge CFN parameters and CFN outputs as cdk doesn't allow same logical ID of constructs in same stack
+ * additional class to merge CFN parameters and CFN outputs as cdk doesnt allow same logical ID of constructs in same stack
  */
 export class AmplifyRootStackOutputs extends cdk.Stack implements AmplifyRootStackTemplate {
+  constructor(scope: cdk.Construct, id: string, props: AmplifyRootStackProps) {
+    super(scope, id, props);
+  }
   deploymentBucket?: s3.CfnBucket;
   authRole?: iam.CfnRole;
   unauthRole?: iam.CfnRole;
 
-  /**
-   * Method not implemented
-   */
-  // eslint-disable-next-line class-methods-use-this
-  addCfnParameter(/* _props: cdk.CfnConditionProps, _logicalId: string */): void {
+  addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
     throw new Error('Method not implemented.');
   }
-
-  /**
-   * Adds an output to the stack
-   */
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void {
     try {
-      // eslint-disable-next-line no-new
       new cdk.CfnOutput(this, logicalId, props);
     } catch (error) {
       throw new Error(error);
     }
   }
-
-  /**
-   * Method not implemented
-   */
-  // eslint-disable-next-line class-methods-use-this
-  addCfnMapping(): void {
+  addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void {
+    throw new Error('Method not implemented.');
+  }
+  addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void {
+    throw new Error('Method not implemented.');
+  }
+  addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void {
     throw new Error('Method not implemented.');
   }
 
-  /**
-   * Method not implemented
-   */
-  // eslint-disable-next-line class-methods-use-this
-  addCfnCondition(/* _props: cdk.CfnConditionProps, _logicalId: string */): void {
-    throw new Error('Method not implemented.');
-  }
-
-  /**
-   * Method not implemented
-   */
-  // eslint-disable-next-line class-methods-use-this
-  addCfnResource(/* _props: cdk.CfnResourceProps, _logicalId: string */): void {
-    throw new Error('Method not implemented.');
-  }
-
-  public renderCloudFormationTemplate =
-    (__: ISynthesisSession): string => JSON.stringify((this as $TSAny)._toCloudFormation(), undefined, 2);
+  public renderCloudFormationTemplate = (_: ISynthesisSession): string => {
+    return JSON.stringify((this as any)._toCloudFormation(), undefined, 2);
+  };
 }


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#10533

Analysis:
The error "A conflicting conditional operation is currently in progress against this resource. Please try again."  is thrown when the BPA (Block Public Access) policy is applied by the amplify generated CloudFormation and AWS at the same time. AWS applies the BPA policy on any S3 bucket resource immediately after its creation. This is applied asynchronously hence it may not show up consistently. As of now, we do not have a way to serialize/coordinate application of the BPA policy with AWS from Cloudformation/CDK. This needs to be researched further.
 
Prior errors seen in Terraform :
https://github.com/hashicorp/terraform-provider-aws/issues/7628 have been resolved by explicitly retrying application of BPA using AWS SDK if the deployment errors contain the above mentioned error.
 
e.g. https://github.com/hashicorp/terraform-provider-aws/pull/12949/files#diff-7ea49767db8110becb01510a3562ba5f3450dc361bf8aa3622a4cc27a540a0e3R1743-R1747
has code to use AWS SDK and retry application of policy.
 
 
Mitigation:
We will revert the PR https://github.com/aws-amplify/amplify-cli/commit/cc36d9babdfd411bdada421bcf3ccb7843d2bc44
 
Solution:
A long term solution would require us to codify the condition ( if account level BPA policy is being enforced by AWS ) and depend on that condition to complete before creating the deployment bucket policies.