### PR TITLE
Improve Windows Test execution time

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -92,6 +92,12 @@ jobs:
           paths:
             - ~/.cache
       - save_cache:
+          key: amplify-cli-node_module-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - node_modules
+            - ~/node_modules
+            - ~/repo/node_modules
+            - ~/.npm-global
+      - save_cache:
           key: amplify-cli-ssh-deps-{{ .Branch }}
           paths:
             - ~/.ssh
@@ -261,6 +267,8 @@ jobs:
           at: ./
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: amplify-cli-node_module-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
@@ -970,7 +978,7 @@ commands:
           condition:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
-            - run: npm install -g ts-node@^8.10.2
+            - run: yarn --cache-folder ~/.cache/yarn
             - run:
                 shell: powershell.exe
                 command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -268,6 +268,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
+      - install_yarn:
+          os: << parameters.os >>
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
@@ -278,7 +280,7 @@ jobs:
           key: amplify-build-artifact-{{ .Revision }}
       - restore_cache:
           key: amplify-pkg-binaries-{{ .Branch }}-{{ .Revision }}
-      - install_yarn:
+      - rename_binary:
           os: << parameters.os >>
       - install_packaged_cli:
           os: << parameters.os >>
@@ -969,9 +971,8 @@ commands:
             - run:
                 name: Confirm Amplify CLI is installed and available in PATH
                 command: amplify version
-
   install_yarn:
-    description: 'Install Amplify Packaged CLI to PATH'
+    description: 'Install Yarn'
     parameters:
       os:
         type: executor
@@ -982,6 +983,17 @@ commands:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
             - run: yarn --cache-folder ~/.cache/yarn
+  rename_binary:
+    description: 'Install Amplify Packaged CLI on Windows'
+    parameters:
+      os:
+        type: executor
+        default: l
+    steps:
+      - when:
+          condition:
+            equal: [*windows-e2e-executor, << parameters.os >>]
+          steps:
             - run:
                 shell: powershell.exe
                 command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -268,8 +268,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
-      - install_yarn:
-          os: << parameters.os >>
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
@@ -280,6 +278,8 @@ jobs:
           key: amplify-build-artifact-{{ .Revision }}
       - restore_cache:
           key: amplify-pkg-binaries-{{ .Branch }}-{{ .Revision }}
+      - install_yarn:
+          os: << parameters.os >>
       - rename_binary:
           os: << parameters.os >>
       - install_packaged_cli:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -970,6 +970,7 @@ commands:
           condition:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
+            - run: npm install -g ts-node@^8.10.2
             - run:
                 shell: powershell.exe
                 command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -83,6 +83,10 @@ jobs:
     executor: l
     steps:
       - checkout
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: amplify-cli-node_module-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run: yarn run production-build
       - run:
           name: Build tests
@@ -95,9 +99,7 @@ jobs:
           key: amplify-cli-node_module-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
-            - ~/node_modules
             - ~/repo/node_modules
-            - ~/.npm-global
       - save_cache:
           key: amplify-cli-ssh-deps-{{ .Branch }}
           paths:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -982,7 +982,7 @@ commands:
           condition:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
-            - run: yarn --cache-folder ~/.cache/yarn
+            - run: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
   rename_binary:
     description: 'Install Amplify Packaged CLI on Windows'
     parameters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -975,7 +975,6 @@ commands:
           condition:
             equal: [*windows-e2e-executor, << parameters.os >>]
           steps:
-            - run: yarn --cache-folder ~/.cache/yarn
             - run:
                 shell: powershell.exe
                 command: cp /home/circleci/repo/out/amplify-pkg-win-x64.exe $env:homedrive\$env:homepath\AppData\Local\Microsoft\WindowsApps\amplify.exe

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -93,6 +93,7 @@ jobs:
             - ~/.cache
       - save_cache:
           key: amplify-cli-node_module-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
             - node_modules
             - ~/node_modules
             - ~/repo/node_modules


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This removes an unnecessary step that adds about 17 minutes to our windows e2e tests.
We don't need this step anymore because we are using the packaged cli.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
