### PR TITLE
use explicit tokenValidityUnits 'days' for userPoolClient refreshToken

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -347,6 +347,9 @@ Object {
         "RefreshTokenValidity": Object {
           "Ref": "userpoolClientRefreshTokenValidity",
         },
+        "TokenValidityUnits": Object {
+          "RefreshToken": "days",
+        },
         "UserPoolId": Object {
           "Ref": "UserPool",
         },
@@ -553,6 +556,9 @@ exports.handler = (event, context, callback) => {
         "ClientName": "authde2c33facd_app_clientWeb",
         "RefreshTokenValidity": Object {
           "Ref": "userpoolClientRefreshTokenValidity",
+        },
+        "TokenValidityUnits": Object {
+          "RefreshToken": "days",
         },
         "UserPoolId": Object {
           "Ref": "UserPool",
@@ -1983,6 +1989,9 @@ exports.handler = (event, context, callback) => {
         "RefreshTokenValidity": Object {
           "Ref": "userpoolClientRefreshTokenValidity",
         },
+        "TokenValidityUnits": Object {
+          "RefreshToken": "days",
+        },
         "UserPoolId": Object {
           "Ref": "UserPool",
         },
@@ -2195,6 +2204,9 @@ exports.handler = (event, context, callback) => {
         },
         "RefreshTokenValidity": Object {
           "Ref": "userpoolClientRefreshTokenValidity",
+        },
+        "TokenValidityUnits": Object {
+          "RefreshToken": "days",
         },
         "UserPoolId": Object {
           "Ref": "UserPool",

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
@@ -110,6 +110,8 @@ describe('generateCognitoStackResources', () => {
       }
     cognitoStack.generateCognitoStackResources(props);
     expect(cognitoStack.userPool!.lambdaConfig).toHaveProperty('preSignUp');
+    expect(cognitoStack.userPoolClientWeb!.tokenValidityUnits).toHaveProperty('refreshToken');
+    expect(cognitoStack.userPoolClient!.tokenValidityUnits).toHaveProperty('refreshToken');
     expect(cognitoStack.lambdaConfigPermissions).toHaveProperty('UserPoolPreSignupLambdaInvokePermission');
   });
 });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -439,6 +439,9 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       this.userPoolClientWeb = new cognito.CfnUserPoolClient(this, 'UserPoolClientWeb', {
         userPoolId: cdk.Fn.ref('UserPool'),
         clientName: `${props.resourceNameTruncated}_app_clientWeb`,
+        tokenValidityUnits: {
+          refreshToken: 'days',
+        },
       });
       if (props.userpoolClientSetAttributes) {
         this.userPoolClientWeb.readAttributes = this._cfnParameterMap.get('userpoolClientReadAttributes')?.valueAsList;
@@ -450,6 +453,9 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       this.userPoolClient = new cognito.CfnUserPoolClient(this, 'UserPoolClient', {
         userPoolId: cdk.Fn.ref('UserPool'),
         clientName: `${props.resourceNameTruncated}_app_client`,
+        tokenValidityUnits: {
+          refreshToken: 'days',
+        },
       });
       if (props.userpoolClientSetAttributes) {
         this.userPoolClient.readAttributes = this._cfnParameterMap.get('userpoolClientReadAttributes')?.valueAsList;


### PR DESCRIPTION
Fixes RefreshToken sometimes not using correct units if it had been manually modified in the past ie https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/606#issuecomment-735740045


#### Description of changes

use explicit tokenValidityUnits 'days' for userPoolClient refreshToken otherwise units may not match what the CLI implies.

#### Issue #, if available

N/A

#### Description of how you validated changes

Added tests and validated CFN.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X ] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
