### PR TITLE
Appsync simulator/fix parse json

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -1,10 +1,12 @@
-import { Unauthorized, ValidateError, TemplateSentError } from './errors';
+/* eslint-disable no-param-reassign */
+/* eslint-disable prefer-arrow/prefer-arrow-functions */
 import { v4 as autoId } from 'uuid';
+import jsStringEscape from 'js-string-escape';
+import { GraphQLResolveInfo, FieldNode } from 'graphql';
+import { Unauthorized, ValidateError, TemplateSentError } from './errors';
 import { JavaString } from '../value-mapper/string';
 import { JavaArray } from '../value-mapper/array';
 import { JavaMap } from '../value-mapper/map';
-import jsStringEscape from 'js-string-escape';
-import { GraphQLResolveInfo, FieldNode } from 'graphql';
 
 export const generalUtils = {
   errors: [],
@@ -14,10 +16,8 @@ export const generalUtils = {
     return jsStringEscape(value);
   },
   urlEncode(value) {
-    // Stringent in adhering to RFC 3986 ( except the asterisk that appsync ingores to encode )
-    return encodeURIComponent(value).replace(/[!'()]/g, function (c) {
-      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
-    });
+    // Stringent in adhering to RFC 3986 ( except the asterisk that appsync ignores to encode )
+    return encodeURIComponent(value).replace(/[!'()]/g, c => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
   },
   urlDecode(value) {
     return decodeURIComponent(value);
@@ -65,16 +65,16 @@ export const generalUtils = {
     throw error;
   },
   isNull(value) {
-    return value === null || typeof value == 'undefined';
+    return value === null || typeof value === 'undefined';
   },
   isNullOrEmpty(value) {
     if (this.isNull(value)) return true;
 
     if (value instanceof JavaMap) {
-      return Object.keys(value.toJSON()).length == 0;
+      return Object.keys(value.toJSON()).length === 0;
     }
     if (value instanceof JavaArray || value instanceof JavaString) {
-      return value.toJSON().length == 0;
+      return value.toJSON().length === 0;
     }
     return !!value;
   },
@@ -130,16 +130,18 @@ export const generalUtils = {
   },
 };
 
-function filterData(info: GraphQLResolveInfo, data = null): any {
+const filterData = (info: GraphQLResolveInfo, data = null): unknown => {
   if (data instanceof JavaMap) {
-    var filteredData = {};
+    const filteredData = {};
     // filter fields in data based on the query selection set
     info.operation.selectionSet.selections
       .map(selection => selection as FieldNode)
       .find(selection => selection.name.value === info.fieldName)
       .selectionSet.selections.map(fieldNode => (fieldNode as FieldNode).name.value)
-      .forEach(field => (filteredData[field] = data.get(field)));
+      .forEach(field => {
+        filteredData[field] = data.get(field);
+      });
     data = filteredData;
   }
   return data;
-}
+};

--- a/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/util/general-utils.ts
@@ -31,7 +31,11 @@ export const generalUtils = {
     return Buffer.from(value, 'base64').toString('ascii');
   },
   parseJson(value) {
-    return JSON.parse(value);
+    try {
+      return JSON.parse(value);
+    } catch (_) {
+      return null;
+    }
   },
   toJson(value) {
     return value !== undefined ? JSON.stringify(value) : JSON.stringify(null);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

`$util.parseJson` function in the simulator doesn't follow the same logic as in Appsync when actually running the resolvers. The latter simply returns `null` when the input cannot be parsed. The only change I added it this one:

```js
  parseJson(value) {
    try {
      return JSON.parse(value);
    } catch (_) {
      return null;
    }
  }
```

all the rest if just due to code formatting.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
