### PR TITLE
fix: retain TPI on "restore backend" codepath

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -163,9 +163,9 @@ jobs:
       - run:
           name: Generate unified changelog
           command: |
-            git reset --hard HEAD
-            yarn update-versions
+            git reset --soft HEAD~1
             yarn ts-node scripts/unified-changelog.ts
+            cat UNIFIED_CHANGELOG.md
       - run:
           name: Save new amplify GitHub tag
           command: node scripts/echo-current-cli-version.js > .amplify-pkg-version

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -62,7 +62,7 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
     force_publish_local_args="--force-publish '@aws-amplify/cli-internal'"
   fi
   # create release commit and release tags
-  npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" $(echo $force_publish_local_args)
+  npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" $(echo $force_publish_local_args) --no-commit-hooks
 
   # if publishing locally to verdaccio
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -17,7 +17,7 @@ export class AmplifyException extends Error {
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, AmplifyException.prototype);
 
-    this.stack ??= options.stack;
+    this.stack = options.stack ?? this.stack;
     this.message = options.message;
     this.details = options.details;
     this.resolution = 'resolution' in options ? options.resolution : undefined;

--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -84,8 +84,25 @@ const generateProjectConfigFile = (context: $TSContext): void => {
  * @deprecated Still creating the TPI file for now, but this will go away in the future
  */
 const generateTeamProviderInfoFile = (context: $TSContext): $TSAny => {
-  const { projectPath } = context.exeInfo.localEnvInfo;
-  const { teamProviderInfo } = context.exeInfo;
+  const { projectPath, envName } = context.exeInfo.localEnvInfo;
+  const { existingTeamProviderInfo, teamProviderInfo } = context.exeInfo;
+
+  if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend) {
+    return stateManager.setTeamProviderInfo(projectPath, existingTeamProviderInfo);
+  }
+
+  if (existingTeamProviderInfo) {
+    if (existingTeamProviderInfo[envName]) {
+      if (existingTeamProviderInfo[envName].categories) {
+        teamProviderInfo[envName] = teamProviderInfo[envName] || {};
+        teamProviderInfo[envName].categories = existingTeamProviderInfo[envName].categories;
+      }
+
+      delete existingTeamProviderInfo[envName];
+    }
+
+    Object.assign(teamProviderInfo, existingTeamProviderInfo);
+  }
 
   stateManager.setTeamProviderInfo(projectPath, teamProviderInfo);
   return undefined;

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -179,6 +179,10 @@ const prepareContext = (context: $TSContext, inputParams): void => {
     localEnvInfo: {
       projectPath,
     },
+    teamProviderInfo: {},
+    existingTeamProviderInfo: stateManager.getTeamProviderInfo(projectPath, {
+      throwIfNotExist: false,
+    }),
     existingProjectConfig: stateManager.getProjectConfig(projectPath, {
       throwIfNotExist: false,
     }),

--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -97,7 +97,26 @@ export const amplifyPullNonInteractive = (
   cwd: string,
   settings: {appId: string, envName: string},
 ): Promise<void> => {
-  const args = ['pull', '--appId', settings.appId, '--envName', settings.envName, '--yes'];
+  const { appId, envName } = settings;
+  const amplifyParamObj = { appId, envName };
+  const providersParamObj = {
+    awscloudformation: {
+      configLevel: 'project',
+      useProfile: true,
+      // eslint-disable-next-line spellcheck/spell-checker
+      profileName: 'amplify-integ-test-user',
+    },
+  };
+  const args = [
+    'pull',
+    '--amplify',
+    JSON.stringify(amplifyParamObj),
+    '--providers',
+    JSON.stringify(providersParamObj),
+    '--no-override',
+    '--no-codegen',
+    '--yes',
+  ];
   return spawn(getCLIPath(), args, { cwd, stripColors: true })
     .wait('Successfully pulled backend environment')
     .runAsync();

--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -1,98 +1,104 @@
+// eslint-disable-next-line import/no-cycle
 import { getCLIPath, nspawn as spawn } from '..';
 
-export function amplifyPull(
+/**
+ * Interactive amplify pull
+ */
+export const amplifyPull = (
   cwd: string,
   settings: { override?: boolean; emptyDir?: boolean; appId?: string; withRestore?: boolean; noUpdateBackend?: boolean; envName?: string },
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    //Note:- Table checks have been removed since they are not necessary for push/pull flows and prone to breaking because
-    //of stylistic changes. A simpler content based check will be added in the future.
-    const args = ['pull'];
+): Promise<void> => {
+  // Note:- Table checks have been removed since they are not necessary for push/pull flows and prone to breaking because
+  // of stylistic changes. A simpler content based check will be added in the future.
+  const args = ['pull'];
 
-    if (settings.appId) {
-      args.push('--appId', settings.appId);
-    }
+  if (settings.appId) {
+    args.push('--appId', settings.appId);
+  }
 
-    if (settings.envName) {
-      args.push('--envName', settings.envName);
-    }
+  if (settings.envName) {
+    args.push('--envName', settings.envName);
+  }
 
-    if (settings.withRestore) {
-      args.push('--restore');
-    }
+  if (settings.withRestore) {
+    args.push('--restore');
+  }
 
-    const chain = spawn(getCLIPath(), args, { cwd, stripColors: true });
+  const chain = spawn(getCLIPath(), args, { cwd, stripColors: true });
 
-    if (settings.emptyDir) {
-      chain
-        .wait('Select the authentication method you want to use:')
-        .sendCarriageReturn()
-        .wait('Please choose the profile you want to use')
-        .sendCarriageReturn()
-        .wait('Choose your default editor:')
-        .sendCarriageReturn()
-        .wait("Choose the type of app that you're building")
-        .sendCarriageReturn()
-        .wait('What javascript framework are you using')
-        .sendCarriageReturn()
-        .wait('Source Directory Path:')
-        .sendCarriageReturn()
-        .wait('Distribution Directory Path:')
-        .sendCarriageReturn()
-        .wait('Build Command:')
-        .sendCarriageReturn()
-        .wait('Start Command:')
-        .sendCarriageReturn()
-        .wait('Do you plan on modifying this backend?')
-        .sendLine(settings.noUpdateBackend ? 'n' : 'y');
-    } else if (!settings.noUpdateBackend) {
-      chain.wait('Pre-pull status').wait('Current Environment');
-    }
-
-    if (settings.override) {
-      chain
-        .wait('Local changes detected')
-        .wait('Pulling changes from the cloud will override your local changes')
-        .wait('Are you sure you would like to continue')
-        .sendConfirmYes();
-    }
-
-    if (settings.noUpdateBackend) {
-      chain.wait('Added backend environment config object to your project.').wait("Run 'amplify pull' to sync future upstream changes.");
-    } else if (settings.emptyDir) {
-      chain.wait(/Successfully pulled backend environment .+ from the cloud\./).wait("Run 'amplify pull' to sync future upstream changes.");
-    } else {
-      chain.wait('Post-pull status').wait('Current Environment');
-    }
-
-    chain.run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        console.error(err);
-        reject(err);
-      }
-    });
-  });
-}
-
-export function amplifyPullSandbox(cwd: string, settings: { sandboxId: string; appType: string; framework: string }) {
-  return new Promise((resolve, reject) => {
-    const args = ['pull', '--sandboxId', settings.sandboxId];
-
-    spawn(getCLIPath(), args, { cwd, stripColors: true })
-      .wait('What type of app are you building')
-      .sendKeyUp()
-      .sendLine(settings.appType)
+  if (settings.emptyDir) {
+    chain
+      .wait('Select the authentication method you want to use:')
+      .sendCarriageReturn()
+      .wait('Please choose the profile you want to use')
+      .sendCarriageReturn()
+      .wait('Choose your default editor:')
+      .sendCarriageReturn()
+      .wait("Choose the type of app that you're building")
+      .sendCarriageReturn()
       .wait('What javascript framework are you using')
-      .sendLine(settings.framework)
-      .wait('Successfully generated models.')
-      .run((err: Error) => {
-        if (!err) {
-          resolve({});
-        } else {
-          reject(err);
-        }
-      });
-  });
-}
+      .sendCarriageReturn()
+      .wait('Source Directory Path:')
+      .sendCarriageReturn()
+      .wait('Distribution Directory Path:')
+      .sendCarriageReturn()
+      .wait('Build Command:')
+      .sendCarriageReturn()
+      .wait('Start Command:')
+      .sendCarriageReturn()
+      .wait('Do you plan on modifying this backend?')
+      .sendLine(settings.noUpdateBackend ? 'n' : 'y');
+  } else if (!settings.noUpdateBackend) {
+    chain.wait('Pre-pull status').wait('Current Environment');
+  }
+
+  if (settings.override) {
+    chain
+      .wait('Local changes detected')
+      .wait('Pulling changes from the cloud will override your local changes')
+      .wait('Are you sure you would like to continue')
+      .sendConfirmYes();
+  }
+
+  if (settings.noUpdateBackend) {
+    chain.wait('Added backend environment config object to your project.').wait("Run 'amplify pull' to sync future upstream changes.");
+  } else if (settings.emptyDir) {
+    chain.wait(/Successfully pulled backend environment .+ from the cloud\./).wait("Run 'amplify pull' to sync future upstream changes.");
+  } else {
+    chain.wait('Post-pull status').wait('Current Environment');
+  }
+
+  return chain.runAsync();
+};
+
+/**
+ * Interactive pull --sandboxId
+ */
+export const amplifyPullSandbox = (
+  cwd: string,
+  settings: { sandboxId: string; appType: string; framework: string },
+): Promise<void> => {
+  const args = ['pull', '--sandboxId', settings.sandboxId];
+
+  return spawn(getCLIPath(), args, { cwd, stripColors: true })
+    .wait('What type of app are you building')
+    .sendKeyUp()
+    .sendLine(settings.appType)
+    .wait('What javascript framework are you using')
+    .sendLine(settings.framework)
+    .wait('Successfully generated models.')
+    .runAsync();
+};
+
+/**
+ * Run non-interactive amplify pull
+ */
+export const amplifyPullNonInteractive = (
+  cwd: string,
+  settings: {appId: string, envName: string},
+): Promise<void> => {
+  const args = ['pull', '--appId', settings.appId, '--envName', settings.envName, '--yes'];
+  return spawn(getCLIPath(), args, { cwd, stripColors: true })
+    .wait('Successfully pulled backend environment')
+    .runAsync();
+};

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-category-auth": "2.12.1",
+    "@aws-amplify/amplify-e2e-core": "4.2.1",
     "@aws-amplify/graphql-transformer-core": "^0.17.11",
     "amplify-cli-core": "3.2.0",
     "amplify-headless-interface": "^1.15.0",

--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 import {
   getAppId,
   addApiWithoutSchema,
@@ -8,9 +9,16 @@ import {
   deleteProject,
   deleteProjectDir,
   initJSProjectWithProfile,
+  addFunction,
+  amplifyPushAuth,
+  getBackendAmplifyMeta,
+  getTeamProviderInfo,
+  amplifyPullNonInteractive,
 } from '@aws-amplify/amplify-e2e-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 
-describe('amplify pull', () => {
+describe('amplify pull in two directories', () => {
   let projRoot: string;
   let projRoot2: string;
   beforeEach(async () => {
@@ -35,5 +43,41 @@ describe('amplify pull', () => {
     const appId = getAppId(projRoot);
     await amplifyPull(projRoot2, { appId, emptyDir: true, noUpdateBackend: true });
     await amplifyPull(projRoot2, { appId, noUpdateBackend: true });
+  });
+});
+
+describe('amplify pull', () => {
+  const envName = 'testing';
+  let projRoot: string;
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('pull-test');
+    await initJSProjectWithProfile(projRoot, { envName, disableAmplifyAppCreation: false });
+  });
+
+  it('preserves team-provider-info contents across restore backend calls', async () => {
+    // add a function with an env var and push
+    await addFunction(projRoot, { functionTemplate: 'Hello World', environmentVariables: { key: 'testVar', value: 'testValue' } }, 'nodejs');
+    await amplifyPushAuth(projRoot);
+
+    // grab the appId from the meta file
+    const appId = getBackendAmplifyMeta(projRoot)?.providers?.awscloudformation?.AmplifyAppId;
+    expect(appId).toBeDefined();
+    const originalTpi = getTeamProviderInfo(projRoot);
+
+    // remove the #current-cloud-backend directory
+    const ccbPath = path.join(projRoot, 'amplify', '#current-cloud-backend');
+    await fs.remove(ccbPath);
+
+    // pull the project which will execute the restore backend codepath because of the missing #current-cloud-backend directory
+    await amplifyPullNonInteractive(projRoot, { appId, envName });
+    const postPullTpi = getTeamProviderInfo(projRoot);
+
+    // assert that the original tpi contents are maintained
+    expect(postPullTpi).toEqual(originalTpi);
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
   });
 });

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -43,7 +43,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
    */
   async init(): Promise<void> {
     // read in the TPI contents
-    const categories = stateManager.getTeamProviderInfo()?.[this.envName]?.categories || {};
+    const categories = stateManager.getTeamProviderInfo(undefined, { throwIfNotExist: false })?.[this.envName]?.categories || {};
     Object.entries(categories as Record<string, unknown>).forEach(([category, resources]) => {
       Object.entries(resources as Record<string, Record<string, string>>).forEach(([resource, parameters]) => {
         this.getResourceParamManager(category, resource).setAllParams(parameters);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Reinstates some logic that was removed in https://github.com/aws-amplify/amplify-cli/pull/10679

When pulling a project that hits the "restore backend" codepath (ie when the #current-cloud-backend directory does not exist), previous versions of the CLI would read in the `team-provider-info.json` file before wiping and reconstructing the `amplify` directory contents. The above PR removed this read which caused the TPI file to not be fully reconstructed on pull. This PR reinstates the initial read and reinstates the original code for including the TPI contents in the reconstructed file.

**update**
A few additional patches have been added to this PR:
1. There was a bug in the stack trace assignment in AmplifyException that has been fixed
2. The changelog generation logic has been fixed to work with the updated publish script and also work with prerelease versions

This PR also contains some lint fixes to test files

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added an E2E test that mimics the non-interactive command run by hosting
Also manually tested in a sample project

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
