### PR TITLE
feat(cli): closed-issue-message workflow

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Closed Issue Message
+on:
+  issues:
+    types: [closed]
+jobs:
+  auto_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/closed-issue-message@v1
+        with:
+          # These inputs are both required
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: |
+            ### ⚠️COMMENT VISIBILITY WARNING⚠️
+            Comments on closed issues are hard for our team to see.
+            If you need more assistance, please either tag a team member or open a new issue that references this one.
+            If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -13,5 +13,5 @@ jobs:
           message: |
             ### ⚠️COMMENT VISIBILITY WARNING⚠️
             Comments on closed issues are hard for our team to see.
-            If you need more assistance, please either tag a team member or open a new issue that references this one.
+            If you need more assistance, please open a new issue that references this one.
             If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- This PR will introduce a GitHub workflow to the Amplify CLI repository.
- The workflow will present a comment visibility warning when an issue is closed.
- It will guide the community members to take appropriate actions since its hard for Amplify team to keep up with new comments on closed issues.
- This GitHub action workflow is being referenced from the `aws-actions` repository: https://github.com/aws-actions/closed-issue-message.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- We already have a similar feature live within the Hosting repository: https://github.com/aws-amplify/amplify-hosting/pull/2820

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
