### PR TITLE
fix: support AWS::S3::Bucket FilterRule properly in the mock mode

### DIFF
--- a/packages/amplify-util-mock/src/storage/storage.ts
+++ b/packages/amplify-util-mock/src/storage/storage.ts
@@ -118,8 +118,12 @@ export class StorageTest {
             if (typeof rules.Value === 'string') {
               node = String(rules.Value);
             }
-            // check prefix given  is the prefix of keyname in the event object
-            if (keyName.indexOf(node) === 0) {
+
+            if (rules.Name === 'prefix' && keyName.startsWith(node)) {
+              triggerName = String(obj.Function.Ref).split('function')[1].split('Arn')[0];
+              break;
+            }
+            if (rules.Name === 'suffix' && keyName.endsWith(node)) {
               triggerName = String(obj.Function.Ref).split('function')[1].split('Arn')[0];
               break;
             }
@@ -128,6 +132,10 @@ export class StorageTest {
         if (triggerName !== undefined) {
           break;
         }
+      }
+
+      if (triggerName === undefined) {
+        return;
       }
 
       const config = await loadLambdaConfig(context, triggerName);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The amplify mock mode does not support [AWS::S3::Bucket FilterRule](https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter-s3key-rules.html) properly.
Name of FilterRule can be set to `prefix` or `suffix`.
But [the code](https://github.com/aws-amplify/amplify-cli/blob/87d15cb3e1c75fbd978c6fc7966e42b42e5d856a/packages/amplify-util-mock/src/storage/storage.ts#L122) checks only the prefix.
As a result, if you have `suffix` FilterRule, the value of `triggerName` becomes `undefined`, and the amplify mock mode crashes in [the method](https://github.com/aws-amplify/amplify-cli/blob/87d15cb3e1c75fbd978c6fc7966e42b42e5d856a/packages/amplify-util-mock/src/storage/storage.ts#L133).

This PR fixes this issue.

#### Issue
- https://github.com/aws-amplify/amplify-cli/issues/10798

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
