### PR TITLE
fix: enables -yes flag on amplify publish

### DIFF
--- a/packages/amplify-cli/src/commands/publish.ts
+++ b/packages/amplify-cli/src/commands/publish.ts
@@ -32,10 +32,11 @@ export const run = async context => {
     return continueToCheckNext;
   });
 
-  // added extra check for -y flag as in publish frontend deploy is getting stuck in CICD if backend has no changes
-  const didPush = await push(context) || !!context?.exeInfo?.inputParams?.yes;
+  const didPush = await push(context);
 
-  let continueToPublish = didPush;
+  // added extra check for -y flag as in publish frontend deploy is getting stuck in CICD if backend has no changes
+
+  let continueToPublish = didPush || !!context?.exeInfo?.inputParams?.yes;
   if (!continueToPublish && isHostingAlreadyPushed) {
     context.print.info('');
     continueToPublish = await context.amplify.confirmPrompt('Do you still want to publish the frontend?');

--- a/packages/amplify-cli/src/commands/publish.ts
+++ b/packages/amplify-cli/src/commands/publish.ts
@@ -1,7 +1,11 @@
-import { run as push } from './push';
 import { FrontendBuildError } from 'amplify-cli-core';
+import { run as push } from './push';
 import { showTroubleshootingURL } from './help';
 
+/**
+ * Entry point to amplify publish
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const run = async context => {
   context.amplify.constructExeInfo(context);
   const { amplifyMeta } = context.exeInfo;
@@ -28,7 +32,8 @@ export const run = async context => {
     return continueToCheckNext;
   });
 
-  const didPush = await push(context);
+  // added extra check for -y flag as in publish frontend deploy is getting stuck in CICD if backend has no changes
+  const didPush = await push(context) || !!context?.exeInfo?.inputParams?.yes;
 
   let continueToPublish = didPush;
   if (!continueToPublish && isHostingAlreadyPushed) {
@@ -39,6 +44,7 @@ export const run = async context => {
   try {
     if (continueToPublish) {
       const frontendPlugins = context.amplify.getFrontendPlugins(context);
+      // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
       const frontendHandlerModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
       await frontendHandlerModule.publish(context);
     }

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -159,6 +159,14 @@ export function amplifyPublishWithoutUpdate(cwd: string): Promise<void> {
   });
 }
 
+/**
+ * executes publish command with yes flag
+ */
+export const amplifyPublishWithoutUpdateWithYesFlag = async (cwd: string): Promise<void> => {
+  const chain = spawn(getCLIPath(), ['publish', '-y'], { cwd, stripColors: true });
+  return chain.runAsync();
+};
+
 export function removeHosting(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['remove', 'hosting'], { cwd, stripColors: true })

--- a/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import {
   amplifyPublishWithoutUpdate,
   createReactTestProject,
@@ -11,8 +12,8 @@ import {
   deleteS3Bucket,
   deleteProjectDir,
   getProjectMeta,
+  amplifyPublishWithoutUpdateWithYesFlag
 } from '@aws-amplify/amplify-e2e-core';
-
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
@@ -34,6 +35,7 @@ describe('amplify add hosting', () => {
     if (hostingBucket) {
       try {
         await deleteS3Bucket(hostingBucket);
+      // eslint-disable-next-line no-empty
       } catch {}
     }
     deleteProjectDir(projRoot);
@@ -50,6 +52,16 @@ describe('amplify add hosting', () => {
     let error;
     try {
       await amplifyPublishWithoutUpdate(projRoot);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).not.toBeDefined();
+  });
+
+  it('publish successfully with yes flag', async () => {
+    let error;
+    try {
+      await amplifyPublishWithoutUpdateWithYesFlag(projRoot);
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Enables yes flag on amplify publish when there no changes in backend for CICD operations

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #10358 , #10164

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- Manually tested
- added an e2e check for above scenario

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
