### PR TITLE
chore: do not execute console integ tests on pr e2e

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -836,8 +836,6 @@ workflows:
             branches:
               only:
                 - dev
-                - master
-                - /run-e2e\/.*/
           requires:
             - build_pkg_binaries
       - github_prerelease:


### PR DESCRIPTION
#### Description of changes
- stop executing console integ tests in PRs e2e

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
