### PR TITLE
chore: refactor error model

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
@@ -56,7 +56,7 @@ export const migrateResourceToSupportOverride = async (resourceName: string): Pr
   } catch (e) {
     rollback(authResourceDirPath, backupAuthResourceFolder!);
     rollback(userPoolGroupResourceDirPath, backupUserPoolGroupResourceFolder!);
-    throw amplifyErrorWithTroubleshootingLink('MigrationError', {
+    throw amplifyErrorWithTroubleshootingLink(e, 'MigrationError', {
       message: `There was an error migrating your project: ${e.message}`,
       details: `Migration operations are rolled back.`,
       stack: e.stack,
@@ -73,7 +73,7 @@ const backup = (authResourcePath: string, projectPath: string, resourceName: str
     const backupAuthResourceDirPath = path.join(projectPath, backupAuthResourceDirName);
 
     if (fs.existsSync(backupAuthResourceDirPath)) {
-      throw new AmplifyError('MigrationError', {
+      throw new AmplifyError(null, 'MigrationError', {
         message: `Backup folder for ${resourceName} already exists.`,
         resolution: `Delete the backup folder and try again.`,
       });

--- a/packages/amplify-category-custom/src/index.ts
+++ b/packages/amplify-category-custom/src/index.ts
@@ -27,7 +27,7 @@ export const executeAmplifyCommand = async (context: $TSContext): Promise<void> 
 
   // Check if project has been initialized
   if (!stateManager.metaFileExists()) {
-    throw new AmplifyError('MissingAmplifyMetaFileError', {
+    throw new AmplifyError(null, 'MissingAmplifyMetaFileError', {
       message: 'Could not find the amplify-meta.json file.',
       resolution: 'Make sure your project is initialized in the cloud.',
     });

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -49,7 +49,7 @@ export const packageFunction: Packager = async (context, resource) => {
   }
 
   if (functionSizeInBytes + layersSizeInBytes > lambdaPackageLimitInMB * 1024 ** 2) {
-    throw amplifyErrorWithTroubleshootingLink('FunctionTooLargeError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'FunctionTooLargeError', {
       message: `The function is too large to package.`,
       details: `
 Total size of Lambda function ${

--- a/packages/amplify-cli-core/src/errors/amplify-error.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-error.ts
@@ -6,10 +6,11 @@ import { AmplifyException, AmplifyExceptionOptions, AmplifyErrorType, PartialAmp
  */
 export class AmplifyError extends AmplifyException {
   constructor(
+    downstreamException: Error | null,
     name: AmplifyErrorType,
     options: AmplifyExceptionOptions,
   ) {
-    super(name, 'ERROR', options);
+    super(downstreamException, name, 'ERROR', options);
   }
 }
 
@@ -17,8 +18,16 @@ export class AmplifyError extends AmplifyException {
  * convenience method to return an amplify error with the default troubleshooting link
  * @deprecated prefer using AmplifyError and passing the resolution steps
  */
-export const amplifyErrorWithTroubleshootingLink = (name: AmplifyErrorType, options: PartialAmplifyExceptionOptions)
-  : AmplifyError => new AmplifyError(name, {
-  ...options,
-  link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-});
+export const amplifyErrorWithTroubleshootingLink = (
+  downstreamException: Error | null,
+  name: AmplifyErrorType, 
+  options: PartialAmplifyExceptionOptions)
+  : AmplifyError => {
+    return new AmplifyError(
+      downstreamException, 
+      name, 
+        {
+        ...options,
+        link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
+      });
+  };

--- a/packages/amplify-cli-core/src/errors/amplify-error.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-error.ts
@@ -1,5 +1,7 @@
 import { AMPLIFY_SUPPORT_DOCS } from '../cliConstants';
-import { AmplifyException, AmplifyExceptionOptions, AmplifyErrorType, PartialAmplifyExceptionOptions } from './amplify-exception';
+import {
+  AmplifyException, AmplifyExceptionOptions, AmplifyErrorType, PartialAmplifyExceptionOptions,
+} from './amplify-exception';
 
 /**
  * Base class for all Amplify errors
@@ -20,14 +22,14 @@ export class AmplifyError extends AmplifyException {
  */
 export const amplifyErrorWithTroubleshootingLink = (
   downstreamException: Error | null,
-  name: AmplifyErrorType, 
-  options: PartialAmplifyExceptionOptions)
-  : AmplifyError => {
-    return new AmplifyError(
-      downstreamException, 
-      name, 
-        {
-        ...options,
-        link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-      });
-  };
+  name: AmplifyErrorType,
+  options: PartialAmplifyExceptionOptions,
+)
+  : AmplifyError => new AmplifyError(
+  downstreamException,
+  name,
+  {
+    ...options,
+    link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
+  },
+);

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -27,7 +27,7 @@ export abstract class AmplifyException extends Error {
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, AmplifyException.prototype);
 
-    if(downstreamException instanceof AmplifyException){
+    if (downstreamException instanceof AmplifyException) {
       this.stack ??= downstreamException.stack;
       this.message = downstreamException.message;
       this.details = downstreamException.details;

--- a/packages/amplify-cli-core/src/errors/amplify-fault.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-fault.ts
@@ -1,5 +1,7 @@
 import { AMPLIFY_SUPPORT_DOCS } from '../cliConstants';
-import { AmplifyException, AmplifyExceptionOptions, AmplifyFaultType, PartialAmplifyExceptionOptions } from './amplify-exception';
+import {
+  AmplifyException, AmplifyExceptionOptions, AmplifyFaultType, PartialAmplifyExceptionOptions,
+} from './amplify-exception';
 
 /**
  * Base class for all Amplify faults
@@ -19,13 +21,13 @@ export class AmplifyFault extends AmplifyException {
  */
 export const amplifyFaultWithTroubleshootingLink = (
   downstreamException: Error | null,
-  name: AmplifyFaultType, 
-  options: PartialAmplifyExceptionOptions)
-  : AmplifyFault => {
-      return  new AmplifyFault(
-        downstreamException, 
-        name, {
-          ...options,
-          link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-        });
-  };
+  name: AmplifyFaultType,
+  options: PartialAmplifyExceptionOptions,
+)
+  : AmplifyFault => new AmplifyFault(
+  downstreamException,
+  name, {
+    ...options,
+    link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
+  },
+);

--- a/packages/amplify-cli-core/src/errors/amplify-fault.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-fault.ts
@@ -6,18 +6,26 @@ import { AmplifyException, AmplifyExceptionOptions, AmplifyFaultType, PartialAmp
  */
 export class AmplifyFault extends AmplifyException {
   constructor(
+    downstreamException: Error | null,
     name: AmplifyFaultType,
     options: AmplifyExceptionOptions,
   ) {
-    super(name, 'FAULT', options);
+    super(downstreamException, name, 'FAULT', options);
   }
 }
 
 /**
  * returns an amplify fault with the default troubleshooting link if not passed
  */
-export const amplifyFaultWithTroubleshootingLink = (name: AmplifyFaultType, options: PartialAmplifyExceptionOptions)
-  : AmplifyFault => new AmplifyFault(name, {
-  ...options,
-  link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-});
+export const amplifyFaultWithTroubleshootingLink = (
+  downstreamException: Error | null,
+  name: AmplifyFaultType, 
+  options: PartialAmplifyExceptionOptions)
+  : AmplifyFault => {
+      return  new AmplifyFault(
+        downstreamException, 
+        name, {
+          ...options,
+          link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
+        });
+  };

--- a/packages/amplify-cli-core/src/errors/project-not-initialized-error.ts
+++ b/packages/amplify-cli-core/src/errors/project-not-initialized-error.ts
@@ -3,7 +3,7 @@ import { AmplifyError } from './amplify-error';
 /**
  * defines the project not initialized error factory method
  */
-export const projectNotInitializedError = (): AmplifyError => new AmplifyError('ProjectNotInitializedError', {
+export const projectNotInitializedError = (): AmplifyError => new AmplifyError(null, 'ProjectNotInitializedError', {
   message: 'No Amplify backend project files detected within this folder.',
   resolution: `
 Either initialize a new Amplify project or pull an existing project.

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -378,7 +378,7 @@ export class FeatureFlags {
         });
 
         if (unknownFlags.length > 0 || otherErrors.length > 0) {
-          throw new AmplifyError('FeatureFlagsValidationError', {
+          throw new AmplifyError(null, 'FeatureFlagsValidationError', {
             message: 'Invalid feature flag configuration',
             details:
               (unknownFlags.length > 0 ? `These feature flags are defined in the "amplify/cli.json" configuration file and are unknown to the currently running Amplify CLI:\n${unknownFlags.map(el => `- ${el}`).join(',\n')}\n` : '')

--- a/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
+++ b/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
@@ -15,7 +15,7 @@ jest.mock('amplify-prompts');
 
 describe('test exception handler', () => {
   it('error handler should call usageData emitError', async () => {
-    const amplifyError = new AmplifyError('NotImplementedError', {
+    const amplifyError = new AmplifyError(null, 'NotImplementedError', {
       message: 'Test Not implemented',
       resolution: 'Test Not implemented',
     });
@@ -36,7 +36,7 @@ describe('test exception handler', () => {
   });
 
   it('error handler should send error report', async () => {
-    const amplifyError = new AmplifyError('NotImplementedError', {
+    const amplifyError = new AmplifyError(null, 'NotImplementedError', {
       message: 'Test Not implemented',
       resolution: 'Test Not implemented',
     });
@@ -57,7 +57,7 @@ describe('test exception handler', () => {
   });
 
   it('error handler should print error', async () => {
-    const amplifyError = new AmplifyError('NotImplementedError', {
+    const amplifyError = new AmplifyError(null, 'NotImplementedError', {
       message: 'Test Not implemented',
       details: 'Test Not implemented',
       resolution: 'Test Not implemented',
@@ -81,7 +81,7 @@ describe('test exception handler', () => {
   });
 
   it('error handler should handle encountered errors gracefully', async () => {
-    const amplifyError = new AmplifyError('NotImplementedError', {
+    const amplifyError = new AmplifyError(null, 'NotImplementedError', {
       message: 'Test Not implemented',
       details: 'Test Not implemented',
       resolution: 'Test Not implemented',

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -45,7 +45,7 @@ export const attachBackend = async (context: $TSContext, inputParams): Promise<v
     removeAmplifyFolderStructure();
     restoreOriginalAmplifyFolder();
 
-    throw amplifyFaultWithTroubleshootingLink('PullBackendFault', {
+    throw amplifyFaultWithTroubleshootingLink(e, 'PullBackendFault', {
       message: 'Failed to pull the backend.',
       details: e.message,
       stack: e.stack,
@@ -112,7 +112,7 @@ const backupAmplifyFolder = (): void => {
     const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
     if (fs.existsSync(backupAmplifyDirPath)) {
-      throw amplifyErrorWithTroubleshootingLink('DirectoryAlreadyExistsError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DirectoryAlreadyExistsError', {
         message: `Backup folder at ${backupAmplifyDirPath} already exists, remove the folder and retry the operation.`,
       });
     }
@@ -120,14 +120,14 @@ const backupAmplifyFolder = (): void => {
       fs.moveSync(amplifyDirPath, backupAmplifyDirPath);
     } catch (e) {
       if (e.code === 'EPERM') {
-        throw amplifyErrorWithTroubleshootingLink('DirectoryError', {
+        throw amplifyErrorWithTroubleshootingLink(e, 'DirectoryError', {
           message: `Could not attach the backend to the project.`,
           resolution: 'Ensure that there are no applications locking the `amplify` folder and try again.',
           details: e.message,
           stack: e.stack,
         });
       }
-      throw amplifyFaultWithTroubleshootingLink('AmplifyBackupFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'AmplifyBackupFault', {
         message: `Could not attach the backend to the project.`,
         details: e.message,
         stack: e.stack,

--- a/packages/amplify-cli/src/commands/env/add.ts
+++ b/packages/amplify-cli/src/commands/env/add.ts
@@ -8,7 +8,7 @@ import { run as init } from '../init';
 export const run = async (context: $TSContext) : Promise<void> => {
   const amplifyMetaFilePath = pathManager.getAmplifyMetaFilePath();
   if (!fs.existsSync(amplifyMetaFilePath)) {
-    throw new AmplifyError('ConfigurationError', {
+    throw new AmplifyError(null, 'ConfigurationError', {
       // eslint-disable-next-line spellcheck/spell-checker
       message: 'Your workspace is not configured to modify the backend.',
       resolution: 'If you wish to change this configuration, remove your `amplify` directory and pull the project again.',

--- a/packages/amplify-cli/src/commands/env/checkout.ts
+++ b/packages/amplify-cli/src/commands/env/checkout.ts
@@ -19,7 +19,7 @@ export const run = async (context: $TSContext): Promise<void> => {
 
   const allEnvs = context.amplify.getEnvDetails();
   if (!envName || !allEnvs[envName]) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name is invalid.',
       resolution: `Run amplify env list to get a list of valid environments.`,
     });
@@ -32,7 +32,7 @@ export const run = async (context: $TSContext): Promise<void> => {
   stateManager.setLocalEnvInfo(undefined, localEnvInfo);
 
   if (localEnvInfo.noUpdateBackend) {
-    throw new AmplifyError('NoUpdateBackendError', {
+    throw new AmplifyError(null, 'NoUpdateBackendError', {
       message: 'The local environment configuration does not allow modifying the backend.',
       resolution: `Use amplify env pull --envName ${envName}`,
     });

--- a/packages/amplify-cli/src/commands/env/get.ts
+++ b/packages/amplify-cli/src/commands/env/get.ts
@@ -10,13 +10,13 @@ export const run = async (context: $TSContext) : Promise<void> => {
   const allEnvs = context.amplify.getEnvDetails();
 
   if (!envName) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name was not specified.',
       resolution: 'Pass in the name of the environment using the --name flag.',
     });
   }
   if (!allEnvs[envName]) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name is invalid.',
       resolution: 'Run amplify env list to get a list of valid environments.',
     });

--- a/packages/amplify-cli/src/commands/env/import.ts
+++ b/packages/amplify-cli/src/commands/env/import.ts
@@ -9,7 +9,7 @@ import { printer } from 'amplify-prompts';
 export const run = async (context: $TSContext): Promise<void> => {
   const envName = context.parameters.options.name;
   if (!envName) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name was not specified.',
       resolution: 'Pass in the name of the environment using the --name flag.',
     });
@@ -47,14 +47,14 @@ export const run = async (context: $TSContext): Promise<void> => {
       /* eslint-enable no-prototype-builtins */
       )
     ) {
-      throw new AmplifyError('EnvironmentConfigurationError', {
+      throw new AmplifyError(null, 'EnvironmentConfigurationError', {
         message: 'The environment configuration provided is missing required properties.',
         resolution: 'Add the required properties and try again.',
         link: 'https://docs.amplify.aws/cli/teams/commands/#import-an-environment',
       });
     }
   } catch (e) {
-    throw new AmplifyError('EnvironmentConfigurationError', {
+    throw new AmplifyError(e, 'EnvironmentConfigurationError', {
       message: 'Environment configuration was not specified or was formatted incorrectly.',
       resolution: 'You must pass in the configuration of the environment in an object format using the --config flag.',
     });
@@ -66,7 +66,7 @@ export const run = async (context: $TSContext): Promise<void> => {
     try {
       awsInfo = JSONUtilities.parse(context.parameters.options.awsInfo);
     } catch (e) {
-      throw new AmplifyError('EnvironmentConfigurationError', {
+      throw new AmplifyError(e, 'EnvironmentConfigurationError', {
         message: 'The AWS credential info was not specified or was incorrectly formatted.',
         resolution: 'Pass in the AWS credential info in an object format using the --awsInfo flag.',
         link: 'https://docs.amplify.aws/cli/teams/commands/#import-an-environment',

--- a/packages/amplify-cli/src/commands/env/remove.ts
+++ b/packages/amplify-cli/src/commands/env/remove.ts
@@ -15,20 +15,20 @@ export const run = async (context: $TSContext): Promise<void> => {
   const allEnvs = context.amplify.getEnvDetails();
 
   if (!envName) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name was not specified.',
       resolution: 'Pass in the name of the environment using the --name flag.',
     });
   }
   if (!allEnvs[envName]) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'Environment name is invalid.',
       resolution: 'Run amplify env list to get a list of valid environments.',
     });
   }
 
   if (currentEnv === envName) {
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: 'You cannot delete your current environment.',
       resolution: 'Switch to another environment before deleting the current environment.',
       details: "If this is your only environment you can use the 'amplify delete' command to delete your project.",

--- a/packages/amplify-cli/src/commands/helpers/projectUtils.ts
+++ b/packages/amplify-cli/src/commands/helpers/projectUtils.ts
@@ -6,7 +6,7 @@ import { AmplifyError, pathManager } from 'amplify-cli-core';
 export const checkForNestedProject = (): void => {
   const projectRoot = pathManager.findProjectRoot() ?? process.cwd();
   if (projectRoot !== process.cwd()) {
-    throw new AmplifyError('NestedProjectInitError', {
+    throw new AmplifyError(null, 'NestedProjectInitError', {
       message: 'Creating a nested amplify project is not supported',
       details: `Project root detected in: ${projectRoot}`,
       resolution: 'Please run amplify in the root of your project',

--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -20,7 +20,7 @@ export const run = async (context: $TSContext): Promise<void> => {
     try {
       await preDeployPullBackend(context, inputParams.sandboxId);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'UnknownFault', {
         message: `Failed to pull sandbox app.`,
         details: e.message || 'An unknown error occurred.',
         stack: e.stack,
@@ -38,12 +38,12 @@ export const run = async (context: $TSContext): Promise<void> => {
     const localEnvNames = Object.keys(stateManager.getLocalAWSInfo(undefined, { throwIfNotExist: false }) || {});
 
     if (inputAppId && appId && inputAppId !== appId) {
-      throw new AmplifyError('InvalidAmplifyAppIdError', {
+      throw new AmplifyError(null, 'InvalidAmplifyAppIdError', {
         message: `Amplify appId mismatch.`,
         resolution: `You are currently working in the amplify project with Id ${appId}`,
       });
     } else if (!appId) {
-      throw new AmplifyError('EnvironmentNotInitializedError', {
+      throw new AmplifyError(null, 'EnvironmentNotInitializedError', {
         message: `Environment '${envName}' not found.`,
         resolution: `Try running "amplify env add" to add a new environment.\nIf this backend already exists, try restoring its definition in your team-provider-info.json file.`,
       });

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -49,7 +49,7 @@ const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
     spinner.succeed(`Successfully pulled backend environment ${currentEnv} from the cloud.`);
   } catch (e) {
     spinner.fail(`There was an error pulling the backend environment ${currentEnv}.`);
-    throw amplifyFaultWithTroubleshootingLink('BackendPullFault', { message: e.message });
+    throw amplifyFaultWithTroubleshootingLink(e, 'BackendPullFault', { message: e.message });
   }
 };
 
@@ -66,7 +66,7 @@ const updateTrackedFiles = async (): Promise<void> => {
 export const run = async (context: $TSContext): Promise<$TSAny> => {
   context.amplify.constructExeInfo(context);
   if (context.exeInfo.localEnvInfo.noUpdateBackend) {
-    throw amplifyErrorWithTroubleshootingLink('NoUpdateBackendError', { message: 'The local environment configuration does not allow backend updates.' });
+    throw amplifyErrorWithTroubleshootingLink(null, 'NoUpdateBackendError', { message: 'The local environment configuration does not allow backend updates.' });
   }
   if (context.parameters.options.force) {
     context.exeInfo.forcePush = true;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.ts
@@ -7,7 +7,7 @@ export const getEnvInfo = (): $TSAny => {
   if (stateManager.localEnvInfoExists()) {
     return stateManager.getLocalEnvInfo();
   }
-  throw new AmplifyError('EnvironmentNotInitializedError', {
+  throw new AmplifyError(null, 'EnvironmentNotInitializedError', {
     message: 'Current environment cannot be determined.',
     resolution: `Use 'amplify init' in the root of your app directory to create a new environment.`,
   });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
@@ -15,7 +15,7 @@ export const invokePluginMethod = async <T>(
   const pluginInfo = context.amplify.getCategoryPluginInfo(context, category, service);
 
   if (!pluginInfo) {
-    throw new AmplifyError('PluginNotFoundError', {
+    throw new AmplifyError(null, 'PluginNotFoundError', {
       message: `Plugin for category: ${category} was not found.`,
       resolution: `Make sure Amplify CLI is properly installed. You may need to run \`amplify plugin scan\``,
     });
@@ -25,7 +25,7 @@ export const invokePluginMethod = async <T>(
   const pluginMethod = plugin[method];
 
   if (!pluginMethod || typeof pluginMethod !== 'function') {
-    throw amplifyErrorWithTroubleshootingLink('PluginMethodNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'PluginMethodNotFoundError', {
       message: `Method ${method} does not exist or is not a function in category plugin: ${category}.`,
     });
   }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -28,7 +28,7 @@ export const pushResources = async (
   if (context.parameters.options['iterative-rollback']) {
     // validate --iterative-rollback with --force
     if (context.parameters.options.force) {
-      throw new AmplifyError('CommandNotSupportedError', {
+      throw new AmplifyError(null, 'CommandNotSupportedError', {
         message: '--iterative-rollback and --force are not supported together',
         resolution: 'Use --force without --iterative-rollback to iteratively rollback and redeploy.',
       });
@@ -55,7 +55,7 @@ export const pushResources = async (
       }
       await initializeEnv(context);
     } else {
-      throw new AmplifyError('EnvironmentNotInitializedError', {
+      throw new AmplifyError(null, 'EnvironmentNotInitializedError', {
         message: 'Current environment cannot be determined.',
         resolution: `Use 'amplify init' in the root of your app directory to create a new environment.`,
       });
@@ -115,7 +115,7 @@ export const pushResources = async (
         if (err instanceof AmplifyException) {
           throw err;
         }
-        throw new AmplifyFault('PushResourcesFault', {
+        throw new AmplifyFault(err, 'PushResourcesFault', {
           message: err.message,
           stack: err.stack,
           link: isAuthError ? AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -33,7 +33,7 @@ export const removeEnvFromCloud = async (context, envName, deleteS3): Promise<vo
     await raiseInternalOnlyPostEnvRemoveEvent(context, envName);
   } catch (e) {
     if (e.code !== 'NotFoundException') {
-      throw amplifyFaultWithTroubleshootingLink('BackendDeleteFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'BackendDeleteFault', {
         message: `Error occurred while deleting env: ${envName}.`,
         details: e.message,
         stack: e.stack,

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -136,7 +136,7 @@ export const run = async (startTime: number): Promise<void> => {
     if (verificationResult.helpCommandAvailable) {
       input.command = constants.HELP;
     } else {
-      throw new AmplifyError('InputValidationError', {
+      throw new AmplifyError(null, 'InputValidationError', {
         message: verificationResult.message ?? 'Invalid input',
         details: JSON.stringify(verificationResult),
         link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
@@ -164,7 +164,7 @@ export const run = async (startTime: number): Promise<void> => {
   prompter.setFlowData(context.usageData);
 
   if (!(await migrateTeamProviderInfo(context))) {
-    throw new AmplifyError('MigrationError', {
+    throw new AmplifyError(null, 'MigrationError', {
       message: 'An error occurred while migrating team provider info',
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
     });

--- a/packages/amplify-cli/src/init-steps/postInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/postInitSetup.ts
@@ -27,7 +27,7 @@ export const postInitSetup = async (context: $TSContext): Promise<void> => {
       if (e instanceof AmplifyError) {
         throw e;
       }
-      throw new AmplifyFault('ProjectInitFault', {
+      throw new AmplifyFault(e, 'ProjectInitFault', {
         message: 'An error occurred during project initialization',
         details: e.message,
         link: 'https://docs.amplify.aws/cli/project/troubleshooting/',

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -35,7 +35,7 @@ const validateGithubRepo = async (repoUrl: string): Promise<void> => {
 
     execSync(`git ls-remote ${repoUrl}`, { stdio: 'ignore' });
   } catch (e) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(e, 'ProjectInitError', {
       message: 'Invalid remote github url',
       details: e.message,
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
@@ -51,7 +51,7 @@ const cloneRepo = async (repoUrl: string): Promise<void> => {
   const files = fs.readdirSync(process.cwd());
 
   if (files.length > 0) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(null, 'ProjectInitError', {
       message: 'Unable to clone repository',
       resolution: 'Please ensure you run this command in an empty directory',
     });
@@ -60,7 +60,7 @@ const cloneRepo = async (repoUrl: string): Promise<void> => {
   try {
     execSync(`git clone ${repoUrl} .`, { stdio: 'inherit' });
   } catch (e) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(e, 'ProjectInitError', {
       message: 'Unable to clone repository',
       details: e.message,
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -219,7 +219,7 @@ const getDefaultEnv = (context: $TSContext): string | undefined => {
       defaultEnv = context.exeInfo.inputParams.amplify.envName;
       return defaultEnv;
     }
-    throw new AmplifyError('EnvironmentNameError', {
+    throw new AmplifyError(null, 'EnvironmentNameError', {
       message: `Invalid environment name: ${context.exeInfo.inputParams.amplify.envName}`,
       resolution: INVALID_ENV_NAME_MSG,
     });
@@ -239,12 +239,12 @@ const getEnvName = async (context: $TSContext): Promise<string> => {
       ({ envName } = context.exeInfo.inputParams.amplify);
       return envName;
     }
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(null, 'ProjectInitError', {
       message: `Invalid environment name: ${context.exeInfo.inputParams.amplify.envName}`,
       resolution: INVALID_ENV_NAME_MSG,
     });
   } else if (context.exeInfo.inputParams && context.exeInfo.inputParams.yes) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(null, 'ProjectInitError', {
       message: `Invalid environment name: ${context.exeInfo.inputParams.amplify.envName}`,
       resolution: INVALID_ENV_NAME_MSG,
     });

--- a/packages/amplify-cli/src/init-steps/s2-initProviders.ts
+++ b/packages/amplify-cli/src/init-steps/s2-initProviders.ts
@@ -28,7 +28,7 @@ const getProviders = async (context, providerPlugins): Promise<$TSAny> => {
   const providerPluginList = Object.keys(providerPlugins);
 
   if (providerPluginList.length === 0) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(null, 'ProjectInitError', {
       message: 'Found no provider plugins',
       resolution: `Run 'amplify plugin scan' to scan your system for provider plugins.`,
     });

--- a/packages/amplify-cli/src/init-steps/s8-scaffoldHeadless.ts
+++ b/packages/amplify-cli/src/init-steps/s8-scaffoldHeadless.ts
@@ -34,7 +34,7 @@ export const scaffoldProjectHeadless = async (context: $TSContext): Promise<void
   );
 
   if (!projectConfigFile) {
-    throw new AmplifyError('ProjectInitError', {
+    throw new AmplifyError(null, 'ProjectInitError', {
       message: `project-config.json template not found for frontend: ${frontend}`,
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
     });

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -50,7 +50,7 @@ export const initializeEnv = async (
           categoryInitializationTasks.push(() => initEnv(context));
         }
       } catch (e) {
-        throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
+        throw amplifyFaultWithTroubleshootingLink(e, 'PluginNotLoadedFault', {
           message: `Could not load plugin for category ${category}.`,
           details: e.message,
           resolution: `Review the error message and stack trace for additional information.`,
@@ -74,7 +74,7 @@ export const initializeEnv = async (
         const providerModule = await import(providerPlugins[provider]);
         initializationTasks.push(() => providerModule.initEnv(context, amplifyMeta.providers[provider]));
       } catch (e) {
-        throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
+        throw amplifyFaultWithTroubleshootingLink(e, 'PluginNotLoadedFault', {
           message: `Could not load plugin for provider ${provider}.`,
           details: e.message,
           resolution: 'Review the error message and stack trace for additional information.',
@@ -91,7 +91,7 @@ export const initializeEnv = async (
       context.usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_PLATFORM);
       await sequential(initializationTasks);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'ProjectInitFault', {
         message: `Could not initialize platform for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
         stack: e.stack,
@@ -113,7 +113,7 @@ export const initializeEnv = async (
       context.usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES);
       await sequential(categoryInitializationTasks);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'ProjectInitFault', {
         message: `Could not initialize categories for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
         stack: e.stack,

--- a/packages/amplify-cli/src/pre-deployment-pull.ts
+++ b/packages/amplify-cli/src/pre-deployment-pull.ts
@@ -21,7 +21,7 @@ export const preDeployPullBackend = async (context: $TSContext, sandboxId: strin
 
   // App not present
   if (resJson.message === 'Requested app was not found') {
-    throw new AmplifyError('ProjectNotFoundError', {
+    throw new AmplifyError(null, 'ProjectNotFoundError', {
       message: `Requested app: ${sandboxId} was not found`,
       link: `${AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url}`,
     });
@@ -29,7 +29,7 @@ export const preDeployPullBackend = async (context: $TSContext, sandboxId: strin
 
   // Handle Deployed App Case
   if (resJson.appId) {
-    throw new AmplifyError('DeploymentError', {
+    throw new AmplifyError(null, 'DeploymentError', {
       message: 'This app is already deployed.',
       resolution: `You can pull it using "amplify pull --appId ${resJson.appId}"`,
     });
@@ -37,7 +37,7 @@ export const preDeployPullBackend = async (context: $TSContext, sandboxId: strin
 
   // Handle missing schema
   if (!resJson.schema) {
-    throw new AmplifyError('ApiCategorySchemaNotFoundError', {
+    throw new AmplifyError(null, 'ApiCategorySchemaNotFoundError', {
       message: 'No GraphQL schema found in the app.',
       link: `${AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url}`,
     });

--- a/packages/amplify-cli/src/utils/mobilehub-support.ts
+++ b/packages/amplify-cli/src/utils/mobilehub-support.ts
@@ -54,7 +54,7 @@ const ensureSupportedCommand = (context: $TSContext): void => {
 
   // env commands are not supported for projects that having resources without provider assigned
   if (command === 'env') {
-    throw new AmplifyError('CommandNotSupportedError', {
+    throw new AmplifyError(null, 'CommandNotSupportedError', {
       message: 'multi-environment support is not available for Amplify projects with Mobile Hub migrated resources.',
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
     });

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -30,7 +30,7 @@ export const getEnvParamManager = (envName: string = stateManager.getLocalEnvInf
   if (envParamManagerMap[envName]) {
     return envParamManagerMap[envName];
   }
-  throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+  throw amplifyFaultWithTroubleshootingLink(null, 'ProjectInitFault', {
     message: `EnvironmentParameterManager for ${envName} environment is not initialized.`,
   });
 };
@@ -63,7 +63,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
 
   getResourceParamManager(category: string, resource: string): ResourceParameterManager {
     if (!category || !resource) {
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+      throw amplifyFaultWithTroubleshootingLink(null, 'ResourceNotFoundFault', {
         message: 'Missing Category or Resource.',
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -2,7 +2,9 @@ import ora from 'ora';
 import util from 'util';
 import readline from 'readline';
 import { Writable } from 'stream';
-import { $TSContext, AmplifyError, AMPLIFY_DOCS_URL, open } from 'amplify-cli-core';
+import {
+  $TSContext, AmplifyError, AMPLIFY_DOCS_URL, open,
+} from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { adminVerifyUrl, adminBackendMap, isAmplifyAdminApp } from './utils/admin-helpers';  // eslint-disable-line
 import { AdminLoginServer } from './utils/admin-login-server';
@@ -16,7 +18,7 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
   if (!region) {
     const { isAdminApp, region: _region } = await isAmplifyAdminApp(appId);
     if (!isAdminApp) {
-      throw new AmplifyError('AmplifyStudioNotEnabledError', {
+      throw new AmplifyError(null, 'AmplifyStudioNotEnabledError', {
         message: `Amplify Studio not enabled for appId: ${appId}`,
         link: `${AMPLIFY_DOCS_URL}/console/adminui/start/#to-get-started-from-an-existing-amplify-app`,
       });

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -64,7 +64,7 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     if (jobCompletionDetails.Status === 'COMPLETED') {
       spinner.succeed('Successfully generated models in the cloud.');
     } else {
-      throw amplifyErrorWithTroubleshootingLink('ModelgenError', { message: `Failed to generate models in the cloud.` });
+      throw amplifyErrorWithTroubleshootingLink(null, 'ModelgenError', { message: `Failed to generate models in the cloud.` });
     }
   } catch (e) {
     spinner.stop();
@@ -100,7 +100,7 @@ const pollUntilDone = async (
       return jobDetails;
     }
     if (timeout !== 0 && Date.now() - start > timeout) {
-      throw amplifyFaultWithTroubleshootingLink('TimeoutFault', { message: `Job Timed out for ${jobId}` });
+      throw amplifyFaultWithTroubleshootingLink(null, 'TimeoutFault', { message: `Job Timed out for ${jobId}` });
     } else {
       // run again with a short delay
       await delay(interval);

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
@@ -56,7 +56,7 @@ async function init(amplifyServiceParams) {
       context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
       amplifyAppId = inputAmplifyAppId;
     } catch (e) {
-      throw new AmplifyError('ProjectNotFoundError', {
+      throw new AmplifyError(e,'ProjectNotFoundError', {
         message: `Amplify AppID ${inputAmplifyAppId} not found.`,
         resolution: `Please ensure your local profile matches the AWS account or region in which the Amplify app exists.`,
       })
@@ -135,7 +135,7 @@ async function init(amplifyServiceParams) {
       ) {
         // Do nothing
       } else {
-        throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+        throw amplifyFaultWithTroubleshootingLink(e,'ProjectInitFault', {
           message: e.message,
           stack: e.stack,
         });
@@ -230,7 +230,7 @@ async function deleteEnv(context, envName, awsConfigInfo) {
         if (ex.code === 'NotFoundException') {
           context.print.warning(ex.message);
         } else {
-          throw amplifyFaultWithTroubleshootingLink('ProjectDeleteFault', {
+          throw amplifyFaultWithTroubleshootingLink(ex,'ProjectDeleteFault', {
             message: ex.message,
             stack: ex.stack,
           });
@@ -318,7 +318,7 @@ async function postPushCheck(context) {
         ) {
           // Do nothing
         } else {
-          throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+          throw amplifyFaultWithTroubleshootingLink(e,'ProjectInitFault', {
             message: e.message,
             stack: e.stack,
           });

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.ts
@@ -49,13 +49,13 @@ export const run = async (context): Promise<void> => {
   if (!amplifyClient) {
     // This happens when the Amplify service is not available in the region
     const message = `Amplify service is not available in the region ${awsConfigInfo.region ? awsConfigInfo.region : ''}`;
-    throw amplifyErrorWithTroubleshootingLink('RegionNotAvailableError', { message });
+    throw amplifyErrorWithTroubleshootingLink(null, 'RegionNotAvailableError', { message });
   }
 
   const hasPermission = await checkAmplifyServiceIAMPermission(context, amplifyClient);
   if (!hasPermission) {
     const message = 'Permissions to access Amplify service is required.';
-    throw amplifyErrorWithTroubleshootingLink('PermissionsError', { message });
+    throw amplifyErrorWithTroubleshootingLink(null, 'PermissionsError', { message });
   }
 
   const { inputParams } = context.exeInfo;
@@ -74,7 +74,7 @@ export const run = async (context): Promise<void> => {
         .promise();
       context.print.info(`Amplify AppID found: ${amplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('ProjectNotFoundError', {
+      throw amplifyErrorWithTroubleshootingLink(e, 'ProjectNotFoundError', {
         message: `Amplify AppID: ${amplifyAppId} not found.`,
         resolution: `Please ensure your local profile matches the AWS account or region in which the Amplify app exists.`,
       });
@@ -124,7 +124,7 @@ export const run = async (context): Promise<void> => {
       logger('run.amplifyClient.getBackendEnvironment', [getEnvParams])();
       const { backendEnvironment } = await amplifyClient.getBackendEnvironment(getEnvParams).promise();
       if (StackName !== backendEnvironment.stackName) {
-        throw amplifyErrorWithTroubleshootingLink('InvalidStackError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'InvalidStackError', {
           message: `Stack name mismatch for the backend environment ${envName}. Local: ${StackName}, Amplify: ${backendEnvironment.stackName}`,
         });
       }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -9,6 +9,9 @@ import {
 import { loadConfiguration } from '../configuration-manager';
 import { pagedAWSCall } from './paged-call';
 
+/**
+ *
+ */
 export const createIdentityPoolService = async (context: $TSContext, options: $TSAny): Promise<IdentityPoolService> => {
   let credentials = {};
 
@@ -23,12 +26,18 @@ export const createIdentityPoolService = async (context: $TSContext, options: $T
   return new IdentityPoolService(cognitoIdentity);
 };
 
+/**
+ *
+ */
 export class IdentityPoolService implements IIdentityPoolService {
   private cachedIdentityPoolIds: IdentityPoolShortDescription[] = [];
   private cachedIdentityPoolDetails: IdentityPool[] = [];
 
   public constructor(private cognitoIdentity: CognitoIdentity) {}
 
+  /**
+   *
+   */
   public async listIdentityPools(): Promise<IdentityPoolShortDescription[]> {
     if (this.cachedIdentityPoolIds.length === 0) {
       const result = await pagedAWSCall<ListIdentityPoolsResponse, IdentityPoolShortDescription, PaginationKey>(
@@ -51,6 +60,9 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolIds;
   }
 
+  /**
+   *
+   */
   public async listIdentityPoolDetails(): Promise<IdentityPool[]> {
     if (this.cachedIdentityPoolDetails.length === 0) {
       const identityPools = await this.listIdentityPools();
@@ -75,6 +87,9 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolDetails;
   }
 
+  /**
+   *
+   */
   public async getIdentityPoolRoles(
     identityPoolId: string,
   ): Promise<{ authRoleArn: string; authRoleName: string; unauthRoleArn: string; unauthRoleName: string }> {
@@ -85,7 +100,7 @@ export class IdentityPoolService implements IIdentityPoolService {
       .promise();
 
     if (!response.Roles || !response.Roles.authenticated || !response.Roles.unauthenticated) {
-      throw amplifyErrorWithTroubleshootingLink('AuthImportError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'AuthImportError', {
         message: `Cannot import Identity Pool without 'authenticated' and 'unauthenticated' roles.`,
       });
     }
@@ -111,7 +126,7 @@ export class IdentityPoolService implements IIdentityPoolService {
 
     // Should not happen anytime
     if (!resourceName) {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw amplifyFaultWithTroubleshootingLink(null, 'UnknownFault', {
         message: `Cannot parse arn: '${arn}'.`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -3,6 +3,9 @@ import { IS3Service } from 'amplify-util-import';
 import S3, { Bucket } from 'aws-sdk/clients/s3';
 import { loadConfiguration } from '../configuration-manager';
 
+/**
+ *
+ */
 export const createS3Service = async (context: $TSContext, options: $TSAny): Promise<S3Service> => {
   let credentials = {};
 
@@ -17,11 +20,17 @@ export const createS3Service = async (context: $TSContext, options: $TSAny): Pro
   return new S3Service(s3);
 };
 
+/**
+ *
+ */
 export class S3Service implements IS3Service {
   private cachedBucketList: Bucket[] = [];
 
   public constructor(private s3: S3) {}
 
+  /**
+   *
+   */
   public async listBuckets(): Promise<Bucket[]> {
     if (this.cachedBucketList.length === 0) {
       const response = await this.s3.listBuckets().promise();
@@ -34,6 +43,9 @@ export class S3Service implements IS3Service {
     return this.cachedBucketList;
   }
 
+  /**
+   *
+   */
   public async bucketExists(bucketName: string): Promise<boolean> {
     try {
       const response = await this.s3
@@ -47,13 +59,16 @@ export class S3Service implements IS3Service {
       if (error.code === 'NotFound') {
         return false;
       }
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw amplifyFaultWithTroubleshootingLink(error, 'UnknownFault', {
         stack: error.stack,
         message: error.message,
       });
     }
   }
 
+  /**
+   *
+   */
   public async getBucketLocation(bucketName: string): Promise<string> {
     const response = await this.s3
       .getBucketLocation({

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -296,13 +296,13 @@ class CloudFormation {
       const Tags = this.context.amplify.getTags(this.context);
 
       if (!stackName) {
-        throw new AmplifyError('StackNotFoundError', {
+        throw new AmplifyError(null,'StackNotFoundError', {
           message: 'Project stack has not been created yet.',
           resolution: 'Use amplify init to initialize the project.',
         });
       }
       if (!deploymentBucketName) {
-        throw new AmplifyError('BucketNotFoundError', {
+        throw new AmplifyError(null,'BucketNotFoundError', {
           message: 'Project deployment bucket has not been created yet.',
           resolution: 'Use amplify init to initialize the project.',
         });
@@ -389,7 +389,7 @@ class CloudFormation {
         throw error;
       }
 
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
+      throw amplifyFaultWithTroubleshootingLink(error,'ResourceNotReadyFault', {
         message: error.message,
         stack: error.stack,
       });
@@ -564,7 +564,7 @@ class CloudFormation {
     const meta = stateManager.getMeta();
     stackId = stackId || _.get(meta, ['providers', providerName, 'StackName'], undefined);
     if (!stackId) {
-      throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+      throw amplifyErrorWithTroubleshootingLink(null,'StackNotFoundError', {
         message: `StackId not found in amplify-meta for provider ${providerName}`,
       });
     }
@@ -577,7 +577,7 @@ class CloudFormation {
     const providerInfo = teamProviderInfo?.[envName]?.[providerName];
     const stackName = providerInfo?.StackName;
     if (!stackName) {
-      throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+      throw amplifyErrorWithTroubleshootingLink(null,'StackNotFoundError', {
         message: `Stack not defined for the environment.`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
@@ -1,13 +1,16 @@
-const aws = require('./aws');
 import { $TSAny, $TSContext, amplifyErrorWithTroubleshootingLink } from 'amplify-cli-core';
 import { Lambda as AwsSdkLambda } from 'aws-sdk';
 import { LayerVersionsListItem, ListLayerVersionsRequest, ListLayerVersionsResponse } from 'aws-sdk/clients/lambda';
 import { AwsSecrets, loadConfiguration } from '../configuration-manager';
 import { fileLogger } from '../utils/aws-logger';
 import { pagedAWSCall } from './paged-call';
+const aws = require('./aws');
 
 const logger = fileLogger('aws-lambda');
 
+/**
+ *
+ */
 export class Lambda {
   private lambda: AwsSdkLambda;
 
@@ -24,6 +27,9 @@ export class Lambda {
     })() as $TSAny;
   }
 
+  /**
+   *
+   */
   async listLayerVersions(layerNameOrArn: string) {
     const startingParams: ListLayerVersionsRequest = { LayerName: layerNameOrArn, MaxItems: 20 };
     const result = await pagedAWSCall<ListLayerVersionsResponse, LayerVersionsListItem, string>(
@@ -33,12 +39,15 @@ export class Lambda {
         return await this.lambda.listLayerVersions(params).promise();
       },
       startingParams,
-      (response?) => response?.LayerVersions,
+      response? => response?.LayerVersions,
       async response => response?.NextMarker,
     );
     return result;
   }
 
+  /**
+   *
+   */
   async deleteLayerVersions(layerNameOrArn: string, versions: number[]) {
     const params = { LayerName: layerNameOrArn, VersionNumber: undefined };
     const deletionPromises = [];
@@ -49,7 +58,7 @@ export class Lambda {
           await this.lambda.deleteLayerVersion(params).promise();
         } catch (err) {
           if (err.code !== 'ParameterNotFound') {
-            throw amplifyErrorWithTroubleshootingLink('LambdaLayerDeleteError', {
+            throw amplifyErrorWithTroubleshootingLink(err, 'LambdaLayerDeleteError', {
               message: err.message,
               stack: err.stack,
             });

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -186,7 +186,7 @@ export class S3 {
       await this.s3.waitFor('bucketExists', params).promise();
       this.context.print.success('S3 bucket successfully created');
     } else if (throwIfExists) {
-      throw amplifyErrorWithTroubleshootingLink('BucketAlreadyExistsError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'BucketAlreadyExistsError', {
         message: `Bucket ${bucketName} already exists`,
       });
     }
@@ -345,14 +345,14 @@ export class S3 {
       logger('ifBucketExists.s3.headBucket', [{ BucketName: bucketName }])(e);
 
       if (e.code === 'NotFound') {
-        throw new AmplifyError('BucketNotFoundError', {
+        throw new AmplifyError(e, 'BucketNotFoundError', {
           message: e.message,
           stack: e.stack,
           resolution: `Check that bucket name is correct: ${bucketName}`,
         });
       }
 
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'UnknownFault', {
         message: e.message,
         stack: e.stack,
       });
@@ -380,7 +380,7 @@ export class S3 {
         return undefined;
       }
 
-      throw amplifyFaultWithTroubleshootingLink('UnexpectedS3Fault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'UnexpectedS3Fault', {
         message: e.message,
         stack: e.stack,
       });

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -38,6 +38,9 @@ interface ProjectConfig {
   config?: AwsConfig;
 }
 
+/**
+ *
+ */
 export interface AwsSecrets {
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -49,6 +52,9 @@ const defaultAWSConfig: AwsConfig = {
   profileName: 'default',
 };
 
+/**
+ *
+ */
 export async function init(context: $TSContext) {
   if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend || (!context.exeInfo.isNewProject && doesAwsConfigExists(context))) {
     return context;
@@ -183,7 +189,7 @@ function normalizeInputParams(context: $TSContext) {
         }
       }
       if (errorMessage) {
-        throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
           message: 'Error in the command line parameter for awscloudformation configuration.',
           details: errorMessage,
         });
@@ -293,7 +299,7 @@ async function create(context: $TSContext) {
   if (awsConfigInfo.configValidated) {
     persistLocalEnvConfig(context);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: 'Invalid configuration settings.',
     });
   }
@@ -312,7 +318,7 @@ async function update(context: $TSContext) {
   if (awsConfigInfo.configValidated) {
     updateProjectConfig(context);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: 'Invalid configuration settings.',
     });
   }
@@ -414,7 +420,7 @@ async function promptForAuthConfig(context: $TSContext, authConfig?: AuthFlowCon
       answers = await prompt(profileNameQuestion(availableProfiles, awsConfigInfo.config.profileName));
       awsConfigInfo.config.profileName = answers.profileName;
       return;
-    } 
+    }
 
     if (authType === 'admin') {
       awsConfigInfo.configLevel = 'amplifyAdmin';
@@ -565,7 +571,7 @@ function getConfigForEnv(context: $TSContext, envName: string) {
         projectConfigInfo.config.secretAccessKey = awsSecrets.secretAccessKey;
         projectConfigInfo.config.region = awsSecrets.region;
       } else {
-        throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
           message: `Corrupt file contents in ${configInfoFilePath}`,
         });
       }
@@ -600,6 +606,9 @@ function removeProjectConfig(envName: string) {
   }
 }
 
+/**
+ *
+ */
 export async function loadConfiguration(context: $TSContext): Promise<AwsSecrets> {
   const { envName } = context.amplify.getEnvInfo();
   const config = await loadConfigurationForEnv(context, envName);
@@ -613,11 +622,14 @@ function loadConfigFromPath(profilePath: string): AwsSdkConfig {
       return config;
     }
   }
-  throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+  throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
     message: `Invalid config ${profilePath}`,
   });
 }
 
+/**
+ *
+ */
 export async function loadConfigurationForEnv(context: $TSContext, env: string, appId?: string): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo || {};
 
@@ -660,6 +672,9 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
   return awsConfig;
 }
 
+/**
+ *
+ */
 export async function resetCache(context: $TSContext) {
   const projectConfigInfo = getCurrentConfig(context);
   if (projectConfigInfo.configLevel === 'project') {
@@ -670,6 +685,9 @@ export async function resetCache(context: $TSContext) {
   }
 }
 
+/**
+ *
+ */
 export function resolveRegion(): string {
   // For details of how aws region is set, check the following link
   // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
@@ -700,7 +718,7 @@ async function newUserCheck(context: $TSContext) {
       }
     }
     if (context.exeInfo.inputParams.yes) {
-      throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
         message: 'AWS access credentials can not be found.',
       });
     } else {
@@ -772,6 +790,9 @@ function getConfigLevel(context: $TSContext): ProjectType {
   return configLevel;
 }
 
+/**
+ *
+ */
 export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
@@ -800,7 +821,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
     try {
       resultAWSConfigInfo = await getTempCredsWithAdminTokens(context, appId);
     } catch (err) {
-      throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+      throw amplifyErrorWithTroubleshootingLink(err, 'AmplifyStudioLoginError', {
         message: 'Failed to fetch Amplify Studio credentials',
         details: err.message,
       });

--- a/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
+++ b/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
@@ -259,7 +259,7 @@ export const showSMSSandboxWarning = async (context) : Promise<void> => {
       // Network error. Sandbox status is for informational purpose and should not stop deployment
       log(e);
     } else {
-      throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+      throw amplifyFaultWithTroubleshootingLink(e, 'DeploymentFault', {
         stack: e.stack,
         message: e.message,
       });

--- a/packages/amplify-provider-awscloudformation/src/download-api-models.ts
+++ b/packages/amplify-provider-awscloudformation/src/download-api-models.ts
@@ -89,7 +89,7 @@ const copyFilesToSrc = (context: $TSContext, apiName: string, framework: string)
       }
       break;
     default:
-      throw amplifyErrorWithTroubleshootingLink('FrameworkNotSupportedError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'FrameworkNotSupportedError', {
         message: `Unsupported framework. ${framework}`,
       });
   }
@@ -129,7 +129,7 @@ const getAPIGWRequestParams = (resource: $TSObject, framework: string): $TSAny =
       };
 
     default:
-      throw amplifyErrorWithTroubleshootingLink('FrameworkNotSupportedError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'FrameworkNotSupportedError', {
         message: `Unsupported framework. ${framework}`,
       });
   }

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -71,7 +71,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSAny[], exp
   } catch (ex) {
     revertToBackup(amplifyExportFolder);
     spinner.fail();
-    throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
+    throw amplifyFaultWithTroubleshootingLink(ex, 'ResourceNotReadyFault', {
       stack: ex.stack,
       message: ex.message,
     });

--- a/packages/amplify-provider-awscloudformation/src/export-update-amplify-meta.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-update-amplify-meta.ts
@@ -38,7 +38,7 @@ export const run = async (context: $TSContext, stackName: string): Promise<void>
 
   // if stack isn't found mostly because the stack isn't accessible by the credentials
   if (!rootStack) {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'StackNotFoundError', {
       message: `${stackName} could not be found.`,
       resolution: 'Please check the stack name and credentials.',
     });
@@ -46,7 +46,7 @@ export const run = async (context: $TSContext, stackName: string): Promise<void>
 
   // if the stack is found and is not in valid state
   if (rootStack.StackStatus !== 'UPDATE_COMPLETE' && rootStack.StackStatus !== 'CREATE_COMPLETE') {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'StackNotFoundError', {
       message: `${stackName} not in UPDATE_COMPLETE or CREATE_COMPLETE state`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -94,7 +94,7 @@ export class GraphQLResourceManager {
 
   constructor(props: GQLResourceManagerProps) {
     if (!props.resourceMeta) {
-      throw new AmplifyError('CategoryNotEnabledError', {
+      throw new AmplifyError(null, 'CategoryNotEnabledError', {
         message: 'No GraphQL API enabled.',
         link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
       });
@@ -124,7 +124,7 @@ export class GraphQLResourceManager {
       sanityCheckDiffs(gqlDiff.diff, gqlDiff.current, gqlDiff.next, diffRules, projectRules);
     } catch (err) {
       if (err.name !== 'InvalidGSIMigrationError') {
-        throw new AmplifyFault('UnknownFault', {
+        throw new AmplifyFault(err, 'UnknownFault', {
           stack: err.stack,
           message: err.message,
           link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
@@ -295,7 +295,7 @@ export class GraphQLResourceManager {
             break;
 
           default:
-            throw new AmplifyFault('UnknownFault', {
+            throw new AmplifyFault(null, 'UnknownFault', {
               message: `Unknown GSI change type ${changeStep.type}`,
               link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
             });
@@ -331,7 +331,7 @@ export class GraphQLResourceManager {
             diff => {
               const keySchemaModified = diff.kind === 'E' && diff.path.length === 8 && diff.path[5] === 'KeySchema';
               const sortKeyAddedOrRemoved = diff.kind === 'A' && diff.path.length === 6 && diff.path[5] === 'KeySchema' && diff.index === 1;
-              const localSecondaryIndexModified = diff.path.some((pathEntry) => pathEntry === 'LocalSecondaryIndexes');
+              const localSecondaryIndexModified = diff.path.some(pathEntry => pathEntry === 'LocalSecondaryIndexes');
               return keySchemaModified || sortKeyAddedOrRemoved || localSecondaryIndexModified;
             },
           ) // filter diffs with changes that require replacement

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
@@ -54,7 +54,7 @@ export const addGSI = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table 
   const existingIndices = getExistingIndexNames(table);
 
   if (existingIndices.length + 1 > MAX_GSI_PER_TABLE) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: `DynamoDB ${table.Properties.TableName || '{UnNamedTable}'} can have max of ${MAX_GSI_PER_TABLE} GSIs`,
     });
   }
@@ -63,7 +63,7 @@ export const addGSI = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table 
   assertNotIntrinsicFunction(indexName);
 
   if (existingIndices.includes(indexName)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: `An index with name ${indexName} already exists`,
     });
   }
@@ -89,7 +89,7 @@ export const removeGSI = (indexName: string, table: DynamoDB.Table): DynamoDB.Ta
   assertNotIntrinsicFunction(gsis);
 
   if (!gsis || gsis.length === 0) {
-    throw new AmplifyError('ConfigurationError', {
+    throw new AmplifyError(null, 'ConfigurationError', {
       message: `No GSIs are present in the table`,
       link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
     });
@@ -97,7 +97,7 @@ export const removeGSI = (indexName: string, table: DynamoDB.Table): DynamoDB.Ta
 
   const indexNames = gsis.map(g => g.IndexName);
   if (!indexNames.includes(indexName)) {
-    throw new AmplifyError('ConfigurationError', {
+    throw new AmplifyError(null, 'ConfigurationError', {
       message: `Table ${table.Properties.TableName || '{UnnamedTable}'} does not contain GSI ${indexName}`,
       link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
     });
@@ -136,7 +136,7 @@ export const removeGSI = (indexName: string, table: DynamoDB.Table): DynamoDB.Ta
  */
 export function assertNotIntrinsicFunction<A>(x: A[] | A | IntrinsicFunction): asserts x is A[] | A {
   if (x instanceof IntrinsicFunction) {
-    throw new AmplifyError('ConfigurationError', {
+    throw new AmplifyError(null, 'ConfigurationError', {
       message: 'Intrinsic functions are not supported in KeySchema and GlobalSecondaryIndex',
       link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
     });

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -201,7 +201,7 @@ const processStackCreationData = (context: $TSContext, amplifyAppId: string | un
 
     setCloudFormationOutputInContext(context, metadata);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'StackNotFoundError', {
       message: 'No stack data present',
     });
   }
@@ -321,7 +321,7 @@ const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
     })
     .catch(ex => {
       spinner.stop('Deployment state save failed.', false);
-      throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+      throw amplifyFaultWithTroubleshootingLink(ex, 'DeploymentFault', {
         message: ex.message,
         stack: ex.stack,
       });

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -80,7 +80,7 @@ export class DeploymentManager {
       assert(cred.region);
       return new DeploymentManager(cred, cred.region, deploymentBucket, spinner, printer, options);
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(e, 'DeploymentError', {
         message: 'Could not load configuration',
         stack: e.stack,
         details: e.message,
@@ -333,7 +333,7 @@ export class DeploymentManager {
       await this.s3Client.headObject({ Bucket: this.deploymentBucket, Key: bucketKey }).promise();
       return true;
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(e, 'DeploymentError', {
         message: e.code === 'NotFound'
           ? `The cloudformation template ${templatePath} was not found in deployment bucket ${this.deploymentBucket}`
           : e.message,
@@ -357,7 +357,7 @@ export class DeploymentManager {
       if (err?.code === 'ResourceNotFoundException') {
         return true; // in the case of an iterative update that recreates a table, non-existence means the table has been fully removed
       }
-      throw amplifyFaultWithTroubleshootingLink('ServiceCallFault', {
+      throw amplifyFaultWithTroubleshootingLink(err, 'ServiceCallFault', {
         message: err.message,
         stack: err.stack,
       });

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
@@ -98,7 +98,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
   public startCurrentStep = async (params?: StepStatusParameters): Promise<void> => {
     if (this.direction === 1) {
       if (this.getCurrentStep().status !== DeploymentStepStatus.WAITING_FOR_DEPLOYMENT) {
-        throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
           message: `Cannot start step when the current step is in ${this.getCurrentStep().status} status.`,
         });
       }
@@ -107,7 +107,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
       if (params?.previousMetaKey) currentStep.previousMetaKey = params.previousMetaKey;
     } else if (this.direction === -1) {
       if (this.getCurrentStep().status !== DeploymentStepStatus.WAITING_FOR_ROLLBACK) {
-        throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
           message: `Cannot start step when the current step is in ${this.getCurrentStep().status} status.`,
         });
       }
@@ -119,17 +119,17 @@ export class DeploymentStateManager implements IDeploymentStateManager {
 
   public advanceStep = async (): Promise<void> => {
     if (!this.isDeploymentInProgress()) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
         message: `Cannot advance a deployment when it was not started.`,
       });
     }
 
     if (this.direction === 1 && this.getCurrentStep().status !== DeploymentStepStatus.DEPLOYING) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
         message: `Cannot advance step when the current step is in ${this.getCurrentStep().status} status.`,
       });
     } else if (this.direction === -1 && this.getCurrentStep().status !== DeploymentStepStatus.ROLLING_BACK) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
         message: `Cannot advance step when the current step is in ${this.getCurrentStep().status} status.`,
       });
     }
@@ -170,7 +170,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
 
   public startRollback = async (): Promise<void> => {
     if (!this.isDeploymentInProgress() || this.direction !== 1) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DeploymentError', {
         message: 'To rollback a deployment, the deployment must be in progress and not already rolling back.',
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/iterative-rollback.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/iterative-rollback.ts
@@ -21,7 +21,7 @@ const loadDeploymentMeta = async (s3: S3, bucketName: string, metaKey: string): 
     return JSONUtilities.parse<DeploymentOp>(metaDeploymentContent);
   }
 
-  throw amplifyErrorWithTroubleshootingLink('IterativeRollbackError', {
+  throw amplifyErrorWithTroubleshootingLink(null, 'IterativeRollbackError', {
     message: `Could not find deployment meta file: ${metaKey}`,
   });
 };
@@ -60,7 +60,7 @@ export const runIterativeRollback = async (
   const stateFiles: string[] = [];
   for (const step of deployedSteps) {
     if (!step.previousMetaKey) {
-      throw amplifyErrorWithTroubleshootingLink('IterativeRollbackError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'IterativeRollbackError', {
         message: `Cannot iteratively rollback as the following step does not contain a previousMetaKey: ${JSON.stringify(step)}`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -3,10 +3,16 @@ import * as aws from 'aws-sdk';
 import { amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
 import { fileLogger, Logger } from '../utils/aws-logger';
 
+/**
+ *
+ */
 export interface StackEventMonitorOptions {
   pollDelay: number;
 }
 
+/**
+ *
+ */
 export interface IStackProgressPrinter {
   addActivity: (activity: StackEvent) => void;
   print: () => void;
@@ -14,6 +20,9 @@ export interface IStackProgressPrinter {
   stop: () => void;
 }
 
+/**
+ *
+ */
 export class StackEventMonitor {
   private active = false;
   private tickTimer?: NodeJS.Timeout;
@@ -36,6 +45,9 @@ export class StackEventMonitor {
     this.logger = fileLogger('stack-event-monitor');
   }
 
+  /**
+   *
+   */
   public start() {
     this.active = true;
     this.printer.start();
@@ -43,6 +55,9 @@ export class StackEventMonitor {
     return this;
   }
 
+  /**
+   *
+   */
   public async stop() {
     this.active = false;
     this.printer.stop();
@@ -143,7 +158,7 @@ export class StackEventMonitor {
         return;
       }
       if (e.code !== 'Throttling') {
-        throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+        throw amplifyFaultWithTroubleshootingLink(e, 'NotImplementedFault', {
           message: e.message,
           stack: e.stack,
         });

--- a/packages/amplify-provider-awscloudformation/src/network/environment-info.ts
+++ b/packages/amplify-provider-awscloudformation/src/network/environment-info.ts
@@ -38,7 +38,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
     const subnets = subnetsCount;
     const AZs = AvailabilityZones.length;
 
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: `The requested number of subnets exceeds the number of AZs for the region. ${JSONUtilities.stringify({ subnets, azs: AZs })}`,
     });
   }
@@ -63,11 +63,10 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
   const { VpcId: vpcId } = vpc;
 
   if (vpcId && !vpc.CidrBlock.endsWith(vpcMask)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: 'Not the right mask',
     });
   }
-
 
   const { InternetGateways } = await ec2
     .describeInternetGateways({
@@ -85,13 +84,12 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
     .promise();
 
   if (vpcId && InternetGateways.length === 0) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: `No attached and available Internet Gateway in VPC ${vpcId}`,
     });
   }
 
   const [{ InternetGatewayId: internetGatewayId = undefined } = {}] = InternetGateways;
-
 
   const { Subnets } = await ec2.describeSubnets({ Filters: [{ Name: 'vpc-id', Values: [vpcId] }] }).promise();
 
@@ -146,7 +144,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
   }
 
   if (envCidrs.size < subnetsCount) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ConfigurationError', {
       message: 'Not enough CIDRs available in VPC',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/permissions-boundary/permissions-boundary.ts
+++ b/packages/amplify-provider-awscloudformation/src/permissions-boundary/permissions-boundary.ts
@@ -1,7 +1,12 @@
-import { $TSContext, stateManager, getPermissionsBoundaryArn, setPermissionsBoundaryArn, AmplifyError, AMPLIFY_DOCS_URL } from 'amplify-cli-core';
+import {
+  $TSContext, stateManager, getPermissionsBoundaryArn, setPermissionsBoundaryArn, AmplifyError, AMPLIFY_DOCS_URL,
+} from 'amplify-cli-core';
 import { prompt } from 'inquirer';
 import { IAMClient } from '../aws-utils/aws-iam';
 
+/**
+ *
+ */
 export const configurePermissionsBoundaryForExistingEnv = async (context: $TSContext) => {
   setPermissionsBoundaryArn(await permissionsBoundarySupplier(context));
   context.print.info(
@@ -9,8 +14,11 @@ export const configurePermissionsBoundaryForExistingEnv = async (context: $TSCon
   );
 };
 
+/**
+ *
+ */
 export const configurePermissionsBoundaryForInit = async (context: $TSContext) => {
-  const envName = context.exeInfo.localEnvInfo.envName; // the new environment name
+  const { envName } = context.exeInfo.localEnvInfo; // the new environment name
   if (context?.exeInfo?.isNewProject) {
     // amplify init
     // on init flow, set the permissions boundary if specified in a cmd line arg, but don't prompt for it
@@ -54,14 +62,13 @@ const permissionsBoundarySupplier = async (
   if (typeof headlessPermissionsBoundary === 'string') {
     if (validate(headlessPermissionsBoundary)) {
       return headlessPermissionsBoundary;
-    } else {
-      context.print.error('The permissions boundary ARN specified is not a valid IAM Policy ARN');
     }
+    context.print.error('The permissions boundary ARN specified is not a valid IAM Policy ARN');
   }
 
   const isYes = context?.input?.options?.yes;
   if (required && (isYes || !doPrompt)) {
-    throw new AmplifyError('InputValidationError', {
+    throw new AmplifyError(null, 'InputValidationError', {
       message: 'A permissions boundary ARN must be specified using --permissions-boundary',
       link: `${AMPLIFY_DOCS_URL}/cli/project/permissions-boundary/`,
     });

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -335,7 +335,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
           if (err?.name === 'ValidationError' && err?.message === 'No updates are to be performed.') {
             return;
           }
-          throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+          throw amplifyFaultWithTroubleshootingLink(err, 'DeploymentFault', {
             stack: err.stack,
             message: err.message,
           });
@@ -462,7 +462,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
       await deploymentStateManager.failDeployment();
     }
     rollbackLambdaLayers(layerResources);
-    throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+    throw amplifyFaultWithTroubleshootingLink(error, 'DeploymentFault', {
       stack: error.stack,
       message: error.message,
     });
@@ -651,7 +651,7 @@ const prepareResource = async (context: $TSContext, resource: $TSAny) => {
   });
 
   if (cfnFiles.length !== 1) {
-    throw amplifyErrorWithTroubleshootingLink('CloudFormationTemplateError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'CloudFormationTemplateError', {
       message: cfnFiles.length > 1 ? 'Only one CloudFormation template is allowed in the resource directory' : 'No CloudFormation template found in the resource directory',
       details: `Resource directory: ${resourceDir}`,
     });
@@ -1114,7 +1114,7 @@ export const formNestedStack = async (
               const dependentResource = _.get(amplifyMeta, [dependsOn[i].category, dependsOn[i].resourceName], undefined);
 
               if (!dependentResource && dependsOn[i].category) {
-                throw amplifyErrorWithTroubleshootingLink('PushResourcesError', {
+                throw amplifyErrorWithTroubleshootingLink(null, 'PushResourcesError', {
                   message: `Cannot get resource: ${dependsOn[i].resourceName} from '${dependsOn[i].category}' category.`,
                 });
               }
@@ -1123,7 +1123,7 @@ export const formNestedStack = async (
                 const outputAttributeValue = _.get(dependentResource, ['output', attribute], undefined);
 
                 if (!outputAttributeValue) {
-                  throw amplifyErrorWithTroubleshootingLink('PushResourcesError', {
+                  throw amplifyErrorWithTroubleshootingLink(null, 'PushResourcesError', {
                     message: `Cannot read the '${attribute}' dependent attribute value from the output section of resource: '${dependsOn[i].resourceName}'.`,
                   });
                 }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -8,10 +8,16 @@ import { amplifyErrorWithTroubleshootingLink, amplifyFaultWithTroubleshootingLin
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
 
+/**
+ *
+ */
 export type AmplifyRootStackProps = {
   synthesizer: IStackSynthesizer;
 };
 
+/**
+ *
+ */
 export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTemplate {
   _scope: cdk.Construct;
   deploymentBucket: s3.CfnBucket;
@@ -69,18 +75,21 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
    */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
     if (this._cfnParameterMap.has(logicalId)) {
-      throw amplifyErrorWithTroubleshootingLink('DuplicateLogicalIdError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'DuplicateLogicalIdError', {
         message: `Logical Id already exists: ${logicalId}.`,
       });
     }
     this._cfnParameterMap.set(logicalId, new cdk.CfnParameter(this, logicalId, props));
   }
 
+  /**
+   *
+   */
   getCfnParameter(logicalId: string): cdk.CfnParameter {
     if (this._cfnParameterMap.has(logicalId)) {
       return this._cfnParameterMap.get(logicalId);
     }
-    throw amplifyErrorWithTroubleshootingLink('ParameterNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ParameterNotFoundError', {
       message: `Cfn Parameter with LogicalId ${logicalId} doesn't exist`,
     });
   }
@@ -147,30 +156,45 @@ export class AmplifyRootStackOutputs extends cdk.Stack implements AmplifyRootSta
   authRole?: iam.CfnRole;
   unauthRole?: iam.CfnRole;
 
+  /**
+   *
+   */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void {
     new cdk.CfnOutput(this, logicalId, props);
   }
 
+  /**
+   *
+   */
   addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -1,6 +1,8 @@
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from '@aws-cdk/core';
-import { $TSContext, amplifyFaultWithTroubleshootingLink, buildOverrideDir, CFNTemplateFormat, pathManager, Template, writeCFNTemplate } from 'amplify-cli-core';
+import {
+  $TSContext, amplifyFaultWithTroubleshootingLink, buildOverrideDir, CFNTemplateFormat, pathManager, Template, writeCFNTemplate,
+} from 'amplify-cli-core';
 import { formatter } from 'amplify-prompts';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -8,6 +10,9 @@ import * as vm from 'vm2';
 import { AmplifyRootStack, AmplifyRootStackOutputs } from './root-stack-builder';
 import { RootStackSynthesizer } from './stack-synthesizer';
 
+/**
+ *
+ */
 export class AmplifyRootStackTransform {
   private app: cdk.App | undefined;
   private _rootTemplateObj: AmplifyRootStack; // Props to modify Root stack data
@@ -201,12 +206,15 @@ export class AmplifyRootStackTransform {
     });
   };
 
+  /**
+   *
+   */
   public getRootStack(): AmplifyRootStack {
     if (this._rootTemplateObj) {
       return this._rootTemplateObj;
     }
 
-    throw amplifyFaultWithTroubleshootingLink('RootStackNotFoundFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'RootStackNotFoundFault', {
       message: `Root Stack Template doesn't exist.`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/stack-synthesizer.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/stack-synthesizer.ts
@@ -16,7 +16,7 @@ export class RootStackSynthesizer extends LegacyStackSynthesizer {
       const templateName = stack.node.id;
       this.setStackAsset(templateName, template);
     } else {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw amplifyFaultWithTroubleshootingLink(null, 'UnknownFault', {
         message: 'Error synthesizing the template. Expected Stack to be either instance of AmplifyRootStack',
       });
     }
@@ -48,7 +48,7 @@ export class RootStackSynthesizer extends LegacyStackSynthesizer {
       return this.stacks.get(stackName)!;
     }
 
-    throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+    throw amplifyFaultWithTroubleshootingLink(null, 'UnknownFault', {
       message: `Stack ${stackName} is not created`,
     });
   };

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.ts
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.ts
@@ -125,7 +125,7 @@ export const run = async (context): Promise<string> => {
     return profileName;
   }
 
-  throw amplifyErrorWithTroubleshootingLink('InputValidationError', {
+  throw amplifyErrorWithTroubleshootingLink(null, 'InputValidationError', {
     message: 'Invalid AWS credentials',
     resolution: 'Please check your AWS credentials',
   });

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -106,7 +106,7 @@ export const getProfiledAwsConfig = async (context: $TSContext, profileName: str
       validateCredentials(awsConfigInfo, profileName);
     }
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ProfileConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ProfileConfigurationError', {
       message: `Profile configuration is missing for: ${profileName}`,
     });
   }
@@ -332,7 +332,7 @@ const validateCredentials = (credentials: $TSAny, profileName: string): void => 
     missingKeys.push('aws_secret_access_key');
   }
   if (missingKeys.length > 0) {
-    throw amplifyErrorWithTroubleshootingLink('ProfileConfigurationError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ProfileConfigurationError', {
       message: `Profile configuration for '${profileName}' is invalid: missing ${missingKeys.join(', ')}`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/src/utility-functions.js
@@ -135,7 +135,7 @@ module.exports = {
       const { code } = error;
 
       if (code !== 'ResourceNotFoundException') {
-        throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+        throw amplifyFaultWithTroubleshootingLink(error, 'ResourceNotFoundFault', {
           message: error.message,
           stack: error.stack,
         });
@@ -184,7 +184,7 @@ module.exports = {
   getTransformerDirectives: async (context, options) => {
     const { resourceDir } = options;
     if (!resourceDir) {
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+      throw amplifyFaultWithTroubleshootingLink(null, 'ResourceNotFoundFault', {
         message: 'Missing resource directory.',
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -10,23 +10,32 @@ import {
   AdminAuthConfig, AwsSdkConfig, CognitoAccessToken, CognitoIdToken,
 } from './auth-types';
 
+/**
+ *
+ */
 export const adminVerifyUrl = (appId: string, envName: string, region: string): string => {
   const baseUrl = process.env.AMPLIFY_CLI_ADMINUI_BASE_URL ?? adminBackendMap[region]?.amplifyAdminUrl;
   return `${baseUrl}/admin/${appId}/${envName}/verify/?loginVersion=1`;
 };
 
+/**
+ *
+ */
 export function doAdminTokensExist(appId: string): boolean {
   if (!appId) {
-    throw amplifyErrorWithTroubleshootingLink('AmplifyStudioError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'AmplifyStudioError', {
       message: `Failed to check if admin credentials exist: appId is undefined`,
     });
   }
   return !!stateManager.getAmplifyAdminConfigEntry(appId);
 }
 
+/**
+ *
+ */
 export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string; userPoolID: string }> {
   if (!appId) {
-    throw amplifyErrorWithTroubleshootingLink('AmplifyStudioError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'AmplifyStudioError', {
       message: `Failed to check if Amplify Studio is enabled: appId is undefined`,
     });
   }
@@ -38,6 +47,9 @@ export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: bo
   return { isAdminApp: !!appState.appId, region: appState.region, userPoolID };
 }
 
+/**
+ *
+ */
 export async function getTempCredsWithAdminTokens(context: $TSContext, appId: string): Promise<AwsSdkConfig> {
   if (!doAdminTokensExist(appId)) {
     await adminLoginFlow(context, appId);

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
@@ -72,7 +72,7 @@ export class AdminLoginServer {
       })
       .promise();
     if (!IdentityId) {
-      throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+      throw amplifyErrorWithTroubleshootingLink(null, 'AmplifyStudioLoginError', {
         message: 'IdentityId not defined. Amplify CLI was unable to retrieve credentials.',
       });
     }
@@ -87,7 +87,7 @@ export class AdminLoginServer {
           this.print.info('Login canceled');
           process.exit(0);
         }
-        throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+        throw amplifyErrorWithTroubleshootingLink(null, 'AmplifyStudioLoginError', {
           message: 'Failed to receive expected authentication tokens.',
         });
       }
@@ -97,7 +97,7 @@ export class AdminLoginServer {
         res.sendStatus(200);
       } catch (err) {
         res.sendStatus(500);
-        throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+        throw amplifyErrorWithTroubleshootingLink(err, 'AmplifyStudioLoginError', {
           message: `Failed to receive expected authentication tokens. Error: [${err}]`,
         });
       }

--- a/packages/amplify-provider-awscloudformation/src/utils/remove-dependent-function.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/remove-dependent-function.ts
@@ -57,7 +57,7 @@ export const ensureValidFunctionModelDependencies = async (
       apiResource[0].resourceName,
     ]);
   } else {
-    throw new AmplifyError('DeploymentError', {
+    throw new AmplifyError(null, 'DeploymentError', {
       message: 'Failed to resolve appId.',
       resolution: `Run “amplify update function” on the affected functions ${dependentFunctionsNames} and remove the access permission to ${tablesDeleted}.`,
     });

--- a/packages/amplify-provider-awscloudformation/src/utils/resolve-appId.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/resolve-appId.ts
@@ -11,13 +11,13 @@ export const resolveAppId = (context: $TSContext): string => {
     if (meta?.providers?.awscloudformation?.AmplifyAppId) {
       return meta.providers.awscloudformation.AmplifyAppId;
     }
-    throw amplifyErrorWithTroubleshootingLink('ProjectAppIdResolveError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ProjectAppIdResolveError', {
       message: 'Could not find AmplifyAppId in amplify-meta.json.',
     });
   } else if (context?.exeInfo?.inputParams?.amplify?.appId) {
     return context.exeInfo.inputParams.amplify.appId;
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ProjectAppIdResolveError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'ProjectAppIdResolveError', {
       message: 'Failed to resolve appId.',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
@@ -38,7 +38,7 @@ export const uploadAuthTriggerTemplate = async (context: $TSContext): Promise<{ 
 
   // This should not happen, so throw
   if (!deploymentBucketName) {
-    throw amplifyErrorWithTroubleshootingLink('BucketNotFoundError', {
+    throw amplifyErrorWithTroubleshootingLink(null, 'BucketNotFoundError', {
       message: 'DeploymentBucket was not found in amplify-meta.json',
     });
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
We recently performed a large lift to increase the visibility of errors, and improve the user experience by providing resolution steps when possible. In fact, there are 162 instances where we are now using AmplifyException classes to provide troubleshooting assistance to customers.
![image](https://user-images.githubusercontent.com/110861985/194189467-67550c60-f069-49b5-a35d-bbe4079f44bd.png)


Our goal is to make sure that AmplifyExceptions (and their resolutions) reach the user.

**Problem**: There were 44 instances where an AmplifyException was being thrown without checking to see if the exception caught was already an AmplifyException. These 44 instances are all potential gaps in our ability to provide resolutions to customers, because the downstream exception might have already provided more detailed resolution steps.

**Solution**: The updated AmplifyException class will now automatically check to see if the downstream exception is already an AmplifyException, and make sure that resolutions steps are forwarded up to the user. This will ensure that resolution steps are as relevant as possible, and that resolution steps are provided as soon as the error happens, not multiple catch blocks later.
This is possible now because the AmplifyException classes require developers to provide the original exception in the constructor. If there is no downstream exception, developers can declare it explicitly by providing 'null'.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
