### PR TITLE
feat: add github action to remove pending-response labels

### DIFF
--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -1,0 +1,13 @@
+name: issue-pending-response
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_commented:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: siegerts/pending-author-response@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pending-response-label: pending-response

--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   issue_commented:
+    if: ${{ !github.event.issue.pull_request  && contains(github.event.issue.labels.*.name, 'pending-response') }}
     runs-on: ubuntu-latest
     steps:
       - uses: siegerts/pending-author-response@v1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

adds GitHub action to remove `pending-response` label when issue author responds, thus helping us define an entrypoint to triaging without also relying on GitHub notifications

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

n/a

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
