### PR TITLE
fix: fallback to tpi when looking for existing envs on init

### DIFF
--- a/packages/amplify-cli/src/__tests__/init-steps/s0-analyzeProject.test.ts
+++ b/packages/amplify-cli/src/__tests__/init-steps/s0-analyzeProject.test.ts
@@ -9,9 +9,11 @@ jest.mock('amplify-cli-core');
 const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
 stateManagerMock.getLocalAWSInfo.mockReturnValue({ envA: 'test', envB: 'test' });
 stateManagerMock.getLocalEnvInfo.mockReturnValue({ defaultEditor: 'Visual Studio Code' });
+stateManagerMock.getTeamProviderInfo.mockReturnValue({});
 
 describe('analyzeProject', () => {
-  it('recognizes the default editor', async () => {
+  let mockContext;
+  beforeEach(() => {
     const mockPluginPlatform = constructMockPluginPlatform();
     const mockProcessArgv = [
       '/Users/userName/.nvm/versions/node/v12.16.1/bin/node',
@@ -20,7 +22,7 @@ describe('analyzeProject', () => {
       '-y',
     ];
     const mockInput = new Input(mockProcessArgv);
-    const mockContext = constructContext(mockPluginPlatform, mockInput) as unknown as $TSContext;
+    mockContext = constructContext(mockPluginPlatform, mockInput) as unknown as $TSContext;
     const frontendPlugins = [
       {
         name: 'amplify-frontend-javascript',
@@ -42,9 +44,36 @@ describe('analyzeProject', () => {
       },
     };
     mockContext.runtime.plugins.push(...frontendPlugins);
+  });
+
+  it('recognizes the default editor', async () => {
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /* noop */ });
     const result = await analyzeProject(mockContext);
     expect(result.exeInfo.localEnvInfo.defaultEditor).toStrictEqual('Visual Studio Code');
     consoleLogSpy.mockClear();
+  });
+
+  it('sets isNewEnv false in context when env exists in tpi file', async () => {
+    mockContext.exeInfo.inputParams = {
+      amplify: {
+        envName: 'test',
+      },
+    };
+    stateManagerMock.getLocalAWSInfo.mockReturnValue({});
+    stateManagerMock.getTeamProviderInfo.mockReturnValue({ test: {}, other: {} });
+    await analyzeProject(mockContext);
+    expect(mockContext.exeInfo.isNewEnv).toBe(false);
+  });
+
+  it('sets isNewEnv true in context when env does not exists in tpi file', async () => {
+    mockContext.exeInfo.inputParams = {
+      amplify: {
+        envName: 'new',
+      },
+    };
+    stateManagerMock.getLocalAWSInfo.mockReturnValue({});
+    stateManagerMock.getTeamProviderInfo.mockReturnValue({ test: {}, other: {} });
+    await analyzeProject(mockContext);
+    expect(mockContext.exeInfo.isNewEnv).toBe(true);
   });
 });

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -292,9 +292,25 @@ const getEnvName = async (context: $TSContext): Promise<string> => {
   return envName;
 };
 
-const isNewEnv = (envName: string): boolean => !Object.keys(
-  stateManager.getLocalAWSInfo(process.cwd(), { throwIfNotExist: false, default: {} }),
-).includes(envName);
+/**
+ * TODO this currently checks both local-aws-info and team-provider-info for environments
+ *
+ * We need to remove the check from team-provider-info and instead use a service call
+ * but this is a breaking change because it means that some init flows will now require additional arguments to correctly
+ * attach to existing environments.
+ * Specifically we need the appId, region and AWS credentials to make a service call to get existing environments
+ *
+ * Most likely we should make a breaking change for this where init can no longer be use to pull existing projects and instead customers
+ * can only use pull for this use case
+ * @param envName the envName to check
+ * @returns whether the env already exists
+ */
+const isNewEnv = (envName: string): boolean => {
+  const localAwsInfoEnvs = Object.keys(stateManager.getLocalAWSInfo(process.cwd(), { throwIfNotExist: false, default: {} }));
+  const tpiEnvs = Object.keys(stateManager.getTeamProviderInfo(undefined, { throwIfNotExist: false, default: {} }));
+  const allEnvs = Array.from(new Set([...localAwsInfoEnvs, ...tpiEnvs]));
+  return !allEnvs.includes(envName);
+};
 
 const isNewProject = (context: $TSContext): boolean => {
   let newProject = true;

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -306,8 +306,10 @@ const getEnvName = async (context: $TSContext): Promise<string> => {
  * @returns whether the env already exists
  */
 const isNewEnv = (envName: string): boolean => {
-  const localAwsInfoEnvs = Object.keys(stateManager.getLocalAWSInfo(process.cwd(), { throwIfNotExist: false, default: {} }));
-  const tpiEnvs = Object.keys(stateManager.getTeamProviderInfo(process.cwd(), { throwIfNotExist: false, default: {} }));
+  const cwd = process.cwd();
+  const readOptions = { throwIfNotExist: false, default: {} };
+  const localAwsInfoEnvs = Object.keys(stateManager.getLocalAWSInfo(cwd, readOptions));
+  const tpiEnvs = Object.keys(stateManager.getTeamProviderInfo(cwd, readOptions));
   const allEnvs = Array.from(new Set([...localAwsInfoEnvs, ...tpiEnvs]));
   return !allEnvs.includes(envName);
 };

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -307,7 +307,7 @@ const getEnvName = async (context: $TSContext): Promise<string> => {
  */
 const isNewEnv = (envName: string): boolean => {
   const localAwsInfoEnvs = Object.keys(stateManager.getLocalAWSInfo(process.cwd(), { throwIfNotExist: false, default: {} }));
-  const tpiEnvs = Object.keys(stateManager.getTeamProviderInfo(undefined, { throwIfNotExist: false, default: {} }));
+  const tpiEnvs = Object.keys(stateManager.getTeamProviderInfo(process.cwd(), { throwIfNotExist: false, default: {} }));
   const allEnvs = Array.from(new Set([...localAwsInfoEnvs, ...tpiEnvs]));
   return !allEnvs.includes(envName);
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This commit reverts a part of https://github.com/aws-amplify/amplify-cli/pull/10679
As part of that change, we no longer checked the contents of the team-provider-info file to determine if an environment already exists when doing an `amplify init`. This caused some issues for customers using init to attach existing environments to their local projects. We now fall back to checking the contents of the `team-provider-info.json` file for existing environments on init.
#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/11120

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested, added unit tests and running the e2e tests here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/11461/workflows/049075f2-67e0-4327-bbe3-b6067b8160ea
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
