### PR TITLE
Remove deploy from dev

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -691,6 +691,7 @@ workflows:
               ignore:
                 - beta
                 - release
+                - /release_rc\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
       - test:
           requires:
@@ -700,6 +701,7 @@ workflows:
               ignore:
                 - beta
                 - release
+                - /release_rc\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
       - mock_e2e_tests:
           requires:
@@ -740,6 +742,7 @@ workflows:
               only:
                 - dev
                 - release
+                - /release_rc\/.*/
                 - /run-e2e-with-rc\/.*/
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
@@ -925,7 +928,7 @@ workflows:
             branches:
               only:
                 - release
-                - dev
+                - /release_rc\/.*/
                 - /run-e2e-with-rc\/.*/
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "update-versions": "lerna version --yes --no-commit-hooks --no-push --exact --conventional-commits --no-git-tag-version",
     "commit": "git-cz",
     "coverage": "codecov || exit 0",
-    "release-rc": "./scripts/release-rc.sh"
+    "release-rc": "./scripts/release-rc.sh",
+    "promote-rc": "./scripts/promote-rc.sh"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-cli/issues"

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+git remote update
+
+rc_tag="$1"
+remote_name="$2"
+
+if [[ $rc_tag == "" ]]; then
+  echo "Please include the rc tag you wish to release as the first argument"
+  exit 1
+fi
+
+if [[ $remote_name == "" ]]; then
+  echo "Please include the remote name of 'aws-amplify/amplify-cli as the second argument"
+  exit 1
+fi
+
+rc_sha="$(git rev-parse --short $rc_tag)"
+branch_name="release_$rc_sha"
+
+git checkout -b "$branch_name" "$rc_tag"
+git push "$remote_name" "$branch_name:release"

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -2,11 +2,11 @@
 
 git remote update
 
-rc_tag="$1"
+rc_sha="$1"
 remote_name="$2"
 
 if [[ $rc_tag == "" ]]; then
-  echo "Please include the rc tag you wish to release as the first argument"
+  echo "Please include the rc sha you wish to release as the first argument"
   exit 1
 fi
 
@@ -15,8 +15,7 @@ if [[ $remote_name == "" ]]; then
   exit 1
 fi
 
-rc_sha="$(git rev-parse --short $rc_tag)"
-branch_name="release_$rc_sha"
+branch_name="release_rc/$rc_sha"
 
-git checkout -b "$branch_name" "$rc_tag"
-git push "$remote_name" "$branch_name:release"
+git checkout -b "$branch_name" "$rc_sha"
+git push "$remote_name" "$branch_name"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This pull request does the following:
- removes the `deploy` step at the end of the e2e tests that run when a PR is merged to `dev`
- updates the `release-rc.sh` script to handle releasing an RC from a SHA
- adds a `promote-rc.sh` script to promote the release candidate to release in NPM
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
