### PR TITLE
chore: log heap usage on unit test runs

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -26,7 +26,7 @@
     "clean": "rimraf ./lib tsconfig.tsbuildinfo tsconfig.tests.tsbuildinfo node_modules",
     "watch": "tsc -w",
     "start": "node ./lib/index.js",
-    "test": "jest --forceExit"
+    "test": "jest --logHeapUsage --forceExit"
   },
   "dependencies": {
     "@graphql-tools/schema": "^8.3.1",

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "test-watch": "jest --watch",
     "generateSchemas": "ts-node ./scripts/generateAuthSchemas.ts"
   },

--- a/packages/amplify-category-custom/package.json
+++ b/packages/amplify-category-custom/package.json
@@ -13,7 +13,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "watch": "tsc -w"
   },

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/packages/amplify-category-hosting/package.json
+++ b/packages/amplify-category-hosting/package.json
@@ -15,7 +15,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest --coverage"
+    "test": "jest --logHeapUsage --coverage"
   },
   "dependencies": {
     "amplify-cli-core": "3.2.1",

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "watch": "tsc --watch"
   },
   "dependencies": {

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -13,7 +13,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "watch": "tsc -w",
     "generateSchemas": "ts-node ./resources/genInputSchema.ts"

--- a/packages/amplify-category-xr/package.json
+++ b/packages/amplify-category-xr/package.json
@@ -15,7 +15,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -17,7 +17,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "test-ci": "jest --ci -i",
     "build": "tsc",
     "watch": "tsc -w",

--- a/packages/amplify-cli-logger/package.json
+++ b/packages/amplify-cli-logger/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules"

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "postinstall": "node scripts/post-install.js",
     "watch": "tsc -w",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo"

--- a/packages/amplify-container-hosting/package.json
+++ b/packages/amplify-container-hosting/package.json
@@ -19,7 +19,7 @@
     "test-ci": "yarn jest --ci",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "watch": "tsc --watch",
-    "test": "jest --coverage --passWithNoTests"
+    "test": "jest --logHeapUsage --coverage --passWithNoTests"
   },
   "dependencies": {
     "@aws-amplify/amplify-category-api": "^4.0.2",

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "node ./scripts/update-ddb-simulator.js",
     "clean": "rimraf emulator",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "dependencies": {
     "amplify-cli-core": "3.2.1",

--- a/packages/amplify-environment-parameters/package.json
+++ b/packages/amplify-environment-parameters/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "dependencies": {
     "amplify-cli-core": "3.2.1",

--- a/packages/amplify-frontend-ios/package.json
+++ b/packages/amplify-frontend-ios/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "generate-xcode-bindings": "node ./scripts/native-bindings-gen",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "test-watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/amplify-frontend-javascript/package.json
+++ b/packages/amplify-frontend-javascript/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.2",
   "description": "amplify-cli front-end plugin for JavaScript projects",
   "scripts": {
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "test-watch": "yarn test --watch"
   },
   "repository": {

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "private": true,
   "scripts": {
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "repository": {
     "type": "git",

--- a/packages/amplify-nodejs-function-runtime-provider/package.json
+++ b/packages/amplify-nodejs-function-runtime-provider/package.json
@@ -20,7 +20,7 @@
     "watch": "tsc -w",
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "dependencies": {
     "amplify-cli-core": "3.2.1",

--- a/packages/amplify-prompts/package.json
+++ b/packages/amplify-prompts/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "demo": "yarn build && node lib/demo/demo.js",
-    "test": "jest --color",
+    "test": "jest --logHeapUsage --color",
     "watch": "tsc -w"
   },
   "repository": {

--- a/packages/amplify-storage-simulator/package.json
+++ b/packages/amplify-storage-simulator/package.json
@@ -17,7 +17,7 @@
     "aws"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "build": "tsc",
     "watch": "tsc -w"
   },

--- a/packages/amplify-util-headless-input/package.json
+++ b/packages/amplify-util-headless-input/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "keywords": [
     "amplify",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -19,7 +19,7 @@
     "e2e": "yarn run e2e_v1 && yarn run e2e_v2",
     "e2e_v2": "jest --runInBand --forceExit ./src/__e2e_v2__/*.test.ts",
     "e2e_v1": "jest --runInBand --forceExit ./src/__e2e__/*.test.ts",
-    "test": "jest src/__tests__/**/*.test.ts",
+    "test": "jest --logHeapUsage src/__tests__/**/*.test.ts",
     "test-watch": "jest --watch",
     "build": "tsc",
     "watch": "tsc -w",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",


### PR DESCRIPTION
#### Description of changes
Add jest flag `--logHeapUsage` to track how much memory our unit tests are using

#### Description of how you validated changes
`yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
