### PR TITLE
fix(amplify-util-mock): add defaults for streamViewType

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -21,7 +21,7 @@ export function dynamoDBResourceHandler(resourceName, resource, cfnContext: Clou
       AttributeDefinitions: resource.Properties.AttributeDefinitions,
       StreamSpecification: {
         StreamEnabled: true,
-        StreamViewType: resource.Properties.StreamSpecification.StreamViewType
+        StreamViewType: resource?.Properties?.StreamSpecification?.StreamViewType || 'NEW_AND_OLD_IMAGES'
       }
     },
   };

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
@@ -1,4 +1,5 @@
-import { appSyncFunctionHandler } from '../../../CFNParser/resource-processors/appsync';
+import { $TSAny } from 'amplify-cli-core';
+import { appSyncFunctionHandler, dynamoDBResourceHandler } from '../../../CFNParser/resource-processors/appsync';
 import { CloudFormationResource } from '../../../CFNParser/stack/types';
 import { CloudFormationParseContext } from '../../../CFNParser/types';
 
@@ -20,5 +21,44 @@ describe('appSyncFunctionHandler', () => {
     const processedResource = appSyncFunctionHandler('', resource, cfnContext);
     const exposedAttribute = processedResource.cfnExposedAttributes.FunctionArn;
     expect(processedResource[exposedAttribute]).toBeDefined();
+  });
+});
+
+describe('dynamoDBResourceHandler', () => {
+  it('defaults the streamViewType param if not present', () => {
+    // resource with only required props
+    const resource: $TSAny = {
+      Type: 'AWS::DynamoDB::Table',
+      Properties: {
+        TableName: 'dummyFunction',
+        KeySchema: [
+          {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+          }
+        ],
+        AttributeDefinitions: [
+          {
+              "AttributeName": "id",
+              "AttributeType": "S"
+          }
+        ]
+      },
+    };
+    const cfnContext: CloudFormationParseContext = {
+      params: {},
+      conditions: {},
+      resources: {},
+      exports: {},
+    };
+    const processedResource = dynamoDBResourceHandler(resource.Properties.TableName, resource, cfnContext);
+    expect(processedResource.Properties.AttributeDefinitions).toEqual(resource.Properties.AttributeDefinitions);
+    expect(processedResource.Properties.KeySchema).toEqual(resource.Properties.KeySchema);
+    expect(processedResource.Properties.TableName).toEqual(resource.Properties.TableName);
+    // sets defaults for stream specification
+    expect(processedResource.Properties.StreamSpecification).toEqual({
+      StreamEnabled: true,
+      StreamViewType: 'NEW_AND_OLD_IMAGES'
+    });
   });
 });

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -69,7 +69,10 @@ export class APITest {
       context.print.info(`AppSync Mock endpoint is running at ${this.appSyncSimulator.url}`);
       await this.startDDBListeners(context, appSyncConfig, false);
     } catch (e) {
-      context.print.error(`Failed to start API Mock endpoint ${e}`);
+      const errMessage = 'Failed to start API Mocking.';
+      context.print.error(errMessage + ' Running cleanup tasks.');
+      await this.stop(context);
+      throw new Error(`${errMessage} Reason: ${e?.message}`);
     }
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Use sane defaults for `StreamSpecification` in CFN parser if there exist any custom DDB tables
- Close the simulators etc, in case of any error in starting up the `API` mock process and exit.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/624

#### Description of how you validated changes
unit test added

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
