### PR TITLE
chore: bump the codegen version

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -52,7 +52,7 @@
     "amplify-cli-core": "2.12.0",
     "amplify-cli-logger": "1.2.0",
     "amplify-cli-shared-interfaces": "1.1.0",
-    "amplify-codegen": "^3.0.1",
+    "amplify-codegen": "^3.0.5",
     "amplify-console-hosting": "2.2.36",
     "amplify-container-hosting": "2.4.42",
     "amplify-dotnet-function-runtime-provider": "1.6.10",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -54,7 +54,7 @@
     "@aws-cdk/region-info": "~1.124.0",
     "amplify-cli-core": "2.12.0",
     "amplify-cli-logger": "1.2.0",
-    "amplify-codegen": "^3.0.1",
+    "amplify-codegen": "^3.0.5",
     "amplify-prompts": "2.2.0",
     "amplify-util-import": "2.2.36",
     "archiver": "^5.3.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -32,7 +32,7 @@
     "@hapi/topo": "^5.0.0",
     "amplify-category-function": "4.0.11",
     "amplify-cli-core": "2.12.0",
-    "amplify-codegen": "^3.0.1",
+    "amplify-codegen": "^3.0.5",
     "amplify-dynamodb-simulator": "2.3.6",
     "amplify-prompts": "2.2.0",
     "amplify-provider-awscloudformation": "6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,10 +181,10 @@
     "@aws-amplify/api-graphql" "2.2.18"
     "@aws-amplify/api-rest" "2.0.29"
 
-"@aws-amplify/appsync-modelgen-plugin@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.0.1.tgz#b47832bf3fb96041b121ccb2c8a80db06a633854"
-  integrity sha512-TmZu6fbe/fNarUe5dQzxWb80Br/6dtXKNtwcUUbe++yHAV4psUJTYs2sjtq0GsNCeb9AJQ8IeDVFBWWEvFoE/g==
+"@aws-amplify/appsync-modelgen-plugin@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.0.5.tgz#4d1360de60976c63c79d21f636bc4b077be6f8a7"
+  integrity sha512-KXnKon7gyHYdd/fRMrIItN/RRsCPbcBFY2lGqjt1kev01ngRneboI8v26ctSp8wyr+J41nbzieYYI690UcpBOg==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^1.18.8"
     "@graphql-codegen/visitor-plugin-common" "^1.22.0"
@@ -303,10 +303,10 @@
     graphql-transformer-common "4.24.0"
     libphonenumber-js "1.9.47"
 
-"@aws-amplify/graphql-docs-generator@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-3.0.1.tgz#0603cfe45900010ad6b60f0858f59a640c74ef8f"
-  integrity sha512-zlbjtbm/SmLqPfKDBwFYJJF8BA2+8IDzZMpCOcw8VnM8qOTu9IYSGEvAi26zOrCoHlmpInxWHDZhbG8gfd9fkA==
+"@aws-amplify/graphql-docs-generator@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-3.0.2.tgz#8784f11010faa83a65890631994fa7d7b43088c8"
+  integrity sha512-URvSlbUo5yiC6ZUe4S/ptCnfS9blfEZYwsAsNrHajC0fw9nFKMU5Ed8N1qGcvuclfMtzsp0pDFgvKpOEkPf78w==
   dependencies:
     graphql "^14.5.8"
     handlebars "4.7.7"
@@ -9683,19 +9683,19 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-codegen@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.0.1.tgz#ac2390bc83a013ee28565f2dcbdf6e9615f10612"
-  integrity sha512-BYCyn8Eh/t/sfWqBh+kiKFEN3Yqhz7E2WBz/QGFBFJkXg4VMo8nIK6AsAmCUQkRqDQDna2iIi3gpjYbXF+2O7A==
+amplify-codegen@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.0.5.tgz#6fc7eafdc3a3441c39575546ee7eab4de81d415e"
+  integrity sha512-iZj1CuxrrGBnszyEqwquKZCMEDwtbR3NtzsMfX/TOpdMxX720EFNRr3qYbYtmysDCWdwSK48lJcWU6+AsFCtSQ==
   dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "2.0.1"
-    "@aws-amplify/graphql-docs-generator" "3.0.1"
+    "@aws-amplify/appsync-modelgen-plugin" "2.0.5"
+    "@aws-amplify/graphql-docs-generator" "3.0.2"
     "@aws-amplify/graphql-types-generator" "3.0.0"
     "@graphql-codegen/core" "1.8.3"
     chalk "^3.0.0"
     fs-extra "^8.1.0"
     glob-all "^3.1.0"
-    glob-parent "^5.1.1"
+    glob-parent "^6.0.2"
     graphql "^14.5.8"
     graphql-config "^2.2.1"
     inquirer "^7.3.3"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Bump the codegen version to `v3.0.5`
The main feature introduced is the modelgen support for custom primary key to be consumed by datastore of amplify libraries. The feature is behind the feature flag and set as false for both old and new projects.
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
