### PR TITLE
Add custom port support for GraphQL mock

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/api/api.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/api.test.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { $TSContext, AmplifyError, pathManager } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, AmplifyError, JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
 import { APITest } from '../../api/api';
 import * as lambdaInvoke from '../../api/lambda-invoke';
 import { getMockSearchableTriggerDirectory } from '../../utils';
 import { ConfigOverrideManager } from '../../utils/config-override';
 import { run } from '../../commands/mock/api';
+import { start } from '../../api';
 
 jest.mock('@aws-amplify/amplify-cli-core', () => ({
   ...(jest.requireActual('@aws-amplify/amplify-cli-core') as Record<string, unknown>),
@@ -138,5 +139,21 @@ describe('Test Mock API methods', () => {
     } as unknown as $TSContext;
     await run(mockContext);
     await expect(mockContext.print.error).toHaveBeenCalledWith('Failed to start API Mocking.');
+  });
+
+  it('attempts to set custom port correctly', async () => {
+    const GRAPHQL_PORT = 8081;
+    const mockContext = {
+      amplify: {
+        getEnvInfo: jest.fn().mockReturnValue({ projectPath: mockProjectRoot }),
+        pathManager: {
+          getGitIgnoreFilePath: jest.fn(),
+        },
+      },
+    } as unknown as $TSContext;
+    const startMock = jest.spyOn(APITest.prototype, 'start').mockResolvedValueOnce();
+    jest.spyOn(JSONUtilities, 'readJson').mockReturnValue({ graphqlPort: GRAPHQL_PORT });
+    await start(mockContext);
+    expect(startMock.mock.calls[0][1]).toBe(GRAPHQL_PORT);
   });
 });

--- a/packages/amplify-util-mock/src/api/index.ts
+++ b/packages/amplify-util-mock/src/api/index.ts
@@ -1,12 +1,14 @@
 import { APITest } from './api';
 import { addMockDataToGitIgnore, addMockAPIResourcesToGitIgnore } from '../utils';
+import { getMockConfig } from '../utils/mock-config-file';
 
 export async function start(context) {
   const testApi = new APITest();
   try {
     addMockDataToGitIgnore(context);
     addMockAPIResourcesToGitIgnore(context);
-    await testApi.start(context);
+    const mockConfig = await getMockConfig(context);
+    await testApi.start(context, mockConfig.graphqlPort, mockConfig.graphqlPort);
   } catch (e) {
     console.log(e);
     // Sending term signal so we clean up after ourselves


### PR DESCRIPTION

#### Description of changes

* Import custom port named `graphqlPort` from `amplify/mock.json`, and add capability to run GraphQL mock on the given port.

**mock.json**
* `port` for DynamoDB Local
* `graphqlPort` for AppSync Simulator
```json
{
  "port": 8000
  "graphqlPort": 8001
}
```

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/384

#
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

* add `graphqlPort` into `amplify/mock.json` like below

```json
{
  "graphqlPort": 8001
}
```
* graphql mock server successfully ran on the given port
* also checked mock server running on port 20002 without `mock.json`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
