### PR TITLE
chore: reset release branches

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -597,10 +597,21 @@ jobs:
       - restore_cache:
           key: amplfiy-pkg-tag-{{ .Branch }}-{{ .Revision }}
       - run:
+          name: Update 'main' branch to match release
+          command: |
+            commit=$(git rev-parse HEAD)
+            version=$(cat .amplify-pkg-version)
+            git push origin release:main -f
+      - run:
+          name: Create branch with release commit
+          command: |
+            git checkout -b release-$version origin/dev
+            git cherry-pick $commit
+            git push origin release-$version
+      - run:
           name: Publish Amplify CLI GitHub release
           command: |
-            version=$(cat .amplify-pkg-version)
-            yarn ts-node scripts/github-release.ts $version
+            yarn ts-node scripts/github-release.ts $version $commit
   cleanup_resources:
     <<: *linux-e2e-executor
     steps:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "verdaccio-stop": "kill -9 $(lsof -n -t -iTCP:4873 -sTCP:LISTEN) || true",
     "update-versions": "lerna version --yes --no-commit-hooks --no-push --exact --conventional-commits --no-git-tag-version",
     "commit": "git-cz",
-    "coverage": "codecov || exit 0"
+    "coverage": "codecov || exit 0",
+    "release-rc": "./scripts/release-rc.sh"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-cli/issues"

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
  * This function expects a pre-release of 'version' to already exist
  * The 'pre-release' flag of the release is turned off (thus making it the latest release)
  */
-const publishRelease = async (version: string) => {
+const publishRelease = async (version: string, commit: string) => {
   const { id: releaseId } = await releasesRequest(join('tags', semverToGithubTag(version)));
   const releaseIdStr = (releaseId as number).toString();
   console.log('Publishing release');
@@ -13,13 +13,14 @@ const publishRelease = async (version: string) => {
     method: 'PATCH',
     body: JSON.stringify({
       prerelease: false,
+      target_commitish: commit,
     }),
   });
 };
 
 const main = async () => {
-  const { version } = getArgs();
-  await publishRelease(version);
+  const { version, commit } = getArgs();
+  await publishRelease(version, commit);
 };
 
 main();

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+git remote update
+
+rc_tag="$1"
+remote_name="$2"
+
+if [[ $rc_tag == "" ]]; then
+  echo "Please include the rc tag you wish to release as the first argument"
+  exit 1
+fi
+
+if [[ $remote_name == "" ]]; then
+  echo "Please include the remote name of 'aws-amplify/amplify-cli as the second argument"
+  exit 1
+fi
+
+rc_sha="$(git rev-parse --short $rc_tag)"
+branch_name="release_$rc_sha"
+
+git checkout -b "$branch_name" "$rc_tag"
+git push "$remote_name" "$branch_name:release"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This pull request includes:
- a script to run when promoting an RC to distribution channels (GitHub releases and NPM)
- added CI step to pull the release commit into a release branch so that release can open PR of release commit
- added CI step to reset `main` to match the latest release
- added to GitHub release payload the release commit so that tag/release includes commit

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
