### PR TITLE
chore: fix dependabot alert e2e tests

### DIFF
--- a/packages/amplify-console-integration-tests/package.json
+++ b/packages/amplify-console-integration-tests/package.json
@@ -34,8 +34,8 @@
   "jest": {
     "verbose": false,
     "preset": "ts-jest",
-    "testRunner": "amplify-e2e-core/runner",
-    "testEnvironment": "amplify-e2e-core/environment",
+    "testRunner": "@aws-amplify/amplify-e2e-core/runner",
+    "testEnvironment": "@aws-amplify/amplify-e2e-core/environment",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -56,7 +56,7 @@
       "default",
       "jest-junit",
       [
-        "amplify-e2e-core/reporter",
+        "@aws-amplify/amplify-e2e-core/reporter",
         {
           "publicPath": "./console-integration-reports",
           "filename": "index.html",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -53,8 +53,8 @@
   "jest": {
     "verbose": false,
     "preset": "ts-jest",
-    "testRunner": "amplify-e2e-core/runner",
-    "testEnvironment": "amplify-e2e-core/environment",
+    "testRunner": "@aws-amplify/amplify-e2e-core/runner",
+    "testEnvironment": "@aws-amplify/amplify-e2e-core/environment",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -75,7 +75,7 @@
       "default",
       "jest-junit",
       [
-        "amplify-e2e-core/reporter",
+        "@aws-amplify/amplify-e2e-core/reporter",
         {
           "publicPath": "./amplify-e2e-reports",
           "filename": "index.html",
@@ -83,7 +83,7 @@
         }
       ],
       [
-        "amplify-e2e-core/failed-test-reporter",
+        "@aws-amplify/amplify-e2e-core/failed-test-reporter",
         {
           "reportPath": "./amplify-e2e-reports/amplify-e2e-failed-test.txt"
         }

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -34,8 +34,8 @@
   "jest": {
     "verbose": false,
     "preset": "ts-jest",
-    "testRunner": "amplify-e2e-core/runner",
-    "testEnvironment": "amplify-e2e-core/environment",
+    "testRunner": "@aws-amplify/amplify-e2e-core/runner",
+    "testEnvironment": "@aws-amplify/amplify-e2e-core/environment",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -56,7 +56,7 @@
       "default",
       "jest-junit",
       [
-        "amplify-e2e-core/reporter",
+        "@aws-amplify/amplify-e2e-core/reporter",
         {
           "publicPath": "./amplify-migration-reports",
           "filename": "index.html",


### PR DESCRIPTION
#### Description of changes
- fixes e2e failures caused by scoping the amplify-e2e-core

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
