### PR TITLE
fix: release process fails due to timeout from bytecode issues with arm64

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -71,7 +71,8 @@ function generatePkgCli {
   # Build pkg cli
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
-    npx pkg -t node14-macos-x64,node14-linux-x64,node14-linux-arm64,node14-win-x64 ../build/node_modules --out-path ../out
+    npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
+    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../out
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -76,7 +76,7 @@ function generatePkgCli {
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64
     mv ../out/amplify-pkg-linux ../out/amplify-pkg-linux-x64
     mv ../out/amplify-pkg-win.exe ../out/amplify-pkg-win-x64.exe
-    mv ../tmp-out/amplify-pkg-linux ../out/amplify-pkg-linux-arm64
+    mv ../tmp-out/amplify-pkg ../out/amplify-pkg-linux-arm64
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -71,8 +71,9 @@ function generatePkgCli {
   # Build pkg cli
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
+    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../tmp-out
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
-    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --output ../out/amplify-pkg-linux-arm64
+    cp ../tmp-out/amplify-pkg-linux-x64 ../out/amplify-pkg-linux-x64
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -71,27 +71,17 @@ function generatePkgCli {
   # Build pkg cli
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
-    # This will generate a file 'amplify-pkg' in the '../tmp-out' directory for our arm64 binary.
-    # The file name does not include the generated <platform>-<arch> suffixes because there is a single target.
-    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../tmp-out
-
-    # This will generate files 'amplify-pkg-<platform>' in the '../out' directory for our x64 binaries.
-    # The <platform> tag is included in the output file names because there are different
-    # platforms (macos/linux/win) being built in the same pkg call.
-    npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
-
-    # this renames the x64 files so that they have the appropriate suffix 'x64'
-    mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64
-    mv ../out/amplify-pkg-linux ../out/amplify-pkg-linux-x64
-    mv ../out/amplify-pkg-win.exe ../out/amplify-pkg-win-x64.exe
-
-    # this renames the arm64 file so that it has the appropriate suffix 'linux-arm64'
-    mv ../tmp-out/amplify-pkg ../out/amplify-pkg-linux-arm64
+    # This will generate a file our arm64 binary
+    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules -o ../out/amplify-pkg-linux-arm64
+    # This will generate files for our x64 binaries.
+    npx pkg -t node14-macos-x64 ../build/node_modules -o ../out/amplify-pkg-macos-x64
+    npx pkg -t node14-linux-x64 ../build/node_modules -o ../out/amplify-pkg-linux-x64
+    npx pkg -t node14-win-x64 ../build/node_modules -o ../out/amplify-pkg-win-x64.exe
   else
-    npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
-    mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64
-    mv ../out/amplify-pkg-linux ../out/amplify-pkg-linux-x64
-    mv ../out/amplify-pkg-win.exe ../out/amplify-pkg-win-x64.exe
+    # This will generate files for our x64 binaries.
+    npx pkg -t node14-macos-x64 ../build/node_modules -o ../out/amplify-pkg-macos-x64
+    npx pkg -t node14-linux-x64 ../build/node_modules -o ../out/amplify-pkg-linux-x64
+    npx pkg -t node14-win-x64 ../build/node_modules -o ../out/amplify-pkg-win-x64.exe
   fi
 
 

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -71,11 +71,21 @@ function generatePkgCli {
   # Build pkg cli
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
+    # This will generate a file 'amplify-pkg' in the '../tmp-out' directory for our arm64 binary.
+    # The file name does not include the generated <platform>-<arch> suffixes because there is a single target.
     npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../tmp-out
+
+    # This will generate files 'amplify-pkg-<platform>' in the '../out' directory for our x64 binaries.
+    # The <platform> tag is included in the output file names because there are different
+    # platforms (macos/linux/win) being built in the same pkg call.
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
+
+    # this renames the x64 files so that they have the appropriate suffix 'x64'
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64
     mv ../out/amplify-pkg-linux ../out/amplify-pkg-linux-x64
     mv ../out/amplify-pkg-win.exe ../out/amplify-pkg-win-x64.exe
+
+    # this renames the arm64 file so that it has the appropriate suffix 'linux-arm64'
     mv ../tmp-out/amplify-pkg ../out/amplify-pkg-linux-arm64
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -73,7 +73,10 @@ function generatePkgCli {
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
     npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../tmp-out
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
-    cp ../tmp-out/amplify-pkg-linux-x64 ../out/amplify-pkg-linux-x64
+    mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64
+    mv ../out/amplify-pkg-linux ../out/amplify-pkg-linux-x64
+    mv ../out/amplify-pkg-win.exe ../out/amplify-pkg-win-x64.exe
+    mv ../tmp-out/amplify-pkg-linux ../out/amplify-pkg-linux-arm64
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -72,7 +72,7 @@ function generatePkgCli {
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
-    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --out-path ../out
+    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules --output ../out/amplify-pkg-linux-arm64
   else
     npx pkg -t node14-macos-x64,node14-linux-x64,node14-win-x64 ../build/node_modules --out-path ../out
     mv ../out/amplify-pkg-macos ../out/amplify-pkg-macos-x64


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, building our binaries for arm64 adds a significant amount of time to our release process, largely due to errors with generating bytecode that occur on every file in node_modules. This process typically takes about 35 minutes to run, but is currently taking 1h 19m due to a recent increase in our node_modules folder. The additional time has led to failures with publishing our binaries to S3 due to a 1h timeout for our aws cli login.

![image](https://user-images.githubusercontent.com/110861985/195211188-0bf879d3-db74-4aa3-94f5-79413b428fa7.png)


This change reduces the time it takes to build our CLI binaries on release,release_rc,run-e2e-with-rc, & tagged-release branches by about an hour, by eliminating the bytecode errors. As a result, our CLI binaries can successfully publish to S3 again.
![image](https://user-images.githubusercontent.com/110861985/195211443-8f4fa9ad-b9c8-4f9f-8899-5769c0f6d43d.png)

Resulting files in S3:
![image](https://user-images.githubusercontent.com/110861985/195211480-57cb0283-6aac-49f7-8860-98d18d69f595.png)

CI Run:
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/11594/workflows/94d829a6-a835-453a-813d-b1b141a4e768

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
