### PR TITLE
fix: handle status api acm for multi file schema projects

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/status.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/status.test.ts
@@ -1,16 +1,46 @@
-import { pathManager } from 'amplify-cli-core';
+import { stateManager, pathManager } from 'amplify-cli-core';
+import { readProjectSchema } from 'graphql-transformer-core';
 
 jest.mock('amplify-category-hosting');
 jest.mock('amplify-cli-core');
-
+jest.mock('graphql-transformer-core', () => ({
+  readProjectSchema: jest.fn(async (__: string) => ''),
+}));
+jest.mock('../../extensions/amplify-helpers/show-auth-acm', () => ({
+  showACM: jest.fn(),
+}));
 const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;
 pathManagerMock.getBackendDirPath.mockReturnValue('testBackendDirPath');
+
+const testApiName = 'testApiName';
+const mockGraphQLAPIMeta = {
+  providers: {
+    awscloudformation: {
+      Region: 'myMockRegion',
+    },
+  },
+  api: {
+    [testApiName]: {
+      service: 'AppSync',
+    },
+  },
+};
+
+const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+stateManagerMock.getMeta = jest.fn().mockImplementation(() => mockGraphQLAPIMeta);
+
+const readProjectSchemaMock = readProjectSchema as jest.MockedFunction<typeof readProjectSchema>;
+
 describe('amplify status:', () => {
   // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
   const { run } = require('../../commands/status');
   const runStatusCmd = run;
   const statusPluginInfo = `${process.cwd()}/../amplify-console-hosting`;
   const mockPath = './';
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
 
   it('status run method should exist', () => {
     expect(runStatusCmd).toBeDefined();
@@ -95,5 +125,32 @@ describe('amplify status:', () => {
     runStatusCmd(mockContextWithHelpSubcommandAndCLArgs);
     // TBD: to move ViewResourceTableParams into a separate file for mocking instance functions.
     expect(mockContextWithHelpSubcommandAndCLArgs.amplify.showStatusTable.mock.calls.length).toBe(0);
+  });
+
+  it('status api -acm Table run method should call readProjectSchema', async () => {
+    const mockContextWithVerboseOptionAndCLArgs = {
+      amplify: {
+        getProviderPlugins: jest.fn().mockReturnValue({ awscloudformation: '../../__mocks__/faked-plugin' }),
+        showStatusTable: jest.fn(),
+        showGlobalSandboxModeWarning: jest.fn(),
+        showHelpfulProviderLinks: jest.fn(),
+        getCategoryPluginInfo: jest.fn().mockReturnValue({ packageLocation: statusPluginInfo }),
+      },
+      input: {
+        command: 'status',
+        options: {
+          verbose: true,
+          api: true,
+          acm: 'Team',
+        },
+      },
+    };
+
+    jest.mock('../../../__mocks__/faked-plugin', () => ({
+      compileSchema: jest.fn().mockReturnValue(Promise.resolve({})),
+    }));
+
+    await runStatusCmd(mockContextWithVerboseOptionAndCLArgs);
+    expect(readProjectSchemaMock.mock.calls.length).toBeGreaterThan(0);
   });
 });

--- a/packages/amplify-cli/src/commands/status.ts
+++ b/packages/amplify-cli/src/commands/status.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
-import * as fs from 'fs-extra';
 import {
   ViewResourceTableParams, CLIParams, $TSAny, $TSContext, pathManager, stateManager, ApiCategoryFacade,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
+import { readProjectSchema } from 'graphql-transformer-core';
 
 /**
  * Entry point for status command
@@ -100,8 +100,7 @@ const showApiAuthAcm = async (context): Promise<void> => {
 
   const apiName = apiNames[0];
   const apiResourceDir = path.join(pathManager.getBackendDirPath(), 'api', apiName);
-  const schemaPath = path.join(apiResourceDir, 'schema.graphql');
-  const schema = fs.readFileSync(schemaPath, 'utf8');
+  const schema = await readProjectSchema(apiResourceDir);
   const cliOptions = context?.input?.options ?? {};
   const { showACM } = await import('../extensions/amplify-helpers/show-auth-acm');
 


### PR DESCRIPTION
#### Description of changes
- handle `amplify status api -acm Table` command for multi-file schema api projects

#### Issue #10914

#### Description of how you validated changes
- manual tests
- unit test added
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
