### PR TITLE
fix: account for Windows only params in nexpect

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/delete-project.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/delete-project.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { $TSAny } from 'amplify-cli-core';
+import { $TSAny, spinner } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { listLocalEnvNames } from '@aws-amplify/amplify-environment-parameters';
 import { deleteProject, getConfirmation } from '../../../extensions/amplify-helpers/delete-project';
@@ -55,11 +55,10 @@ jest.mock('../../../extensions/amplify-helpers/get-plugin-instance', () => ({
   }),
 }));
 
-jest.mock('ora', () => () => ({
-  start: jest.fn(),
-  fail: jest.fn(),
-  succeed: jest.fn(),
-}));
+const spinnerMock = spinner as jest.Mocked<typeof spinner>;
+spinnerMock.start = jest.fn();
+spinnerMock.fail = jest.fn();
+spinnerMock.succeed = jest.fn();
 
 jest.mock('@aws-amplify/amplify-environment-parameters');
 

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -713,7 +713,7 @@ export function nspawn(command: string | string[], params: string[] = [], option
   // For push operations in E2E we have to explicitly disable the Amplify Console App creation
   // as for the tests that need it, it is already enabled for init, setting the env var here
   // disables the post push check we have in the CLI.
-  if (params.length > 0 && params[0].toLowerCase() === 'push') {
+  if (params.length > 0 && params.find((param: string) => param.toLowerCase() === 'push')) {
     pushEnv = {
       CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
     };

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
@@ -59,12 +59,12 @@ export const init = async amplifyServiceParams => {
           appId: inputAmplifyAppId,
         })
         .promise();
-      context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
+      printer.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
       amplifyAppId = inputAmplifyAppId;
     } catch (e) {
       throw new AmplifyError('ProjectNotFoundError', {
         message: `Amplify AppID ${inputAmplifyAppId} not found.`,
-        resolution: `Please ensure your local profile matches the AWS account or region in which the Amplify app exists.`,
+        resolution: `Ensure your local profile matches the AWS account or region in which the Amplify app exists.`,
       }, e);
     }
   }
@@ -141,7 +141,7 @@ export const init = async amplifyServiceParams => {
   }
 
   if (needToCreateNewBackendEnv) {
-    context.print.info(`Adding backend environment ${envName} to AWS Amplify app: ${amplifyAppId}`);
+    printer.info(`Adding backend environment ${envName} to AWS Amplify app: ${amplifyAppId}`);
     const createEnvParams = {
       appId: amplifyAppId,
       environmentName: envName,
@@ -184,7 +184,7 @@ export const deleteEnv = async (context, envName, awsConfigInfo?) => {
     await amplifyClient.deleteBackendEnvironment(deleteEnvParams).promise();
   } catch (ex) {
     if (ex.code === 'NotFoundException') {
-      context.print.warning(ex.message);
+      printer.warn(ex.message);
     } else {
       throw amplifyFaultWithTroubleshootingLink('ProjectDeleteFault', {
         message: ex.message,
@@ -198,7 +198,7 @@ export const postPushCheck = async (context: $TSContext) => {
   const envMeta = await ensureEnvMeta(context);
   const { AmplifyAppId: appId, StackName: stackName, DeploymentBucketName: deploymentBucket } = envMeta;
 
-  if (appId) {
+  if (appId || !amplifyAppCreationEnabled()) {
     return;
   }
 
@@ -286,7 +286,7 @@ const selectFromExistingAppId = async (
 
 export const storeArtifactsForAmplifyService = async (context: $TSContext) => {
   const s3 = await S3.getInstance(context);
-  const currentCloudBackendDir = context.amplify.pathManager.getCurrentCloudBackendDirPath();
+  const currentCloudBackendDir = pathManager.getCurrentCloudBackendDirPath();
   const amplifyMetaFilePath = path.join(currentCloudBackendDir, 'amplify-meta.json');
   const backendConfigFilePath = path.join(currentCloudBackendDir, 'backend-config.json');
   await uploadFile(s3, amplifyMetaFilePath, 'amplify-meta.json');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Merging into `tpi-multi-env-refactor`
- fixed an issue where on an environment parameter was not correctly injected on Windows
- updated spinner mock for failing delete unit test
- some lint fixes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
e2e passed: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/11850/workflows/fc91151e-5fbb-4ceb-914f-550a6ced5acd

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
