### PR TITLE
chore: fix publish scripts and verdaccio config

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -17,8 +17,13 @@ if [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
     echo "Tag name is missing. Name your branch with either tagged-release/<tag-name> or tagged-release-without-e2e-tests/<tag-name>"
     exit 1
   fi
-  echo "Publishing to NPM with tag $NPM_TAG"
-  npx lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --yes --include-merged-tags
+    if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
+    echo "Publishing to local registry under latest tag"
+    npx lerna publish --exact --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-push --yes --include-merged-tags
+  else
+    echo "Publishing to NPM under $NPM_TAG tag"
+    npx lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --yes --include-merged-tags
+  fi
 
 # @latest release
 elif [[ "$CIRCLE_BRANCH" == "release" ]]; then
@@ -42,13 +47,13 @@ elif [[ "$CIRCLE_BRANCH" == "release" ]]; then
 
   # fast forward main to release
   git fetch origin main
-  git switch main
+  git checkout main
   git merge release --ff-only
   git push origin main
 
   # fast forward hotfix to release
   git fetch origin hotfix
-  git switch hotfix
+  git checkout hotfix
   git merge release --ff-only
   git push origin hotfix
 

--- a/.circleci/verdaccio.yaml
+++ b/.circleci/verdaccio.yaml
@@ -26,6 +26,12 @@ uplinks:
       maxFreeSockets: 10
 
 packages:
+  # do NOT proxy our cli-internal package to npm
+  # in our current set up, the requested version should always be present in the local registry
+  # if it is not, something else has gone wrong and we should fail to esure that we don't install an unexpected version
+  '@aws-amplify/cli-internal':
+    access: $all
+    publish: $all
   '@*/*':
     # scoped packages
     access: $all

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -2,11 +2,13 @@
 set -e
 
 # This script is for promoting a CLI release candidate to @latest
-# Usage: ./scripts/promote-rc.sh <hash> where <hash> is the commit hash of the change going out. It is the hash in the release candidate version 1.2.3-rc.<hash>.0
+# Usage: ./scripts/promote-rc.sh <hash> where <hash> is the same hash previously used to run `release-rc`.
+# It is the hash in the release candidate version 1.2.3-rc.<hash>.0
 
-# It will
+# It will:
 # pull the latest changes from the release candidate branch
-# push HEAD~1 of the release candidate branch to the release branch. HEAD~1 is used instead of HEAD so that the prerelease version commit is dropped from the latest release
+# push HEAD~1 of the release candidate branch to the release branch.
+#   HEAD~1 is used instead of HEAD so that the prerelease version commit is dropped from the latest release
 
 # This will kick off a CCI workflow that will publish the @latest release
 
@@ -28,6 +30,8 @@ if [[ -z ${remote_name+x} ]]; then
 fi
 
 rc_branch="release_rc/$rc_sha"
-git switch "$rc_branch"
-git pull "$remote_name" "$rc_branch"
+
+git fetch "$remote_name" "$rc_branch"
+git checkout "$rc_branch"
+git reset --hard "$remote_name"/"$rc_branch"
 git push "$remote_name" "$rc_branch"~1:refs/heads/release

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -32,8 +32,11 @@ branch_name="release_rc/$rc_sha"
 
 git checkout -B "$branch_name" "$rc_sha"
 git fetch "$remote_name" main
-git merge "$remote_name"/main || merge_exit_code=$? || true
-if [[ $merge_exit_code != 0 ]]; then
+set +e
+git merge "$remote_name"/main
+merge_exit_code=$?
+set -e
+if [[ $merge_exit_code -gt 0 ]]; then
   # could not automatically merge
   echo "Resolve merge conflicts and resume release candidate publish by running 'kill -CONT $$'"
   kill -TSTP $$


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a few different release script issues:
1. adds an if statement in the tagged release script to publish to `@latest` when publishing locally to verdaccio and publish to `@<tag>` when publishing to npm
2. uses `git checkout` instead of `git switch` where applicable because the git version in CCI does not support `switch`
3. Updates the verdaccio config to not allow proxying `@aws-amplify/cli-internal` to npm. This is a safety measure against installing an unexpected version of the CLI when packaging the binaries
4. A few tweaks to the publish scripts that run locally. The main change is fixing the exit code handling logic around merges that cannot be completed automatically

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
local release scripts were tested as much as possible locally.
Doing an e2e run here to make sure verdaccio publish / pkg builds are still working: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/10159/workflows/6e22d581-870a-48e0-933e-a319fd2de87b
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
