### PR TITLE
chore: use correct commit when publishing git tag

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -568,8 +568,9 @@ jobs:
       - run:
           name: Publish Amplify CLI GitHub prerelease
           command: |
+            commit=$(git rev-parse HEAD)
             version=$(cat .amplify-pkg-version)
-            yarn ts-node scripts/github-prerelease.ts $version
+            yarn ts-node scripts/github-prerelease.ts $version $commit
 
   github_prerelease_install_sanity_check:
     <<: *linux-e2e-executor

--- a/scripts/github-common.ts
+++ b/scripts/github-common.ts
@@ -34,11 +34,14 @@ export const uploadReleaseFile = async (releaseId: string, filepath: string) => 
   });
 };
 
-export const getVersionFromArgs = () => {
-  if (process.argv.length !== 3) {
-    throw new Error(`Expected semver version as first and only argument`);
+export const getArgs = () => {
+  if (process.argv.length > 4) {
+    throw new Error(`Expected semver version and commit SHA to be the only arguments`);
   }
-  return process.argv[2].trim();
+  return {
+    version: process.argv[2].trim(),
+    commit: process.argv[3].trim(),
+  };
 };
 
 export const githubTagToSemver = (tag: string) => tag.slice(1);

--- a/scripts/github-prerelease.ts
+++ b/scripts/github-prerelease.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { valid, lte } from 'semver';
-import { getVersionFromArgs, githubTagToSemver, releasesRequest, semverToGithubTag, uploadReleaseFile } from './github-common';
+import { getArgs, githubTagToSemver, releasesRequest, semverToGithubTag, uploadReleaseFile } from './github-common';
 import { readFile } from 'fs-extra';
 import { unifiedChangelogPath } from './constants';
 
@@ -31,7 +31,7 @@ const validateVersion = async (version: string) => {
   }
 };
 
-const createPreRelease = async (version: string) => {
+const createPreRelease = async (version: string, commit: string) => {
   console.log('Creating draft pre-release');
   const { id: releaseId } = await releasesRequest('', {
     method: 'POST',
@@ -41,6 +41,7 @@ const createPreRelease = async (version: string) => {
       body: await readFile(unifiedChangelogPath, 'utf8'),
       draft: true,
       prerelease: true,
+      target_commitish: commit,
     }),
   });
 
@@ -68,9 +69,9 @@ const createPreRelease = async (version: string) => {
 
 const main = async () => {
   try {
-    const version = getVersionFromArgs();
+    const { version, commit } = getArgs();
     await validateVersion(version);
-    await createPreRelease(version);
+    await createPreRelease(version, commit);
     console.log('Done!');
   } catch (ex) {
     console.error(ex);

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -1,4 +1,4 @@
-import { getVersionFromArgs, releasesRequest, semverToGithubTag } from './github-common';
+import { getArgs, releasesRequest, semverToGithubTag } from './github-common';
 import { join } from 'path';
 
 /**
@@ -18,7 +18,7 @@ const publishRelease = async (version: string) => {
 };
 
 const main = async () => {
-  const version = getVersionFromArgs();
+  const { version } = getArgs();
   await publishRelease(version);
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This changes the prerelease scripts to make sure we are publishing tags and releases linked to the correct commit SHA.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
