### PR TITLE
chore: add internal debug env var to printer

### DIFF
--- a/packages/amplify-prompts/src/flags.ts
+++ b/packages/amplify-prompts/src/flags.ts
@@ -1,7 +1,7 @@
 /**
  * If this flag is set, debug messages will be printed.
  */
-export const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_DEV_INTERNAL_DEBUG === 'true';
+export const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_ENABLE_DEBUG_OUTPUT === 'true';
 /**
  * If this flag is set, only warn and error messages will be printed.
  */

--- a/packages/amplify-prompts/src/flags.ts
+++ b/packages/amplify-prompts/src/flags.ts
@@ -1,8 +1,7 @@
 /**
  * If this flag is set, debug messages will be printed.
  */
-export const isDebug = process.argv.includes('--debug');
-
+export const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_DEV_INTERNAL_DEBUG === 'true';
 /**
  * If this flag is set, only warn and error messages will be printed.
  */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds an internal environment variable check to the printer debug logic so that debug logs can be printed by setting an environment variable.

This will allow us to get debug logging in local or test environments without having to specify `--debug` to every command
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
