### PR TITLE
fix: add FF input to show ACM correctly

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/show-auth-acm.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/show-auth-acm.ts
@@ -10,6 +10,7 @@ import {
 import { parse, ObjectTypeDefinitionNode, DirectiveNode, FieldDefinitionNode } from 'graphql';
 import { printer } from 'amplify-prompts';
 import { DirectiveWrapper } from '@aws-amplify/graphql-transformer-core';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export function showACM(sdl: string, nodeName: string) {
   const schema = parse(sdl);
@@ -24,7 +25,9 @@ export function showACM(sdl: string, nodeName: string) {
     const acm = new AccessControlMatrix({ name: type.name.value, operations: MODEL_OPERATIONS, resources: fields });
     const parentAuthDirective = type.directives?.find(dir => dir.name.value === 'auth');
     if (parentAuthDirective) {
-      const authRules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(parentAuthDirective));
+      const authRules: AuthRule[] = getAuthDirectiveRules(new DirectiveWrapper(parentAuthDirective), false, {
+        deepMergeArguments: FeatureFlags.getBoolean('shouldDeepMergeDirectiveConfigDefaults'),
+      });
       convertModelRulesToRoles(acm, authRules);
     }
     for (let fieldNode of type.fields || []) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Due to fun typescript issues we can't access the feature flag from the transformer core package, so it needs to be given as input from outside. This adds the necessary input for showing ACM rules. This should not be merged until the API category version is bumped that includes this PR: https://github.com/aws-amplify/amplify-category-api/pull/747

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
