### PR TITLE
fix(amplify-category-function): add default pramater value

### DIFF
--- a/packages/amplify-category-function/resources/awscloudformation/cloudformation-templates/lambda-function-cloudformation-template.json.ejs
+++ b/packages/amplify-category-function/resources/awscloudformation/cloudformation-templates/lambda-function-cloudformation-template.json.ejs
@@ -19,7 +19,8 @@
         <% for(var i = 0; Object.keys(props.environmentVariables).length > i; i++) { %>
         ,
         "<%- props.environmentMap[Object.keys(props.environmentVariables)[i]].Ref %>": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "<%= Object.values(props.environmentVariables)[i] %>"
         }
         <% } %>
         <% } %>

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
@@ -93,3 +93,13 @@ describe('ensureEnvironmentVariableValues', () => {
     });
   });
 });
+
+describe('ensureDefaultEnvironmentVariableValue', () => {
+  it('add an environment variable', () => {
+    saveEnvironmentVariables('name', { envKey: 'envValue' });
+    expect(JSONUtilitiesMock.writeJson.mock.calls[2][1].Parameters.envKey).toEqual({
+      Type: 'String',
+      Default: 'envValue',
+    });
+  });
+});

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -243,7 +243,7 @@ const setEnvironmentVariable = (resourceName: string, newEnvironmentVariableKey:
     environmentVariableName: newEnvironmentVariableKey,
   });
   newReferences[newEnvironmentVariableKey] = { Ref: camelCaseKey };
-  newParameters[camelCaseKey] = { Type: 'String' };
+  newParameters[camelCaseKey] = { Type: 'String', Default: newEnvironmentVariableValue };
   newKeyValue[camelCaseKey] = newEnvironmentVariableValue;
 
   setStoredList(resourceName, newList);


### PR DESCRIPTION
#### Description of changes

* Add Lambda Env variable to not only `team-provider-info.json` but also CloudFormation default parameter value, which will avoid deployment error when enabling auto branch detection on Amplify Hosting

#### Issue #, if available

#10970 

#### Description of how you validated changes

* `amplify add env`
* `amplify add function` with environment variables
* deleted the value of the environment variable at `team-provider-info.json` to reproduce the condition of Amplify Hosting
* successfully deployed

> changed the value of the environment variable at **team-provider-info.json** like below
```json
"categories": {
      "function": {
        "resourceName": {
          "key": {}
        }
      }
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
