### PR TITLE
fix: AmplifyHelper.getProjectInfo() in overrides

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -111,10 +111,17 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
         sandbox: {},
         require: {
           context: 'sandbox',
-          builtin: ['path'],
+          builtin: ['*'],
           external: true,
         },
       });
+
+      // https://github.com/patriksimek/vm2/issues/428
+      sandboxNode.sandbox.process.stdin = process.stdin;
+      sandboxNode.sandbox.process.stdout = process.stdout;
+      sandboxNode.sandbox.process.stderr = process.stderr;
+      sandboxNode.sandbox.process.binding = (<$TSAny>process).binding;
+
       try {
         await sandboxNode
           .run(overrideCode, path.join(overrideDir, 'build', 'override.js'))

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -198,7 +198,19 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
         console: 'inherit',
         timeout: 5000,
         sandbox: {},
+        require: {
+          context: 'sandbox',
+          builtin: ['*'],
+          external: true,
+        },
       });
+
+      // https://github.com/patriksimek/vm2/issues/428
+      sandboxNode.sandbox.process.stdin = process.stdin;
+      sandboxNode.sandbox.process.stdout = process.stdout;
+      sandboxNode.sandbox.process.stderr = process.stderr;
+      sandboxNode.sandbox.process.binding = (<$TSAny>process).binding;
+
       try {
         sandboxNode.run(overrideCode).override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate);
       } catch (err: $TSAny) {

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -194,10 +194,17 @@ export class AmplifyS3ResourceStackTransform {
           sandbox: {},
           require: {
             context: 'sandbox',
-            builtin: ['path'],
+            builtin: ['*'],
             external: true,
           },
         });
+
+        // https://github.com/patriksimek/vm2/issues/428
+        sandboxNode.sandbox.process.stdin = process.stdin;
+        sandboxNode.sandbox.process.stdout = process.stdout;
+        sandboxNode.sandbox.process.stderr = process.stderr;
+        sandboxNode.sandbox.process.binding = (<$TSAny>process).binding;
+
         try {
           await sandboxNode.run(overrideCode, overrideJSFilePath).override(this.resourceTemplateObj as AmplifyS3ResourceTemplate);
         } catch (err: $TSAny) {

--- a/packages/amplify-e2e-tests/overrides/override-api-gql.ts
+++ b/packages/amplify-e2e-tests/overrides/override-api-gql.ts
@@ -1,3 +1,9 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 export function override(resource: any): any {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   resource.api.GraphQLAPI.xrayEnabled = true;
 }

--- a/packages/amplify-e2e-tests/overrides/override-api-rest.ts
+++ b/packages/amplify-e2e-tests/overrides/override-api-rest.ts
@@ -1,4 +1,10 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 export function override(resources: any) {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   const desc = {
     'Fn::Join': [' ', ['Description', 'override', 'successful']],
   };

--- a/packages/amplify-e2e-tests/overrides/override-auth.ts
+++ b/packages/amplify-e2e-tests/overrides/override-auth.ts
@@ -1,4 +1,10 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 export function override(props: any): any {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   props.userPool.deviceConfiguration = {
     challengeRequiredOnNewDevice: true,
   };

--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -1,7 +1,13 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 function getRandomInt(max) {
   return Math.floor(Math.random() * max);
 }
 export function override(props: any): void {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
   return props;
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
@@ -1,4 +1,10 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 export function override(props: any) {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   props.dynamoDBTable.streamSpecification = {
     streamViewType: 'NEW_AND_OLD_IMAGES',
   };

--- a/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
@@ -1,4 +1,10 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
 export function override(props: any) {
+
+  // This tests that proper builtin packages are allowed when calling an override with vm2.
+  AmplifyHelpers.getProjectInfo();
+
   //Enable versioning on the bucket
   props.s3Bucket.versioningConfiguration = {
     status: 'Enabled',

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -3,6 +3,7 @@
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {
+  $TSAny,
   $TSContext,
   $TSObject,
   amplifyErrorWithTroubleshootingLink,
@@ -103,10 +104,17 @@ export const run = async (context: $TSContext): Promise<void> => {
           sandbox: {},
           require: {
             context: 'sandbox',
-            builtin: ['path'],
+            builtin: ['*'],
             external: true,
           },
         });
+
+        // https://github.com/patriksimek/vm2/issues/428
+        sandboxNode.sandbox.process.stdin = process.stdin;
+        sandboxNode.sandbox.process.stdout = process.stdout;
+        sandboxNode.sandbox.process.stderr = process.stderr;
+        sandboxNode.sandbox.process.binding = (<$TSAny>process).binding;
+
         sandboxNode.run(overrideCode).override(configuration);
       }
     } catch (e) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
