### PR TITLE
Feature: add disabled flag for deep merging directive defaults

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -643,6 +643,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: false,
       },
+      {
+        name: 'shouldDeepMergeDirectiveConfigDefaults',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: false,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This adds a new feature flag, not yet defaulting to true for new projects. The purpose is to deep merge directive defaults, so that if the default is:

```json
{
    "foo": "bar",
    "obj": {
        "val": true,
        "this": "that"
    }
}
```
and a customer provides
```json
{
    "obj": {
        "val": false
    }
}
```

the result will be
```json
{
    "foo": "bar",
    "obj": {
        "val": false,
        "this": "that"
    }
}
```

instead of the current result, which is

```json
{
    "foo": "bar",
    "obj": {
        "val": false
    }
}
```
since only top level values are currently being merged for config defaults.

Documentation PR will be coming, I'm waiting until the feature is actually out. This enables work on the API category

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Internally tracked
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
It's a feature flag, no way to validate changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
