### PR TITLE
chore: scope GITHUB_TOKEN to only issue write

### DIFF
--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -2,7 +2,8 @@ name: issue-pending-response
 on:
   issue_comment:
     types: [created]
-
+permissions:
+  issues: write
 jobs:
   issue_commented:
     if: ${{ !github.event.issue.pull_request  && contains(github.event.issue.labels.*.name, 'pending-response') }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Scopes down built-in GITHUB_TOKEN to only allow issue read/write

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

tested in a dummy repo to ensure token has necessary permissions

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
