### PR TITLE
fix: use correct region as provided in client call

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -134,8 +134,8 @@ export async function getConfiguredSSMClient(context) {
   return await SSM.getInstance(context);
 }
 
-export async function getConfiguredLocationServiceClient(context: $TSContext) {
-  return await LocationService.getInstance(context);
+export async function getConfiguredLocationServiceClient(context: $TSContext, options?: {}) {
+  return await LocationService.getInstance(context, options);
 }
 
 async function getLambdaSdk(context: $TSContext) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use the region and other options as provided in the client creation call. Will fix the issue with cross region resource mapping.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
Uncovered in e2e test failure in unsupported geo region.

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
