### PR TITLE
fix: prevent removal of analytics and auth when being depended on

### DIFF
--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "jest"
   },
   "dependencies": {
     "@aws-amplify/amplify-environment-parameters": "1.1.3",
@@ -26,5 +27,21 @@
     "fs-extra": "^8.1.0",
     "inquirer": "^7.3.3",
     "uuid": "^8.3.2"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testURL": "http://localhost",
+    "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/packages/amplify-category-analytics/package.json
+++ b/packages/amplify-category-analytics/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules",
     "watch": "tsc --watch",
-    "test": "jest"
+    "test": "jest --logHeapUsage"
   },
   "dependencies": {
     "@aws-amplify/amplify-environment-parameters": "1.1.3",

--- a/packages/amplify-category-analytics/src/__tests__/commands/analytics/remove.test.ts
+++ b/packages/amplify-category-analytics/src/__tests__/commands/analytics/remove.test.ts
@@ -13,7 +13,11 @@ checkResourceInUseByNotificationsMock.mockResolvedValue(true);
 describe('remove analytics handler', () => {
   it('throws error if notifications exists', async () => {
     const stubContext = ({
-      amplify: {},
+      amplify: {
+        removeResource: jest.fn().mockImplementation(async (__context, __category, resourceName, __config, callback) => {
+          await callback(resourceName);
+        }),
+      },
       parameters: {
         first: 'testing',
       },

--- a/packages/amplify-category-analytics/src/__tests__/commands/analytics/remove.test.ts
+++ b/packages/amplify-category-analytics/src/__tests__/commands/analytics/remove.test.ts
@@ -1,0 +1,25 @@
+import { $TSContext } from 'amplify-cli-core';
+import { run as runRemove } from '../../../commands/analytics/remove';
+import { checkResourceInUseByNotifications } from '../../../plugin-client-api-notifications';
+
+jest.mock('../../../plugin-client-api-notifications');
+
+const checkResourceInUseByNotificationsMock = checkResourceInUseByNotifications as jest.MockedFunction<
+  typeof checkResourceInUseByNotifications
+>;
+
+checkResourceInUseByNotificationsMock.mockResolvedValue(true);
+
+describe('remove analytics handler', () => {
+  it('throws error if notifications exists', async () => {
+    const stubContext = ({
+      amplify: {},
+      parameters: {
+        first: 'testing',
+      },
+    } as unknown) as $TSContext;
+    await expect(() => runRemove(stubContext)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Analytics resource testing is being used by the notifications category and cannot be removed"`,
+    );
+  });
+});

--- a/packages/amplify-category-analytics/src/commands/analytics/remove.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/remove.ts
@@ -1,30 +1,12 @@
 import {
-  $TSContext, AmplifyCategories, amplifyFaultWithTroubleshootingLink,
+  $TSContext, AmplifyError,
 } from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
-import { checkResourceInUseByNotifications, invokeNotificationsAPIRecursiveRemoveApp } from '../../plugin-client-api-notifications';
+import { checkResourceInUseByNotifications } from '../../plugin-client-api-notifications';
 
 const subcommand = 'remove';
 const category = 'analytics';
-/**
- * Check if Notifications is using the given Analytics resource.
- * note:- TBD: This function will be replaced by a generic pre-remove hook handler in the future.
- * The eventual goal is to remove all explicit binding in the code between categories and abstract them out
- * by role (capabilities, providerCategory and subscriberCategory ).
- */
-const removeResourceDependencies = async (context:$TSContext, resourceName: string): Promise<void> => {
-  const isResourceInUse = await checkResourceInUseByNotifications(context, resourceName);
-  if (isResourceInUse) {
-    // Pinpoint App is in use by Notifications.
-    printer.warn(`Disabling all notifications on ${resourceName}`);
-    const result = await invokeNotificationsAPIRecursiveRemoveApp(context, resourceName);
-    if (!result.status) {
-      throw amplifyFaultWithTroubleshootingLink('ResourceRemoveFault', {
-        message: result.reasonMsg || `Failed to remove ${resourceName} from ${AmplifyCategories.NOTIFICATIONS} category`,
-      });
-    }
-  }
-};
+
+export const name = subcommand;
 
 /**
  * Analytics remove resource handler.
@@ -35,8 +17,19 @@ export const run = async (context: $TSContext): Promise<void> => {
   const { amplify, parameters } = context;
   const resourceName = parameters.first;
 
-  await amplify.removeResource(context, category, resourceName, { headless: false });
-  return removeResourceDependencies(context, resourceName);
-};
+  const blockRemovalOfInUseAnalytics = async (selectedAnalyticsResource: string): Promise<void> => {
+    const isResourceInUse = await checkResourceInUseByNotifications(context, selectedAnalyticsResource);
+    if (isResourceInUse) {
+      throw new AmplifyError('ResourceInUseError', {
+        message: `Analytics resource ${selectedAnalyticsResource} is being used by the notifications category and cannot be removed`,
+        resolution: `Run 'amplify remove notifications', then retry removing analytics`,
+      });
+    }
+  };
 
-export const name = subcommand;
+  // check if the CLI input analytics name is in use by notification
+  await blockRemovalOfInUseAnalytics(resourceName);
+
+  // remove resource with a resourceName callback that will block removal if selecting an analytics resource that notifications depends on
+  await amplify.removeResource(context, category, resourceName, { headless: false }, blockRemovalOfInUseAnalytics);
+};

--- a/packages/amplify-category-analytics/src/commands/analytics/remove.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/remove.ts
@@ -17,7 +17,7 @@ export const run = async (context: $TSContext): Promise<void> => {
   const { amplify, parameters } = context;
   const resourceName = parameters.first;
 
-  const blockRemovalOfInUseAnalytics = async (selectedAnalyticsResource: string): Promise<void> => {
+  const throwIfUsedByNotifications = async (selectedAnalyticsResource: string): Promise<void> => {
     const isResourceInUse = await checkResourceInUseByNotifications(context, selectedAnalyticsResource);
     if (isResourceInUse) {
       throw new AmplifyError('ResourceInUseError', {
@@ -28,5 +28,5 @@ export const run = async (context: $TSContext): Promise<void> => {
   };
 
   // remove resource with a resourceName callback that will block removal if selecting an analytics resource that notifications depends on
-  await amplify.removeResource(context, category, resourceName, { headless: false }, blockRemovalOfInUseAnalytics);
+  await amplify.removeResource(context, category, resourceName, { headless: false }, throwIfUsedByNotifications);
 };

--- a/packages/amplify-category-analytics/src/commands/analytics/remove.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/remove.ts
@@ -27,9 +27,6 @@ export const run = async (context: $TSContext): Promise<void> => {
     }
   };
 
-  // check if the CLI input analytics name is in use by notification
-  await blockRemovalOfInUseAnalytics(resourceName);
-
   // remove resource with a resourceName callback that will block removal if selecting an analytics resource that notifications depends on
   await amplify.removeResource(context, category, resourceName, { headless: false }, blockRemovalOfInUseAnalytics);
 };

--- a/packages/amplify-category-analytics/src/plugin-client-api-notifications.ts
+++ b/packages/amplify-category-analytics/src/plugin-client-api-notifications.ts
@@ -29,9 +29,9 @@ export const invokeNotificationsAPIRecursiveRemoveApp = async (
  * @param resourceName Pinpoint resource name
  * @returns true if Pinpoint resource is in use
  */
-export const checkResourceInUseByNotifications = async (context: $TSContext, resourceName?: string): Promise<boolean> => {
-  if (!resourceName) return false;
+export const checkResourceInUseByNotifications = async (context: $TSContext, resourceName: string): Promise<boolean> => {
   const notificationsResource = await invokeNotificationsAPIGetResource(context);
+  if (!notificationsResource?.resourceName) return false;
   return (notificationsResource?.resourceName === resourceName);
 };
 

--- a/packages/amplify-category-analytics/src/plugin-client-api-notifications.ts
+++ b/packages/amplify-category-analytics/src/plugin-client-api-notifications.ts
@@ -29,7 +29,8 @@ export const invokeNotificationsAPIRecursiveRemoveApp = async (
  * @param resourceName Pinpoint resource name
  * @returns true if Pinpoint resource is in use
  */
-export const checkResourceInUseByNotifications = async (context: $TSContext, resourceName: string): Promise<boolean> => {
+export const checkResourceInUseByNotifications = async (context: $TSContext, resourceName?: string): Promise<boolean> => {
+  if (!resourceName) return false;
   const notificationsResource = await invokeNotificationsAPIGetResource(context);
   return (notificationsResource?.resourceName === resourceName);
 };

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -141,8 +141,9 @@ export type AmplifyErrorType =
   | 'PushResourcesError'
   | 'RegionNotAvailableError'
   | 'RemoveNotificationAppError'
-  | 'ResourceNotReadyError'
   | 'ResourceAlreadyExistsError'
+  | 'ResourceInUseError'
+  | 'ResourceNotReadyError'
   | 'StackNotFoundError'
   | 'StackStateError'
   | 'UserInputError';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds a check in the remove analytics handler to throw if notifications exists (because it depends on analytics) and likewise adds a check in auth remove to throw if analytics exists (because analytics depends on auth). In both cases an error message is printed telling the customer to remove the upstream dependency first, then retry the removal

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested and added a unit tests.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
