### PR TITLE
fix(uibuilder): change recommended ui-react version

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "^2.3.0",
-    "@aws-amplify/codegen-ui-react": "^2.3.0",
+    "@aws-amplify/codegen-ui": "^2.3.1",
+    "@aws-amplify/codegen-ui-react": "^2.3.1",
     "amplify-cli-core": "2.11.0",
     "amplify-prompts": "2.2.0",
     "aws-sdk": "^2.1113.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.3.0.tgz#73af267b37df6741675c8b4c66a484b5f347a390"
-  integrity sha512-182YEIBd16LuJCktEj+UiOPR/lxQVUVjK00bty8AV3bODw1KYUKR24EjajGPLV1V+vyB1pa2Izo9xXa/zGFWow==
+"@aws-amplify/codegen-ui-react@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.3.1.tgz#22a6751e99b2b51b2cb97d274de4838912472460"
+  integrity sha512-1gosRpJAVuTaP+66moYVJciLyxqik4CLnQthIUHWX81XHhLqhylWiYpjF7P2NwFGlcmcReH5XPCE5k48ZV47PA==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.3.0"
+    "@aws-amplify/codegen-ui" "2.3.1"
     "@typescript/vfs" "~1.3.5"
     typescript "~4.4.4"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.3.0.tgz#9dd225277c54c92ec43ec5878c175f5cdfb9861f"
-  integrity sha512-uI+SBlWNQ8mPVRBLcK6GPQfHUIO6cmFSbYJD4WjiD6j8V2x2fdSGSLJa7kiey5KC2Iem2s+Z2ImYKj/etspQfQ==
+"@aws-amplify/codegen-ui@2.3.1", "@aws-amplify/codegen-ui@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.3.1.tgz#4a60f4a399b41a54dfa23deaabe39458e8134e66"
+  integrity sha512-+lz33K8m2JttOP136KgLDVkcsL/fU7wE1zHm5Bn0qsRoWrWw+d/mreUyZ3jQkJsk10A4eJJ7C0tjKRdlcCwMXA==
   dependencies:
     yup "^0.32.11"
 


### PR DESCRIPTION
#### Description of changes
- updates lastest version of codegen to v2.3.1

Reason: https://github.com/aws-amplify/amplify-codegen-ui/pull/521
Codegen currently recommends a ui-react version that does not exist because of a typo.
A fix for that was merged into codegen-ui/ codegen-ui-react version 2.3.1.
So this PR bumps CLI's codegen version 2.3.1

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
