### PR TITLE
fix: timeout bug due to zip process taking too long

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -46,6 +46,15 @@ executors:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
 
+  xl: &linux-xlarge-executor
+    docker:
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+    working_directory: ~/repo
+    resource_class: xlarge
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
+
 defaults: &defaults
   working_directory: ~/repo
   parameters:
@@ -214,7 +223,7 @@ jobs:
             - ~/repo/.amplify-pkg-version
 
   build_pkg_binaries:
-    <<: *linux-e2e-executor
+    <<: *linux-xlarge-executor
     steps:
       - restore_cache:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}
@@ -555,7 +564,7 @@ jobs:
           path: /root/aws-amplify-cypress-api/cypress/screenshots
 
   deploy:
-    <<: *linux-e2e-executor
+    <<: *linux-xlarge-executor
     steps:
       - restore_cache:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -13,9 +13,6 @@ function startLocalRegistry {
 }
 
 function uploadPkgCli {
-    aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
-    aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
-    aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
     cd out/
     export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
@@ -25,6 +22,11 @@ function uploadPkgCli {
         tar -czvf amplify-pkg-linux-x64.tgz amplify-pkg-linux-x64
         tar -czvf amplify-pkg-macos-x64.tgz amplify-pkg-macos-x64
         tar -czvf amplify-pkg-win-x64.tgz amplify-pkg-win-x64.exe
+
+        # Move AWS configure here, because tar/zip may take long, & default AWS session is 1 hour
+        aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
+        aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
+        aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
 
         aws --profile=s3-uploader s3 cp amplify-pkg-win-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win-x64-$(echo $hash).tgz
         aws --profile=s3-uploader s3 cp amplify-pkg-macos-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos-x64-$(echo $hash).tgz
@@ -43,6 +45,12 @@ function uploadPkgCli {
 
     else
         tar -czvf amplify-pkg-linux-x64.tgz amplify-pkg-linux-x64
+        
+        # Move AWS configure here, because tar/zip may take long, & default AWS session is 1 hour
+        aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
+        aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
+        aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
+
         aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
     fi
 

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -13,6 +13,9 @@ function startLocalRegistry {
 }
 
 function uploadPkgCli {
+    aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
+    aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
+    aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
     cd out/
     export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
@@ -23,10 +26,6 @@ function uploadPkgCli {
         tar -czvf amplify-pkg-macos-x64.tgz amplify-pkg-macos-x64
         tar -czvf amplify-pkg-win-x64.tgz amplify-pkg-win-x64.exe
 
-        # Move AWS configure here, because tar/zip may take long, & default AWS session is 1 hour
-        aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
-        aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
-        aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
 
         aws --profile=s3-uploader s3 cp amplify-pkg-win-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win-x64-$(echo $hash).tgz
         aws --profile=s3-uploader s3 cp amplify-pkg-macos-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos-x64-$(echo $hash).tgz
@@ -46,11 +45,6 @@ function uploadPkgCli {
     else
         tar -czvf amplify-pkg-linux-x64.tgz amplify-pkg-linux-x64
         
-        # Move AWS configure here, because tar/zip may take long, & default AWS session is 1 hour
-        aws configure --profile=s3-uploader set aws_access_key_id $S3_ACCESS_KEY
-        aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
-        aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
-
         aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
     fi
 

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -73,7 +73,8 @@ function generatePkgCli {
   # Build pkg cli
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
-    npx pkg -t node14-macos-x64,node14-linux-x64,node14-linux-arm64,node14-win-x64 ../build/node_modules --out-path ../out
+    npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
+    npx pkg -t --no-bytecode node14-linux-arm64 ../build/node_modules --out-path ../out
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Our process of building and uploading pkg binaries was taking over an hour, which is just over the 1 hour default limit for AWS assumed role timeout. Moving the signing until after the build is complete will fix that.

Here you can see the build exceeds 1H and fails:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/110861985/194977808-fe85be50-3bba-4890-bb2c-bc44cb5c4771.png">

One other alternative we could do is to disable generating bytecode for the platforms not supported:
https://github.com/vercel/pkg#targets

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
