### PR TITLE
fix: mark amplify-environment-parameters as having publish access

### DIFF
--- a/packages/amplify-environment-parameters/package.json
+++ b/packages/amplify-environment-parameters/package.json
@@ -15,6 +15,9 @@
     "amplify",
     "aws"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fix amplify-environment-parameters. Mark it as public. To avoid.
```
lerna http fetch PUT 402 https://registry.npmjs.org/@aws-amplify%2famplify-environment-parameters 706ms
lerna ERR! E402 You must sign up for private packages
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [x ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
