### PR TITLE
chore: upgrade instances for e2e testing

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -3,7 +3,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@6.15.3
 machine:
   environment:
-    PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
 parameters:
   nightly_console_integration_tests:
@@ -19,8 +19,8 @@ parameters:
 executors:
   w: &windows-e2e-executor
     machine:
-      image: 'windows-server-2019-vs2019:stable'
-      resource_class: 'windows.medium'
+      image: "windows-server-2019-vs2019:stable"
+      resource_class: "windows.large"
       shell: bash.exe
     working_directory: ~/repo
     environment:
@@ -31,7 +31,7 @@ executors:
     docker:
       - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
-    resource_class: large
+    resource_class: xlarge
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
@@ -140,7 +140,7 @@ jobs:
             yarn e2e
           no_output_timeout: 90m
           environment:
-            JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
+            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
       - store_test_results:
           path: packages/amplify-util-mock/
 
@@ -227,7 +227,7 @@ jobs:
             cd packages/graphql-transformers-e2e-tests/
             retry yarn e2e --maxWorkers=3 $TEST_SUITE
           environment:
-            AMPLIFY_CLI_DISABLE_LOGGING: 'true'
+            AMPLIFY_CLI_DISABLE_LOGGING: "true"
           no_output_timeout: 90m
       - store_test_results:
           path: packages/graphql-transformers-e2e-tests/
@@ -405,7 +405,7 @@ jobs:
             amplify -v
             cd packages/amplify-console-integration-tests
             retry yarn run console-integration --maxWorkers=3
-          name: 'Run Amplify Console integration tests'
+          name: "Run Amplify Console integration tests"
           no_output_timeout: 90m
       - run: *scan_e2e_test_artifacts
       - store_test_results:
@@ -416,7 +416,7 @@ jobs:
 
   integration_test:
     working_directory: ~/repo
-    resource_class: large
+    resource_class: xlarge
     docker:
       - image: cypress/base:14.17.0
         environment:
@@ -608,7 +608,7 @@ jobs:
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
       - run:
-          name: 'Run cleanup script'
+          name: "Run cleanup script"
           command: |
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources
@@ -626,7 +626,7 @@ jobs:
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ arch }}
       - run:
-          name: 'Run cleanup script'
+          name: "Run cleanup script"
           command: |
             cd packages/amplify-e2e-tests
             yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
@@ -641,7 +641,7 @@ workflows:
   nightly_console_integration_tests:
     triggers:
       - schedule:
-          cron: '0 14 * * *'
+          cron: "0 14 * * *"
           filters:
             branches:
               only:
@@ -668,7 +668,7 @@ workflows:
   e2e_resource_cleanup:
     triggers:
       - schedule:
-          cron: '45 0,12 * * *'
+          cron: "45 0,12 * * *"
           filters:
             branches:
               only:
@@ -901,7 +901,7 @@ workflows:
 
 commands:
   install_packaged_cli:
-    description: 'Install Amplify Packaged CLI to PATH'
+    description: "Install Amplify Packaged CLI to PATH"
     parameters:
       os:
         type: executor
@@ -944,7 +944,7 @@ commands:
                 command: amplify version
 
   install_yarn:
-    description: 'Install Amplify Packaged CLI to PATH'
+    description: "Install Amplify Packaged CLI to PATH"
     parameters:
       os:
         type: executor
@@ -959,7 +959,7 @@ commands:
                 shell: powershell.exe
                 command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe
   run_e2e_tests:
-    description: 'Run Amplify E2E tests'
+    description: "Run Amplify E2E tests"
     parameters:
       os:
         type: executor
@@ -990,7 +990,7 @@ commands:
                   retry runE2eTest
                 no_output_timeout: 90m
   scan_e2e_test_artifacts:
-    description: 'Scan And Cleanup E2E Test Artifacts'
+    description: "Scan And Cleanup E2E Test Artifacts"
     parameters:
       os:
         type: executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
     docker:
       - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
-    resource_class: large
+    resource_class: xlarge
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
@@ -31,7 +31,7 @@ executors:
 # our defined job, and its steps
 jobs:
   setup:
-    executor: 'linux'
+    executor: "linux"
     steps:
       - checkout # checkout code
       - run: # run a command
@@ -68,7 +68,7 @@ jobs:
                   - image: >-
                       public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
                 working_directory: ~/repo
-                resource_class: large
+                resource_class: xlarge
                 environment:
                   AMPLIFY_DIR: /home/circleci/repo/out
                   AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
@@ -81,7 +81,7 @@ jobs:
     docker:
       - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
-    resource_class: large
+    resource_class: xlarge
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Upgraded all linux instances to xlarge and windows instance to large for E2E testing.
The goal here is to reduce the probability of reducing latency by eliminating memory paging requirements.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
