### PR TITLE
fix: account for extra lines when detecting known dynamodb simulator errors

### DIFF
--- a/packages/amplify-dynamodb-simulator/__test__/index.test.js
+++ b/packages/amplify-dynamodb-simulator/__test__/index.test.js
@@ -48,14 +48,18 @@ describe('emulator operations', () => {
     }
   };
 
+  const realProcessEnv = process.env;
+
   let emulators;
   beforeEach(async () => {
+    jest.resetModules();
     ensureNoDbPath();
     emulators = [];
     jest.setTimeout(40 * 1000);
   });
 
   afterEach(async () => {
+    process.env = { ...realProcessEnv };
     await Promise.all(emulators.map(emu => emu.terminate()));
     ensureNoDbPath();
   });
@@ -99,6 +103,13 @@ describe('emulator operations', () => {
 
   it('reports on invalid dbPath values', async () => {
     expect.assertions(1);
+    await expect(ddbSimulator.launch({ dbPath: 'dynamodb-data' })).rejects.toThrow('invalid directory for database creation');
+  });
+
+  it('reports on invalid dbPath values with extra stderr output', async () => {
+    expect.assertions(1);
+    // This makes JVM running DynamoDB simulator print an extra line before surfacing real error.
+    process.env.JAVA_TOOL_OPTIONS = '-Dlog4j2.formatMsgNoLookups=true';
     await expect(ddbSimulator.launch({ dbPath: 'dynamodb-data' })).rejects.toThrow('invalid directory for database creation');
   });
 });

--- a/packages/amplify-dynamodb-simulator/index.js
+++ b/packages/amplify-dynamodb-simulator/index.js
@@ -162,7 +162,7 @@ async function launch(givenOptions = {}, retry = 0, startTime = Date.now()) {
           stderr += buffer.toString();
 
           // Check stderr for any known errors.
-          if (/^Invalid directory for database creation.$/.test(stderr)) {
+          if (/^Invalid directory for database creation.$/m.test(stderr)) {
             proc.stdout.removeListener('data', readStdoutBuffer);
             proc.stderr.removeListener('data', readStderrBuffer);
             const err = new Error('invalid directory for database creation');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Under certain circumstances the JVM running DynamoDB simulator may print extra lines before printing out the actual DynamoDB simulator output. For example such output has been observed on Amazon managed device when running existing `reports on invalid dbPath values` test.
```
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Invalid directory for database creation.
```

The changes are:
- Change regex that's looking for known error message to be multi-line. I.e. account for the fact that there might be more in the output.
- Add test that covers it.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Added test covering that case.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
