### PR TITLE
fix: register save to process.exit instead of beforeExit

### DIFF
--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -54,7 +54,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
       });
     });
 
-    process.on('beforeExit', () => this.save());
+    process.on('exit', () => this.save());
   }
 
   removeResourceParamManager(category: string, resource: string): void {
@@ -83,11 +83,14 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
       // assume that the project is deleted if we cannot find a project root
       return;
     }
-    const tpiContent = stateManager.getTeamProviderInfo();
+    const tpiContent = stateManager.getTeamProviderInfo(undefined, { throwIfNotExist: false, default: {} });
     const categoriesContent = this.serializeTPICategories();
     if (Object.keys(categoriesContent).length === 0) {
-      delete tpiContent[this.envName].categories;
+      delete tpiContent?.[this.envName]?.categories;
     } else {
+      if (!tpiContent[this.envName]) {
+        tpiContent[this.envName] = {};
+      }
       tpiContent[this.envName].categories = this.serializeTPICategories();
     }
     stateManager.setTeamProviderInfo(undefined, tpiContent);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Switched `envParamManager` save callback to be registered to process.exit rather than process.beforeExit.
beforeExit can put more events on the event loop and if save throws an exception for some reason, the exception handler will put more events on the loop causing beforeExit to be executed again, and fail again leading to recursive errors.
process.exit cannot put anymore events on the loop so a failure during save will still end the process.

I also added some additional defensive logic in the save method to prevent some errors when the TPI file does not exist or doesn't have expected keys.

As a follow up to this work, we should implement a new mechanism for writing out state changes at the end of the process that can be async but not recursively called if there's a failure.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Verified manually and updated unit tests. 
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
