### PR TITLE
chore: remove unused CI triggers

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -655,52 +655,6 @@ jobs:
 
 workflows:
   version: 2
-  nightly_console_integration_tests:
-    triggers:
-      - schedule:
-          cron: '0 14 * * *'
-          filters:
-            branches:
-              only:
-                - master
-                - dev
-    jobs:
-      - build
-      - publish_to_local_registry:
-          requires:
-            - build
-      - build_pkg_binaries:
-          context:
-            - e2e-auth-credentials
-            - e2e-test-context
-            - amplify-s3-upload
-          requires:
-            - publish_to_local_registry
-      - amplify_console_integration_tests:
-          context:
-            - console-e2e-test
-            - e2e-auth-credentials
-            - e2e-test-context
-          requires:
-            - build_pkg_binaries
-  e2e_resource_cleanup:
-    triggers:
-      - schedule:
-          cron: '45 0,12 * * *'
-          filters:
-            branches:
-              only:
-                - master
-                - dev
-    jobs:
-      - build
-      - cleanup_resources:
-          context:
-            - cleanup-resources
-            - e2e-test-context
-          requires:
-            - build
-
   build_test_deploy:
     jobs:
       - build:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
These triggers aren't being used because the nightlys are invoked here: https://github.com/aws-amplify/amplify-cli/blob/nightly-jobs/.circleci/config.yml.

These also are creating this error that we see in builds:
```
No configuration was found in your project. Please refer to https://circleci.com/docs/2.0/ to
get started with your configuration.
```

Deleting these triggers in favor of the nightly triggers that are invoked via CI API.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
