### PR TITLE
test: fix polling logic in studio e2e test

### DIFF
--- a/packages/amplify-e2e-core/src/utils/retrier.ts
+++ b/packages/amplify-e2e-core/src/utils/retrier.ts
@@ -39,7 +39,7 @@ export const retry = async <T>(
       if (typeof failurePredicate === 'function' && failurePredicate(result)) {
         throw new Error('Retry-able function execution result matched failure predicate. Stopping retries.');
       }
-      console.warn(`Retry-able function execution did not match success predicate. Result was [${result}]. Retrying...`);
+      console.warn(`Retry-able function execution did not match success predicate. Result was [${JSON.stringify(result)}]. Retrying...`);
     } catch (err) {
       console.warn(`Retry-able function execution failed with [${err.message || err}]`);
       if (stopOnError) {

--- a/packages/amplify-e2e-core/src/utils/retrier.ts
+++ b/packages/amplify-e2e-core/src/utils/retrier.ts
@@ -11,36 +11,54 @@ const defaultSettings: RetrySettings = {
 /**
  * Retries the function func until the predicate pred returns true, or until one of the retry limits is met.
  * @param func The function to retry
- * @param pred The predicate that determines successful output of func
+ * @param successPredicate The predicate that determines successful output of func
  * @param settings Retry limits (defaults to defaultSettings above)
+ * @param failurePredicate An optional predicate that determines that the retry operation has failed and should not be retried anymore
  */
-export const retry = async <T>(func: () => Promise<T>, pred: (res?: T) => boolean, settings?: Partial<RetrySettings>) => {
-  const { times, delayMS, timeoutMS, stopOnError } = _.merge({}, defaultSettings, settings);
+export const retry = async <T>(
+  func: () => Promise<T>,
+  successPredicate: (res?: T) => boolean,
+  settings?: Partial<RetrySettings>,
+  failurePredicate?: (res?: T) => boolean,
+): Promise<T> => {
+  const {
+    times, delayMS, timeoutMS, stopOnError,
+  } = _.merge({}, defaultSettings, settings);
 
   let count = 0;
-  let result: T = undefined;
+  let result: T;
   let terminate = false;
   const startTime = Date.now();
 
   do {
     try {
       result = await func();
-      if (pred(result)) {
+      if (successPredicate(result)) {
         return result;
-      } else {
-        console.warn(`Retryable function execution did not match predicate. Result was [${JSON.stringify(result)}]. Retrying...`);
       }
+      if (typeof failurePredicate === 'function' && failurePredicate(result)) {
+        throw new Error('Retry-able function execution result matched failure predicate. Stopping retries.');
+      }
+      console.warn(`Retry-able function execution did not match success predicate. Result was [${result}]. Retrying...`);
     } catch (err) {
-      console.warn(`Retryable function execution failed with [${err}]. Retrying...`);
+      console.warn(`Retry-able function execution failed with [${err.message || err}]`);
+      if (stopOnError) {
+        console.log('Stopping retries on error.');
+      } else {
+        console.log('Retrying...');
+      }
       terminate = stopOnError;
     }
     count++;
     await sleep(delayMS);
   } while (!terminate && count <= times && Date.now() - startTime < timeoutMS);
 
-  throw new Error('Retryable function did not match predicate within the given retry constraints');
+  throw new Error('Retry-able function did not match predicate within the given retry constraints');
 };
 
+/**
+ * Configuration for retry limits
+ */
 export type RetrySettings = {
   times: number; // specifying 1 will execute func once and if not successful, retry one time
   delayMS: number; // delay between each attempt to execute func (there is no initial delay)

--- a/packages/amplify-e2e-core/src/utils/sleep.ts
+++ b/packages/amplify-e2e-core/src/utils/sleep.ts
@@ -1,3 +1,4 @@
-export function sleep(millis) {
-  return new Promise(resolve => setTimeout(resolve, millis));
-}
+/**
+ * "Sleep" for the specified number of milliseconds
+ */
+export const sleep = async (milliseconds: number): Promise<void> => new Promise(resolve => setTimeout(resolve, milliseconds));

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -44,10 +44,12 @@
     "node-fetch": "^2.6.7",
     "rimraf": "^3.0.0",
     "uuid": "^8.3.2",
+    "ws": "^7.5.7",
     "yargs": "^15.1.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",
+    "@types/ws": "^7.4.4",
     "ts-node": "^8.10.2"
   },
   "jest": {

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   addApiWithBlankSchemaAndConflictDetection,
   amplifyPush,
@@ -14,17 +13,17 @@ import {
   getTransformConfig,
   initJSProjectWithProfile,
   updateApiSchema,
-  updateAPIWithResolutionStrategyWithModels
+  updateAPIWithResolutionStrategyWithModels,
 } from '@aws-amplify/amplify-e2e-core';
 import AWSAppSyncClient, {
-  AUTH_TYPE
+  AUTH_TYPE,
 } from 'aws-appsync';
 import {
-  existsSync
+  existsSync,
 } from 'fs';
 import gql from 'graphql-tag';
 import {
-  TRANSFORM_CURRENT_VERSION
+  TRANSFORM_CURRENT_VERSION,
 } from 'graphql-transformer-core';
 import _ from 'lodash';
 import * as path from 'path';
@@ -51,6 +50,7 @@ describe('amplify add api (GraphQL)', () => {
   });
 
   it('init a project with conflict detection enabled and a schema with @key, test update mutation', async () => {
+    // eslint-disable-next-line spellcheck/spell-checker
     const name = 'keyconflictdetection';
     await initJSProjectWithProfile(projRoot, { name });
     await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
@@ -136,6 +136,7 @@ describe('amplify add api (GraphQL)', () => {
   });
 
   it('init a project with conflict detection enabled and toggle disable', async () => {
+    // eslint-disable-next-line spellcheck/spell-checker
     const name = 'conflictdetection';
     await initJSProjectWithProfile(projRoot, { name });
     await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
@@ -164,7 +165,7 @@ describe('amplify add api (GraphQL)', () => {
     expect(transformConfig.ResolverConfig.project.ConflictDetection).toEqual('VERSION');
     expect(transformConfig.ResolverConfig.project.ConflictHandler).toEqual('AUTOMERGE');
 
-    // remove datastore feature
+    // remove DataStore feature
     await apiDisableDataStore(projRoot, {});
     await amplifyPushUpdate(projRoot);
     const disableDSConfig = getTransformConfig(projRoot, name);
@@ -172,7 +173,8 @@ describe('amplify add api (GraphQL)', () => {
     expect(_.isEmpty(disableDSConfig.ResolverConfig)).toBe(true);
   });
 
-  it('init a project with conflict detection enabled and admin UI enabled to generate datastore models in the cloud', async () => {
+  it('init a project with conflict detection enabled and admin UI enabled to generate DataStore models in the cloud', async () => {
+    // eslint-disable-next-line spellcheck/spell-checker
     const name = 'dsadminui';
     await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, name });
 
@@ -185,7 +187,7 @@ describe('amplify add api (GraphQL)', () => {
     const localEnvInfo = getLocalEnvInfo(projRoot);
     const { envName } = localEnvInfo;
 
-    // setupAdminUI
+    // setup Amplify Studio backend
     await enableAdminUI(appId, envName, region);
 
     await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
@@ -208,6 +210,7 @@ describe('amplify add api (GraphQL)', () => {
   });
 
   it('init a sync enabled project and update conflict resolution strategy', async () => {
+    // eslint-disable-next-line spellcheck/spell-checker
     const name = 'syncenabled';
     await initJSProjectWithProfile(projRoot, { name });
     await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 1 });
@@ -245,5 +248,3 @@ describe('amplify add api (GraphQL)', () => {
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
   });
 });
-
-/* eslint-enable */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Refactored the studio setup polling logic to use the `retry` function in our test utils and tweaked the retry settings. Also used the `BackendEnvironmentName` from the initial response in the subsequent polling calls

#### Issue #, if available
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/9603/workflows/61796c9d-787a-40e3-bd4c-b6b041868f74/jobs/302223
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran e2e tests locally in multiple regions
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
