### PR TITLE
test: update api e2e timeout

### DIFF
--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -201,13 +201,14 @@ export function amplifyPushUpdate(
   waitForText?: RegExp,
   testingWithLatestCodebase = false,
   allowDestructiveUpdates = false,
+  overridePushTimeoutMS = 0,
 ): Promise<void> {
   const args = ['push'];
   if (allowDestructiveUpdates) {
     args.push('--allow-destructive-graphql-schema-updates');
   }
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(testingWithLatestCodebase), args, { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
+    spawn(getCLIPath(testingWithLatestCodebase), args, { cwd, stripColors: true, noOutputTimeout: overridePushTimeoutMS || pushTimeoutMS })
       .wait('Are you sure you want to continue?')
       .sendConfirmYes()
       .wait(waitForText || /.*/)

--- a/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2.test.ts
@@ -167,7 +167,7 @@ describe('amplify add api (GraphQL)', () => {
 
     // remove DataStore feature
     await apiDisableDataStore(projRoot, {});
-    await amplifyPushUpdate(projRoot);
+    await amplifyPushUpdate(projRoot, undefined, false, false, 1000 * 60 * 45 /* 45 minutes */);
     const disableDSConfig = getTransformConfig(projRoot, name);
     expect(disableDSConfig).toBeDefined();
     expect(_.isEmpty(disableDSConfig.ResolverConfig)).toBe(true);


### PR DESCRIPTION
#### Description of changes
- updates the timeout for api2 e2e test to avoid flakiness

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
