### PR TITLE
fix: failing env init when user pool is defined

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
@@ -287,9 +287,9 @@ export const updateUserPoolGroups = async (context: $TSContext, resourceName: st
     context.amplify.updateamplifyMetaAfterResourceUpdate(AmplifyCategories.AUTH, 'userPoolGroups', 'service', 'Cognito-UserPool-Groups');
     context.amplify.updateamplifyMetaAfterResourceUpdate(AmplifyCategories.AUTH, 'userPoolGroups', 'providerPlugin', 'awscloudformation');
 
-    const authParameters = stateManager.getResourceParametersJson(undefined, AmplifyCategories.AUTH, resourceName);
+    const authInputs = stateManager.getResourceInputsJson(undefined, AmplifyCategories.AUTH, resourceName);
     const attributes = ['UserPoolId', 'AppClientIDWeb', 'AppClientID'];
-    if (authParameters?.identityPoolName) {
+    if (authInputs?.cognitoConfig?.identityPoolName) {
       attributes.push('IdentityPoolId');
     }
     context.amplify.updateamplifyMetaAfterResourceUpdate(AmplifyCategories.AUTH, 'userPoolGroups', 'dependsOn', [

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -1,6 +1,5 @@
 import {
   addAuthUserPoolOnly,
-  addAuthWithDefault,
   amplifyPushAuth,
   createNewProjectDir,
   deleteProject,
@@ -42,7 +41,6 @@ describe('amplify init', () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projectRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
-    await addAuthWithDefault(projectRoot, {});
     await addAuthUserPoolOnly(projectRoot, {});
     await amplifyPushAuth(projectRoot);
     const teamInfo = getTeamProviderInfo(projectRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -1,5 +1,6 @@
 import {
-  addAuthWithMaxOptions,
+  addAuthUserPoolOnly,
+  addAuthWithDefault,
   amplifyPushAuth,
   createNewProjectDir,
   deleteProject,
@@ -41,7 +42,8 @@ describe('amplify init', () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projectRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
-    await addAuthWithMaxOptions(projectRoot, {});
+    await addAuthWithDefault(projectRoot, {});
+    await addAuthUserPoolOnly(projectRoot, {});
     await amplifyPushAuth(projectRoot);
     const teamInfo = getTeamProviderInfo(projectRoot);
     expect(teamInfo).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -1,5 +1,5 @@
 import {
-  addAuthWithDefault,
+  addAuthWithMaxOptions,
   amplifyPushAuth,
   createNewProjectDir,
   deleteProject,
@@ -41,7 +41,7 @@ describe('amplify init', () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projectRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
-    await addAuthWithDefault(projectRoot, {});
+    await addAuthWithMaxOptions(projectRoot, {});
     await amplifyPushAuth(projectRoot);
     const teamInfo = getTeamProviderInfo(projectRoot);
     expect(teamInfo).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -1,5 +1,5 @@
 import {
-  addAuthUserPoolOnly,
+  addAuthWithDefault,
   amplifyPushAuth,
   createNewProjectDir,
   deleteProject,
@@ -10,6 +10,7 @@ import {
   getTeamProviderInfo,
   initJSProjectWithProfile,
   transformCurrentProjectToGitPulledProject,
+  updateAuthAddUserGroups,
   updatedInitNewEnvWithProfile,
 } from '@aws-amplify/amplify-e2e-core';
 import * as specialCaseInit from '../init-special-cases';
@@ -41,7 +42,8 @@ describe('amplify init', () => {
     const envName = 'dev';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projectRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
-    await addAuthUserPoolOnly(projectRoot, {});
+    await addAuthWithDefault(projectRoot, {});
+    await updateAuthAddUserGroups(projectRoot, ['group']);
     await amplifyPushAuth(projectRoot);
     const teamInfo = getTeamProviderInfo(projectRoot);
     expect(teamInfo).toBeDefined();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixes https://github.com/aws-amplify/amplify-cli/issues/11211 .

The fix is to use `cli-inputs.json` instead of `parameters.json` for identity pool related logic.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/11211

#### Description of how you validated changes

- Got manual repro of https://github.com/aws-amplify/amplify-cli/issues/11211 working.
- Ran `auth_3` e2e tests that are covering a former bugfix related to change that broke init
- Added user pools to the `test init on a git pulled project` to cover this regression.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
