### PR TITLE
fix: detect table requiring replacement

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -317,10 +317,9 @@ export class GraphQLResourceManager {
           .filter(
             diff => {
               const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
-              const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
-              const sortKeyRemoved = diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+              const sortKeyAddedOrRemoved = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
               const localSecondaryIndexModified = diff.path.some((pathEntry) => pathEntry === 'LocalSecondaryIndexes');
-              return keySchemaModified || sortKeyAdded || sortKeyRemoved || localSecondaryIndexModified;
+              return keySchemaModified || sortKeyAddedOrRemoved || localSecondaryIndexModified;
             },
           ) // filter diffs with changes that require replacement
           .map(diff => ({

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -315,7 +315,12 @@ export class GraphQLResourceManager {
         diffs
           // diff.path looks like [ "stacks", "ModelName.json", "Resources", "TableName", "Properties", "KeySchema", 0, "AttributeName"]
           .filter(
-            diff => (diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema') || diff.path.includes('LocalSecondaryIndexes'),
+            diff => {
+              const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
+              const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+              const localSecondaryIndexModified = diff.path.some((pathEntry) => pathEntry === 'LocalSecondaryIndexes');
+              return keySchemaModified || sortKeyAdded || localSecondaryIndexModified;
+            },
           ) // filter diffs with changes that require replacement
           .map(diff => ({
             // extract table name and stack name from diff path

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -318,8 +318,9 @@ export class GraphQLResourceManager {
             diff => {
               const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
               const sortKeyAdded = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
+              const sortKeyRemoved = diff.kind === 'D' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
               const localSecondaryIndexModified = diff.path.some((pathEntry) => pathEntry === 'LocalSecondaryIndexes');
-              return keySchemaModified || sortKeyAdded || localSecondaryIndexModified;
+              return keySchemaModified || sortKeyAdded || sortKeyRemoved || localSecondaryIndexModified;
             },
           ) // filter diffs with changes that require replacement
           .map(diff => ({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add in a condition to detect destructive updates when a sort key is added to a primary key, currently there is no warning and deploys just fail, using the `--allow-destructive-graphql-schema-updates` flag doesn't work

This is tied to the API category PR which adds in the sanity check and warning https://github.com/aws-amplify/amplify-category-api/pull/714

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
This is the same condition that I used in the API category, manually tested to verify it picks up the right changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
