### PR TITLE
fix: upload files spinner when executing amplify push command

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -81,8 +81,6 @@ const logger = fileLogger('push-resources');
 // keep in sync with ServiceName in amplify-category-api, but probably it will not change
 const ApiServiceNameElasticContainer = 'ElasticContainer';
 
-const spinner = ora('Updating resources in the cloud. This may take a few minutes...');
-
 const optionalBuildDirectoryName = 'build';
 const cfnTemplateGlobPattern = '*template*.+(yaml|yml|json)';
 const parametersJson = 'parameters.json';
@@ -271,6 +269,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
       // if there are deploymentSteps, need to do an iterative update
       if (deploymentSteps.length > 0) {
         // create deployment manager
+        const spinner = ora('Updating resources in the cloud. This may take a few minutes...');
         const deploymentManager = await DeploymentManager.createInstance(context, cloudformationMeta.DeploymentBucketName, spinner, {
           userAgent: formUserAgentParam(context, generateUserAgentAction(resourcesToBeCreated, resourcesToBeUpdated)),
         });
@@ -544,12 +543,12 @@ const uploadStudioBackendFiles = async (s3: S3, bucketName: string) => {
       Key: path.join(studioBackendDirName, filePath.replace('#current-cloud-backend', '')),
     }));
 
-  const uploadSpinner = ora('Uploading files.');
+  const spinner = ora('Uploading files.');
   try {
-    uploadSpinner.start();
+    spinner.start();
     await Promise.all(uploadFileParams.map(params => s3.uploadFile(params, false)));
   } finally {
-    uploadSpinner.stop();
+    spinner.stop();
   }
 };
 

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -543,7 +543,14 @@ const uploadStudioBackendFiles = async (s3: S3, bucketName: string) => {
       Body: fs.createReadStream(path.join(amplifyDirPath, filePath)),
       Key: path.join(studioBackendDirName, filePath.replace('#current-cloud-backend', '')),
     }));
-  await Promise.all(uploadFileParams.map(params => s3.uploadFile(params)));
+
+  const uploadSpinner = ora('Uploading files.');
+  try {
+    uploadSpinner.start();
+    await Promise.all(uploadFileParams.map(params => s3.uploadFile(params, false)));
+  } finally {
+    uploadSpinner.stop();
+  }
 };
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Ora does not support multiple spinners, i.e. when uploads go in parallel with Promise.all on top of them. This is known Ora limitation that leads to corrupted console output.
This change:
- disables spinner at each concurrent file upload.
- adds one spinner on top of batch upload.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Manual verification (no established automation for spinner testing).

##### Before
![image](https://user-images.githubusercontent.com/5849952/188930495-53a9c0be-dcf9-4edd-9a8b-c57c4d487000.png)

##### After
![image](https://user-images.githubusercontent.com/5849952/188930564-498d4a40-21db-46b8-bbf0-9c56ae66a06a.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
