### PR TITLE
feat: add API key extension headless config

### DIFF
--- a/packages/amplify-headless-interface/src/interface/api/add.ts
+++ b/packages/amplify-headless-interface/src/interface/api/add.ts
@@ -40,6 +40,10 @@ export interface AppSyncServiceConfiguration {
    * The strategy for resolving API write conflicts.
    */
   conflictResolution?: ConflictResolution;
+  /**
+   * Configuration for how long to extend an API key from current set expiration
+   */
+  apiKeyExpiration: AppSyncAPIKeyExpiration;
 }
 
 /**
@@ -133,6 +137,13 @@ export interface AppSyncAPIKeyAuthType {
   expirationTime?: number;
   apiKeyExpirationDate?: Date;
   keyDescription?: string;
+}
+
+/**
+ * Specifies how to extend an AppSync API key
+ */
+export interface AppSyncAPIKeyExpiration {
+  days: number;
 }
 
 /**

--- a/packages/amplify-headless-interface/src/interface/api/add.ts
+++ b/packages/amplify-headless-interface/src/interface/api/add.ts
@@ -43,7 +43,7 @@ export interface AppSyncServiceConfiguration {
   /**
    * Configuration for how long to extend an API key from current set expiration
    */
-  apiKeyExpiration: AppSyncAPIKeyExpiration;
+  apiKeyExpiration?: AppSyncAPIKeyExpiration;
 }
 
 /**

--- a/packages/amplify-headless-interface/src/interface/api/update.ts
+++ b/packages/amplify-headless-interface/src/interface/api/update.ts
@@ -15,4 +15,4 @@ export interface UpdateApiRequest {
  * A subset of the AppSyncServiceConfiguration that are mutable.
  */
 export type AppSyncServiceModification = Pick<AppSyncServiceConfiguration, 'serviceName'> &
-  Partial<Pick<AppSyncServiceConfiguration, 'transformSchema' | 'defaultAuthType' | 'additionalAuthTypes' | 'conflictResolution'>>;
+  Partial<Pick<AppSyncServiceConfiguration, 'transformSchema' | 'defaultAuthType' | 'additionalAuthTypes' | 'conflictResolution' | 'apiKeyExpiration'>>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add config option to API headless for extending API keys

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/598

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
No functional changes yet, this is an optional addition to headless input

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
