### PR TITLE
Add Mocking support for DynamoDB lambda triggers

### DIFF
--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -34,6 +34,7 @@
     "amplify-cli-core": "2.10.0",
     "amplify-codegen": "^3.0.0",
     "amplify-dynamodb-simulator": "2.3.4",
+    "amplify-prompts": "2.2.0",
     "amplify-provider-awscloudformation": "6.4.2",
     "amplify-storage-simulator": "1.6.7",
     "chokidar": "^3.5.3",

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -19,6 +19,10 @@ export function dynamoDBResourceHandler(resourceName, resource, cfnContext: Clou
       BillingMode: 'PAY_PER_REQUEST',
       KeySchema: resource.Properties.KeySchema,
       AttributeDefinitions: resource.Properties.AttributeDefinitions,
+      StreamSpecification: {
+        StreamEnabled: true,
+        StreamViewType: resource.Properties.StreamSpecification.StreamViewType
+      }
     },
   };
 

--- a/packages/amplify-util-mock/src/__tests__/api/find-lambda-triggers.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/find-lambda-triggers.test.ts
@@ -1,0 +1,80 @@
+import { $TSContext, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { findLambdaTriggers } from '../../utils/lambda/find-lambda-triggers';
+
+const mockContext = {} as $TSContext;
+
+describe('Find DDB Lambda Triggers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stateManager.getMeta = jest.fn().mockReturnValue({
+        function: {
+          lambda1: {
+            service: 'Lambda',
+          }
+        }
+    }),
+    pathManager.getBackendDirPath = jest.fn().mockReturnValue('backend');
+    JSONUtilities.readJson = jest.fn().mockReturnValue({});
+  });
+
+  it('Returns empty map when no lambda triggers exist', async () => {
+    stateManager.getMeta = jest.fn().mockReturnValueOnce({});
+    const mockTables = ['TodoTable'];
+    const result = await findLambdaTriggers(mockContext, mockTables);
+    expect(JSONUtilities.readJson).toBeCalledTimes(0);
+    expect(result).toEqual({});
+  });
+
+  it('Does not Map types other than event source mappings', async () => {
+    const mockTables = ['TodoTable'];
+    JSONUtilities.readJson = jest.fn().mockReturnValue({
+      Resources: {
+        LambdaEventSourceMappingTodo: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            EventSourceArn: "mockResourceReference"
+          }
+        }
+      }
+    });
+    const result = await findLambdaTriggers(mockContext, mockTables);
+    expect(JSONUtilities.readJson).toBeCalledTimes(1);
+    expect(result).toEqual({});
+  });
+
+  it('Does not Map event source mappings other than DDB streams', async () => {
+    const mockTables = ['TodoTable'];
+    JSONUtilities.readJson = jest.fn().mockReturnValue({
+      Resources: {
+        LambdaEventSourceMappingTodo: {
+          Type: 'AWS::Lambda::EventSourceMapping',
+          Properties: {
+            EventSourceArn: "mockResourceReference"
+          }
+        }
+      }
+    });
+    const result = await findLambdaTriggers(mockContext, mockTables);
+    expect(JSONUtilities.readJson).toBeCalledTimes(1);
+    expect(result).toEqual({});
+  });
+
+  it('Maps existing triggers correctly', async () => {
+    const mockTables = ['TodoTable'];
+    JSONUtilities.readJson = jest.fn().mockReturnValue({
+      Resources: {
+        LambdaEventSourceMappingTodo: {
+          Type: 'AWS::Lambda::EventSourceMapping',
+          Properties: {
+            EventSourceArn: {"Fn::ImportValue":{"Fn::Sub":"${apimocklambdatrigrGraphQLAPIIdOutput}:GetAtt:TodoTable:StreamArn"}}
+          }
+        }
+      }
+    });
+    const result = await findLambdaTriggers(mockContext, mockTables);
+    expect(JSONUtilities.readJson).toBeCalledTimes(1);
+    expect(result).toEqual({
+      TodoTable: ['lambda1']
+    });
+  });
+});

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
@@ -1,0 +1,57 @@
+import { $TSContext } from 'amplify-cli-core';
+import { invokeLambda } from '../../api/lambda-invoke';
+import { ProcessedLambdaFunction } from '../../CFNParser/stack/types';
+import { loadLambdaConfig } from '../../utils/lambda/load-lambda-config';
+import { getInvoker, getBuilder } from 'amplify-category-function';
+import { timeConstrainedInvoker } from '../../func';
+
+jest.mock('../../utils/lambda/load-lambda-config', () => ({
+  loadLambdaConfig: jest.fn()
+}));
+const loadLambdaConfigMock = loadLambdaConfig as jest.MockedFunction<typeof loadLambdaConfig>;
+
+jest.mock('amplify-category-function', () => ({
+    getInvoker: jest.fn().mockResolvedValue(() => new Promise(resolve => setTimeout(() => resolve('lambda value'), 10))),
+    getBuilder: jest.fn().mockReturnValue(() => {}),
+    isMockable: jest.fn().mockReturnValue({ isMockable: true }),
+    category: 'function',
+}));
+const getInvoker_mock = getInvoker as jest.MockedFunction<typeof getInvoker>;
+const getBuilder_mock = getBuilder as jest.MockedFunction<typeof getBuilder>;
+
+  
+jest.mock('../../func', () => ({
+    timeConstrainedInvoker: jest.fn().mockResolvedValue({})
+}));
+const timeConstrainedInvokerMock = timeConstrainedInvoker as jest.MockedFunction<typeof timeConstrainedInvoker>;
+
+const expectedLambdaConfig = { name: 'mocklambda', handler: 'mock.handler', environment: {} } as ProcessedLambdaFunction;
+loadLambdaConfigMock.mockResolvedValue(expectedLambdaConfig);
+
+const mockContext = {
+    print: {
+        success: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        blue: jest.fn(),
+    }
+} as unknown as $TSContext;
+
+describe('Invoke local lambda function', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('invoke the local lambda with given data', async () => {
+    let isBuilt = false;
+    getInvoker_mock.mockResolvedValueOnce(() => new Promise(resolve => setTimeout(() => resolve('lambda value'), 11000)));
+    getBuilder_mock.mockReturnValueOnce(async () => {
+        isBuilt = true;
+    });
+    const echoInput = { key: 'value' };
+    timeConstrainedInvokerMock.mockResolvedValue(echoInput);
+    await invokeLambda(mockContext, 'lambda1', echoInput);
+    expect(loadLambdaConfigMock.mock.calls[0][1]).toEqual('lambda1');
+    expect(mockContext.print.info).toBeCalledWith(JSON.stringify(echoInput, undefined, 2));
+    expect(mockContext.print.error).toBeCalledTimes(0);
+    expect(mockContext.print.blue).toBeCalledWith('Finished execution.');
+  });
+});

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
@@ -4,6 +4,9 @@ import { ProcessedLambdaFunction } from '../../CFNParser/stack/types';
 import { loadLambdaConfig } from '../../utils/lambda/load-lambda-config';
 import { getInvoker, getBuilder } from 'amplify-category-function';
 import { timeConstrainedInvoker } from '../../func';
+import { printer } from 'amplify-prompts';
+
+jest.mock('amplify-prompts');
 
 jest.mock('../../utils/lambda/load-lambda-config', () => ({
   loadLambdaConfig: jest.fn()
@@ -16,8 +19,8 @@ jest.mock('amplify-category-function', () => ({
     isMockable: jest.fn().mockReturnValue({ isMockable: true }),
     category: 'function',
 }));
-const getInvoker_mock = getInvoker as jest.MockedFunction<typeof getInvoker>;
-const getBuilder_mock = getBuilder as jest.MockedFunction<typeof getBuilder>;
+const getInvokerMock = getInvoker as jest.MockedFunction<typeof getInvoker>;
+const getBuilderMock = getBuilder as jest.MockedFunction<typeof getBuilder>;
 
   
 jest.mock('../../func', () => ({
@@ -28,30 +31,28 @@ const timeConstrainedInvokerMock = timeConstrainedInvoker as jest.MockedFunction
 const expectedLambdaConfig = { name: 'mocklambda', handler: 'mock.handler', environment: {} } as ProcessedLambdaFunction;
 loadLambdaConfigMock.mockResolvedValue(expectedLambdaConfig);
 
-const mockContext = {
-    print: {
-        success: jest.fn(),
-        info: jest.fn(),
-        error: jest.fn(),
-        blue: jest.fn(),
-    }
-} as unknown as $TSContext;
+const mockContext = {} as $TSContext;
 
 describe('Invoke local lambda function', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    printer.info = jest.fn();
+    printer.success = jest.fn();
+    printer.error = jest.fn();
+  });
 
   it('invoke the local lambda with given data', async () => {
     let isBuilt = false;
-    getInvoker_mock.mockResolvedValueOnce(() => new Promise(resolve => setTimeout(() => resolve('lambda value'), 11000)));
-    getBuilder_mock.mockReturnValueOnce(async () => {
+    getInvokerMock.mockResolvedValueOnce(() => new Promise(resolve => setTimeout(() => resolve('lambda value'), 11000)));
+    getBuilderMock.mockReturnValueOnce(async () => {
         isBuilt = true;
     });
     const echoInput = { key: 'value' };
     timeConstrainedInvokerMock.mockResolvedValue(echoInput);
     await invokeLambda(mockContext, 'lambda1', echoInput);
     expect(loadLambdaConfigMock.mock.calls[0][1]).toEqual('lambda1');
-    expect(mockContext.print.info).toBeCalledWith(JSON.stringify(echoInput, undefined, 2));
-    expect(mockContext.print.error).toBeCalledTimes(0);
-    expect(mockContext.print.blue).toBeCalledWith('Finished execution.');
+    expect(printer.info).toBeCalledWith(JSON.stringify(echoInput, undefined, 2));
+    expect(printer.error).toBeCalledTimes(0);
+    expect(printer.info).toBeCalledWith('Finished execution.');
   });
 });

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-trigger-handler.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-trigger-handler.test.ts
@@ -24,7 +24,7 @@ describe('Lambda Trigger Handler', () => {
 
   it('throws error if lambda trigger name is not specified', async () => {
     try {
-        await lambdaTriggerHandlers.lambdaTriggerHandler(
+        await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
             mockContext,
             mockStreamArn,
             null,
@@ -39,7 +39,7 @@ describe('Lambda Trigger Handler', () => {
 
   it('throws error if stream Arn is not specified', async () => {
     try {
-        await lambdaTriggerHandlers.lambdaTriggerHandler(
+        await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
             mockContext,
             null,
             mockTriggerName,
@@ -54,7 +54,7 @@ describe('Lambda Trigger Handler', () => {
 
   it('throws error if dynamoDB local endpoint is not specified', async () => {
     try {
-        await lambdaTriggerHandlers.lambdaTriggerHandler(
+        await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
             mockContext,
             mockStreamArn,
             mockTriggerName,
@@ -73,7 +73,7 @@ describe('Lambda Trigger Handler', () => {
         reason: 'Mocking a function with layers is not supported.'
     });
     try {
-        await lambdaTriggerHandlers.lambdaTriggerHandler(
+        await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
             mockContext,
             mockStreamArn,
             mockTriggerName,
@@ -87,8 +87,8 @@ describe('Lambda Trigger Handler', () => {
   });
 
   it('Polls for records from given DDB stream', async () => {
-    const pollForRecordsMock = jest.spyOn(lambdaTriggerHandlers, 'pollForRecords').mockResolvedValueOnce();
-    await lambdaTriggerHandlers.lambdaTriggerHandler(
+    const pollForRecordsMock = jest.spyOn(lambdaTriggerHandlers, 'pollDDBStreamAndInvokeLamba').mockResolvedValueOnce();
+    await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
         mockContext,
         mockStreamArn,
         mockTriggerName,
@@ -112,7 +112,7 @@ describe('Lambda Trigger Handler', () => {
         shardIterator: null // to prevent continuously running loop
     });
     invokeLambdaMock.mockResolvedValueOnce();
-    await lambdaTriggerHandlers.lambdaTriggerHandler(
+    await lambdaTriggerHandlers.ddbLambdaTriggerHandler(
         mockContext,
         mockStreamArn,
         mockTriggerName,

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-trigger-handler.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-trigger-handler.test.ts
@@ -1,0 +1,126 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { invokeLambda } from '../../api/lambda-invoke';
+import { isMockable } from 'amplify-category-function';
+import * as lambdaTriggerHandlers from '../../api/lambda-trigger-handler';
+import { DynamoDBStreams, Endpoint } from 'aws-sdk';
+
+jest.mock('../../api/lambda-invoke', () => ({
+    invokeLambda: jest.fn()
+}));
+const invokeLambdaMock = invokeLambda as jest.MockedFunction<typeof invokeLambda>;
+
+jest.mock('amplify-category-function', () => ({
+    isMockable: jest.fn().mockReturnValue({ isMockable: true })
+}));
+const isMockableMock = isMockable as jest.MockedFunction<typeof isMockable>;
+
+const mockContext = {} as $TSContext;
+const mockStreamArn = 'mock-arn';
+const mockTriggerName = 'mock-trigger';
+const mockDDBEndpoint = new Endpoint('mock');
+
+describe('Lambda Trigger Handler', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('throws error if lambda trigger name is not specified', async () => {
+    try {
+        await lambdaTriggerHandlers.lambdaTriggerHandler(
+            mockContext,
+            mockStreamArn,
+            null,
+            mockDDBEndpoint
+        );
+        expect(true).toEqual(false);
+    }
+    catch (err) {
+        expect(err.message).toBe('Name of the lambda trigger function must be specified');
+    }
+  });
+
+  it('throws error if stream Arn is not specified', async () => {
+    try {
+        await lambdaTriggerHandlers.lambdaTriggerHandler(
+            mockContext,
+            null,
+            mockTriggerName,
+            mockDDBEndpoint
+        );
+        expect(true).toEqual(false);
+    }
+    catch (err) {
+        expect(err.message).toBe('Stream Arn must be specified');
+    }
+  });
+
+  it('throws error if dynamoDB local endpoint is not specified', async () => {
+    try {
+        await lambdaTriggerHandlers.lambdaTriggerHandler(
+            mockContext,
+            mockStreamArn,
+            mockTriggerName,
+            null
+        );
+        expect(true).toEqual(false);
+    }
+    catch (err) {
+        expect(err.message).toBe('Local URL where DDB is running should be specified');
+    }
+  });
+
+  it('throws error if local lambda is not mockable', async () => {
+    isMockableMock.mockReturnValueOnce({ 
+        isMockable: false,
+        reason: 'Mocking a function with layers is not supported.'
+    });
+    try {
+        await lambdaTriggerHandlers.lambdaTriggerHandler(
+            mockContext,
+            mockStreamArn,
+            mockTriggerName,
+            mockDDBEndpoint
+        );
+        expect(true).toEqual(false);
+    }
+    catch (err) {
+        expect(err.message).toBe(`Unable to mock ${mockTriggerName}. Mocking a function with layers is not supported.`);
+    }
+  });
+
+  it('Polls for records from given DDB stream', async () => {
+    const pollForRecordsMock = jest.spyOn(lambdaTriggerHandlers, 'pollForRecords').mockResolvedValueOnce();
+    await lambdaTriggerHandlers.lambdaTriggerHandler(
+        mockContext,
+        mockStreamArn,
+        mockTriggerName,
+        mockDDBEndpoint
+    );
+    expect(pollForRecordsMock).toBeCalledTimes(1);
+    expect(pollForRecordsMock).toBeCalledWith(
+        mockContext, 
+        mockStreamArn, 
+        expect.any(DynamoDBStreams), 
+        mockTriggerName
+    );
+  });
+
+  it('Invokes the local lambda when records are available to be processed', async () => {
+    const mockRecord = { eventID: 'mockEventID' };
+    const mockData = { Records: [mockRecord], NextShardIterator: null } as $TSAny;
+    const getLatestShardIteratorMock = jest.spyOn(lambdaTriggerHandlers, 'getLatestShardIterator').mockResolvedValueOnce('mockShardIterator');
+    const getStreamRecordsMock = jest.spyOn(lambdaTriggerHandlers, 'getStreamRecords').mockResolvedValueOnce({
+        data: mockData,
+        shardIterator: null // to prevent continuously running loop
+    });
+    invokeLambdaMock.mockResolvedValueOnce();
+    await lambdaTriggerHandlers.lambdaTriggerHandler(
+        mockContext,
+        mockStreamArn,
+        mockTriggerName,
+        mockDDBEndpoint
+    );
+    expect(getLatestShardIteratorMock).toBeCalledTimes(1);
+    expect(getStreamRecordsMock).toBeCalledTimes(1);
+    expect(invokeLambdaMock).toBeCalledTimes(1);
+    expect(invokeLambdaMock).toBeCalledWith(mockContext, mockTriggerName, mockData);
+  });
+});

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -5,6 +5,7 @@ import { $TSContext, $TSAny } from 'amplify-cli-core';
 import { add, generate, isCodegenConfigured, switchToSDLSchema } from 'amplify-codegen';
 import * as path from 'path';
 import * as chokidar from 'chokidar';
+import _ from 'lodash';
 
 import { getAmplifyMeta, getMockDataDirectory } from '../utils';
 import { checkJavaVersion } from '../utils/index';
@@ -19,7 +20,7 @@ import { getMockConfig } from '../utils/mock-config-file';
 import { getInvoker } from 'amplify-category-function';
 import { lambdaArnToConfig } from './lambda-arn-to-config';
 import { timeConstrainedInvoker } from '../func';
-import { lambdaTriggerHandler } from './lambda-trigger-handler';
+import { ddbLambdaTriggerHandler } from './lambda-trigger-handler';
 import { TableDescription } from 'aws-sdk/clients/dynamodb';
 
 export const GRAPHQL_API_ENDPOINT_OUTPUT = 'GraphQLAPIEndpointOutput';
@@ -200,10 +201,10 @@ export class APITest {
       const tableStreamArns: {[index: string]: TableDescription;} = await describeTables(this.ddbClient, tables);
       const allListeners = [];
       Object.entries(tableLambdaTriggers).forEach(([tableName, lambdaTriggers]) => {
-        if(lambdaTriggers && lambdaTriggers.length > 0) {
+        if(!(_.isEmpty(lambdaTriggers))) {
           lambdaTriggers.forEach( (lambdaTriggerName: string) => {
             allListeners.push(
-              lambdaTriggerHandler(
+              ddbLambdaTriggerHandler(
                 context, 
                 tableStreamArns[tableName].LatestStreamArn, 
                 lambdaTriggerName, 

--- a/packages/amplify-util-mock/src/api/lambda-invoke.ts
+++ b/packages/amplify-util-mock/src/api/lambda-invoke.ts
@@ -1,0 +1,36 @@
+import { $TSAny, $TSContext } from "amplify-cli-core";
+import { loadLambdaConfig } from '../utils/lambda/load-lambda-config';
+import { BuildType } from 'amplify-function-plugin-interface';
+import { getInvoker, getBuilder } from 'amplify-category-function';
+import { timeConstrainedInvoker } from '../func';
+
+/**
+ * Utility method to invoke the lambda function locally. 
+ * Ensures latest function changes are built before invoking it.
+ * @param context The CLI context
+ * @param functionName Lambda function to invoke locally
+ * @param data Data to be passed to the local lambda function invocation.
+ */
+export const invokeLambda = async (context: $TSContext, functionName: string, data: $TSAny): Promise<void> => {
+    const lambdaConfig = await loadLambdaConfig(context, functionName);
+      if (!lambdaConfig?.handler) {
+        throw new Error(`Could not parse handler for ${functionName} from cloudformation file`);
+      }
+      // Ensuring latest function changes are built
+      await getBuilder(context, functionName, BuildType.DEV)();
+      const invoker = await getInvoker(context, { resourceName: functionName, handler: lambdaConfig.handler, envVars: lambdaConfig.environment });
+      context.print.blue('Starting execution...');
+      try {
+        const result = await timeConstrainedInvoker(invoker({ event: data }), context?.input?.options);
+        const stringResult =
+          typeof result === 'object' ? JSON.stringify(result, undefined, 2) : typeof result === 'undefined' ? 'undefined' : result;
+        context.print.success('Result:');
+        context.print.info(typeof result === 'undefined' ? '' : stringResult);
+      } catch (err) {
+        context.print.error(`${functionName} failed with the following error:`);
+        context.print.info(err);
+      } finally {
+        context.print.blue('Finished execution.');
+      }
+
+}

--- a/packages/amplify-util-mock/src/api/lambda-invoke.ts
+++ b/packages/amplify-util-mock/src/api/lambda-invoke.ts
@@ -12,7 +12,7 @@ import { timeConstrainedInvoker } from '../func';
  * @param data Data to be passed to the local lambda function invocation.
  */
 export const invokeLambda = async (context: $TSContext, functionName: string, data: $TSAny): Promise<void> => {
-    const lambdaConfig = await loadLambdaConfig(context, functionName);
+    const lambdaConfig = await loadLambdaConfig(context, functionName, true);
       if (!lambdaConfig?.handler) {
         throw new Error(`Could not parse handler for ${functionName} from cloudformation file`);
       }

--- a/packages/amplify-util-mock/src/api/lambda-trigger-handler.ts
+++ b/packages/amplify-util-mock/src/api/lambda-trigger-handler.ts
@@ -1,0 +1,134 @@
+import { $TSContext } from 'amplify-cli-core';
+import { DynamoDBStreams, Endpoint } from 'aws-sdk';
+import { invokeLambda } from './lambda-invoke';
+import { isMockable } from 'amplify-category-function';
+
+/**
+ * Asynchronous function that handles invoking the given lambda trigger function
+ * when there are DynamoDB records available to be processed via DDB stream.
+ * @param context The CLI context
+ * @param streamArn ARN corresponding to the DDB stream to listen to
+ * @param lambdaTriggerName Lambda function to trigger
+ * @param localDynamoDBEndpoint Local DDB endpoint that was provisioned
+ */
+export const lambdaTriggerHandler = async (
+    context: $TSContext,
+    streamArn: string,
+    lambdaTriggerName: string,
+    localDynamoDBEndpoint: Endpoint
+): Promise<void> => {
+    if (!lambdaTriggerName) {
+        throw new Error('Name of the lambda trigger function must be specified');
+    }
+    if (!streamArn) {
+        throw new Error('Stream Arn must be specified');
+    }
+    if (!localDynamoDBEndpoint) {
+        throw new Error('Local URL where DDB is running should be specified');
+    }
+
+    // Lambda functions with layers are not mockable
+    const mockable = isMockable(context, lambdaTriggerName);
+    if (!mockable.isMockable) {
+        throw new Error(`Unable to mock ${lambdaTriggerName}. ${mockable.reason}`);
+    }
+
+    const streams = getDDBStreamsClient(localDynamoDBEndpoint);
+
+    await pollForRecords(context, streamArn, streams, lambdaTriggerName);
+}
+
+/**
+ * Shards are ephemeral and last for ~15 mins. This method fetches the latest Shard iterator.
+ * @param streamArn DDB stream ARN
+ * @param streams DDB streams client
+ * @returns latest active shard iterator
+ */
+export const getLatestShardIterator = async (streamArn: string, streams: DynamoDBStreams): Promise<string> => {
+    const stream = await streams
+        .describeStream({ StreamArn: streamArn })
+        .promise();
+
+    if (!stream) {
+        throw new Error(`Local DynamoDB stream with ARN ${streamArn} cannot be found`);
+    }
+
+    const { ShardId: shardId } =
+        stream.StreamDescription.Shards.filter(
+        x =>
+            x.SequenceNumberRange &&
+            x.SequenceNumberRange.StartingSequenceNumber &&
+            !x.SequenceNumberRange.EndingSequenceNumber
+        )[0] || {}
+
+    if (!shardId) {
+        throw new Error('There is no shard that is open');
+    }
+
+    const { ShardIterator: start } = await streams
+        .getShardIterator({
+            StreamArn: streamArn,
+            ShardId: shardId,
+            ShardIteratorType: 'LATEST'
+        })
+        .promise();
+    
+    return start;
+}
+
+/**
+ * Gets the latest available records from a stream. Refreshes the shard iterator if the shard has expired.
+ * @param shardIterator current shard iterator
+ * @param streamArn DDB stream ARN
+ * @param streams DDB streams client
+ * @returns latest available records from stream
+ */
+export const getStreamRecords = async (shardIterator: string, streamArn: string, streams: DynamoDBStreams) => {
+    const shardIteratorCopy = shardIterator;
+    try {
+        const data = await streams.getRecords({ ShardIterator: shardIteratorCopy }).promise();
+        return { data: data, shardIterator: shardIteratorCopy };
+    } catch (error) {
+        console.log('Re-Trying with a new shard');
+        const latestShardIterator = await getLatestShardIterator(streamArn, streams);
+        const data = await streams.getRecords({ ShardIterator: latestShardIterator }).promise();
+        return { data: data, shardIterator: latestShardIterator };
+    }
+}
+
+/**
+ * Checks if there are any new DDB records available 
+ * via stream to be processed in the trigger
+ */
+export const pollForRecords = async(context: $TSContext, streamArn: string, streams: DynamoDBStreams, lambdaTriggerName: string) => {
+    let shardIterator = await getLatestShardIterator(streamArn, streams);
+    while (shardIterator) {
+        await getStreamRecords(shardIterator, streamArn, streams).then( async (result) => {
+            const data = result.data;
+            shardIterator = result.shardIterator;
+
+            if (data.Records.length) {
+                // when the records are available to be processed, trigger the local lambda
+                await invokeLambda(context, lambdaTriggerName, data).then( () => {
+                    shardIterator = data.NextShardIterator;
+                });
+            }
+
+            // The frequency of polling is 4 per second - same as the cloud
+            await new Promise((resolve, reject) => setTimeout(resolve, 0.25 * 1000));
+        });
+    }
+}
+
+export const getDDBStreamsClient = (localDynamoDBEndpoint: Endpoint) => {
+    const MOCK_REGION = 'us-fake-1';
+    const MOCK_ACCESS_KEY = 'fake';
+    const MOCK_SECRET_ACCESS_KEY = 'fake';
+
+    return new DynamoDBStreams({
+        endpoint: localDynamoDBEndpoint,
+        region: MOCK_REGION,
+        accessKeyId: MOCK_ACCESS_KEY,
+        secretAccessKey: MOCK_SECRET_ACCESS_KEY
+    });
+}

--- a/packages/amplify-util-mock/src/utils/lambda/find-lambda-triggers.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/find-lambda-triggers.ts
@@ -1,0 +1,43 @@
+import { $TSContext, pathManager, stateManager, JSONUtilities, $TSObject } from "amplify-cli-core";
+import * as path from 'path';
+import _ = require('lodash');
+import { ServiceName } from 'amplify-category-function';
+
+/**
+ * Checks the function CFN templates for event source mappings that 
+ * correspond to the DDB stream of any of the tables
+ * @param context The CLI context
+ * @param tables List of known tables that each correspond to a '@model' type
+ * @returns List of lambda trigger names for each table if present
+ */
+ export const findLambdaTriggers = async (context: $TSContext , tables: string[]): Promise<Record<string, string[]>> => {
+    const lambdaTriggersMap: { [index: string] : string[]} = {};
+    const lambdaNames = _.entries<{ service: string }>(_.get(stateManager.getMeta(), ['function']))
+      .filter(([_, funcMeta]) => funcMeta.service === ServiceName.LambdaFunction)
+      .map(([key]) => key);
+    
+    lambdaNames.forEach( (resourceName) => {
+      const resourcePath = path.join(pathManager.getBackendDirPath(), 'function', resourceName);
+      const { Resources: cfnResources } = JSONUtilities.readJson<{ Resources: $TSObject }>(
+        path.join(resourcePath, `${resourceName}-cloudformation-template.json`),
+      );
+  
+      const tablesAttached = tables.filter((tableName: string) => {
+        const eventSourceMappingResourceName = `LambdaEventSourceMapping${tableName.substring(0, tableName.lastIndexOf('Table'))}`;
+        return cfnResources && cfnResources[eventSourceMappingResourceName] &&
+          cfnResources[eventSourceMappingResourceName]?.Type === 'AWS::Lambda::EventSourceMapping' &&
+          _.get(cfnResources[eventSourceMappingResourceName], 'Properties.EventSourceArn.Fn::ImportValue.Fn::Sub')?.includes(`:GetAtt:${tableName}:StreamArn`);
+      });
+      
+      tablesAttached.forEach( (attachedTable: string) => {
+        if (lambdaTriggersMap[attachedTable]) {
+          lambdaTriggersMap[attachedTable].push(resourceName);
+        }
+        else {
+          lambdaTriggersMap[attachedTable] = [resourceName];
+        }
+      });
+    })
+    return lambdaTriggersMap;
+}
+  

--- a/packages/amplify-util-mock/src/utils/lambda/load-lambda-config.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/load-lambda-config.ts
@@ -32,7 +32,7 @@ export const loadLambdaConfig = async (
   if (!lambdaDef) {
     return;
   }
-  const cfnParams = populateCfnParams(context.print, resourceName, overrideApiToLocal);
+  const cfnParams = populateCfnParams(resourceName, overrideApiToLocal);
   const processedLambda = lambdaFunctionHandler(lambdaDef[0], lambdaDef[1], {
     conditions: CFN_DEFAULT_CONDITIONS,
     params: cfnParams,

--- a/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
+++ b/packages/amplify-util-mock/src/utils/lambda/populate-cfn-params.ts
@@ -57,12 +57,6 @@ const getAmplifyMetaParams = (
   return dependencies.reduce((acc, dependency) => {
     dependency.attributes.forEach(attribute => {
       let val = projectMeta?.[dependency.category]?.[dependency.resourceName]?.output?.[attribute];
-      if (!val) {
-        print.warning(
-          `No output found for attribute '${attribute}' on resource '${dependency.resourceName}' in category '${dependency.category}'`,
-        );
-        print.warning('This attribute will be undefined in the mock environment until you run `amplify push`');
-      }
 
       if (overrideApiToLocal) {
         switch (attribute) {
@@ -75,6 +69,13 @@ const getAmplifyMetaParams = (
           default:
             // noop
         }
+      }
+
+      if (!val) {
+        print.warning(
+          `No output found for attribute '${attribute}' on resource '${dependency.resourceName}' in category '${dependency.category}'`,
+        );
+        print.warning('This attribute will be undefined in the mock environment until you run `amplify push`');
       }
 
       acc[dependency.category + dependency.resourceName + attribute] = val;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Customers with lambda triggers setup on `@model` types in their Appsync API schema [following this guide](https://docs.amplify.aws/cli/usage/lambda-triggers/#as-a-part-of-the-graphql-api-types-with-model-annotation) can now take advantage of this feature to test their triggers in a mock environment by simply using `amplify mock api`.

The asynchronous DDB stream listeners will poll for any available records @ 4 times per sec and invoke the attached `function` trigger. The default configurations that the Amplify CLI uses to create the `function` trigger are used in the mock. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/332
https://github.com/aws-amplify/amplify-category-api/issues/269

#### Description of how you validated changes
Unit and Manual testing with many-to-many triggers-models relationships.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
