### PR TITLE
chore: local publish scripts

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -157,14 +157,8 @@ jobs:
             source .circleci/local_publish_helpers.sh
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
-            git config user.email not@used.com
-            git config user.name "Doesnt Matter"
-            setNpmTag
-            if [ -z $NPM_TAG ]; then
-              yarn publish-to-verdaccio
-            else
-              yarn lerna publish --exact --dist-tag=latest --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-verify-access --yes --no-commit-hooks --no-push --no-git-tag-version
-            fi
+            export LOCAL_PUBLISH_TO_LATEST=true
+            ./.circleci/publish.sh
             unsetNpmRegistryUrl
       - run:
           name: Generate unified changelog
@@ -204,8 +198,7 @@ jobs:
             startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
             setNpmRegistryUrlToLocal
             changeNpmGlobalPath
-            yarn yarn-use-bash
-            yarn pkg-all
+            generatePkgCli
             unsetNpmRegistryUrl
             uploadPkgCli
       - save_cache:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -12,24 +12,6 @@ function startLocalRegistry {
     grep -q 'http address' <(tail -f $tmp_registry_log)
 }
 
-function setNpmTag {
-    if [ -z $NPM_TAG ]; then
-        if [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
-            if [[ "$CIRCLE_BRANCH" =~ ^tagged-release-without-e2e-tests\/.* ]]; then
-                export NPM_TAG="${CIRCLE_BRANCH/tagged-release-without-e2e-tests\//}"
-            elif [[ "$CIRCLE_BRANCH" =~ ^tagged-release\/.* ]]; then
-                export NPM_TAG="${CIRCLE_BRANCH/tagged-release\//}"
-            fi
-        fi
-        if [[ "$CIRCLE_BRANCH" == "beta" ]]; then
-            export NPM_TAG="beta"
-        fi
-    else
-        echo "NPM tag was already set!"
-    fi
-    echo 'NPM tag is' ${NPM_TAG:-'not set'}
-}
-
 function uploadPkgCli {
     aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
     aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -25,6 +25,15 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
   # create release commit and release tags
   npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]"
 
+  # if publishing locally to verdaccio
+  if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
+    # publish to verdaccio with no dist tag (default to latest)
+    npx lerna publish from-git --yes --no-push
+    echo "Published packages to verdaccio"
+    echo "Exiting without pushing release commit or release tags"
+    exit 1
+  fi
+
   # publish versions that were just computed
   npx lerna publish from-git --yes --no-push --dist-tag rc
 
@@ -37,7 +46,7 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
 # @latest release
 elif [[ "$CIRCLE_BRANCH" == "release" ]]; then
   # create release commit and release tags
-  npx lerna version --exact --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish [ci skip]"
+  npx lerna version --exact --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish latest [ci skip]"
 
   # publish versions that were just computed
   npx lerna publish from-git --yes --no-push

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -21,7 +21,7 @@ if [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
   npx lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --yes --include-merged-tags
 
 # release candidate
-elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]]; then
+elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
   # create release commit and release tags
   npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]"
 

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -31,7 +31,7 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
     npx lerna publish from-git --yes --no-push
     echo "Published packages to verdaccio"
     echo "Exiting without pushing release commit or release tags"
-    exit 1
+    exit 0
   fi
 
   # publish versions that were just computed


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use the `publish.sh` script when publishing to verdaccio instead of the `publish-to-verdaccio` package.json script. This ensures that the local publish will always publish the same version that is being released

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran script locally
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
