### PR TITLE
docs(cli): added yarn global bin instruction to CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ This section should get you running with **Amplify CLI** and get you familiar wi
 
    > Ensure that [Yarn global bin](https://classic.yarnpkg.com/en/docs/cli/global) is added to your PATH. For example, add `export PATH="$(yarn global bin):$PATH"` to your shell profile file on Linux or macOS.
 
+1. Ensure you have [Java](https://adoptopenjdk.net/) installed and `java` command is available in your system. This is required for DynamoDB emulator.
+
 1. Start by [forking](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the _dev_ branch of [amplify-cli](https://github.com/aws-amplify/amplify-cli). Then clone it to your machine to work with it locally using one of the following methods:
 
    ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This section should get you running with **Amplify CLI** and get you familiar wi
 
    > Ensure that [Yarn global bin](https://classic.yarnpkg.com/en/docs/cli/global) is added to your PATH. For example, add `export PATH="$(yarn global bin):$PATH"` to your shell profile file on Linux or macOS.
 
-1. Ensure you have [Java](https://adoptium.net/) installed and `java` command is available in your system. This is required for DynamoDB emulator.
+1. Ensure you have [Java](https://aws.amazon.com/corretto/) installed and `java` command is available in your system. This is required for DynamoDB emulator.
 
 1. Start by [forking](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the _dev_ branch of [amplify-cli](https://github.com/aws-amplify/amplify-cli). Then clone it to your machine to work with it locally using one of the following methods:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ This section should get you running with **Amplify CLI** and get you familiar wi
 
    > If you are using Yarn v2, run `yarn set version classic` to change to Yarn Classic.
 
+   > Ensure that [Yarn global bin](https://classic.yarnpkg.com/en/docs/cli/global) is added to your PATH. For example, add `export PATH="$(yarn global bin):$PATH"` to your shell profile file on Linux or macOS.
+
 1. Start by [forking](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the _dev_ branch of [amplify-cli](https://github.com/aws-amplify/amplify-cli). Then clone it to your machine to work with it locally using one of the following methods:
 
    ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This section should get you running with **Amplify CLI** and get you familiar wi
 
    > Ensure that [Yarn global bin](https://classic.yarnpkg.com/en/docs/cli/global) is added to your PATH. For example, add `export PATH="$(yarn global bin):$PATH"` to your shell profile file on Linux or macOS.
 
-1. Ensure you have [Java](https://adoptopenjdk.net/) installed and `java` command is available in your system. This is required for DynamoDB emulator.
+1. Ensure you have [Java](https://adoptium.net/) installed and `java` command is available in your system. This is required for DynamoDB emulator.
 
 1. Start by [forking](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the _dev_ branch of [amplify-cli](https://github.com/aws-amplify/amplify-cli). Then clone it to your machine to work with it locally using one of the following methods:
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
When setting up environment from scratch (brand new mac with zero tools installed) I noticed that we have the following gaps:
- DynamoDB simulator depends on `java` which is not explicitly mentioned in setup guide.
-  it's hard to discover where `amplify-dev` command is. Therefore adding a line in the CONTRIBUTING guide to add Yarn's global bin to PATH - that's where the `amplify-dev` ends up being.

The result can be seen [here](https://github.com/sobolk/amplify-cli/blob/add-yarn-global-to-contribution-guide/CONTRIBUTING.md#local-environment-setup)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
