### PR TITLE
fix: pass httpProxy agent to node-fetch.

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -50,7 +50,8 @@ async function getAdminAppState(appId: string, region: string) {
   // environment variable AMPLIFY_CLI_APPSTATE_BASE_URL useful for development against beta/gamma appstate endpoints
   const appStateBaseUrl = process.env.AMPLIFY_CLI_APPSTATE_BASE_URL ?? adminBackendMap[region].appStateUrl;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
-  const res = await fetch(`${appStateBaseUrl}/AppState/?appId=${appId}`, { agent: proxyAgent(httpProxy) });
+  const fetchOptions = httpProxy ? { agent: proxyAgent(httpProxy) } : {};
+  const res = await fetch(`${appStateBaseUrl}/AppState/?appId=${appId}`, fetchOptions);
   return res.json();
 }
 

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import fetch from 'node-fetch';
 import { adminLoginFlow } from '../admin-login';
 import { AdminAuthConfig, AwsSdkConfig, CognitoAccessToken, CognitoIdToken } from './auth-types';
+import proxyAgent from 'proxy-agent';
 
 export const adminVerifyUrl = (appId: string, envName: string, region: string): string => {
   const baseUrl = process.env.AMPLIFY_CLI_ADMINUI_BASE_URL ?? adminBackendMap[region]?.amplifyAdminUrl;
@@ -48,7 +49,8 @@ export async function getTempCredsWithAdminTokens(context: $TSContext, appId: st
 async function getAdminAppState(appId: string, region: string) {
   // environment variable AMPLIFY_CLI_APPSTATE_BASE_URL useful for development against beta/gamma appstate endpoints
   const appStateBaseUrl = process.env.AMPLIFY_CLI_APPSTATE_BASE_URL ?? adminBackendMap[region].appStateUrl;
-  const res = await fetch(`${appStateBaseUrl}/AppState/?appId=${appId}`);
+  const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+  const res = await fetch(`${appStateBaseUrl}/AppState/?appId=${appId}`, { agent: proxyAgent(httpProxy) });
   return res.json();
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
In amplify-provider-awscloudformation, pass proxyAgent to `fetch()`.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#8536
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- yarn test, then `amplify-provider-awscloudformation:test` is passed.
- In  behind a proxy, set HTTP_PROXY variable and `amplify-dev pull --appId xxxxxx --envName dev`
- I don't set HTTP_PROXY variable and `amplify-dev pull --appId xxxxxx --envName dev`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
