### PR TITLE
fix: bug with carriage return after ctrl A

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -323,7 +323,7 @@ function chain(context: Context): ExecutionContext {
     sendCtrlA(): ExecutionContext {
       const _send: ExecutionStep = {
         fn: () => {
-          context.process.write(`${CONTROL_A}${EOL}`);
+          context.process.write(`${CONTROL_A}`);
           return true;
         },
         name: '_send',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a follow up to fix additional issues with Geo, and any test that uses sendCtrlA.

Problem: sendCtrlA was also sending a carriageReturn, which might unintentionally skip any prompts after it. Tests were using sendCtrlA and following it up with sendCarriageReturn, which produced 2 carriage returns (bad).
Example, in geo-remove-3
![image](https://user-images.githubusercontent.com/110861985/194413296-c00e2ce7-8177-4a67-af15-605c91b741b6.png)


Solution: sendCtrlA will no longer send a carriageReturn. All existing tests will continue to explicitly use sendCarriageReturn after using sendCtrlA.

E2E Results (All Passing): https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/11427/workflows/350ad677-bbb9-4b72-8d4a-069ab2819d91

Tests that were affected by this, based on usage of sendCtrlA+sendCarriageReturn, call chain depth of 2:
auth_1.test.ts
auth_4.test.ts
auth-migration.test.ts
api_5.test.ts
api_8.test.ts
function_2.test.ts
import_auth_2.test.ts
import_s3_1.test.ts
import_s3_2.test.ts
geo-remove-3.test.ts
goe-add.test.ts
geo-update.test.ts


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
