### PR TITLE
test: force geo e2e test region to us-west-2

### DIFF
--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -72,7 +72,7 @@ const AWS_REGIONS_TO_RUN_TESTS = [
 
 // Some services (eg. amazon lex) are not available in all regions
 // Tests added to this list will always run in us-west-2
-const FORCE_US_WEST_2 = ['interactions'];
+const FORCE_US_WEST_2 = ['interactions', 'geo'];
 
 const USE_PARENT_ACCOUNT = [
   'api_2',


### PR DESCRIPTION
#### Description of changes
- forces geo e2e test to use us-west-2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
