### PR TITLE
chore: upload metadata files required by Studio to the deployment bucket root

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -574,10 +574,10 @@ const uploadStudioBackendFiles = async (s3: S3, bucketName: string) => {
     'parameters.json',
   ]
     .flatMap(baseName => glob.sync(`**/${baseName}`, { cwd: amplifyDirPath }))
-    .filter(filePath => !filePath.startsWith('backend/'))
+    .filter(filePath => !filePath.startsWith('backend'))
     .map(filePath => ({
       Body: fs.createReadStream(path.join(amplifyDirPath, filePath)),
-      Key: path.join(studioBackendDirName, filePath.replace('#current-cloud-backend/', '')),
+      Key: path.join(studioBackendDirName, filePath.replace('#current-cloud-backend', '')),
     }));
   await Promise.all(uploadFileParams.map(params => s3.uploadFile(params)));
 };

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -557,7 +557,7 @@ export const updateStackForAPIMigration = async (context: $TSContext, category: 
 
 /**
  * Publish files that Amplify Studio depends on outside the zip file so that can read
- * without sreaming from the zip.
+ * without streaming from the zip.
  */
 const uploadStudioBackendFiles = async (s3: S3, bucketName: string) => {
   const amplifyDirPath = pathManager.getAmplifyDirPath();

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -556,6 +556,33 @@ export const updateStackForAPIMigration = async (context: $TSContext, category: 
 };
 
 /**
+ * Publish files that Amplify Studio depends on outside the zip file so that can read
+ * without sreaming from the zip.
+ */
+const uploadStudioBackendFiles = async (s3: S3, bucketName: string) => {
+  const amplifyDirPath = pathManager.getAmplifyDirPath();
+  const studioBackendDirName = 'studio-backend';
+  // Delete the contents of the studio backend directory first
+  await s3.deleteDirectory(bucketName, studioBackendDirName);
+  // Create a list of file params to upload to the deployment bucket
+  const uploadFileParams = [
+    'cli.json',
+    'amplify-meta.json',
+    'backend-config.json',
+    'schema.graphql',
+    'transform.conf.json',
+    'parameters.json',
+  ]
+    .flatMap(baseName => glob.sync(`**/${baseName}`, { cwd: amplifyDirPath }))
+    .filter(filePath => !filePath.startsWith('backend/'))
+    .map(filePath => ({
+      Body: fs.createReadStream(path.join(amplifyDirPath, filePath)),
+      Key: path.join(studioBackendDirName, filePath.replace('#current-cloud-backend/', '')),
+    }));
+  await Promise.all(uploadFileParams.map(params => s3.uploadFile(params)));
+};
+
+/**
  *
  */
 export const storeCurrentCloudBackend = async (context: $TSContext) => {
@@ -595,7 +622,8 @@ export const storeCurrentCloudBackend = async (context: $TSContext) => {
   log = logger('storeCurrentcoudBackend.s3.uploadFile', [{ Key: s3Key }]);
   log();
   try {
-    await s3.uploadFile(s3Params);
+    const deploymentBucketName = await s3.uploadFile(s3Params);
+    await uploadStudioBackendFiles(s3, deploymentBucketName);
   } catch (error) {
     log(error);
     throw error;


### PR DESCRIPTION
#### Description of changes

**Problem:**
Amplify Studio is currently using the unzipper library to stream
metatdata files out of the zip file in the customer's deployment bucket
in order to retrieve data it needs for deployments and/or display in the
UI. However, this library is out of active development and has
significant error handling bugs that causing the Amplify Backend control
plane availability to degrade.

**Solution:**
Upload the needed metadata files to the s3 bucket outside of the zip
file so they are accessible with a single GetObject call and reaching
into the zip file is no longer required.

#### Issue #, if available
N/A

#### Description of how you validated changes

```
yarn setup-dev
amplify-dev init
amplify-dev add auth
amplify-dev push
```
Manually check the S3 console to see if files exist outside the zip

```
amplify-dev remove auth
amplify-dev push
```

Manually check the S3 console to see if files have been removed

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
