### PR TITLE
feat(amplify-auth-simulator): add auth mock sim

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -254,6 +254,7 @@ module.exports = {
     '/packages/amplify-prompts/lib',
     '/packages/amplify-provider-awscloudformation/lib',
     '/packages/amplify-storage-simulator/lib',
+    '/packages/amplify-auth-simulator/lib',
     '/packages/amplify-ui-tests/lib',
     '/packages/amplify-util-headless-input/lib',
     '/packages/amplify-util-mock/lib',

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ packages/*/package-lock.json
 amplify-integ*/
 console-integ*/
 packages/amplify-storage-simulator/lib
+packages/amplify-auth-simulator/lib
 packages/*-template-provider/lib
 packages/*-runtime-provider/lib
 packages/amplify-function-plugin-interface/lib

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
   projects: [
     '<rootDir>/packages/amplify-app',
     '<rootDir>/packages/amplify-appsync-simulator',
+    '<rootDir>/packages/amplify-auth-simulator',
     '<rootDir>/packages/amplify-category-analytics',
     '<rootDir>/packages/amplify-category-auth',
     '<rootDir>/packages/amplify-category-geo',

--- a/packages/amplify-auth-simulator/.npmignore
+++ b/packages/amplify-auth-simulator/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/amplify-auth-simulator/CHANGELOG.md
+++ b/packages/amplify-auth-simulator/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+# 1.0.0 (2022-08-08)
+
+### Features
+
+- mock support for Auth

--- a/packages/amplify-auth-simulator/package.json
+++ b/packages/amplify-auth-simulator/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "amplify-auth-simulator",
+  "version": "1.0.0",
+  "description": "An Auth simulator to test Auth APIs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "directory": "packages/amplify-auth-simulator"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "keywords": [
+    "graphql",
+    "appsync",
+    "aws"
+  ],
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "dependencies": {
+    "body-parser": "^1.19.2",
+    "cors": "^2.8.5",
+    "etag": "^1.8.1",
+    "express": "^4.17.3",
+    "fs-extra": "^8.1.0",
+    "glob": "^7.2.0",
+    "object-to-xml": "^2.0.0",
+    "promise-toolbox": "^0.20.0",
+    "serve-static": "^1.14.2",
+    "uuid": "^8.3.2",
+    "xml": "^1.0.1",
+    "xml-js": "^1.6.11"
+  },
+  "devDependencies": {
+    "@types/body-parser": "^1.19.2",
+    "@types/cors": "^2.8.6",
+    "@types/etag": "^1.8.0",
+    "@types/glob": "^7.1.1",
+    "@types/serve-static": "^1.13.3",
+    "@types/uuid": "^8.3.1",
+    "@types/xml": "^1.0.4",
+    "aws-sdk": "^2.1113.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "**/*.ts",
+      "!**/node_modules/**",
+      "!**/lib/**",
+      "!__tests__/**"
+    ],
+    "testURL": "http://localhost/",
+    "testRegex": "(src/__tests__/.*.test.*)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/lib/"
+    ]
+  }
+}

--- a/packages/amplify-auth-simulator/src/__tests__/S3server.test.ts
+++ b/packages/amplify-auth-simulator/src/__tests__/S3server.test.ts
@@ -1,0 +1,58 @@
+import * as AWS from 'aws-sdk';
+// import * as fs from 'fs-extra';
+import { AmplifyAuthSimulator } from '..';
+
+const port = 20005; // for testing
+const route = '/mock-testing';
+// const bucket = 'mock-testing';
+const localDirS3 = `${__dirname}/test-data/`;
+// const actual_file = `${__dirname}/test-data/2.png`;
+
+let s3client;
+let simulator;
+
+jest.setTimeout(2000000);
+
+beforeAll(async () => {
+  AWS.config.update({
+    accessKeyId: 'testKey',
+    secretAccessKey: 'testSecretKey',
+    region: 'eu-west-2',
+  });
+
+  const ep = new AWS.Endpoint('http://localhost:20005');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  s3client = new AWS.S3({
+    apiVersion: '2006-03-01',
+    // eslint-disable-next-line spellcheck/spell-checker
+    endpoint: ep.href,
+    s3BucketEndpoint: true,
+    sslEnabled: false,
+    s3ForcePathStyle: true,
+  });
+
+  simulator = new AmplifyAuthSimulator({ port, route, localDirS3 });
+  await simulator.start();
+});
+
+afterAll(async () => {
+  if (simulator) {
+    await simulator.stop();
+  }
+});
+
+/**
+ * Test api below
+ */
+
+describe('test server running', () => {
+  test('server is running', async () => {
+    try {
+      expect(simulator).toBeDefined();
+      expect(simulator.url).toEqual('http://localhost:20005');
+    } catch (e) {
+      console.log(e);
+      // expect(true).toEqual(false);
+    }
+  });
+});

--- a/packages/amplify-auth-simulator/src/__tests__/authserver.test.ts
+++ b/packages/amplify-auth-simulator/src/__tests__/authserver.test.ts
@@ -2,13 +2,12 @@ import * as AWS from 'aws-sdk';
 // import * as fs from 'fs-extra';
 import { AmplifyAuthSimulator } from '..';
 
-const port = 20005; // for testing
+const port = 20009; // for testing
 const route = '/mock-testing';
 // const bucket = 'mock-testing';
-const localDirS3 = `${__dirname}/test-data/`;
+const localDir = `${__dirname}/test-data/`;
 // const actual_file = `${__dirname}/test-data/2.png`;
 
-let s3client;
 let simulator;
 
 jest.setTimeout(2000000);
@@ -20,18 +19,7 @@ beforeAll(async () => {
     region: 'eu-west-2',
   });
 
-  const ep = new AWS.Endpoint('http://localhost:20005');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  s3client = new AWS.S3({
-    apiVersion: '2006-03-01',
-    // eslint-disable-next-line spellcheck/spell-checker
-    endpoint: ep.href,
-    s3BucketEndpoint: true,
-    sslEnabled: false,
-    s3ForcePathStyle: true,
-  });
-
-  simulator = new AmplifyAuthSimulator({ port, route, localDirS3 });
+  simulator = new AmplifyAuthSimulator({ port, route, localDir });
   await simulator.start();
 });
 
@@ -49,10 +37,11 @@ describe('test server running', () => {
   test('server is running', async () => {
     try {
       expect(simulator).toBeDefined();
-      expect(simulator.url).toEqual('http://localhost:20005');
+      expect(simulator.url).toEqual('http://localhost:20009');
     } catch (e) {
       console.log(e);
-      // expect(true).toEqual(false);
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(true).toEqual(false);
     }
   });
 });

--- a/packages/amplify-auth-simulator/src/index.ts
+++ b/packages/amplify-auth-simulator/src/index.ts
@@ -1,0 +1,58 @@
+// eslint-disable-next-line import/no-cycle
+import { AuthServer } from './server/authserver';
+
+/**
+ * Config type for the mock auth server
+ */
+export type AuthSimulatorServerConfig = {
+  port: number;
+  route: string;
+  localDirS3: string;
+};
+
+/**
+ * Simulates Cognito for mock auth
+ */
+export class AmplifyAuthSimulator {
+  private _server: AuthServer;
+  private _serverConfig: AuthSimulatorServerConfig;
+
+  constructor(serverConfig: AuthSimulatorServerConfig) {
+    this._serverConfig = serverConfig;
+
+    try {
+      this._server = new AuthServer(serverConfig);
+    } catch (e) {
+      console.log('Mock auth sever failed to start');
+      console.log(e);
+    }
+  }
+
+  /**
+   * Start the mock auth server
+   */
+  async start() :Promise<void> {
+    await this._server.start();
+  }
+
+  /**
+   * Stops the mock auth server
+   */
+  stop():void {
+    this._server.stop();
+  }
+
+  /**
+   * Returns the url for the mock auth server
+   */
+  get url():string {
+    return this._server.url;
+  }
+
+  /**
+   * Returns the server object for mock auth
+   */
+  get getServer() :AuthServer {
+    return this._server;
+  }
+}

--- a/packages/amplify-auth-simulator/src/index.ts
+++ b/packages/amplify-auth-simulator/src/index.ts
@@ -7,7 +7,7 @@ import { AuthServer } from './server/authserver';
 export type AuthSimulatorServerConfig = {
   port: number;
   route: string;
-  localDirS3: string;
+  localDir: string;
 };
 
 /**

--- a/packages/amplify-auth-simulator/src/server/authserver.ts
+++ b/packages/amplify-auth-simulator/src/server/authserver.ts
@@ -58,7 +58,7 @@ export class AuthServer extends EventEmitter {
 
   constructor(private config: AuthSimulatorServerConfig) {
     super();
-    this.localDirectoryPath = config.localDirS3;
+    this.localDirectoryPath = config.localDir;
     this.app = express();
     this.app.use(cors(corsOptions));
     // eslint-disable-next-line spellcheck/spell-checker
@@ -98,6 +98,4 @@ export class AuthServer extends EventEmitter {
       this.connection = null;
     }
   }
-
-  // build event obj for s3 trigger
 }

--- a/packages/amplify-auth-simulator/src/server/authserver.ts
+++ b/packages/amplify-auth-simulator/src/server/authserver.ts
@@ -1,0 +1,103 @@
+/* eslint-disable class-methods-use-this */
+import express from 'express';
+import cors from 'cors';
+import * as bodyParser from 'body-parser';
+import { fromEvent } from 'promise-toolbox';
+import serveStatic from 'serve-static';
+import { EventEmitter } from 'events';
+// eslint-disable-next-line import/no-cycle
+import { AuthSimulatorServerConfig } from '../index';
+
+// import * as util from './utils';
+
+// const LIST_CONTENT = 'Contents';
+// const LIST_COMMOM_PREFIXES = 'CommonPrefixes';
+// const EVENT_RECORDS = 'Records';
+type ServerResponse =
+{
+test: string;
+} & import('http').ServerResponse
+
+type Response= serveStatic.ServeStaticOptions<ServerResponse>
+type Request = serveStatic.RequestHandler<ServerResponse>
+const corsOptions = {
+  maxAge: 20000,
+  exposedHeaders: ['x-amz-server-side-encryption', 'x-amz-request-id', 'x-amz-id-2', 'ETag'],
+};
+/**
+ * Mock Auth Server
+ */
+export class AuthServer extends EventEmitter {
+  private app;
+  private server;
+  private connection;
+  private route; // bucket name get from the CFN parser
+  url: string;
+
+  private localDirectoryPath: string;
+
+  private async handleRequestGet(request:Request, response:Response) :Promise<void> {
+    console.log(request, response);
+  }
+
+  private async handleRequestList(request:Request, response:Response):Promise<void> {
+    console.log(request, response);
+  }
+
+  private async handleRequestDelete(request:Request, response:Response):Promise<void> {
+    console.log(request, response);
+  }
+
+  private async handleRequestPut(request:Request, response:Response):Promise<void> {
+    console.log(request, response);
+  }
+
+  private async handleRequestPost(request:Request, response:Response) :Promise<void> {
+    console.log(request, response);
+  }
+
+  constructor(private config: AuthSimulatorServerConfig) {
+    super();
+    this.localDirectoryPath = config.localDirS3;
+    this.app = express();
+    this.app.use(cors(corsOptions));
+    // eslint-disable-next-line spellcheck/spell-checker
+    this.app.use(bodyParser.raw({ limit: '100mb', type: '*/*' }));
+    //    this.app.use(serveStatic<ServerResponse>(this.localDirectoryPath), this.handleRequestAll.bind(this));
+
+    this.server = null;
+    this.route = config.route;
+  }
+
+  /**
+   * Starts the auth mock server
+   */
+  start() :void {
+    if (this.server) {
+      throw new Error('Server is already running');
+    }
+    try {
+      this.server = this.app.listen(this.config.port);
+    } catch (e) {
+      console.log(e);
+    }
+    return fromEvent(this.server, 'listening').then(() => {
+      this.connection = this.server.address();
+      this.url = `http://localhost:${this.connection.port}`;
+      return this.server;
+    });
+  }
+
+  /**
+   * Stops the auth mock server
+   */
+  stop() :void {
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+      this.connection = null;
+    }
+  }
+
+  // build event obj for s3 trigger
+}

--- a/packages/amplify-auth-simulator/src/server/utils.ts
+++ b/packages/amplify-auth-simulator/src/server/utils.ts
@@ -1,0 +1,87 @@
+import * as path from 'path';
+
+/**
+ *  parse the request url to get the path and storing in the request.params.path  with the prefix if present
+ */
+export const parseUrl = (request, route: string):void => {
+  request.url = path.normalize(decodeURIComponent(request.url));
+  const temp = request.url.split(route);
+  request.params.path = '';
+
+  if (request.query.prefix !== undefined) {
+    request.params.path = `${request.query.prefix}/`;
+  }
+
+  if (temp[1] !== undefined) {
+    request.params.path = path.normalize(path.join(request.params.path, temp[1].split('?')[0]));
+  } else {
+    // change for IOS as no bucket name is present in the original url
+    request.params.path = path.normalize(path.join(request.params.path, temp[0].split('?')[0]));
+  }
+
+  if (request.params.path[0] === '/' || request.params.path[0] === '.') {
+    request.params.path = request.params.path.substring(1);
+  }
+
+  // changing file path by removing invalid file path characters for windows
+  if (process.platform === 'win32') {
+    request.params.path = request.params.path.replace(/[<>:"|?*]/g, match => `%${Buffer.from(match, 'utf8').toString('hex')}`);
+  }
+
+  if (request.method === 'GET') {
+    if (request.query.prefix !== undefined || (temp[1] === '' && temp[0] === '') || (temp[1] === '/' && temp[0] === '')) {
+      request.method = 'LIST';
+    }
+  }
+};
+
+/**
+ * check for the delimiter in the file for list object request
+ */
+// eslint-disable-next-line spellcheck/spell-checker
+export const checkfile = (file: string, prefix: string, delimiter: string):boolean => {
+  if (delimiter === '') {
+    return true;
+  }
+  const temp = file.split(String(prefix))[1].split(String(delimiter));
+  if (temp[1] === undefined) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * removing chunk siognature from request payload if present
+ */
+export const stripChunkSignature = (buf: Buffer):Buffer => {
+  const str = buf.toString();
+  const regex = /^[A-Fa-f0-9]+;chunk-signature=[0-9a-f]{64}/gm;
+  let m;
+  const offset = [];
+  const chunkSize = [];
+  const arr = [];
+  // eslint-disable-next-line spellcheck/spell-checker
+  // eslint-disable-next-line no-cond-assign
+  while ((m = regex.exec(str)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    m.forEach(match => {
+      offset.push(Buffer.from(match).byteLength);
+      const temp = match.split(';')[0];
+      chunkSize.push(parseInt(temp, 16));
+    });
+  }
+  let start = 0;
+  // if no chunk signature is present
+  if (offset.length === 0) {
+    return buf;
+  }
+  for (let i = 0; i < offset.length - 1; i++) {
+    start = start + offset[i] + 2;
+    arr.push(buf.slice(start, start + chunkSize[i]));
+    start = start + chunkSize[i] + 2;
+  }
+  return Buffer.concat(arr);
+};

--- a/packages/amplify-auth-simulator/tsconfig.json
+++ b/packages/amplify-auth-simulator/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "strict": false, // TODO enable
+    "rootDir": "src",
+    "outDir": "lib"
+  }
+}

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -11,6 +11,7 @@ const constants = require('./constants');
 const MOCK_RESERVED_EXPORT_KEYS = [
   'aws_user_files_s3_dangerously_connect_to_http_endpoint_for_testing',
   'aws_appsync_dangerously_connect_to_http_endpoint_for_testing',
+  'aws_cognito_endpoint',
 ];
 
 // These are the set of keys that are reserved for amplify and customers are not allowed to override
@@ -397,6 +398,9 @@ function getCognitoConfig(cognitoResources, projectRegion) {
     frontendAuthConfig.aws_cognito_mfa_types = cognitoResource.frontendAuthConfig.mfaTypes;
     frontendAuthConfig.aws_cognito_password_protection_settings = cognitoResource.frontendAuthConfig.passwordProtectionSettings;
     frontendAuthConfig.aws_cognito_verification_mechanisms = cognitoResource.frontendAuthConfig.verificationMechanisms;
+  }
+  if (cognitoResource.testMode) {
+    frontendAuthConfig.aws_cognito_endpoint = cognitoResource.output.endpoint;
   }
 
   return {

--- a/packages/amplify-util-mock/amplify-plugin.json
+++ b/packages/amplify-util-mock/amplify-plugin.json
@@ -1,12 +1,6 @@
 {
-    "name": "mock",
-    "type": "util",
-    "commands": [
-        "api",
-        "function",
-        "mock",
-        "storage",
-        "help"
-    ],
-    "eventHandlers": []
+  "name": "mock",
+  "type": "util",
+  "commands": ["api", "auth", "function", "mock", "storage", "help"],
+  "eventHandlers": []
 }

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-amplify/amplify-appsync-simulator": "2.5.1",
     "@hapi/topo": "^5.0.0",
+    "amplify-auth-simulator": "1.0.0",
     "amplify-category-function": "4.0.11",
     "amplify-cli-core": "2.12.0",
     "amplify-codegen": "^3.0.1",

--- a/packages/amplify-util-mock/src/auth/auth.ts
+++ b/packages/amplify-util-mock/src/auth/auth.ts
@@ -49,7 +49,7 @@ export class AuthTest {
 
     this.bucketName = `auth-${localEnvInfo.envName}`;
     const route = path.join('/', 'auth');
-    const localDirS3 = createLocalStorage(context, `${this.bucketName}`);
+    const localDir = createLocalStorage(context, `${this.bucketName}`);
 
     try {
       context.amplify.addCleanUpTask(async () => {
@@ -57,7 +57,7 @@ export class AuthTest {
       });
       this.configOverrideManager = await ConfigOverrideManager.getInstance(context);
       this.authName = await getAuth(context);
-      const authConfig = { port, route, localDirS3 };
+      const authConfig = { port, route, localDir };
       this.authSimulator = new AmplifyAuthSimulator(authConfig);
       await this.authSimulator.start();
       console.log('Mock Auth endpoint is running at', this.authSimulator.url);
@@ -100,8 +100,7 @@ export class AuthTest {
         ...authMeta,
         output: {
           ...authMeta.output,
-          BucketName: this.bucketName,
-          Region: this.authRegion,
+          endpoint: localStorageDetails.endpoint,
         },
         testMode: localStorageDetails.testMode,
         lastPushTimeStamp: new Date(),

--- a/packages/amplify-util-mock/src/auth/auth.ts
+++ b/packages/amplify-util-mock/src/auth/auth.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { AmplifyAuthSimulator } from '../../../amplify-auth-simulator';
+import { getAmplifyMeta, getMockDataDirectory } from '../utils';
+import { ConfigOverrideManager } from '../utils/config-override';
+
+const port = 20009; // port for Auth
+
+const getAuth = async (context:any):Promise<string> => {
+  const currentMeta = await getAmplifyMeta(context);
+  const { auth: tmp = {} } = currentMeta;
+  let name = null;
+  Object.entries(tmp).some((entry: any):boolean => {
+    if (entry[1].service === 'Cognito') {
+      // eslint-disable-next-line prefer-destructuring
+      name = entry[0];
+      return true;
+    }
+    return false;
+  });
+  return name;
+};
+/**
+ * Auth mock test object
+ */
+export class AuthTest {
+  private authName: string;
+  private authSimulator: AmplifyAuthSimulator;
+  private configOverrideManager: ConfigOverrideManager;
+  private authRegion: string;
+  private bucketName: string;
+
+  /**
+   * Start the auth simulator
+   */
+  async start(context:any) :Promise<void> {
+    // loading s3 resource config form parameters.json
+    const meta = context.amplify.getProjectDetails().amplifyMeta;
+    const existingCognito = meta.auth;
+    this.authRegion = meta.providers.awscloudformation.Region;
+    if (existingCognito === undefined || Object.keys(existingCognito).length === 0) {
+      context.print.warning('Auth has not yet been added to this project.');
+      return;
+    }
+
+    const localEnvFilePath = context.amplify.pathManager.getLocalEnvFilePath();
+    const localEnvInfo = context.amplify.readJsonFile(localEnvFilePath);
+
+    this.bucketName = `auth-${localEnvInfo.envName}`;
+    const route = path.join('/', 'auth');
+    const localDirS3 = createLocalStorage(context, `${this.bucketName}`);
+
+    try {
+      context.amplify.addCleanUpTask(async () => {
+        await this.stop();
+      });
+      this.configOverrideManager = await ConfigOverrideManager.getInstance(context);
+      this.authName = await getAuth(context);
+      const authConfig = { port, route, localDirS3 };
+      this.authSimulator = new AmplifyAuthSimulator(authConfig);
+      await this.authSimulator.start();
+      console.log('Mock Auth endpoint is running at', this.authSimulator.url);
+      await this.generateTestFrontendExports(context);
+    } catch (e) {
+      console.error('Failed to start Mock Auth server', e);
+    }
+  }
+
+  /**
+   * Stops the auth simulator
+   */
+  async stop():Promise<void> {
+    await this.authSimulator.stop();
+  }
+
+  private async generateTestFrontendExports(context):Promise<void> {
+    await this.generateFrontendExports(context, {
+      endpoint: this.authSimulator.url,
+      name: this.authName,
+      testMode: true,
+    });
+  }
+
+  // generate aws-exports.js
+  private async generateFrontendExports(
+    context: any,
+    localStorageDetails?: {
+      endpoint: string;
+      name: string;
+      testMode: boolean;
+    },
+  ):Promise<void> {
+    const currentMeta = await getAmplifyMeta(context);
+    const override = currentMeta.auth || {};
+    if (localStorageDetails) {
+      const authMeta = override[localStorageDetails.name] || { output: {} };
+      override[localStorageDetails.name] = {
+        service: 'Cognito',
+        ...authMeta,
+        output: {
+          ...authMeta.output,
+          BucketName: this.bucketName,
+          Region: this.authRegion,
+        },
+        testMode: localStorageDetails.testMode,
+        lastPushTimeStamp: new Date(),
+      };
+    }
+
+    this.configOverrideManager.addOverride('auth', override);
+
+    await this.configOverrideManager.generateOverriddenFrontendExports(context);
+  }
+
+  // create local storage for S3 on disk which is fixes as the test folder
+
+  /**
+   * Returns the auth simulator object
+   */
+  get getSimulatorObject() :AmplifyAuthSimulator {
+    return this.authSimulator;
+  }
+}
+const createLocalStorage = (context, resourceName: string):string => {
+  const directoryPath = path.join(getMockDataDirectory(context), 'auth'); // get bucket through parameters remove afterwards
+  fs.ensureDirSync(directoryPath);
+
+  const localPath = path.join(directoryPath, resourceName);
+  fs.ensureDirSync(localPath);
+  return localPath;
+};

--- a/packages/amplify-util-mock/src/auth/index.ts
+++ b/packages/amplify-util-mock/src/auth/index.ts
@@ -1,0 +1,34 @@
+import { AuthTest } from './auth';
+
+const MOCK_SUPPORTED_CATEGORY = ['Cognito'];
+
+/**
+ * Start Cognito Mock
+ */
+export const start = async (context):Promise<void> => {
+  console.log('Starting Cognito Mock');
+  const resources = await context.amplify.getResourceStatus();
+  const mockableResources = resources.allResources.filter(
+    resource => resource.service && MOCK_SUPPORTED_CATEGORY.includes(resource.service),
+  );
+  //  const resourceToBePushed = [...resources.resourcesToBeCreated].filter(
+  //    resource => resource.service && RESOURCE_NEEDS_PUSH.includes(resource.service),
+  //  );
+
+  if (mockableResources.length) {
+    /*    if (resourceToBePushed.length) {
+      context.print.info(
+        'Auth Mocking needs Auth resources to be pushed to the cloud. Please run `amplify auth push` before running storage mock',
+      );
+      return Promise.resolve(false);
+    }*/
+    const mockAuth = new AuthTest();
+    try {
+      await mockAuth.start(context);
+    } catch (e) {
+      console.log(e);
+      // Sending term signal so we clean up after our-self
+      process.kill(process.pid, 'SIGTERM');
+    }
+  }
+};

--- a/packages/amplify-util-mock/src/commands/mock/auth.ts
+++ b/packages/amplify-util-mock/src/commands/mock/auth.ts
@@ -1,0 +1,21 @@
+import { $TSContext } from 'amplify-cli-core';
+import { start } from '../../auth';
+
+export const name = 'auth';
+
+/**
+ * Run command for mock auth
+ */
+export const run = async (context: $TSContext) :Promise<void> => {
+  if (context.parameters.options.help) {
+    const header = `amplify mock ${name} \nDescriptions:
+    Mock Auth locally`;
+    context.amplify.showHelp(header, []);
+    return;
+  }
+  try {
+    await start(context);
+  } catch (e) {
+    context.print.error(e.message);
+  }
+};

--- a/packages/amplify-util-mock/src/commands/mock/help.ts
+++ b/packages/amplify-util-mock/src/commands/mock/help.ts
@@ -2,13 +2,20 @@ import { $TSContext } from 'amplify-cli-core';
 
 export const name = 'help';
 
-export const run = (context: $TSContext) => {
+/**
+ * Show the help mock info
+ */
+export const run = (context: $TSContext):void => {
   const header = `amplify ${name} [subcommand]\nDescription:\nMock resources locally`;
 
   const commands = [
     {
       name: 'storage',
       description: 'Run Storage Mock Endpoint',
+    },
+    {
+      name: 'auth',
+      description: 'Run Auth Mock Endpoint',
     },
     {
       name: 'api',
@@ -20,5 +27,4 @@ export const run = (context: $TSContext) => {
     },
   ];
   context.amplify.showHelp(header, commands);
-  return;
 };

--- a/packages/amplify-util-mock/src/mockAll.ts
+++ b/packages/amplify-util-mock/src/mockAll.ts
@@ -1,9 +1,15 @@
+import { ServiceName as FunctionServiceName } from 'amplify-category-function';
+import { start as startAuthServer } from './auth';
 import { start as startAppSyncServer } from './api';
 import { start as startS3Server } from './storage';
-import { ServiceName as FunctionServiceName } from 'amplify-category-function';
-const MOCK_SUPPORTED_CATEGORY = ['AppSync', 'S3', FunctionServiceName.LambdaFunction];
 
-export async function mockAllCategories(context: any) {
+const MOCK_SUPPORTED_CATEGORY = ['Cognito', 'AppSync', 'S3', FunctionServiceName.LambdaFunction];
+
+/**
+ * Mock all categories
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const mockAllCategories = async (context: any):Promise<void> => {
   const resources = await context.amplify.getResourceStatus();
   const mockableResources = resources.allResources.filter(
     resource => resource.service && MOCK_SUPPORTED_CATEGORY.includes(resource.service),
@@ -32,6 +38,10 @@ export async function mockAllCategories(context: any) {
     }
     // Run the mock servers
     const serverPromises = [];
+    if (mockableResources.find(r => r.service === 'Cognito')) {
+      serverPromises.push(startAuthServer(context));
+    }
+
     if (mockableResources.find(r => r.service === 'AppSync')) {
       serverPromises.push(startAppSyncServer(context));
     }
@@ -42,4 +52,4 @@ export async function mockAllCategories(context: any) {
   } else {
     context.print.info('No resource in project can be mocked locally.');
   }
-}
+};

--- a/packages/amplify-util-mock/tsconfig.json
+++ b/packages/amplify-util-mock/tsconfig.json
@@ -14,8 +14,12 @@
       "path": "../amplify-cli-core"
     },
     {
+      "path": "../amplify-auth-simulator"
+    },
+    {
       "path": "../amplify-storage-simulator"
     },
+    
     {
       "path": "../amplify-provider-awscloudformation"
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

Add auth mock

Creates a server to connect to, repoints cognito-js and then crafts appropriate return messages

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#10831 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

- [X] Add sim
- [X] Add mock auth to commands/help
- [x] Update frontend config to set aws_cognito_endpoint when in testMode
- [x] PR for amplify-js to pickup aws_cognito_endpoint
- [ ] Determine what Auth.signIn sends to server, and what needs to be returned


<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
