### PR TITLE
fix: add default ref for unauthrole for imported auth

### DIFF
--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -59,6 +59,7 @@
   "extensibility",
   "extentions",
   "facebook",
+  "fargate",
   "filenames",
   "filesystem",
   "firebase",

--- a/.eslint-dictionary.json
+++ b/.eslint-dictionary.json
@@ -172,6 +172,7 @@
   "transpile",
   "transpiled",
   "tsconfig",
+  "ttla",
   "typename",
   "uibuilder",
   "uint",

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -5,6 +5,7 @@
 /* eslint-disable func-style */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { $TSAny } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -624,9 +625,9 @@ export function updateRestApi(cwd: string, settings: Partial<typeof updateRestAp
 
 const allAuthTypes = ['API key', 'Amazon Cognito User Pool', 'IAM', 'OpenID Connect'];
 
-export function addApi(projectDir: string, settings?: any, requireAuthSetup = true) {
-  const transformerVersion = settings?.transformerVersion ?? 2;
-  delete settings?.transformerVersion;
+export function addApi(projectDir: string, authTypesConfig?: Record<string, $TSAny>, requireAuthSetup = true) {
+  const transformerVersion = authTypesConfig?.transformerVersion ?? 2;
+  delete authTypesConfig?.transformerVersion;
 
   let authTypesToSelectFrom = allAuthTypes.slice();
   return new Promise<void>((resolve, reject) => {
@@ -634,8 +635,8 @@ export function addApi(projectDir: string, settings?: any, requireAuthSetup = tr
       .wait('Select from one of the below mentioned services:')
       .sendCarriageReturn();
 
-    if (settings && Object.keys(settings).length > 0) {
-      const authTypesToAdd = Object.keys(settings);
+    if (authTypesConfig && Object.keys(authTypesConfig).length > 0) {
+      const authTypesToAdd = Object.keys(authTypesConfig);
       const defaultType = authTypesToAdd[0];
 
       chain
@@ -644,7 +645,7 @@ export function addApi(projectDir: string, settings?: any, requireAuthSetup = tr
         .sendCarriageReturn();
 
       singleSelect(chain.wait('Choose the default authorization type for the API'), defaultType, authTypesToSelectFrom);
-      if (requireAuthSetup) setupAuthType(defaultType, chain, settings);
+      if (requireAuthSetup) setupAuthType(defaultType, chain, authTypesConfig);
 
       if (authTypesToAdd.length > 1) {
         authTypesToAdd.shift();
@@ -660,7 +661,7 @@ export function addApi(projectDir: string, settings?: any, requireAuthSetup = tr
         );
 
         authTypesToAdd.forEach(authType => {
-          if (requireAuthSetup) setupAuthType(authType, chain, settings);
+          if (requireAuthSetup) setupAuthType(authType, chain, authTypesConfig);
         });
       } else {
         chain.wait('Configure additional auth types?').sendLine('n');
@@ -746,11 +747,9 @@ function setupOIDC(chain: any, settings?: any) {
     .send(settings['OpenID Connect'].oidcClientId)
     .sendCarriageReturn()
     .wait('Enter the number of milliseconds a token is valid after being issued to a user')
-    // eslint-disable-next-line spellcheck/spell-checker
     .send(settings['OpenID Connect'].ttlaIssueInMillisecond)
     .sendCarriageReturn()
     .wait('Enter the number of milliseconds a token is valid after being authenticated')
-    // eslint-disable-next-line spellcheck/spell-checker
     .send(settings['OpenID Connect'].ttlaAuthInMillisecond)
     .sendCarriageReturn();
 }

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -59,6 +59,11 @@ export const getCloudBackendConfig = (projectRoot: string): $TSAny => {
   return JSON.parse(fs.readFileSync(currentCloudPath, 'utf8'));
 };
 
+export const getRootStackTemplate = (projectRoot: string): $TSAny => {
+  const rootStackPath = path.join(projectRoot, 'amplify', 'backend', 'awscloudformation', 'build', 'root-cloudformation-stack.json');
+  return JSON.parse(fs.readFileSync(rootStackPath, 'utf8'));
+};
+
 const getParameterPath = (projectRoot: string, category: string, resourceName: string): string => path.join(projectRoot, 'amplify', 'backend', category, resourceName, 'build', 'parameters.json');
 
 const getCLIInputsPath = (projectRoot: string, category: string, resourceName: string): string => path.join(projectRoot, 'amplify', 'backend', category, resourceName, 'cli-inputs.json');

--- a/packages/amplify-e2e-tests/schemas/model_with_owner_and_iam_auth.graphql
+++ b/packages/amplify-e2e-tests/schemas/model_with_owner_and_iam_auth.graphql
@@ -1,0 +1,10 @@
+type Todo
+  @model
+  @auth(rules: [
+  { allow: owner },
+  { allow: public, provider: iam }
+]) {
+  id: ID!
+  task: String!
+  description: String
+}

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1203,7 +1203,7 @@ export const formNestedStack = async (
           }
 
           if (parameters.unauthRoleName) {
-            parameters.unauthRoleName = unauthRoleName;
+            parameters.unauthRoleName = unauthRoleName || { Ref: 'UnauthRoleName' }; // if only a user pool is imported, we ref the root stack UnauthRoleName because the child stacks still need this parameter
           }
         }
         if (resourceDetails.providerMetadata) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add the default unauth role name reference for import auth since it is required for child stacks.
#### Issue #, if available
Fix https://github.com/aws-amplify/amplify-category-api/issues/677
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
