### PR TITLE
fix(api): minify cfn before deployment

### DIFF
--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -39,18 +39,21 @@ export enum CFNTemplateFormat {
 
 export type WriteCFNTemplateOptions = {
   templateFormat?: CFNTemplateFormat;
+  minify?: boolean;
 };
 
 const writeCFNTemplateDefaultOptions: Required<WriteCFNTemplateOptions> = {
   templateFormat: CFNTemplateFormat.JSON,
+  minify: false,
 };
 
 export async function writeCFNTemplate(template: object, filePath: string, options?: WriteCFNTemplateOptions): Promise<void> {
   const mergedOptions = { ...writeCFNTemplateDefaultOptions, ...options };
   let serializedTemplate: string | undefined;
+  const minify = mergedOptions.minify;
   switch (mergedOptions.templateFormat) {
     case CFNTemplateFormat.JSON:
-      serializedTemplate = JSONUtilities.stringify(template);
+      serializedTemplate = minify ? JSON.stringify(template) : JSON.stringify(template, null, 4)
       break;
     case CFNTemplateFormat.YAML:
       serializedTemplate = yaml.dump(template);

--- a/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
+++ b/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
@@ -1,4 +1,5 @@
 import { pathManager, readCFNTemplate, writeCFNTemplate, generateCustomPoliciesInTemplate } from 'amplify-cli-core';
+import { bool } from 'aws-sdk/clients/signer';
 import * as path from 'path';
 import { ProviderName as providerName } from '../constants';
 import { prePushCfnTemplateModifier } from './pre-push-cfn-modifier';
@@ -12,7 +13,7 @@ const buildDir = 'build';
  * @param filePath the original template path
  * @returns The file path of the modified template
  */
-export const preProcessCFNTemplate = async (filePath: string): Promise<string> => {
+export const preProcessCFNTemplate = async (filePath: string, options?: { minify?: bool }): Promise<string> => {
   const { templateFormat, cfnTemplate } = readCFNTemplate(filePath);
 
   await prePushCfnTemplateModifier(cfnTemplate);
@@ -20,7 +21,10 @@ export const preProcessCFNTemplate = async (filePath: string): Promise<string> =
   const pathSuffix = filePath.startsWith(backendDir) ? filePath.slice(backendDir.length) : path.parse(filePath).base;
   const newPath = path.join(backendDir, providerName, buildDir, pathSuffix);
 
-  await writeCFNTemplate(cfnTemplate, newPath, { templateFormat });
+  await writeCFNTemplate(cfnTemplate, newPath, {
+    templateFormat,
+    minify: options?.minify,
+  });
   return newPath;
 };
 

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -802,12 +802,14 @@ export const getCfnFiles = (category: string, resourceName: string, options?: gl
 
 const updateS3Templates = async (context: $TSContext, resourcesToBeUpdated: $TSAny, amplifyMeta: $TSMeta) => {
   const promises = [];
-
+  const { parameters: { options } } = context;
   for (const { category, resourceName, service } of resourcesToBeUpdated) {
     const { resourceDir, cfnFiles } = getCfnFiles(category, resourceName);
     for (const cfnFile of cfnFiles) {
       await writeCustomPoliciesToCFNTemplate(resourceName, service, cfnFile, category);
-      const transformedCFNPath = await preProcessCFNTemplate(path.join(resourceDir, cfnFile));
+      const transformedCFNPath = await preProcessCFNTemplate(path.join(resourceDir, cfnFile), {
+        minify: options['minify'],
+      });
 
       promises.push(uploadTemplateToS3(context, transformedCFNPath, category, resourceName, amplifyMeta));
     }

--- a/packages/amplify-provider-awscloudformation/src/template-description-utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/template-description-utils.ts
@@ -45,10 +45,13 @@ export async function setDefaultTemplateDescription(
   cfnFilePath: string,
 ) {
   const { templateFormat, cfnTemplate } = readCFNTemplate(cfnFilePath);
-
+  const { parameters: { options } } = context;
   cfnTemplate.Description = getDefaultTemplateDescription(context, category, service);
 
-  await writeCFNTemplate(cfnTemplate, cfnFilePath, { templateFormat });
+  await writeCFNTemplate(cfnTemplate, cfnFilePath, {
+    templateFormat,
+    minify: options['minify'],
+  });
 }
 
 export function getDefaultTemplateDescription(context: $TSContext, category: string, service?: string): string {


### PR DESCRIPTION
#### Description of changes

Minifies the CFN template uploaded to the S3 bucket if `--minify` option is specified.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
