### PR TITLE
fix: Await Metadata file updates to avoid race conditions

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -115,6 +115,8 @@ jobs:
       - run:
           name: Collect code coverage
           command: yarn coverage
+    environment:
+      NODE_OPTIONS: --max-old-space-size=4096
 
   lint:
     <<: *linux-e2e-executor

--- a/packages/amplify-cli-core/src/types.ts
+++ b/packages/amplify-cli-core/src/types.ts
@@ -362,7 +362,7 @@ export type $TSCopyJob = $TSAny;
   updateamplifyMetaAfterResourceDelete: (category: string, resourceName: string) => void;
   /* eslint-disable-next-line spellcheck/spell-checker */
   updateProviderAmplifyMeta: (providerName: string, options: $TSObject) => void;
-  updateamplifyMetaAfterPush: (resources: $TSObject[]) => void;
+  updateamplifyMetaAfterPush: (resources: $TSObject[]) => Promise<void>;
   // buildType is from amplify-function-plugin-interface but can't be imported here because it would create a circular dependency
   updateamplifyMetaAfterBuild: (resource: ResourceTuple, buildType?: string) => void;
   updateAmplifyMetaAfterPackage: (resource: ResourceTuple, zipFilename: string, hash?: { resourceKey: string; hashValue: string }) => void;

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -154,7 +154,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
         const {
           exposedContainer,
           pipelineInfo: { consoleUrl },
-        } = await context.amplify.invokePluginMethod(context, 'api', undefined, 'generateContainersArtifacts', [context, resource]);
+        } : $TSAny = await context.amplify.invokePluginMethod(context, 'api', undefined, 'generateContainersArtifacts', [context, resource]);
         await context.amplify.updateamplifyMetaAfterResourceUpdate('api', resource.resourceName, 'exposedContainer', exposedContainer);
 
         printer.blankLine();
@@ -330,7 +330,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
           await updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated, eventMap);
           await storeRootStackTemplate(context, nestedStack);
           // if the only root stack updates, function is called with empty resources . this fn copies amplifyMeta and backend Config to #current-cloud-backend
-          context.amplify.updateamplifyMetaAfterPush([]);
+          await context.amplify.updateamplifyMetaAfterPush([]);
         } catch (err) {
           if (err?.name === 'ValidationError' && err?.message === 'No updates are to be performed.') {
             return;
@@ -525,7 +525,7 @@ export const updateStackForAPIMigration = async (context: $TSContext, category: 
     await updateCloudFormationNestedStack(context, nestedStack, resourcesToBeCreated, resourcesToBeUpdated, eventMap);
   }
 
-  context.amplify.updateamplifyMetaAfterPush(resources);
+  await context.amplify.updateamplifyMetaAfterPush(resources);
 };
 
 /**

--- a/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
+++ b/packages/amplify-provider-awscloudformation/src/resource-package/resource-packager.ts
@@ -245,7 +245,7 @@ export abstract class ResourcePackager {
     switch (resource.category) {
       case API_CATEGORY.NAME:
         if (resource.service === API_CATEGORY.SERVICE.ELASTIC_CONTAINER) {
-          const { exposedContainer } = await this.context.amplify.invokePluginMethod(
+          const { exposedContainer }: $TSAny = await this.context.amplify.invokePluginMethod(
             this.context,
             'api',
             undefined,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed occurrences of un-awaited promises in our push logic. This will ensure better consistency when running e2e tests that should await file updates on push.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
