### PR TITLE
refactor(amplify-cli): convert require()s to import()s

### DIFF
--- a/packages/amplify-cli/src/attach-backend-steps/a10-queryProvider.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a10-queryProvider.ts
@@ -8,7 +8,7 @@ export async function queryProvider(context) {
   const provider = await getProvider(context, providerPlugins);
   context.exeInfo.projectConfig.providers = [provider];
 
-  const providerModule = require(providerPlugins[provider]);
+  const providerModule = await import(providerPlugins[provider]);
   await providerModule.attachBackend(context);
 
   return context;

--- a/packages/amplify-cli/src/attach-backend-steps/a30-initFrontend.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a30-initFrontend.ts
@@ -16,19 +16,19 @@ export async function initFrontend(context) {
     let suitableFrontend;
     let fitToHandleScore = -1;
 
-    Object.keys(frontendPlugins).forEach(key => {
-      const { scanProject } = require(frontendPlugins[key]);
+    for (const key of Object.keys(frontendPlugins)) {
+      const { scanProject } = await import(frontendPlugins[key]);
       const newScore = scanProject(context.exeInfo.localEnvInfo.projectPath);
       if (newScore > fitToHandleScore) {
         fitToHandleScore = newScore;
         suitableFrontend = key;
       }
-    });
+    }
 
     const frontend = await getFrontendHandler(context, frontendPlugins, suitableFrontend);
 
     context.exeInfo.projectConfig.frontend = frontend;
-    const frontendModule = require(frontendPlugins[frontend]);
+    const frontendModule = await import(frontendPlugins[frontend]);
     await frontendModule.init(context);
   }
 

--- a/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
+++ b/packages/amplify-cli/src/attach-backend-steps/a40-generateFiles.ts
@@ -27,19 +27,17 @@ export const generateFiles = async (context: $TSContext): Promise<$TSContext> =>
   const providerOnSuccessTasks: (() => Promise<$TSAny>)[] = [];
 
   const frontendPlugins = getFrontendPlugins(context);
-  // eslint-disable-next-line
-  const frontendModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
+  const frontendModule = await import(frontendPlugins[context.exeInfo.projectConfig.frontend]);
 
   await frontendModule.onInitSuccessful(context);
 
   generateLocalRuntimeFiles(context);
   generateNonRuntimeFiles(context);
 
-  context.exeInfo.projectConfig.providers.forEach(provider => {
-    // eslint-disable-next-line
-    const providerModule = require(providerPlugins[provider]);
+  for (const provider of context.exeInfo.projectConfig.providers) {
+    const providerModule = await import(providerPlugins[provider]);
     providerOnSuccessTasks.push(() => providerModule.onInitSuccessful(context));
-  });
+  }
 
   await sequential(providerOnSuccessTasks);
 

--- a/packages/amplify-cli/src/commands/export.ts
+++ b/packages/amplify-cli/src/commands/export.ts
@@ -101,7 +101,7 @@ async function createFrontEndConfigFile(context: $TSContext, exportPath: string)
     const meta = stateManager.getMeta();
     const cloudMeta = stateManager.getCurrentMeta();
     const frontendPlugins = context.amplify.getFrontendPlugins(context);
-    const frontendHandlerModule = require(frontendPlugins[frontend]);
+    const frontendHandlerModule = await import(frontendPlugins[frontend]);
     const validatedExportPath = validateExportDirectoryPath(exportPath, PathConstants.DefaultFrontEndExportFolder);
     await frontendHandlerModule.createFrontendConfigsAtPath(
       context,

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -29,11 +29,10 @@ const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
     const providerPlugins = getProviderPlugins(context);
     const pullCurrentCloudTasks: (() => Promise<$TSAny>)[] = [];
 
-    context.exeInfo.projectConfig.providers.forEach(provider => {
-      // eslint-disable-next-line
-      const providerModule = require(providerPlugins[provider]);
+    for (const provider of context.exeInfo.projectConfig.providers) {
+      const providerModule = await import(providerPlugins[provider]);
       pullCurrentCloudTasks.push(() => providerModule.initEnv(context, amplifyMeta.providers[provider]));
-    });
+    }
 
     await notifySecurityEnhancement(context);
 

--- a/packages/amplify-cli/src/config-steps/c0-analyzeProject.ts
+++ b/packages/amplify-cli/src/config-steps/c0-analyzeProject.ts
@@ -29,7 +29,7 @@ export async function analyzeProject(context) {
   if (!frontend) {
     frontend = 'javascript';
   }
-  const frontendModule = require(frontendPlugins[frontend]);
+  const frontendModule = await import(frontendPlugins[frontend]);
   await frontendModule.displayFrontendDefaults(context, projectPath);
   context.print.info('');
 

--- a/packages/amplify-cli/src/config-steps/c1-configFrontend.ts
+++ b/packages/amplify-cli/src/config-steps/c1-configFrontend.ts
@@ -10,11 +10,11 @@ export async function configFrontendHandler(context) {
 
   if (selectedFrontend !== frontend) {
     delete context.exeInfo.projectConfig[frontend];
-    const frontendModule = require(frontendPlugins[selectedFrontend]);
+    const frontendModule = await import(frontendPlugins[selectedFrontend]);
     await frontendModule.init(context);
     context.exeInfo.projectConfig.frontend = selectedFrontend;
   } else {
-    const frontendModule = require(frontendPlugins[selectedFrontend]);
+    const frontendModule = await import(frontendPlugins[selectedFrontend]);
     await frontendModule.configure(context);
   }
 

--- a/packages/amplify-cli/src/config-steps/c2-configProviders.ts
+++ b/packages/amplify-cli/src/config-steps/c2-configProviders.ts
@@ -13,15 +13,15 @@ export async function configProviders(context) {
   const initializationTasks: (() => Promise<any>)[] = [];
   const onInitSuccessfulTasks: (() => Promise<any>)[] = [];
 
-  selectedProviders.forEach(provider => {
-    const providerModule = require(providerPlugins[provider]);
+  for (const provider of selectedProviders) {
+    const providerModule = await import(providerPlugins[provider]);
     if (currentProviders.includes(provider)) {
       configTasks.push(() => providerModule.configure(context));
     } else {
       initializationTasks.push(() => providerModule.init(context));
       onInitSuccessfulTasks.push(() => providerModule.onInitSuccessful(context));
     }
-  });
+  }
 
   await sequential(configTasks);
   await sequential(initializationTasks);

--- a/packages/amplify-cli/src/context-extensions.ts
+++ b/packages/amplify-cli/src/context-extensions.ts
@@ -1,8 +1,10 @@
-import { Context } from './domain/context';
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import importedColors from 'colors/safe';
 import CLITable from 'cli-table3';
+import importedColors from 'colors/safe';
+import ejs from 'ejs';
+import * as fs from 'fs-extra';
+import inquirer from 'inquirer';
+import * as path from 'path';
+import { Context } from './domain/context';
 
 importedColors.setTheme({
   highlight: 'cyan',
@@ -45,7 +47,6 @@ export function attachExtentions(context: Context) {
 }
 
 function attachPrompt(context: Context) {
-  const inquirer = require('inquirer');
   context.prompt = {
     confirm: async (message: string, defaultValue: boolean = false): Promise<boolean> => {
       const { yesno } = await inquirer.prompt({
@@ -313,7 +314,6 @@ const CLI_TABLE_MARKDOWN = {
 function attachTemplate(context: Context) {
   context.template = {
     async generate(opts: { template: string; target: string; props: object; directory: string }): Promise<string> {
-      const ejs = require('ejs');
       const template = opts.template;
       const target = opts.target;
       const props = opts.props || {};

--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -161,7 +161,7 @@ const executePluginModuleCommand = async (context: Context, plugin: PluginInfo):
   }
 
   const handler = await getHandler(plugin, context);
-  attachContextExtensions(context, plugin);
+  await attachContextExtensions(context, plugin);
   await raisePreEvent(context);
   context.usageData.stopCodePathTimer(FromStartupTimedCodePaths.PLATFORM_STARTUP);
   context.usageData.startCodePathTimer(ManuallyTimedCodePath.PLUGIN_TIME);
@@ -216,7 +216,7 @@ const legacyCommandExecutor = async (context: Context, plugin: PluginInfo): Prom
   }
 
   if (commandModule) {
-    attachContextExtensions(context, plugin);
+    await attachContextExtensions(context, plugin);
     await commandModule.run(context);
   } else {
     const { showAllHelp } = await import('./extensions/amplify-helpers/show-all-help');
@@ -338,9 +338,8 @@ export const raiseEvent = async (context: Context, args: AmplifyEventArgs): Prom
       .map(plugin => {
         const eventHandler = async (): Promise<void> => {
           try {
-            attachContextExtensions(context, plugin);
-            // eslint-disable-next-line global-require, import/no-dynamic-require, @typescript-eslint/no-var-requires
-            const pluginModule = require(plugin.packageLocation);
+            await attachContextExtensions(context, plugin);
+            const pluginModule = await import(plugin.packageLocation);
             await pluginModule.handleAmplifyEvent(context, args);
           } catch {
             // no need to need anything
@@ -353,23 +352,21 @@ export const raiseEvent = async (context: Context, args: AmplifyEventArgs): Prom
 };
 
 // for backward compatibility, adds extensions to the context object
-const attachContextExtensions = (context: Context, plugin: PluginInfo): void => {
+const attachContextExtensions = async (context: Context, plugin: PluginInfo): Promise<void> => {
   const extensionsDirPath = path.normalize(path.join(plugin.packageLocation, 'extensions'));
   if (fs.existsSync(extensionsDirPath)) {
     const stats = fs.statSync(extensionsDirPath);
     if (stats.isDirectory()) {
       const itemNames = fs.readdirSync(extensionsDirPath);
-      itemNames.forEach(itemName => {
+      for (const itemName of itemNames) {
         const itemPath = path.join(extensionsDirPath, itemName);
-        let itemModule;
         try {
-          // eslint-disable-next-line global-require, import/no-dynamic-require
-          itemModule = require(itemPath);
+          const itemModule = await import(itemPath);
           itemModule(context);
         } catch (e) {
           // do nothing
         }
-      });
+      }
     }
   }
 };

--- a/packages/amplify-cli/src/extensions/amplify-helpers/show-helpful-provider-links.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/show-helpful-provider-links.ts
@@ -10,10 +10,10 @@ export async function showHelpfulProviderLinks(context: $TSContext) {
 
   const { allResources } = await getResourceStatus();
 
-  providers.forEach(providerName => {
-    const pluginModule = require(providerPlugins[providerName]);
+  for (const providerName of providers) {
+    const pluginModule = await import(providerPlugins[providerName]);
     providerPromises.push(pluginModule.showHelpfulLinks(context, allResources));
-  });
+  }
 
   return Promise.all(providerPromises);
 }

--- a/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
+++ b/packages/amplify-cli/src/init-steps/s0-analyzeProject.ts
@@ -76,18 +76,17 @@ const displayAndSetDefaults = async (context: $TSContext, projectPath: string, p
   context.print.success('The following configuration will be applied:');
   context.print.info('');
 
-  await displayConfigurationDefaults(context, defaultProjectName, defaultEnv, defaultEditorName);
+  displayConfigurationDefaults(context, defaultProjectName, defaultEnv, defaultEditorName);
 
   const frontendPlugins = getFrontendPlugins(context);
   const defaultFrontend = getSuitableFrontend(context, frontendPlugins, projectPath);
-  // eslint-disable-next-line
-  const frontendModule = require(frontendPlugins[defaultFrontend]);
+  const frontendModule = await import(frontendPlugins[defaultFrontend]);
 
   await frontendModule.displayFrontendDefaults(context, projectPath);
   context.print.info('');
 
   if (context.exeInfo.inputParams.yes || (await context.amplify.confirmPrompt('Initialize the project with the above configuration?'))) {
-    await setConfigurationDefaults(context, projectPath, defaultProjectName, defaultEnv, defaultEditorName);
+    setConfigurationDefaults(context, projectPath, defaultProjectName, defaultEnv, defaultEditorName);
     await frontendModule.setFrontendDefaults(context, projectPath);
   }
 };

--- a/packages/amplify-cli/src/init-steps/s1-initFrontend.ts
+++ b/packages/amplify-cli/src/init-steps/s1-initFrontend.ts
@@ -19,8 +19,7 @@ export const initFrontend = async (context: $TSContext): Promise<$TSContext> => 
   const frontend = await getFrontendHandler(context, frontendPlugins, suitableFrontend);
 
   context.exeInfo.projectConfig.frontend = frontend;
-  // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
-  const frontendModule = require(frontendPlugins[frontend]);
+  const frontendModule = await import(frontendPlugins[frontend]);
   await frontendModule.init(context);
 
   return context;

--- a/packages/amplify-cli/src/init-steps/s2-initProviders.ts
+++ b/packages/amplify-cli/src/init-steps/s2-initProviders.ts
@@ -13,11 +13,10 @@ export const initProviders = async (context): Promise<void> => {
   context.exeInfo.projectConfig.providers = providers;
   const initializationTasks: (() => Promise<$TSAny>)[] = [];
 
-  providers.forEach(provider => {
-    // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
-    const providerModule = require(providerPlugins[provider]);
+  for (const provider of providers) {
+    const providerModule = await import(providerPlugins[provider]);
     initializationTasks.push(() => providerModule.init(context));
-  });
+  }
 
   await sequential(initializationTasks);
   return context;

--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -18,8 +18,7 @@ import { DebugConfig } from '../app-config/debug-config';
  */
 export const onHeadlessSuccess = async (context: $TSContext): Promise<void> => {
   const frontendPlugins = getFrontendPlugins(context);
-  // eslint-disable-next-line
-  const frontendModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
+  const frontendModule = await import(frontendPlugins[context.exeInfo.projectConfig.frontend]);
   await frontendModule.onInitSuccessful(context);
 };
 
@@ -49,7 +48,7 @@ export const onSuccess = async (context: $TSContext): Promise<void> => {
 
   const frontendPlugins = getFrontendPlugins(context);
   // eslint-disable-next-line
-  const frontendModule = require(frontendPlugins[context.exeInfo.projectConfig.frontend]);
+  const frontendModule = await import(frontendPlugins[context.exeInfo.projectConfig.frontend]);
 
   await frontendModule.onInitSuccessful(context);
 
@@ -72,11 +71,11 @@ export const onSuccess = async (context: $TSContext): Promise<void> => {
     DebugConfig.Instance.setAndWriteShareProject(actualResult);
   }
 
-  context.exeInfo.projectConfig.providers.forEach(provider => {
+  for (const provider of context.exeInfo.projectConfig.providers) {
     // eslint-disable-next-line
-    const providerModule = require(providerPlugins[provider]);
+    const providerModule = await import(providerPlugins[provider]);
     providerOnSuccessTasks.push(() => providerModule.onInitSuccessful(context));
-  });
+  }
 
   await sequential(providerOnSuccessTasks);
 

--- a/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
+++ b/packages/amplify-cli/src/plugin-helpers/verify-plugin.ts
@@ -79,7 +79,7 @@ async function verifyAmplifyManifest(context: VerificationContext): Promise<Plug
 
       let result = verifyCommands(context);
 
-      result = result.verified ? verifyEventHandlers(context) : result;
+      result = result.verified ? await verifyEventHandlers(context) : result;
       result.manifest = manifest;
 
       return result;
@@ -110,12 +110,12 @@ function verifyCommands(context: VerificationContext): PluginVerificationResult 
   return new PluginVerificationResult(true);
 }
 
-function verifyEventHandlers(context: VerificationContext): PluginVerificationResult {
+async function verifyEventHandlers(context: VerificationContext): Promise<PluginVerificationResult> {
   let isVerified = true;
   if (context.manifest!.eventHandlers && context.manifest!.eventHandlers.length > 0) {
     // Lazy load the plugin if not yet loaded
     if (!context.pluginModule) {
-      context.pluginModule = require(context.pluginDirPath);
+      context.pluginModule = await import(context.pluginDirPath);
     }
 
     isVerified =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
 - Remove dynamic require()s where possible in the `amplify-cli-internal` package
 - Converted a number of `.forEach` loops to `for...of` for simpler `await` usage

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
`yarn test`, e2e passes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
