### PR TITLE
chore: Refine Dart config parsing

### DIFF
--- a/packages/amplify-frontend-flutter/lib/dart-fs.js
+++ b/packages/amplify-frontend-flutter/lib/dart-fs.js
@@ -6,16 +6,23 @@ function readJsonFromDart(jsonFilePath, encoding = 'utf8', throwOnError = true) 
     return undefined;
   }
   const fileContents = fs.readFileSync(jsonFilePath, encoding);
-  let jsonValue = fileContents.substring(fileContents.indexOf('{'), fileContents.lastIndexOf('}') + 1);
+  const configStart = fileContents.indexOf('const amplifyconfig');
+  if (configStart === -1) {
+    return undefined;
+  }
+  const QUOTE = "'''";
+  const jsonStart = fileContents.indexOf(QUOTE, configStart) + QUOTE.length;
+  const jsonEnd = fileContents.indexOf(QUOTE, jsonStart);
+  const jsonValue = fileContents.substring(jsonStart, jsonEnd).trim();
   return JSON.parse(jsonValue);
 }
 
-function writeJsonToDart(dest, obj) {
+function writeJsonToDart(dest, json) {
   const destPath = path.parse(dest).dir;
   if (!fs.existsSync(destPath)) {
     fs.mkdirSync(destPath, { recursive: true });
   }
-  const dartContent = `const amplifyconfig = ''' ${obj}''';`;
+  const dartContent = `const amplifyconfig = '''${json}''';\n`;
   fs.writeFileSync(dest, dartContent);
 }
 

--- a/packages/amplify-frontend-flutter/package.json
+++ b/packages/amplify-frontend-flutter/package.json
@@ -10,6 +10,9 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
   "keywords": [
     "graphql",
     "appsync",

--- a/packages/amplify-frontend-flutter/package.json
+++ b/packages/amplify-frontend-flutter/package.json
@@ -10,9 +10,6 @@
   "author": "Amazon Web Services",
   "license": "Apache-2.0",
   "main": "index.js",
-  "scripts": {
-    "test": "jest"
-  },
   "keywords": [
     "graphql",
     "appsync",

--- a/packages/amplify-frontend-flutter/tests/amplify-config-helper.test.js
+++ b/packages/amplify-frontend-flutter/tests/amplify-config-helper.test.js
@@ -54,46 +54,64 @@ describe('Dart configuration file', () => {
     fs.rmSync(tmpDir, { recursive: true });
   });
 
-  const writeTempConfig = config => {
+  const writeTempConfig = (config) => {
     const filepath = `${tmpDir}/amplifyconfiguration.dart`;
     fs.writeFileSync(filepath, config);
     return filepath;
   };
 
-  const runTest = (name, config) => {
-    it(name, () => {
-      const configPath = writeTempConfig(config);
-      const parsedConfig = readJsonFromDart(configPath);
-      expect(parsedConfig).toMatchObject({
-        UserAgent: 'aws-amplify-cli/2.0',
-        Version: '1.0',
-      });
-    });
+  const parseConfig = (config) => {
+    const configPath = writeTempConfig(config);
+    return readJsonFromDart(configPath);
   };
 
-  runTest('parses old format', `const amplifyconfig = ''' {
+  it('parses old format', () => {
+    const parsedConfig = parseConfig(`const amplifyconfig = ''' {
     "UserAgent": "aws-amplify-cli/2.0",
     "Version": "1.0"
 }''';`);
+    expect(parsedConfig).toMatchObject({
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+    });
+  });
 
-  runTest('parses new format', `const amplifyconfig = '''{
-    "UserAgent": "aws-amplify-cli/2.0",
-    "Version": "1.0"
-}''';`);
+  it('parses new format', () => {
+    const parsedConfig = parseConfig(`const amplifyconfig = '''{
+      "UserAgent": "aws-amplify-cli/2.0",
+      "Version": "1.0"
+  }''';`);
+    expect(parsedConfig).toMatchObject({
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+    });
+  });
 
-  runTest('parses with data before', `
+  it('parses with data before', () => {
+    const parsedConfig = parseConfig(`
     const someOtherConfig = '{}';
 
     const amplifyconfig = '''{
         "UserAgent": "aws-amplify-cli/2.0",
         "Version": "1.0"
     }''';`);
+    expect(parsedConfig).toMatchObject({
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+    });
+  });
 
-  runTest('parses with data after', `
+  it('parses with data after', () => {
+    const parsedConfig = parseConfig(`
   const amplifyconfig = '''{
         "UserAgent": "aws-amplify-cli/2.0",
         "Version": "1.0"
     }''';
     
     const someOtherConfig = {};`);
+    expect(parsedConfig).toMatchObject({
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+    });
+  });
 });


### PR DESCRIPTION
We are experimenting with some new config layouts and the current parsing behavior prevents changing the config structure. This expands on the current behavior to allow more flexibility in the config file contents.