### PR TITLE
feat: show warning when the cloud backend build dir does not match local backend build dir

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
@@ -76,6 +76,13 @@ describe('showBuildDirChangesMessage', () => {
     setInBackendDir = false;
   });
 
+  describe('project does not have auth', () => {
+    it('does not call warn', async () => {
+      await showBuildDirChangesMessage();
+      expect(printerMock.warn).not.toBeCalled();
+    });
+  });
+
   describe('warning message for UserAttributeUpdateSettings addition for cognito', () => {
     describe('#cloud-backend has UserAttributeUpdateSettings', () => {
       describe('backend dir does have UserAttributeUpdateSettings', () => {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
@@ -5,46 +5,61 @@ const cloudBackendCfnTemplatePath = '/amplify/#cloud-backend/auth/cognito/build/
 const backendCfnTemplatePath = '/amplify/backend/auth/cognito/build/cognito-cloudformation-template.json';
 
 let setInCloudBackendDir: boolean;
+let setInCloudBackendDirWithoutRequireVerification: boolean;
 let setInBackendDir: boolean;
 
 jest.mock('amplify-prompts');
-jest.mock('amplify-cli-core', () => ({
-  JSONUtilities: {
-    readJson: jest.fn().mockImplementation(path => {
-      const cfnTemplate = {
-        Resources: {
-          UserPool: {
-            Properties: {},
-          },
-        },
-      };
-      if ((path === cloudBackendCfnTemplatePath && setInCloudBackendDir) || (path === backendCfnTemplatePath && setInBackendDir)) {
-        cfnTemplate.Resources.UserPool.Properties = {
-          UserAttributeUpdateSettings: {
-            AttributesRequireVerificationBeforeUpdate: [
-              'email',
-            ],
+jest.mock('amplify-cli-core', () => {
+  const { stateManager } = jest.requireActual('amplify-cli-core');
+
+  return {
+    JSONUtilities: {
+      readJson: jest.fn().mockImplementation(path => {
+        const cfnTemplate = {
+          Resources: {
+            UserPool: {
+              Properties: {},
+            },
           },
         };
-      }
-      return cfnTemplate;
-    }),
-  },
-  pathManager: {
-    getBackendDirPath: jest.fn().mockReturnValue('/amplify/backend'),
-    getCurrentCloudBackendDirPath: jest.fn().mockReturnValue('/amplify/#cloud-backend'),
-  },
-  stateManager: {
-    getMeta: jest.fn().mockReturnValue({
-      auth: {
-        cognito: {
-          service: 'Cognito',
+
+        if ((path === cloudBackendCfnTemplatePath && setInCloudBackendDir) || (path === backendCfnTemplatePath && setInBackendDir)) {
+          cfnTemplate.Resources.UserPool.Properties = {
+            UserAttributeUpdateSettings: {
+              AttributesRequireVerificationBeforeUpdate: [
+                'email',
+              ],
+            },
+          };
+        }
+
+        if (path === cloudBackendCfnTemplatePath && setInCloudBackendDirWithoutRequireVerification) {
+          cfnTemplate.Resources.UserPool.Properties = {
+            UserAttributeUpdateSettings: {
+              AttributesRequireVerificationBeforeUpdate: [],
+            },
+          };
+        }
+
+        return cfnTemplate;
+      }),
+    },
+    pathManager: {
+      getBackendDirPath: jest.fn().mockReturnValue('/amplify/backend'),
+      getCurrentCloudBackendDirPath: jest.fn().mockReturnValue('/amplify/#cloud-backend'),
+    },
+    stateManager: {
+      ...stateManager,
+      getMeta: jest.fn().mockReturnValue({
+        auth: {
+          cognito: {
+            service: 'Cognito',
+          },
         },
-      },
-    }),
-    getResourceFromMeta: jest.fn().mockReturnValue({ resourceName: 'cognito' }),
-  },
-}));
+      }),
+    },
+  };
+});
 
 describe('showBuildDirChangesMessage', () => {
   const printerMock = printer as jest.Mocked<typeof printer>;
@@ -55,18 +70,67 @@ describe('showBuildDirChangesMessage', () => {
 
   afterEach(() => {
     printerMock.warn.mockReset();
+
+    setInCloudBackendDir = false;
+    setInCloudBackendDirWithoutRequireVerification = false;
+    setInBackendDir = false;
   });
 
   describe('warning message for UserAttributeUpdateSettings addition for cognito', () => {
     describe('#cloud-backend has UserAttributeUpdateSettings', () => {
-      beforeEach(() => {
-        setInCloudBackendDir = true;
-        setInBackendDir = true;
+      describe('backend dir does have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = true;
+          setInBackendDir = true;
+        });
+
+        it('does not call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).not.toBeCalled();
+        });
       });
 
-      it('does not call warn', async () => {
-        await showBuildDirChangesMessage();
-        expect(printerMock.warn).not.toBeCalled();
+      describe('backend dir does not have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = true;
+          setInBackendDir = false;
+        });
+
+        it('does not call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).not.toBeCalled();
+        });
+      });
+    });
+
+    describe('#cloud-backend has UserAttributeUpdateSettings and not AttributesRequireVerificationBeforeUpdate with "email"', () => {
+      describe('backend dir does have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = false;
+          setInCloudBackendDirWithoutRequireVerification = true;
+          setInBackendDir = true;
+        });
+
+        it('does call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).toBeCalledWith(
+            `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
+https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+          );
+        });
+      });
+
+      describe('backend dir does not have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = true;
+          setInCloudBackendDirWithoutRequireVerification = true;
+          setInBackendDir = false;
+        });
+
+        it('does not call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).not.toBeCalled();
+        });
       });
     });
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
@@ -121,8 +121,8 @@ describe('showBuildDirChangesMessage', () => {
         it('does call warn', async () => {
           await showBuildDirChangesMessage();
           expect(printerMock.warn).toBeCalledWith(
-            `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
-https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+            `Amplify CLI now supports verifying a Cognito user email address that has been changed and will automatically update your auth \
+configuration. Read more: https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
           );
         });
       });
@@ -151,8 +151,8 @@ https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verify
         it('does call warn', async () => {
           await showBuildDirChangesMessage();
           expect(printerMock.warn).toBeCalledWith(
-            `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
-https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+            `Amplify CLI now supports verifying a Cognito user email address that has been changed and will automatically update your auth \
+configuration. Read more: https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
           );
         });
       });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/auto-updates.test.ts
@@ -1,0 +1,102 @@
+import { printer } from 'amplify-prompts';
+import { showBuildDirChangesMessage } from '../../utils/auto-updates';
+
+const cloudBackendCfnTemplatePath = '/amplify/#cloud-backend/auth/cognito/build/cognito-cloudformation-template.json';
+const backendCfnTemplatePath = '/amplify/backend/auth/cognito/build/cognito-cloudformation-template.json';
+
+let setInCloudBackendDir: boolean;
+let setInBackendDir: boolean;
+
+jest.mock('amplify-prompts');
+jest.mock('amplify-cli-core', () => ({
+  JSONUtilities: {
+    readJson: jest.fn().mockImplementation(path => {
+      const cfnTemplate = {
+        Resources: {
+          UserPool: {
+            Properties: {},
+          },
+        },
+      };
+      if ((path === cloudBackendCfnTemplatePath && setInCloudBackendDir) || (path === backendCfnTemplatePath && setInBackendDir)) {
+        cfnTemplate.Resources.UserPool.Properties = {
+          UserAttributeUpdateSettings: {
+            AttributesRequireVerificationBeforeUpdate: [
+              'email',
+            ],
+          },
+        };
+      }
+      return cfnTemplate;
+    }),
+  },
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('/amplify/backend'),
+    getCurrentCloudBackendDirPath: jest.fn().mockReturnValue('/amplify/#cloud-backend'),
+  },
+  stateManager: {
+    getMeta: jest.fn().mockReturnValue({
+      auth: {
+        cognito: {
+          service: 'Cognito',
+        },
+      },
+    }),
+    getResourceFromMeta: jest.fn().mockReturnValue({ resourceName: 'cognito' }),
+  },
+}));
+
+describe('showBuildDirChangesMessage', () => {
+  const printerMock = printer as jest.Mocked<typeof printer>;
+
+  beforeEach(() => {
+    printerMock.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    printerMock.warn.mockReset();
+  });
+
+  describe('warning message for UserAttributeUpdateSettings addition for cognito', () => {
+    describe('#cloud-backend has UserAttributeUpdateSettings', () => {
+      beforeEach(() => {
+        setInCloudBackendDir = true;
+        setInBackendDir = true;
+      });
+
+      it('does not call warn', async () => {
+        await showBuildDirChangesMessage();
+        expect(printerMock.warn).not.toBeCalled();
+      });
+    });
+
+    describe('#cloud-backend does not have UserAttributeUpdateSettings', () => {
+      describe('backend dir does have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = false;
+          setInBackendDir = true;
+        });
+
+        it('does call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).toBeCalledWith(
+            `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
+https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+          );
+        });
+      });
+
+      describe('backend dir does not have UserAttributeUpdateSettings', () => {
+        beforeEach(() => {
+          setInCloudBackendDir = false;
+          setInBackendDir = false;
+        });
+
+        it('does not call warn', async () => {
+          await showBuildDirChangesMessage();
+          expect(printerMock.warn).not.toBeCalled();
+        });
+      });
+    });
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -63,6 +63,7 @@ import { isAmplifyAdminApp } from './utils/admin-helpers';
 import { fileLogger } from './utils/aws-logger';
 import { APIGW_AUTH_STACK_LOGICAL_ID, loadApiCliInputs } from './utils/consolidate-apigw-policies';
 import { createEnvLevelConstructs } from './utils/env-level-constructs';
+import { showBuildDirChangesMessage } from './utils/auto-updates';
 import { NETWORK_STACK_LOGICAL_ID } from './network/stack';
 import { preProcessCFNTemplate, writeCustomPoliciesToCFNTemplate } from './pre-push-cfn-processor/cfn-pre-processor';
 import { AUTH_TRIGGER_STACK, AUTH_TRIGGER_TEMPLATE } from './utils/upload-auth-trigger-template';
@@ -191,6 +192,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
     await prePushLambdaLayerPrompt(context, resources);
     await prepareBuildableResources(context, resources);
     await buildOverridesEnabledResources(context, resources);
+    await showBuildDirChangesMessage();
 
     // Removed api transformation to generate resources befoe starting deploy/
 

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -29,7 +29,13 @@ const showCognitoAttributesRequireVerificationBeforeUpdateMessage = async (
   localBackendDir: string,
   amplifyMeta: $TSMeta,
 ): Promise<void> => {
-  const { resourceName } = stateManager.getResourceFromMeta(amplifyMeta, 'auth', 'Cognito');
+  const cognitoResource = stateManager.getResourceFromMeta(amplifyMeta, 'auth', 'Cognito', undefined, false);
+
+  if (!cognitoResource) {
+    return;
+  }
+
+  const { resourceName } = cognitoResource;
   const cloudBackendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(currentCloudBackendDir, resourceName);
   const backendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(localBackendDir, resourceName);
   const updateNotInCloudBackend = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -45,8 +45,8 @@ const showCognitoAttributesRequireVerificationBeforeUpdateMessage = async (
 
   if (updateNotInCloudBackend && updateInLocalBackend) {
     printer.warn(
-      `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
-https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+      `Amplify CLI now supports verifying a Cognito user email address that has been changed and will automatically update your auth \
+configuration. Read more: https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
     );
   }
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -1,0 +1,60 @@
+import * as path from 'path';
+import {
+  $TSAny,
+  $TSMeta,
+  JSONUtilities,
+  pathManager,
+  stateManager,
+} from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
+
+const {
+  readJson,
+} = JSONUtilities;
+
+/**
+ * Displays messages to users when CLI makes updates for them in their build directories and is not detected by version control
+ * or 'amplify status'
+ */
+export const showBuildDirChangesMessage = async (): Promise<void> => {
+  const currentCloudBackendDir = pathManager.getCurrentCloudBackendDirPath();
+  const localBackendDir = pathManager.getBackendDirPath();
+  const amplifyMeta = stateManager.getMeta();
+
+  await showCognitoAttributesRequireVerificationBeforeUpdateMessage(currentCloudBackendDir, localBackendDir, amplifyMeta);
+};
+
+const showCognitoAttributesRequireVerificationBeforeUpdateMessage = async (
+  currentCloudBackendDir: string,
+  localBackendDir: string,
+  amplifyMeta: $TSMeta,
+): Promise<void> => {
+  const { resourceName } = stateManager.getResourceFromMeta(amplifyMeta, 'auth', 'Cognito');
+  const cloudBackendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(currentCloudBackendDir, resourceName);
+  const backendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(localBackendDir, resourceName);
+  const updateNotInCloudBackend = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate;
+  const updateInLocalBackend: boolean = backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate.length === 1
+    && backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate[0] === 'email';
+
+  if (updateNotInCloudBackend && updateInLocalBackend) {
+    printer.warn(
+      `We now support verifying a Cognito user email address that has been changed and are updating your auth configuration. Read more: \
+https://docs.amplify.aws/lib/auth/manageusers/q/platform/js/#updating-and-verifying-a-cognito-user-email-address`,
+    );
+  }
+};
+
+type UserAttributeUpdateSettings = {
+  AttributesRequireVerificationBeforeUpdate: string[]
+}
+
+const readCfnTemplateUserAttributeSettings = async (
+  backendDir: string,
+  resourceName: string,
+): Promise<UserAttributeUpdateSettings | undefined> => {
+  const cfnTemplatePath = path.join(backendDir, 'auth', resourceName, 'build', `${resourceName}-cloudformation-template.json`);
+  const cfnTemplate: $TSAny = readJson(cfnTemplatePath);
+  const { Resources: { UserPool: { Properties: { UserAttributeUpdateSettings } } } } = cfnTemplate;
+
+  return UserAttributeUpdateSettings;
+};

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -38,7 +38,7 @@ const showCognitoAttributesRequireVerificationBeforeUpdateMessage = async (
   const { resourceName } = cognitoResource;
   const cloudBackendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(currentCloudBackendDir, resourceName);
   const backendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(localBackendDir, resourceName);
-  const updateNotInCloudBackend = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate
+  const updateNotInCloudBackend: boolean = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate
     || cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate[0] !== 'email';
   const updateInLocalBackend: boolean = backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate.length === 1
     && backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate[0] === 'email';
@@ -60,7 +60,12 @@ const readCfnTemplateUserAttributeSettings = async (
   resourceName: string,
 ): Promise<UserAttributeUpdateSettings | undefined> => {
   const cfnTemplatePath = path.join(backendDir, 'auth', resourceName, 'build', `${resourceName}-cloudformation-template.json`);
-  const cfnTemplate: $TSAny = readJson(cfnTemplatePath);
+  const cfnTemplate: $TSAny = readJson(cfnTemplatePath, { throwIfNotExist: false });
+
+  if (!cfnTemplate) {
+    return undefined;
+  }
+
   const { Resources: { UserPool: { Properties: { UserAttributeUpdateSettings } } } } = cfnTemplate;
 
   return UserAttributeUpdateSettings;

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -66,7 +66,5 @@ const readCfnTemplateUserAttributeSettings = async (
     return undefined;
   }
 
-  const { Resources: { UserPool: { Properties: { UserAttributeUpdateSettings } } } } = cfnTemplate;
-
-  return UserAttributeUpdateSettings;
+  return cfnTemplate.Resources.UserPool?.Properties?.UserAttributeUpdateSettings;
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/auto-updates.ts
@@ -32,7 +32,8 @@ const showCognitoAttributesRequireVerificationBeforeUpdateMessage = async (
   const { resourceName } = stateManager.getResourceFromMeta(amplifyMeta, 'auth', 'Cognito');
   const cloudBackendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(currentCloudBackendDir, resourceName);
   const backendUserAttrUpdateSettings = await readCfnTemplateUserAttributeSettings(localBackendDir, resourceName);
-  const updateNotInCloudBackend = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate;
+  const updateNotInCloudBackend = !cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate
+    || cloudBackendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate[0] !== 'email';
   const updateInLocalBackend: boolean = backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate.length === 1
     && backendUserAttrUpdateSettings?.AttributesRequireVerificationBeforeUpdate[0] === 'email';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This sets up a function that will check the diff between the local build directory and the `#cloud-backend` directory to check for diffs and let the developer know (via console output warning) that generated files have changed. This PR looks specifically for Cognito attributes related to user verification, and lets the user know that the generated files have been changed and will be updated in their Amplify app for them. 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Description of how you validated changes

Unit tests; ensure all integration tests are passing.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
