### PR TITLE
chore: print downstream exception on debug

### DIFF
--- a/packages/amplify-category-analytics/src/index.ts
+++ b/packages/amplify-category-analytics/src/index.ts
@@ -90,9 +90,7 @@ export const getPermissionPolicies = async (context: $TSContext, resourceOpsMapp
     } catch (e) {
       throw amplifyFaultWithTroubleshootingLink('AnalyticsCategoryFault', {
         message: `Could not get policies for ${category}: ${resourceName}`,
-        stack: e.stack,
-        details: e.message,
-      });
+      }, e);
     }
   }
   return { permissionPolicies, resourceAttributes };

--- a/packages/amplify-category-analytics/src/index.ts
+++ b/packages/amplify-category-analytics/src/index.ts
@@ -1,4 +1,4 @@
-import { $TSContext, $TSAny, amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSContext, $TSAny, AmplifyFault } from 'amplify-cli-core';
 import * as path from 'path';
 import inquirer, { QuestionCollection } from 'inquirer';
 import { printer } from 'amplify-prompts';
@@ -88,7 +88,7 @@ export const getPermissionPolicies = async (context: $TSContext, resourceOpsMapp
         printer.error(`Provider not configured for ${category}: ${resourceName}`);
       }
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('AnalyticsCategoryFault', {
+      throw new AmplifyFault('AnalyticsCategoryFault', {
         message: `Could not get policies for ${category}: ${resourceName}`,
       }, e);
     }

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
@@ -59,7 +59,6 @@ export const migrateResourceToSupportOverride = async (resourceName: string): Pr
     throw amplifyErrorWithTroubleshootingLink('MigrationError', {
       message: `There was an error migrating your project: ${e.message}`,
       details: `Migration operations are rolled back.`,
-      stack: e.stack,
     }, e);
   } finally {
     cleanUp(backupAuthResourceFolder);

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/migrate-override-resource.ts
@@ -1,5 +1,5 @@
 import {
-  $TSObject, AmplifyCategories, projectNotInitializedError, AmplifyError, amplifyErrorWithTroubleshootingLink, JSONUtilities, pathManager,
+  $TSObject, AmplifyCategories, projectNotInitializedError, AmplifyError, JSONUtilities, pathManager,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';
@@ -56,7 +56,7 @@ export const migrateResourceToSupportOverride = async (resourceName: string): Pr
   } catch (e) {
     rollback(authResourceDirPath, backupAuthResourceFolder!);
     rollback(userPoolGroupResourceDirPath, backupUserPoolGroupResourceFolder!);
-    throw amplifyErrorWithTroubleshootingLink('MigrationError', {
+    throw new AmplifyError('MigrationError', {
       message: `There was an error migrating your project: ${e.message}`,
       details: `Migration operations are rolled back.`,
     }, e);

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -1,5 +1,5 @@
 import {
-  amplifyErrorWithTroubleshootingLink, convertNumBytes, getFolderSize, pathManager,
+  AmplifyError, convertNumBytes, getFolderSize, pathManager,
 } from 'amplify-cli-core';
 import { LambdaLayer } from 'amplify-function-plugin-interface';
 import * as fs from 'fs-extra';
@@ -49,7 +49,7 @@ export const packageFunction: Packager = async (context, resource) => {
   }
 
   if (functionSizeInBytes + layersSizeInBytes > lambdaPackageLimitInMB * 1024 ** 2) {
-    throw amplifyErrorWithTroubleshootingLink('FunctionTooLargeError', {
+    throw new AmplifyError('FunctionTooLargeError', {
       message: `The function is too large to package.`,
       details: `
 Total size of Lambda function ${

--- a/packages/amplify-category-notifications/src/__tests__/channel-apns.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-apns.test.ts
@@ -155,12 +155,12 @@ describe('channel-APNS', () => {
     mockirer(inquirer, { DefaultAuthenticationMethod: 'Certificate' });
     const errCert: AmplifyFault = await getError(async () => channelAPNS.enable(mockContextReject as unknown as $TSContext, 'successMessage'));
     expect(mockContextReject.exeInfo.pinpointClient.updateApnsChannel).toBeCalled();
-    expect(errCert.details).toContain(mockPinpointResponseErr.message);
+    expect(errCert?.downstreamException?.message).toContain(mockPinpointResponseErr.message);
 
     mockirer(inquirer, { DefaultAuthenticationMethod: 'Key' });
     const errKey: AmplifyFault = await getError(async () => channelAPNS.enable(mockContextReject as unknown as $TSContext, 'successMessage'));
     expect(mockPinpointClient.updateApnsChannel).toBeCalled();
-    expect(errKey.details).toContain(mockPinpointResponseErr.message);
+    expect(errKey?.downstreamException?.message).toContain(mockPinpointResponseErr.message);
   });
 
   test('disable', async () => {
@@ -174,6 +174,6 @@ describe('channel-APNS', () => {
   test('disable unsuccessful', async () => {
     const errKey: AmplifyFault = await getError(async () => channelAPNS.disable(mockContextReject as unknown as $TSContext));
     expect(mockPinpointClient.updateApnsChannel).toBeCalled();
-    expect(errKey.details).toContain(mockPinpointResponseErr.message);
+    expect(errKey?.downstreamException?.message).toContain(mockPinpointResponseErr.message);
   });
 });

--- a/packages/amplify-category-notifications/src/auth-helper.ts
+++ b/packages/amplify-category-notifications/src/auth-helper.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, AmplifyCategories, amplifyErrorWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyCategories, AmplifyError,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import ora from 'ora';
@@ -122,7 +122,7 @@ const checkAuth = async (context : $TSContext, resourceName : string) : Promise<
   // If auth is imported and configured, we have to throw the error instead of printing since there is no way to adjust the auth
   // configuration.
   if (checkResult.authImported === true && checkResult.errors && checkResult.errors.length > 0) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: checkResult.errors.join(os.EOL),
     });
   }

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -118,8 +118,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     spinner.stop();
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
       message: `Failed to enable the ${channelName} channel.`,
-      details: e.message,
-    });
+    }, e);
   }
 
   if (!successMessage) {
@@ -207,7 +206,7 @@ export const disable = async (context: $TSContext) : Promise<$TSAny> => {
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
       message: `Failed to update the ${channelName} channel.`,
       details: `Action: ${ChannelAction.DISABLE}. ${e.message}`,
-    });
+    }, e);
   }
   spinner.succeed(`The ${channelName} channel has been disabled.`);
   context.exeInfo.serviceMeta.output[channelName] = data.APNSChannelResponse;
@@ -238,7 +237,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny): Promise<$TSA
       throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
         message: `Failed to pull the ${channelName} channel.`,
         details: `Action: ${ChannelAction.PULL}. ${err.message}`,
-      });
+      }, err);
     }
 
     return undefined;

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -4,7 +4,7 @@ import inquirer, { QuestionCollection } from 'inquirer';
 import ora from 'ora';
 import fs from 'fs-extra';
 import {
-  $TSAny, $TSContext, amplifyFaultWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyFault,
 } from 'amplify-cli-core';
 
 import { printer } from 'amplify-prompts';
@@ -116,7 +116,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     context.exeInfo.serviceMeta.output[channelName] = data.APNSChannelResponse;
   } catch (e) {
     spinner.stop();
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+    throw new AmplifyFault('NotificationsChannelAPNSFault', {
       message: `Failed to enable the ${channelName} channel.`,
     }, e);
   }
@@ -133,41 +133,41 @@ const validateInputParams = (action: ChannelAction, channelInput: $TSAny): $TSAn
     const authMethod = channelInput.DefaultAuthenticationMethod;
     if (authMethod === 'Certificate') {
       if (!channelInput.P12FilePath) {
-        throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+        throw new AmplifyFault('NotificationsChannelAPNSFault', {
           message: 'P12FilePath is missing for the APNS channel',
           details: `Action: ${action}`,
         });
       } else if (!fs.existsSync(channelInput.P12FilePath)) {
-        throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+        throw new AmplifyFault('NotificationsChannelAPNSFault', {
           message: `P12 file ${channelInput.P12FilePath} can NOT be found for the APNS channel`,
           details: `Action: ${action}`,
         });
       }
     } else if (authMethod === 'Key') {
       if (!channelInput.BundleId || !channelInput.TeamId || !channelInput.TokenKeyId) {
-        throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+        throw new AmplifyFault('NotificationsChannelAPNSFault', {
           message: 'Missing BundleId, TeamId or TokenKeyId for the APNS channel',
           details: `Action: ${action}`,
         });
       } else if (!channelInput.P8FilePath) {
-        throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+        throw new AmplifyFault('NotificationsChannelAPNSFault', {
           message: 'P8FilePath is missing for the APNS channel',
           details: `Action: ${action}`,
         });
       } else if (!fs.existsSync(channelInput.P8FilePath)) {
-        throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+        throw new AmplifyFault('NotificationsChannelAPNSFault', {
           message: `P8 file ${channelInput.P8FilePath} can NOT be found for the APNS channel`,
           details: `Action: ${action}`,
         });
       }
     } else {
-      throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+      throw new AmplifyFault('NotificationsChannelAPNSFault', {
         message: `DefaultAuthenticationMethod ${authMethod} is unrecognized for the APNS channel`,
         details: `Action: ${action}`,
       });
     }
   } else {
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+    throw new AmplifyFault('NotificationsChannelAPNSFault', {
       message: 'DefaultAuthenticationMethod is missing for the APNS channel',
       details: `Action: ${action}`,
     });
@@ -203,7 +203,7 @@ export const disable = async (context: $TSContext) : Promise<$TSAny> => {
     await context.exeInfo.pinpointClient.updateApnsSandboxChannel(sandboxParams).promise();
   } catch (e) {
     spinner.fail(`Failed to update the ${channelName} channel.`);
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+    throw new AmplifyFault('NotificationsChannelAPNSFault', {
       message: `Failed to update the ${channelName} channel.`,
       details: `Action: ${ChannelAction.DISABLE}. ${e.message}`,
     }, e);
@@ -234,7 +234,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny): Promise<$TSA
   } catch (err) {
     spinner.stop();
     if (err.code !== 'NotFoundException') {
-      throw amplifyFaultWithTroubleshootingLink('NotificationsChannelAPNSFault', {
+      throw new AmplifyFault('NotificationsChannelAPNSFault', {
         message: `Failed to pull the ${channelName} channel.`,
         details: `Action: ${ChannelAction.PULL}. ${err.message}`,
       }, err);

--- a/packages/amplify-category-notifications/src/channel-email.ts
+++ b/packages/amplify-category-notifications/src/channel-email.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, AmplifyError, amplifyFaultWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyError, AmplifyFault,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 
@@ -107,7 +107,7 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
     }
 
     spinner.stop();
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelEmailFault', {
       message: `Failed to enable the ${channelName} channel.`,
       details: err.message,
     }, err);
@@ -154,7 +154,7 @@ export const disable = async (context:$TSContext) : Promise<$TSAny> => {
     }
 
     spinner.fail(`Failed to disable the ${channelName} channel.`);
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelEmailFault', {
       message: `Failed to disable the ${channelName} channel.`,
       details: err.message,
     }, err);
@@ -182,7 +182,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny):Promise<$TSAn
   } catch (err) {
     spinner.stop();
     if (err.code !== 'NotFoundException') {
-      throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
+      throw new AmplifyFault('NotificationsChannelEmailFault', {
         message: `Failed to pull the ${channelName} channel.`,
       }, err);
     }

--- a/packages/amplify-category-notifications/src/channel-email.ts
+++ b/packages/amplify-category-notifications/src/channel-email.ts
@@ -110,7 +110,7 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
       message: `Failed to enable the ${channelName} channel.`,
       details: err.message,
-    });
+    }, err);
   }
 };
 
@@ -157,7 +157,7 @@ export const disable = async (context:$TSContext) : Promise<$TSAny> => {
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
       message: `Failed to disable the ${channelName} channel.`,
       details: err.message,
-    });
+    }, err);
   }
 };
 
@@ -184,8 +184,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny):Promise<$TSAn
     if (err.code !== 'NotFoundException') {
       throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
         message: `Failed to pull the ${channelName} channel.`,
-        details: err.message,
-      });
+      }, err);
     }
 
     return undefined;

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, AmplifyError, amplifyFaultWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyError, AmplifyFault,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import inquirer from 'inquirer';
@@ -91,7 +91,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     );
   } catch (err) {
     spinner.stop();
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
+    throw new AmplifyFault('NotificationsChannelFCMFault', {
       message: `Failed to enable the ${channelName} channel`,
     }, err);
   }
@@ -148,7 +148,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     return buildPinpointChannelResponseSuccess(ChannelAction.DISABLE, deploymentType, channelName, data.GCMChannelResponse);
   } catch (err) {
     spinner.stop();
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
+    throw new AmplifyFault('NotificationsChannelFCMFault', {
       message: `Failed to disable the ${channelName} channel`,
     }, err);
   }
@@ -175,7 +175,7 @@ export const pull = async (context: $TSContext, pinpointApp: $TSAny):Promise<$TS
   } catch (err) {
     spinner.stop();
     if (err.code !== 'NotFoundException') {
-      throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
+      throw new AmplifyFault('NotificationsChannelFCMFault', {
         message: `Failed to retrieve channel information for ${channelName}`,
       }, err);
     }

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -93,7 +93,6 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     spinner.stop();
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
       message: `Failed to enable the ${channelName} channel`,
-      details: err.message,
     });
   }
 };
@@ -151,8 +150,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     spinner.stop();
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
       message: `Failed to disable the ${channelName} channel`,
-      details: err.message,
-    });
+    }, err);
   }
 };
 
@@ -179,8 +177,7 @@ export const pull = async (context: $TSContext, pinpointApp: $TSAny):Promise<$TS
     if (err.code !== 'NotFoundException') {
       throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
         message: `Failed to retrieve channel information for ${channelName}`,
-        details: err.message,
-      });
+      }, err);
     }
 
     return undefined;

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -93,7 +93,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     spinner.stop();
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelFCMFault', {
       message: `Failed to enable the ${channelName} channel`,
-    });
+    }, err);
   }
 };
 

--- a/packages/amplify-category-notifications/src/channel-in-app-msg.ts
+++ b/packages/amplify-category-notifications/src/channel-in-app-msg.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import {
-  $TSAny, $TSContext, AmplifyCategories, amplifyFaultWithTroubleshootingLink, AmplifySupportedService,
+  $TSAny, $TSContext, AmplifyCategories, AmplifyFault, AmplifySupportedService,
   IPluginCapabilityAPIResponse,
   NotificationChannels,
   stateManager,
@@ -71,7 +71,7 @@ const invokeInlineEnableInAppMessagingChannel = (
   __context: $TSContext,
   __pinpointAppStatus: IPinpointAppStatus,
 ): IPluginCapabilityAPIResponse => {
-  throw amplifyFaultWithTroubleshootingLink('ConfigurationFault', {
+  throw new AmplifyFault('ConfigurationFault', {
     message: 'Inline enable not supported for In-App Messaging channel.',
     details: 'Adding In-App Messaging to a project with Analytics or Push Notification enabled is currently not supported. Please refer to this Github issue for updates: https://github.com/aws-amplify/amplify-cli/issues/11087',
   });

--- a/packages/amplify-category-notifications/src/channel-sms.ts
+++ b/packages/amplify-category-notifications/src/channel-sms.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyFault } from 'amplify-cli-core';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { printer } from 'amplify-prompts';
@@ -63,7 +63,7 @@ export const enable = async (context:$TSContext):Promise<$TSAny> => {
     return buildPinpointChannelResponseSuccess(ChannelAction.ENABLE, deploymentType, channelName, data.SMSChannelResponse);
   } catch (e) {
     spinner.stop();
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelEmailFault', {
       message: `Failed to enable the ${channelName} channel.`,
     }, e);
   }
@@ -92,7 +92,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     return buildPinpointChannelResponseSuccess(ChannelAction.DISABLE, deploymentType, channelName, data.SMSChannelResponse);
   } catch (e) {
     spinner.fail(`Failed to disable the ${channelName} channel.`);
-    throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelEmailFault', {
       message: `Failed to disable the ${channelName} channel.`,
     }, e);
   }
@@ -118,7 +118,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny) : Promise<$TS
   } catch (err) {
     spinner.stop();
     if (err.code !== 'NotFoundException') {
-      throw amplifyFaultWithTroubleshootingLink('NotificationsChannelSmsFault', {
+      throw new AmplifyFault('NotificationsChannelSmsFault', {
         message: `Channel ${channelName} not found in the notifications metadata.`,
       }, err);
     }

--- a/packages/amplify-category-notifications/src/channel-sms.ts
+++ b/packages/amplify-category-notifications/src/channel-sms.ts
@@ -65,8 +65,7 @@ export const enable = async (context:$TSContext):Promise<$TSAny> => {
     spinner.stop();
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
       message: `Failed to enable the ${channelName} channel.`,
-      details: e.message,
-    });
+    }, e);
   }
 };
 
@@ -95,8 +94,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     spinner.fail(`Failed to disable the ${channelName} channel.`);
     throw amplifyFaultWithTroubleshootingLink('NotificationsChannelEmailFault', {
       message: `Failed to disable the ${channelName} channel.`,
-      details: e.message,
-    });
+    }, e);
   }
 };
 
@@ -122,8 +120,7 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny) : Promise<$TS
     if (err.code !== 'NotFoundException') {
       throw amplifyFaultWithTroubleshootingLink('NotificationsChannelSmsFault', {
         message: `Channel ${channelName} not found in the notifications metadata.`,
-        details: err.message,
-      });
+      }, err);
     }
 
     return undefined;

--- a/packages/amplify-category-notifications/src/commands/notifications/add.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/add.ts
@@ -88,9 +88,7 @@ export const run = async (context: $TSContext): Promise<$TSContext> => {
         throw new AmplifyError('DeploymentError', {
           message: 'Failed to deploy Auth and Pinpoint resources.',
           resolution: 'Deploy the Auth and Pinpoint resources manually.',
-          details: err.message,
-          stack: err.stack,
-        });
+        }, err);
       }
       context = pinpointAppStatus.context;
     }

--- a/packages/amplify-category-notifications/src/commands/notifications/add.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/add.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { $TSContext, AmplifyError, amplifyErrorWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSContext, AmplifyError } from 'amplify-cli-core';
 import { printer, prompter } from 'amplify-prompts';
 import {
   ensurePinpointApp, isPinpointAppDeployed, isPinpointDeploymentRequired, pushAuthAndAnalyticsPinpointResources,
@@ -55,7 +55,7 @@ const viewQuestionAskNotificationChannelToBeEnabled = async (
  */
 export const run = async (context: $TSContext): Promise<$TSContext> => {
   if (await checkMigratedFromMobileHub(context.exeInfo.amplifyMeta)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Notifications has been migrated from Mobile Hub and channels cannot be added with Amplify CLI.',
     });
   }

--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -41,8 +41,6 @@ export const run = async (context:$TSContext): Promise<$TSContext> => {
         throw new AmplifyError('DeploymentError', {
           message: 'Failed to deploy Auth and Pinpoint resources.',
           resolution: 'Deploy Auth and Pinpoint resources manually.',
-          details: err.message,
-          stack: err.stack,
         });
       }
       // eslint-disable-next-line no-param-reassign

--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -41,7 +41,7 @@ export const run = async (context:$TSContext): Promise<$TSContext> => {
         throw new AmplifyError('DeploymentError', {
           message: 'Failed to deploy Auth and Pinpoint resources.',
           resolution: 'Deploy Auth and Pinpoint resources manually.',
-        });
+        }, err);
       }
       // eslint-disable-next-line no-param-reassign
       context = pinpointAppStatus.context;

--- a/packages/amplify-category-notifications/src/commands/notifications/remove.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/remove.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, AmplifyCategories, amplifyErrorWithTroubleshootingLink, stateManager,
+  $TSContext, AmplifyCategories, AmplifyError, stateManager,
 } from 'amplify-cli-core';
 import { printer, prompter } from 'amplify-prompts';
 import chalk from 'chalk';
@@ -31,13 +31,13 @@ export const run = async (context: $TSContext): Promise<$TSContext> => {
   const notificationsMeta = context.exeInfo.amplifyMeta[AmplifyCategories.NOTIFICATIONS];
   const notificationConfig = await getNotificationsAppConfig(context.exeInfo.backendConfig);
   if (!notificationConfig) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Notifications have not been added to your project.',
     });
   }
 
   if (await checkMigratedFromMobileHub(context.exeInfo.amplifyMeta)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Notifications has been migrated from Mobile Hub and channels cannot be added with Amplify CLI.',
     });
   }

--- a/packages/amplify-category-notifications/src/multi-env-manager-utils.ts
+++ b/packages/amplify-category-notifications/src/multi-env-manager-utils.ts
@@ -1,6 +1,6 @@
 import { ensureEnvParamManager, getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
 import {
-  $TSAny, $TSContext, $TSMeta, AmplifyCategories, amplifyFaultWithTroubleshootingLink, AmplifySupportedService, stateManager,
+  $TSAny, $TSContext, $TSMeta, AmplifyCategories, AmplifyFault, AmplifySupportedService, stateManager,
 } from 'amplify-cli-core';
 import { ChannelConfigDeploymentType, IChannelAPIResponse } from './channel-types';
 import { getEnabledChannelsFromAppMeta, getNotificationsAppMeta } from './notifications-amplify-meta-api';
@@ -99,7 +99,7 @@ export const writeData = async (context: $TSContext, channelAPIResponse: IChanne
     const enabledChannels: Array<string> = await getEnabledChannelsFromAppMeta(context.exeInfo.amplifyMeta);
 
     if (!notificationsServiceMeta) {
-      throw amplifyFaultWithTroubleshootingLink('ConfigurationFault', {
+      throw new AmplifyFault('ConfigurationFault', {
         message: 'Failed to store notifications meta. Amplify Meta not found for Notifications.',
       });
     }

--- a/packages/amplify-category-notifications/src/multi-env-manager.ts
+++ b/packages/amplify-category-notifications/src/multi-env-manager.ts
@@ -356,9 +356,8 @@ export const checkAndCreatePinpointApp = async (context: $TSContext, channelName
       await viewShowInlineModeInstructionsFail(channelName, err);
       throw new AmplifyError('DeploymentError', {
         message: 'Failed to deploy Auth and Pinpoint resources.',
-        details: err.message,
         resolution: 'Deploy the Auth and Pinpoint resources manually.',
-      });
+      }, err);
     }
     // eslint-disable-next-line no-param-reassign
     context = pinpointAppStatus.context;

--- a/packages/amplify-category-notifications/src/notifications-amplify-meta-api.ts
+++ b/packages/amplify-category-notifications/src/notifications-amplify-meta-api.ts
@@ -11,7 +11,7 @@ import {
   $TSContext,
   INotificationsResourceMeta,
   pathManager,
-  amplifyErrorWithTroubleshootingLink,
+  AmplifyError,
 } from 'amplify-cli-core';
 import { ICategoryMeta } from './notifications-amplify-meta-types';
 import { invokeGetLastPushTimeStamp } from './plugin-client-api-analytics';
@@ -190,7 +190,7 @@ export const getPinpointRegionMapping = async (context: $TSContext): Promise<str
   const projectPath = pathManager.findProjectRoot();
   const applicationRegion = stateManager.getCurrentRegion(projectPath);
   if (!applicationRegion) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: `Invalid Region for project at ${projectPath}`,
     });
   }

--- a/packages/amplify-category-notifications/src/notifications-api.ts
+++ b/packages/amplify-category-notifications/src/notifications-api.ts
@@ -2,7 +2,7 @@ import {
   $TSAny,
   $TSContext,
   AmplifyCategories,
-  amplifyErrorWithTroubleshootingLink,
+  AmplifyError,
   AmplifySupportedService,
   INotificationsResourceMeta,
   stateManager,
@@ -38,7 +38,7 @@ export const generateMetaFromConfig = (envName: string, cfg:$TSAny): Partial<INo
   const outputRecords: Record<string, $TSAny>|undefined = (cfg?.channels?.length && cfg.channels.length > 0)
     ? buildPartialChannelMeta(cfg.channels) : undefined;
   if (cfg.resourceName === undefined) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Pinpoint resource name is missing in the backend config',
     });
   }

--- a/packages/amplify-category-notifications/src/notifications-backend-cfg-channel-api.ts
+++ b/packages/amplify-category-notifications/src/notifications-backend-cfg-channel-api.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, stateManager, AmplifyCategories, AmplifySupportedService, AmplifyError, amplifyErrorWithTroubleshootingLink,
+  $TSContext, stateManager, AmplifyCategories, AmplifySupportedService, AmplifyError,
 } from 'amplify-cli-core';
 import * as path from 'path';
 import {
@@ -114,7 +114,7 @@ export const getChannelNameFromView = (channelViewString: string): string => {
       return channelName;
     }
   }
-  throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+  throw new AmplifyError('ConfigurationError', {
     message: `No channel name found for view: ${channelViewString}`,
   });
 };

--- a/packages/amplify-category-notifications/src/pinpoint-helper.ts
+++ b/packages/amplify-category-notifications/src/pinpoint-helper.ts
@@ -9,8 +9,8 @@ import {
   IAnalyticsResource,
   INotificationsResourceMeta,
   $TSMeta,
-  amplifyErrorWithTroubleshootingLink,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyError,
+  AmplifyFault,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import {
@@ -255,7 +255,7 @@ export const updateContextFromAnalyticsOutput = async (
 export const createAnalyticsPinpointApp = async (context: $TSContext): Promise<void> => {
   const pushResponse = await invokeAnalyticsPush(context, AmplifySupportedService.PINPOINT);
   if (!pushResponse.status) {
-    throw amplifyFaultWithTroubleshootingLink('PushResourcesFault', {
+    throw new AmplifyFault('PushResourcesFault', {
       message: `Failed to create Pinpoint resource for the given environment: ${pushResponse.reasonMsg}`,
     });
   }
@@ -335,7 +335,7 @@ export const ensurePinpointApp = async (
         pinpointApp = await updateContextFromAnalyticsOutput(context, amplifyMeta, pinpointAppStatus);
         resourceName = pinpointAppStatus?.app?.resourceName;
         if (!resourceName) {
-          throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+          throw new AmplifyFault('ResourceNotFoundFault', {
             message: `Pinpoint resource name is not found in amplify-meta.json : ${pinpointAppStatus?.app}`,
           });
         }
@@ -374,7 +374,7 @@ export const ensurePinpointApp = async (
       break;
     }
     default:
-      throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+      throw new AmplifyError('ConfigurationError', {
         message: `Invalid Pinpoint App Status ${pinpointAppStatus.status} : App: ${pinpointAppStatus.app}`,
       });
   }

--- a/packages/amplify-cli-core/src/errors/amplify-error.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-error.ts
@@ -1,6 +1,5 @@
-import { AMPLIFY_SUPPORT_DOCS } from '../cliConstants';
 import {
-  AmplifyException, AmplifyExceptionOptions, AmplifyErrorType, PartialAmplifyExceptionOptions,
+  AmplifyException, AmplifyExceptionOptions, AmplifyErrorType,
 } from './amplify-exception';
 
 /**

--- a/packages/amplify-cli-core/src/errors/amplify-error.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-error.ts
@@ -29,21 +29,3 @@ export class AmplifyError extends AmplifyException {
     super(name, 'ERROR', options, downstreamException);
   }
 }
-
-/**
- * convenience method to return an amplify error with the default troubleshooting link
- * @deprecated prefer using AmplifyError and passing the resolution steps
- */
-export const amplifyErrorWithTroubleshootingLink = (
-  name: AmplifyErrorType,
-  options: PartialAmplifyExceptionOptions,
-  downstreamException?: Error,
-)
-  : AmplifyError => new AmplifyError(
-  name,
-  {
-    ...options,
-    link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-  },
-  downstreamException,
-);

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-cycle
+import { AMPLIFY_SUPPORT_DOCS } from '../cliConstants';
+
 /**
  * Base class for all Amplify exceptions
  */
@@ -37,8 +40,8 @@ export abstract class AmplifyException extends Error {
 
     this.message = options.message;
     this.details = options.details;
-    this.resolution = 'resolution' in options ? options.resolution : undefined;
-    this.link = 'link' in options ? options.link : undefined;
+    this.resolution = options.resolution;
+    this.link = options.link ?? AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url;
   }
 
   toObject = (): object => {
@@ -63,11 +66,9 @@ export type AmplifyExceptionClassification = 'FAULT' | 'ERROR';
 export type AmplifyExceptionOptions = {
   message: string,
   details?: string,
-} & ({
-  resolution: string
-} | {
-  link: string
-});
+  resolution?: string,
+  link?: string,
+};
 
 /**
  * Amplify Error partial options object

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -25,29 +25,20 @@ export abstract class AmplifyException extends Error {
   constructor(
     public readonly name: AmplifyExceptionType,
     public readonly classification: AmplifyExceptionClassification,
-    private readonly options: AmplifyExceptionOptions,
+    public readonly options: AmplifyExceptionOptions,
     public readonly downstreamException?: Error,
   ) {
     // If an AmplifyException was already thrown, we must allow it to reach the user.
     // This ensures that resolution steps, and the original error are bubbled up.
-    super(downstreamException instanceof AmplifyException ? downstreamException.message : options.message);
+    super(options.message);
 
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, AmplifyException.prototype);
 
-    if (downstreamException instanceof AmplifyException) {
-      this.stack = downstreamException.stack ? downstreamException.stack : this.stack;
-      this.message = downstreamException.message;
-      this.details = downstreamException.details;
-      this.resolution = downstreamException.resolution;
-      this.link = downstreamException.link;
-    } else {
-      this.stack = options.stack ? options.stack : this.stack;
-      this.message = options.message;
-      this.details = options.details;
-      this.resolution = 'resolution' in options ? options.resolution : undefined;
-      this.link = 'link' in options ? options.link : undefined;
-    }
+    this.message = options.message;
+    this.details = options.details;
+    this.resolution = 'resolution' in options ? options.resolution : undefined;
+    this.link = 'link' in options ? options.link : undefined;
   }
 
   toObject = (): object => {
@@ -72,7 +63,6 @@ export type AmplifyExceptionClassification = 'FAULT' | 'ERROR';
 export type AmplifyExceptionOptions = {
   message: string,
   details?: string,
-  stack?: string,
 } & ({
   resolution: string
 } | {

--- a/packages/amplify-cli-core/src/errors/amplify-fault.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-fault.ts
@@ -30,19 +30,3 @@ export class AmplifyFault extends AmplifyException {
     super(name, 'FAULT', options, downstreamException);
   }
 }
-
-/**
- * returns an amplify fault with the default troubleshooting link if not passed
- */
-export const amplifyFaultWithTroubleshootingLink = (
-  name: AmplifyFaultType,
-  options: PartialAmplifyExceptionOptions,
-  downstreamException?: Error,
-)
-  : AmplifyFault => new AmplifyFault(
-  name, {
-    ...options,
-    link: 'link' in options && options.link ? options.link : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
-  },
-  downstreamException,
-);

--- a/packages/amplify-cli-core/src/errors/amplify-fault.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-fault.ts
@@ -1,6 +1,5 @@
-import { AMPLIFY_SUPPORT_DOCS } from '../cliConstants';
 import {
-  AmplifyException, AmplifyExceptionOptions, AmplifyFaultType, PartialAmplifyExceptionOptions,
+  AmplifyException, AmplifyExceptionOptions, AmplifyFaultType,
 } from './amplify-exception';
 
 /**

--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import { CLIEnvironmentProvider } from '../cliEnvironmentProvider';
 import { AmplifyError } from '../errors/amplify-error';
-import { amplifyFaultWithTroubleshootingLink } from '../errors/amplify-fault';
+import { AmplifyFault } from '../errors/amplify-fault';
 import { JSONUtilities } from '../jsonUtilities';
 import { pathManager, stateManager } from '../state-manager'; // eslint-disable-line import/no-cycle
 /* eslint-disable import/no-cycle */
@@ -161,7 +161,7 @@ export class FeatureFlags {
     if (!envNames) {
       // this is an internal issue, we either couldn't load the environment names
       // or their configuration is invalid, further troubleshooting is needed
-      throw amplifyFaultWithTroubleshootingLink('ConfigurationFault', {
+      throw new AmplifyFault('ConfigurationFault', {
         message: 'Environment names could not be loaded or were not provided.',
       });
     }

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -7,8 +7,7 @@ import {
   HooksMeta,
 } from 'amplify-cli-core';
 import { logger } from 'amplify-cli-logger';
-import { AmplifyPrinter, printer } from 'amplify-prompts';
-import { isDebug } from 'amplify-prompts/src/flags';
+import { AmplifyPrinter, printer, isDebug } from 'amplify-prompts';
 import { reportError } from './commands/diagnose';
 import { isHeadlessCommand } from './context-manager';
 import { Context } from './domain/context';

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -57,7 +57,7 @@ export const handleException = async (exception: unknown): Promise<void> => {
         downstreamException = downstreamException.downstreamException;
       } else {
         printError(downstreamException);
-        downstreamException = null;
+        downstreamException = undefined;
       }
     }
   }

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -54,11 +54,11 @@ export const handleException = async (exception: unknown): Promise<void> => {
 
       if (downstreamException instanceof AmplifyException) {
         printAmplifyException(downstreamException);
+        downstreamException = downstreamException.downstreamException;
       } else {
         printError(downstreamException);
+        downstreamException = null;
       }
-
-      downstreamException = downstreamException.downstreamException;
     }
   }
 

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -2,7 +2,7 @@ import {
   $TSAny,
   AmplifyException,
   AmplifyFaultType,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyFault,
   executeHooks,
   HooksMeta,
 } from 'amplify-cli-core';
@@ -132,21 +132,21 @@ const printHeadlessAmplifyException = (amplifyException: AmplifyException): void
   errorPrinter.error(JSON.stringify(amplifyException.toObject()));
 };
 
-const unknownErrorToAmplifyException = (err: unknown): AmplifyException => amplifyFaultWithTroubleshootingLink(
+const unknownErrorToAmplifyException = (err: unknown): AmplifyException => new AmplifyFault(
   unknownErrorTypeToAmplifyExceptionType(err), {
     message: (typeof err === 'object' && err !== null && 'message' in err) ? (err as $TSAny).message : 'Unknown error',
     resolution: mapUnknownErrorToResolution(err),
   },
 );
 
-const genericErrorToAmplifyException = (err: Error): AmplifyException => amplifyFaultWithTroubleshootingLink(
+const genericErrorToAmplifyException = (err: Error): AmplifyException => new AmplifyFault(
   genericErrorTypeToAmplifyExceptionType(err), {
     message: err.message,
     resolution: mapGenericErrorToResolution(err),
   }, err,
 );
 
-const nodeErrorToAmplifyException = (err: NodeJS.ErrnoException): AmplifyException => amplifyFaultWithTroubleshootingLink(
+const nodeErrorToAmplifyException = (err: NodeJS.ErrnoException): AmplifyException => new AmplifyFault(
   nodeErrorTypeToAmplifyExceptionType(err), {
     message: err.message,
     resolution: mapNodeErrorToResolution(err),

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -47,6 +47,19 @@ export const handleException = async (exception: unknown): Promise<void> => {
     printHeadlessAmplifyException(amplifyException);
   } else {
     printAmplifyException(amplifyException);
+
+    let { downstreamException } = amplifyException;
+    while (isDebug && downstreamException) {
+      printer.blankLine();
+
+      if (downstreamException instanceof AmplifyException) {
+        printAmplifyException(downstreamException);
+      } else {
+        printError(downstreamException);
+      }
+
+      downstreamException = downstreamException.downstreamException;
+    }
   }
 
   // Swallow and continue if any operations fail
@@ -107,15 +120,6 @@ const printAmplifyException = (amplifyException: AmplifyException): void => {
   printer.blankLine();
   if (stack) {
     printer.debug(stack);
-  }
-
-  if (isDebug && amplifyException.downstreamException) {
-    printer.blankLine();
-    if (amplifyException.downstreamException instanceof AmplifyException) {
-      printAmplifyException(amplifyException.downstreamException);
-    } else {
-      printError(amplifyException.downstreamException);
-    }
   }
 };
 

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -47,8 +47,6 @@ export const attachBackend = async (context: $TSContext, inputParams): Promise<v
 
     throw amplifyFaultWithTroubleshootingLink('PullBackendFault', {
       message: 'Failed to pull the backend.',
-      details: e.message,
-      stack: e.stack,
     }, e);
   }
 };
@@ -129,14 +127,10 @@ const backupAmplifyFolder = (): void => {
         throw amplifyErrorWithTroubleshootingLink('DirectoryError', {
           message: `Could not attach the backend to the project.`,
           resolution: 'Ensure that there are no applications locking the `amplify` folder and try again.',
-          details: e.message,
-          stack: e.stack,
         }, e);
       }
       throw amplifyFaultWithTroubleshootingLink('AmplifyBackupFault', {
         message: `Could not attach the backend to the project.`,
-        details: e.message,
-        stack: e.stack,
       }, e);
     }
   }

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -1,7 +1,7 @@
 import {
   $TSContext,
-  amplifyErrorWithTroubleshootingLink,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyError,
+  AmplifyFault,
   FeatureFlags,
   pathManager,
   stateManager,
@@ -45,7 +45,7 @@ export const attachBackend = async (context: $TSContext, inputParams): Promise<v
     removeAmplifyFolderStructure();
     restoreOriginalAmplifyFolder();
 
-    throw amplifyFaultWithTroubleshootingLink('PullBackendFault', {
+    throw new AmplifyFault('PullBackendFault', {
       message: 'Failed to pull the backend.',
     }, e);
   }
@@ -116,7 +116,7 @@ const backupAmplifyFolder = (): void => {
     const backupAmplifyDirPath = path.join(projectPath, backupAmplifyDirName);
 
     if (fs.existsSync(backupAmplifyDirPath)) {
-      throw amplifyErrorWithTroubleshootingLink('DirectoryAlreadyExistsError', {
+      throw new AmplifyError('DirectoryAlreadyExistsError', {
         message: `Backup folder at ${backupAmplifyDirPath} already exists, remove the folder and retry the operation.`,
       });
     }
@@ -124,12 +124,12 @@ const backupAmplifyFolder = (): void => {
       fs.moveSync(amplifyDirPath, backupAmplifyDirPath);
     } catch (e) {
       if (e.code === 'EPERM') {
-        throw amplifyErrorWithTroubleshootingLink('DirectoryError', {
+        throw new AmplifyError('DirectoryError', {
           message: `Could not attach the backend to the project.`,
           resolution: 'Ensure that there are no applications locking the `amplify` folder and try again.',
         }, e);
       }
-      throw amplifyFaultWithTroubleshootingLink('AmplifyBackupFault', {
+      throw new AmplifyFault('AmplifyBackupFault', {
         message: `Could not attach the backend to the project.`,
       }, e);
     }

--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -23,7 +23,6 @@ export const run = async (context: $TSContext): Promise<void> => {
       throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
         message: `Failed to pull sandbox app.`,
         details: e.message || 'An unknown error occurred.',
-        stack: e.stack,
       }, e);
     }
     return;

--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, stateManager, AmplifyError, amplifyFaultWithTroubleshootingLink,
+  $TSContext, stateManager, AmplifyError, AmplifyFault,
 } from 'amplify-cli-core';
 import { pullBackend } from '../pull-backend';
 import { preDeployPullBackend } from '../pre-deployment-pull';
@@ -20,7 +20,7 @@ export const run = async (context: $TSContext): Promise<void> => {
     try {
       await preDeployPullBackend(context, inputParams.sandboxId);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw new AmplifyFault('UnknownFault', {
         message: `Failed to pull sandbox app.`,
         details: e.message || 'An unknown error occurred.',
       }, e);

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -1,8 +1,8 @@
 import {
   $TSAny,
   $TSContext,
-  amplifyErrorWithTroubleshootingLink,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyError,
+  AmplifyFault,
   spinner,
   stateManager,
 } from 'amplify-cli-core';
@@ -49,7 +49,7 @@ const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
     spinner.succeed(`Successfully pulled backend environment ${currentEnv} from the cloud.`);
   } catch (e) {
     spinner.fail(`There was an error pulling the backend environment ${currentEnv}.`);
-    throw amplifyFaultWithTroubleshootingLink('BackendPullFault', { message: e.message }, e);
+    throw new AmplifyFault('BackendPullFault', { message: e.message }, e);
   }
 };
 
@@ -66,7 +66,7 @@ const updateTrackedFiles = async (): Promise<void> => {
 export const run = async (context: $TSContext): Promise<$TSAny> => {
   context.amplify.constructExeInfo(context);
   if (context.exeInfo.localEnvInfo.noUpdateBackend) {
-    throw amplifyErrorWithTroubleshootingLink('NoUpdateBackendError', { message: 'The local environment configuration does not allow backend updates.' });
+    throw new AmplifyError('NoUpdateBackendError', { message: 'The local environment configuration does not allow backend updates.' });
   }
   if (context.parameters.options.force) {
     context.exeInfo.forcePush = true;

--- a/packages/amplify-cli/src/domain/amplify-usageData/SerializableError.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/SerializableError.ts
@@ -7,9 +7,11 @@ const regex = /^\s*at (?:((?:\[object object\])?[^\\/]+(?: \[as \S+\])?) )?\(?(.
  */
 export class SerializableError {
   name: string;
+  message: string;
   trace?: Trace[];
   constructor(error: Error) {
     this.name = error.name;
+    this.message = error.message;
     this.trace = this.extractStackTrace(error);
   }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
@@ -4,7 +4,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import {
-  FeatureFlags, $TSContext, amplifyFaultWithTroubleshootingLink,
+  FeatureFlags, $TSContext, AmplifyFault,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { removeEnvFromCloud } from './remove-env-from-cloud';
@@ -49,7 +49,7 @@ export const deleteProject = async (context: $TSContext): Promise<void> => {
         spinner.succeed('Project already deleted in the cloud.');
       } else {
         spinner.fail('Project delete failed.');
-        throw amplifyFaultWithTroubleshootingLink('BackendDeleteFault', {
+        throw new AmplifyFault('BackendDeleteFault', {
           message: 'Project delete failed.',
           details: ex.message,
         }, ex);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/delete-project.ts
@@ -51,7 +51,6 @@ export const deleteProject = async (context: $TSContext): Promise<void> => {
         spinner.fail('Project delete failed.');
         throw amplifyFaultWithTroubleshootingLink('BackendDeleteFault', {
           message: 'Project delete failed.',
-          stack: ex.stack,
           details: ex.message,
         }, ex);
       }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/invoke-plugin-method.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, AmplifyError, amplifyErrorWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyError,
 } from 'amplify-cli-core';
 
 /**
@@ -25,7 +25,7 @@ export const invokePluginMethod = async <T>(
   const pluginMethod = plugin[method];
 
   if (!pluginMethod || typeof pluginMethod !== 'function') {
-    throw amplifyErrorWithTroubleshootingLink('PluginMethodNotFoundError', {
+    throw new AmplifyError('PluginMethodNotFoundError', {
       message: `Method ${method} does not exist or is not a function in category plugin: ${category}.`,
     });
   }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -117,7 +117,6 @@ export const pushResources = async (
         }
         throw new AmplifyFault('PushResourcesFault', {
           message: err.message,
-          stack: err.stack,
           link: isAuthError ? AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url : AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url,
           resolution: isAuthError ? 'Some @auth rules are defined in the GraphQL schema without enabling the corresponding auth providers. Run `amplify update api` to configure your GraphQL API to include the appropriate auth providers as an authorization mode.' : undefined,
         }, err);

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -32,12 +32,10 @@ export const removeEnvFromCloud = async (context, envName, deleteS3): Promise<vo
     await Promise.all(providerPromises);
     await raiseInternalOnlyPostEnvRemoveEvent(context, envName);
   } catch (ex) {
-    if (!(ex?.name === 'BucketNotFoundError')) {
+    if (ex?.name !== 'BucketNotFoundError') {
       throw amplifyFaultWithTroubleshootingLink('BackendDeleteFault', {
         message: `Error occurred while deleting env: ${envName}.`,
-        details: ex.message,
-        stack: ex.stack,
-      });
+      }, ex);
     }
   }
 };

--- a/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/remove-env-from-cloud.ts
@@ -1,4 +1,4 @@
-import { $TSAny, amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSAny, AmplifyFault } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { getProjectConfig } from './get-project-config';
 import { getAllCategoryPluginInfo } from './get-all-category-pluginInfos';
@@ -33,7 +33,7 @@ export const removeEnvFromCloud = async (context, envName, deleteS3): Promise<vo
     await raiseInternalOnlyPostEnvRemoveEvent(context, envName);
   } catch (ex) {
     if (ex?.name !== 'BucketNotFoundError') {
-      throw amplifyFaultWithTroubleshootingLink('BackendDeleteFault', {
+      throw new AmplifyFault('BackendDeleteFault', {
         message: `Error occurred while deleting env: ${envName}.`,
       }, ex);
     }

--- a/packages/amplify-cli/src/init-steps/postInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/postInitSetup.ts
@@ -29,9 +29,7 @@ export const postInitSetup = async (context: $TSContext): Promise<void> => {
       }
       throw new AmplifyFault('ProjectInitFault', {
         message: 'An error occurred during project initialization',
-        details: e.message,
         link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
-        stack: e.stack,
       }, e);
     }
   }

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -37,9 +37,7 @@ const validateGithubRepo = async (repoUrl: string): Promise<void> => {
   } catch (e) {
     throw new AmplifyError('ProjectInitError', {
       message: 'Invalid remote github url',
-      details: e.message,
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
-      stack: e.stack,
     }, e);
   }
 };
@@ -64,7 +62,6 @@ const cloneRepo = async (repoUrl: string): Promise<void> => {
       message: 'Unable to clone repository',
       details: e.message,
       link: 'https://docs.amplify.aws/cli/project/troubleshooting/',
-      stack: e.stack,
     }, e);
   }
 };

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import sequential from 'promise-sequential';
 import {
-  stateManager, $TSAny, $TSMeta, $TSContext, amplifyFaultWithTroubleshootingLink,
+  stateManager, $TSAny, $TSMeta, $TSContext, AmplifyFault,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { ensureEnvParamManager, IEnvironmentParameterManager } from '@aws-amplify/amplify-environment-parameters';
@@ -50,7 +50,7 @@ export const initializeEnv = async (
           categoryInitializationTasks.push(() => initEnv(context));
         }
       } catch (e) {
-        throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
+        throw new AmplifyFault('PluginNotLoadedFault', {
           message: `Could not load plugin for category ${category}.`,
           resolution: `Review the error message and stack trace for additional information.`,
         }, e);
@@ -72,7 +72,7 @@ export const initializeEnv = async (
         const providerModule = await import(providerPlugins[provider]);
         initializationTasks.push(() => providerModule.initEnv(context, amplifyMeta.providers[provider]));
       } catch (e) {
-        throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
+        throw new AmplifyFault('PluginNotLoadedFault', {
           message: `Could not load plugin for provider ${provider}.`,
           resolution: 'Review the error message and stack trace for additional information.',
         }, e);
@@ -87,7 +87,7 @@ export const initializeEnv = async (
       context.usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_PLATFORM);
       await sequential(initializationTasks);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+      throw new AmplifyFault('ProjectInitFault', {
         message: `Could not initialize platform for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
       }, e);
@@ -108,7 +108,7 @@ export const initializeEnv = async (
       context.usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES);
       await sequential(categoryInitializationTasks);
     } catch (e) {
-      throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+      throw new AmplifyFault('ProjectInitFault', {
         message: `Could not initialize categories for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
       }, e);

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -52,9 +52,7 @@ export const initializeEnv = async (
       } catch (e) {
         throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
           message: `Could not load plugin for category ${category}.`,
-          details: e.message,
           resolution: `Review the error message and stack trace for additional information.`,
-          stack: e.stack,
         }, e);
       }
     };
@@ -76,9 +74,7 @@ export const initializeEnv = async (
       } catch (e) {
         throw amplifyFaultWithTroubleshootingLink('PluginNotLoadedFault', {
           message: `Could not load plugin for provider ${provider}.`,
-          details: e.message,
           resolution: 'Review the error message and stack trace for additional information.',
-          stack: e.stack,
         }, e);
       }
     }
@@ -94,7 +90,6 @@ export const initializeEnv = async (
       throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
         message: `Could not initialize platform for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
-        stack: e.stack,
       }, e);
     } finally {
       context.usageData.stopCodePathTimer(ManuallyTimedCodePath.INIT_ENV_PLATFORM);
@@ -116,7 +111,6 @@ export const initializeEnv = async (
       throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
         message: `Could not initialize categories for '${currentEnv}': ${e.message}`,
         resolution: 'Review the error message and stack trace for additional information.',
-        stack: e.stack,
       }, e);
     } finally {
       context.usageData.stopCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES);

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -1,5 +1,5 @@
 import {
-  amplifyFaultWithTroubleshootingLink, pathManager, stateManager,
+  AmplifyFault, pathManager, stateManager,
 } from 'amplify-cli-core';
 import _ from 'lodash';
 import { ResourceParameterManager } from './resource-parameter-manager';
@@ -30,7 +30,7 @@ export const getEnvParamManager = (envName: string = stateManager.getLocalEnvInf
   if (envParamManagerMap[envName]) {
     return envParamManagerMap[envName];
   }
-  throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+  throw new AmplifyFault('ProjectInitFault', {
     message: `EnvironmentParameterManager for ${envName} environment is not initialized.`,
   });
 };
@@ -63,7 +63,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
 
   getResourceParamManager(category: string, resource: string): ResourceParameterManager {
     if (!category || !resource) {
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+      throw new AmplifyFault('ResourceNotFoundFault', {
         message: 'Missing Category or Resource.',
       });
     }

--- a/packages/amplify-prompts/src/index.ts
+++ b/packages/amplify-prompts/src/index.ts
@@ -5,3 +5,4 @@ export * from './validators';
 export * from './progressbars/progressbar';
 export * from './progressbars/multibar';
 export * from './progressbars/spinner';
+export * from './flags';

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, amplifyErrorWithTroubleshootingLink, amplifyFaultWithTroubleshootingLink, pathManager, stateManager,
+  $TSAny, $TSContext, AmplifyError, AmplifyFault, pathManager, stateManager,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import AWS from 'aws-sdk';
@@ -64,7 +64,7 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     if (jobCompletionDetails.Status === 'COMPLETED') {
       spinner.succeed('Successfully generated models in the cloud.');
     } else {
-      throw amplifyErrorWithTroubleshootingLink('ModelgenError', { message: `Failed to generate models in the cloud.` });
+      throw new AmplifyError('ModelgenError', { message: `Failed to generate models in the cloud.` });
     }
   } catch (e) {
     spinner.stop();
@@ -100,7 +100,7 @@ const pollUntilDone = async (
       return jobDetails;
     }
     if (timeout !== 0 && Date.now() - start > timeout) {
-      throw amplifyFaultWithTroubleshootingLink('TimeoutFault', { message: `Job Timed out for ${jobId}` });
+      throw new AmplifyFault('TimeoutFault', { message: `Job Timed out for ${jobId}` });
     } else {
       // run again with a short delay
       await delay(interval);

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
@@ -137,7 +137,6 @@ async function init(amplifyServiceParams) {
       } else {
         throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
           message: e.message,
-          stack: e.stack,
         }, e);
       }
     }
@@ -232,7 +231,6 @@ async function deleteEnv(context, envName, awsConfigInfo) {
         } else {
           throw amplifyFaultWithTroubleshootingLink('ProjectDeleteFault', {
             message: ex.message,
-            stack: ex.stack,
           }, ex);
         }
       }
@@ -320,7 +318,6 @@ async function postPushCheck(context) {
         } else {
           throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
             message: e.message,
-            stack: e.stack,
           }, e);
         }
       }

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.js
@@ -8,7 +8,7 @@ const { S3 } = require('./aws-utils/aws-s3');
 const { getConfiguredAmplifyClient } = require('./aws-utils/aws-amplify');
 const { ProviderName, AmplifyAppIdLabel } = require('./constants');
 const { checkAmplifyServiceIAMPermission } = require('./amplify-service-permission-check');
-const { stateManager, amplifyFaultWithTroubleshootingLink, AmplifyError } = require('amplify-cli-core');
+const { stateManager, AmplifyFault, AmplifyError } = require('amplify-cli-core');
 const { fileLogger } = require('./utils/aws-logger');
 const { loadConfigurationForEnv } = require('./configuration-manager');
 const logger = fileLogger('amplify-service-manager');
@@ -135,7 +135,7 @@ async function init(amplifyServiceParams) {
       ) {
         // Do nothing
       } else {
-        throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+        throw new AmplifyFault('ProjectInitFault', {
           message: e.message,
         }, e);
       }
@@ -229,7 +229,7 @@ async function deleteEnv(context, envName, awsConfigInfo) {
         if (ex.code === 'NotFoundException') {
           context.print.warning(ex.message);
         } else {
-          throw amplifyFaultWithTroubleshootingLink('ProjectDeleteFault', {
+          throw new AmplifyFault('ProjectDeleteFault', {
             message: ex.message,
           }, ex);
         }
@@ -316,7 +316,7 @@ async function postPushCheck(context) {
         ) {
           // Do nothing
         } else {
-          throw amplifyFaultWithTroubleshootingLink('ProjectInitFault', {
+          throw new AmplifyFault('ProjectInitFault', {
             message: e.message,
           }, e);
         }

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-migrate.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { amplifyErrorWithTroubleshootingLink, stateManager } from 'amplify-cli-core';
+import { AmplifyError, stateManager } from 'amplify-cli-core';
 import * as configurationManager from './configuration-manager';
 import { getConfiguredAmplifyClient } from './aws-utils/aws-amplify';
 import { checkAmplifyServiceIAMPermission } from './amplify-service-permission-check';
@@ -49,13 +49,13 @@ export const run = async (context): Promise<void> => {
   if (!amplifyClient) {
     // This happens when the Amplify service is not available in the region
     const message = `Amplify service is not available in the region ${awsConfigInfo.region ? awsConfigInfo.region : ''}`;
-    throw amplifyErrorWithTroubleshootingLink('RegionNotAvailableError', { message });
+    throw new AmplifyError('RegionNotAvailableError', { message });
   }
 
   const hasPermission = await checkAmplifyServiceIAMPermission(context, amplifyClient);
   if (!hasPermission) {
     const message = 'Permissions to access Amplify service is required.';
-    throw amplifyErrorWithTroubleshootingLink('PermissionsError', { message });
+    throw new AmplifyError('PermissionsError', { message });
   }
 
   const { inputParams } = context.exeInfo;
@@ -74,7 +74,7 @@ export const run = async (context): Promise<void> => {
         .promise();
       context.print.info(`Amplify AppID found: ${amplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('ProjectNotFoundError', {
+      throw new AmplifyError('ProjectNotFoundError', {
         message: `Amplify AppID: ${amplifyAppId} not found.`,
         resolution: `Please ensure your local profile matches the AWS account or region in which the Amplify app exists.`,
       }, e);
@@ -124,7 +124,7 @@ export const run = async (context): Promise<void> => {
       logger('run.amplifyClient.getBackendEnvironment', [getEnvParams])();
       const { backendEnvironment } = await amplifyClient.getBackendEnvironment(getEnvParams).promise();
       if (StackName !== backendEnvironment.stackName) {
-        throw amplifyErrorWithTroubleshootingLink('InvalidStackError', {
+        throw new AmplifyError('InvalidStackError', {
           message: `Stack name mismatch for the backend environment ${envName}. Local: ${StackName}, Amplify: ${backendEnvironment.stackName}`,
         });
       }

--- a/packages/amplify-provider-awscloudformation/src/attach-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.ts
@@ -51,7 +51,6 @@ export const run = async (context): Promise<void> => {
       } catch (e) {
         throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
           message: `Failed to authenticate: ${e.message || 'Unknown error occurred.'}`,
-          stack: e.stack,
         }, e);
       }
     }
@@ -244,7 +243,6 @@ async function getBackendEnv(context, amplifyClient, amplifyApp) {
     } catch (e) {
       throw amplifyErrorWithTroubleshootingLink('EnvironmentNotInitializedError', {
         message: `Cannot find backend environment ${inputEnvName} in Amplify Console app: ${amplifyApp.name}`,
-        stack: e.stack,
         details: e.message,
       }, e);
     }

--- a/packages/amplify-provider-awscloudformation/src/attach-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.ts
@@ -9,7 +9,7 @@ import {
   exitOnNextTick,
   pathManager,
   PathConstants,
-  amplifyErrorWithTroubleshootingLink,
+  AmplifyError,
 } from 'amplify-cli-core';
 import * as configurationManager from './configuration-manager';
 import { getConfiguredAmplifyClient } from './aws-utils/aws-amplify';
@@ -41,7 +41,7 @@ export const run = async (context): Promise<void> => {
     isAdminApp = res.isAdminApp;
     if (isAdminApp) {
       if (!envName) {
-        throw amplifyErrorWithTroubleshootingLink('EnvironmentNameError', {
+        throw new AmplifyError('EnvironmentNameError', {
           message: 'Missing --envName <environment name> in parameters.',
         });
       }
@@ -49,7 +49,7 @@ export const run = async (context): Promise<void> => {
       try {
         await adminLoginFlow(context, appId, envName, res.region);
       } catch (e) {
-        throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+        throw new AmplifyError('AmplifyStudioLoginError', {
           message: `Failed to authenticate: ${e.message || 'Unknown error occurred.'}`,
         }, e);
       }
@@ -71,14 +71,14 @@ export const run = async (context): Promise<void> => {
   if (!amplifyClient) {
     // This happens when the Amplify service is not available in the region
     const region = awsConfigInfo && awsConfigInfo.region ? awsConfigInfo.region : '<unknown>';
-    throw amplifyErrorWithTroubleshootingLink('RegionNotAvailableError', {
+    throw new AmplifyError('RegionNotAvailableError', {
       message: `Amplify service is not available in the region ${region}`,
     });
   }
 
   const hasPermission = await checkAmplifyServiceIAMPermission(context, amplifyClient);
   if (!hasPermission) {
-    throw amplifyErrorWithTroubleshootingLink('PermissionsError', {
+    throw new AmplifyError('PermissionsError', {
       message: 'Permissions to access Amplify service is required.',
     });
   }
@@ -161,7 +161,7 @@ async function getAmplifyApp(context, amplifyClient) {
       context.print.info(`Amplify AppID found: ${inputAmplifyAppId}. Amplify App name is: ${getAppResult.app.name}`);
       return getAppResult.app;
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('ProjectNotFoundError', {
+      throw new AmplifyError('ProjectNotFoundError', {
         message: e.message && e.name && e.name === 'NotFoundException'
           ? e.message
           : `Amplify AppID: ${inputAmplifyAppId} not found.`,
@@ -214,7 +214,7 @@ async function getAmplifyApp(context, amplifyClient) {
     return selection;
   }
 
-  throw amplifyErrorWithTroubleshootingLink('ProjectNotFoundError', {
+  throw new AmplifyError('ProjectNotFoundError', {
     message: 'No Amplify apps found.',
     resolution: 'Ensure your local profile matches the AWS account or region in which the Amplify app exists.',
   });
@@ -241,7 +241,7 @@ async function getBackendEnv(context, amplifyClient, amplifyApp) {
       context.print.info(`Backend environment ${inputEnvName} found in Amplify Console app: ${amplifyApp.name}`);
       return getBackendEnvironmentResult.backendEnvironment;
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('EnvironmentNotInitializedError', {
+      throw new AmplifyError('EnvironmentNotInitializedError', {
         message: `Cannot find backend environment ${inputEnvName} in Amplify Console app: ${amplifyApp.name}`,
         details: e.message,
       }, e);
@@ -291,7 +291,7 @@ async function getBackendEnv(context, amplifyClient, amplifyApp) {
     context.print.info(`Backend environment '${backendEnvs[0].environmentName}' found. Initializing...`);
     return backendEnvs[0];
   }
-  throw amplifyErrorWithTroubleshootingLink('EnvironmentNotInitializedError', {
+  throw new AmplifyError('EnvironmentNotInitializedError', {
     message: `Cannot find backend environment in Amplify Console app: ${amplifyApp.name}`,
   });
 }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -9,9 +9,6 @@ import {
 import { loadConfiguration } from '../configuration-manager';
 import { pagedAWSCall } from './paged-call';
 
-/**
- *
- */
 export const createIdentityPoolService = async (context: $TSContext, options: $TSAny): Promise<IdentityPoolService> => {
   let credentials = {};
 
@@ -26,18 +23,12 @@ export const createIdentityPoolService = async (context: $TSContext, options: $T
   return new IdentityPoolService(cognitoIdentity);
 };
 
-/**
- *
- */
 export class IdentityPoolService implements IIdentityPoolService {
   private cachedIdentityPoolIds: IdentityPoolShortDescription[] = [];
   private cachedIdentityPoolDetails: IdentityPool[] = [];
 
   public constructor(private cognitoIdentity: CognitoIdentity) {}
 
-  /**
-   *
-   */
   public async listIdentityPools(): Promise<IdentityPoolShortDescription[]> {
     if (this.cachedIdentityPoolIds.length === 0) {
       const result = await pagedAWSCall<ListIdentityPoolsResponse, IdentityPoolShortDescription, PaginationKey>(
@@ -60,9 +51,6 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolIds;
   }
 
-  /**
-   *
-   */
   public async listIdentityPoolDetails(): Promise<IdentityPool[]> {
     if (this.cachedIdentityPoolDetails.length === 0) {
       const identityPools = await this.listIdentityPools();
@@ -87,9 +75,6 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolDetails;
   }
 
-  /**
-   *
-   */
   public async getIdentityPoolRoles(
     identityPoolId: string,
   ): Promise<{ authRoleArn: string; authRoleName: string; unauthRoleArn: string; unauthRoleName: string }> {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, amplifyFaultWithTroubleshootingLink, amplifyErrorWithTroubleshootingLink,
+  $TSAny, $TSContext, AmplifyFault, AmplifyError,
 } from 'amplify-cli-core';
 import { IIdentityPoolService } from 'amplify-util-import';
 import { CognitoIdentity } from 'aws-sdk';
@@ -9,6 +9,9 @@ import {
 import { loadConfiguration } from '../configuration-manager';
 import { pagedAWSCall } from './paged-call';
 
+/**
+ *
+ */
 export const createIdentityPoolService = async (context: $TSContext, options: $TSAny): Promise<IdentityPoolService> => {
   let credentials = {};
 
@@ -23,12 +26,18 @@ export const createIdentityPoolService = async (context: $TSContext, options: $T
   return new IdentityPoolService(cognitoIdentity);
 };
 
+/**
+ *
+ */
 export class IdentityPoolService implements IIdentityPoolService {
   private cachedIdentityPoolIds: IdentityPoolShortDescription[] = [];
   private cachedIdentityPoolDetails: IdentityPool[] = [];
 
   public constructor(private cognitoIdentity: CognitoIdentity) {}
 
+  /**
+   *
+   */
   public async listIdentityPools(): Promise<IdentityPoolShortDescription[]> {
     if (this.cachedIdentityPoolIds.length === 0) {
       const result = await pagedAWSCall<ListIdentityPoolsResponse, IdentityPoolShortDescription, PaginationKey>(
@@ -51,6 +60,9 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolIds;
   }
 
+  /**
+   *
+   */
   public async listIdentityPoolDetails(): Promise<IdentityPool[]> {
     if (this.cachedIdentityPoolDetails.length === 0) {
       const identityPools = await this.listIdentityPools();
@@ -75,6 +87,9 @@ export class IdentityPoolService implements IIdentityPoolService {
     return this.cachedIdentityPoolDetails;
   }
 
+  /**
+   *
+   */
   public async getIdentityPoolRoles(
     identityPoolId: string,
   ): Promise<{ authRoleArn: string; authRoleName: string; unauthRoleArn: string; unauthRoleName: string }> {
@@ -85,7 +100,7 @@ export class IdentityPoolService implements IIdentityPoolService {
       .promise();
 
     if (!response.Roles || !response.Roles.authenticated || !response.Roles.unauthenticated) {
-      throw amplifyErrorWithTroubleshootingLink('AuthImportError', {
+      throw new AmplifyError('AuthImportError', {
         message: `Cannot import Identity Pool without 'authenticated' and 'unauthenticated' roles.`,
       });
     }
@@ -111,7 +126,7 @@ export class IdentityPoolService implements IIdentityPoolService {
 
     // Should not happen anytime
     if (!resourceName) {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw new AmplifyFault('UnknownFault', {
         message: `Cannot parse arn: '${arn}'.`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -3,9 +3,6 @@ import { IS3Service } from 'amplify-util-import';
 import S3, { Bucket } from 'aws-sdk/clients/s3';
 import { loadConfiguration } from '../configuration-manager';
 
-/**
- *
- */
 export const createS3Service = async (context: $TSContext, options: $TSAny): Promise<S3Service> => {
   let credentials = {};
 
@@ -20,17 +17,11 @@ export const createS3Service = async (context: $TSContext, options: $TSAny): Pro
   return new S3Service(s3);
 };
 
-/**
- *
- */
 export class S3Service implements IS3Service {
   private cachedBucketList: Bucket[] = [];
 
   public constructor(private s3: S3) {}
 
-  /**
-   *
-   */
   public async listBuckets(): Promise<Bucket[]> {
     if (this.cachedBucketList.length === 0) {
       const response = await this.s3.listBuckets().promise();
@@ -43,9 +34,6 @@ export class S3Service implements IS3Service {
     return this.cachedBucketList;
   }
 
-  /**
-   *
-   */
   public async bucketExists(bucketName: string): Promise<boolean> {
     try {
       const response = await this.s3
@@ -65,9 +53,6 @@ export class S3Service implements IS3Service {
     }
   }
 
-  /**
-   *
-   */
   public async getBucketLocation(bucketName: string): Promise<string> {
     const response = await this.s3
       .getBucketLocation({

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -1,8 +1,11 @@
-import { $TSAny, $TSContext, amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyFault } from 'amplify-cli-core';
 import { IS3Service } from 'amplify-util-import';
 import S3, { Bucket } from 'aws-sdk/clients/s3';
 import { loadConfiguration } from '../configuration-manager';
 
+/**
+ *
+ */
 export const createS3Service = async (context: $TSContext, options: $TSAny): Promise<S3Service> => {
   let credentials = {};
 
@@ -17,11 +20,17 @@ export const createS3Service = async (context: $TSContext, options: $TSAny): Pro
   return new S3Service(s3);
 };
 
+/**
+ *
+ */
 export class S3Service implements IS3Service {
   private cachedBucketList: Bucket[] = [];
 
   public constructor(private s3: S3) {}
 
+  /**
+   *
+   */
   public async listBuckets(): Promise<Bucket[]> {
     if (this.cachedBucketList.length === 0) {
       const response = await this.s3.listBuckets().promise();
@@ -34,6 +43,9 @@ export class S3Service implements IS3Service {
     return this.cachedBucketList;
   }
 
+  /**
+   *
+   */
   public async bucketExists(bucketName: string): Promise<boolean> {
     try {
       const response = await this.s3
@@ -47,12 +59,15 @@ export class S3Service implements IS3Service {
       if (error.code === 'NotFound') {
         return false;
       }
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw new AmplifyFault('UnknownFault', {
         message: error.message,
       }, error);
     }
   }
 
+  /**
+   *
+   */
   public async getBucketLocation(bucketName: string): Promise<string> {
     const response = await this.s3
       .getBucketLocation({

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -48,7 +48,6 @@ export class S3Service implements IS3Service {
         return false;
       }
       throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
-        stack: error.stack,
         message: error.message,
       }, error);
     }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -390,8 +390,7 @@ class CloudFormation {
       }
 
       throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
-        message: error.message,
-        stack: error.stack,
+        message: error.message
       }, error);
     }
   }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -12,7 +12,7 @@ const { S3 } = require('./aws-s3');
 const providerName = require('../constants').ProviderName;
 const { formUserAgentParam } = require('./user-agent');
 const configurationManager = require('../configuration-manager');
-const { stateManager, pathManager, AmplifyError, AmplifyException, amplifyFaultWithTroubleshootingLink, amplifyErrorWithTroubleshootingLink } = require('amplify-cli-core');
+const { stateManager, pathManager, AmplifyError, AmplifyException, AmplifyFault } = require('amplify-cli-core');
 const { fileLogger } = require('../utils/aws-logger');
 const logger = fileLogger('aws-cfn');
 const { pagedAWSCall } = require('./paged-call');
@@ -389,7 +389,7 @@ class CloudFormation {
         throw error;
       }
 
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
+      throw new AmplifyFault('ResourceNotReadyFault', {
         message: error.message
       }, error);
     }
@@ -563,7 +563,7 @@ class CloudFormation {
     const meta = stateManager.getMeta();
     stackId = stackId || _.get(meta, ['providers', providerName, 'StackName'], undefined);
     if (!stackId) {
-      throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+      throw new AmplifyError('StackNotFoundError', {
         message: `StackId not found in amplify-meta for provider ${providerName}`,
       });
     }
@@ -576,7 +576,7 @@ class CloudFormation {
     const providerInfo = teamProviderInfo?.[envName]?.[providerName];
     const stackName = providerInfo?.StackName;
     if (!stackName) {
-      throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+      throw new AmplifyError('StackNotFoundError', {
         message: `Stack not defined for the environment.`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, amplifyErrorWithTroubleshootingLink } from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyError } from 'amplify-cli-core';
 import { Lambda as AwsSdkLambda } from 'aws-sdk';
 import { LayerVersionsListItem, ListLayerVersionsRequest, ListLayerVersionsResponse } from 'aws-sdk/clients/lambda';
 import { AwsSecrets, loadConfiguration } from '../configuration-manager';
@@ -9,6 +9,9 @@ const aws = require('./aws');
 
 const logger = fileLogger('aws-lambda');
 
+/**
+ *
+ */
 export class Lambda {
   private lambda: AwsSdkLambda;
 
@@ -25,6 +28,9 @@ export class Lambda {
     })() as $TSAny;
   }
 
+  /**
+   *
+   */
   async listLayerVersions(layerNameOrArn: string) {
     const startingParams: ListLayerVersionsRequest = { LayerName: layerNameOrArn, MaxItems: 20 };
     const result = await pagedAWSCall<ListLayerVersionsResponse, LayerVersionsListItem, string>(
@@ -40,6 +46,9 @@ export class Lambda {
     return result;
   }
 
+  /**
+   *
+   */
   async deleteLayerVersions(layerNameOrArn: string, versions: number[]) {
     const params = { LayerName: layerNameOrArn, VersionNumber: undefined };
     const deletionPromises = [];
@@ -50,7 +59,7 @@ export class Lambda {
           await this.lambda.deleteLayerVersion(params).promise();
         } catch (err) {
           if (err.code !== 'ParameterNotFound') {
-            throw amplifyErrorWithTroubleshootingLink('LambdaLayerDeleteError', {
+            throw new AmplifyError('LambdaLayerDeleteError', {
               message: err.message,
             }, err);
           }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
@@ -9,9 +9,6 @@ const aws = require('./aws');
 
 const logger = fileLogger('aws-lambda');
 
-/**
- *
- */
 export class Lambda {
   private lambda: AwsSdkLambda;
 
@@ -28,9 +25,6 @@ export class Lambda {
     })() as $TSAny;
   }
 
-  /**
-   *
-   */
   async listLayerVersions(layerNameOrArn: string) {
     const startingParams: ListLayerVersionsRequest = { LayerName: layerNameOrArn, MaxItems: 20 };
     const result = await pagedAWSCall<ListLayerVersionsResponse, LayerVersionsListItem, string>(
@@ -46,9 +40,6 @@ export class Lambda {
     return result;
   }
 
-  /**
-   *
-   */
   async deleteLayerVersions(layerNameOrArn: string, versions: number[]) {
     const params = { LayerName: layerNameOrArn, VersionNumber: undefined };
     const deletionPromises = [];

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-lambda.ts
@@ -52,7 +52,6 @@ export class Lambda {
           if (err.code !== 'ParameterNotFound') {
             throw amplifyErrorWithTroubleshootingLink('LambdaLayerDeleteError', {
               message: err.message,
-              stack: err.stack,
             }, err);
           }
         }

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -347,14 +347,12 @@ export class S3 {
       if (e.code === 'NotFound') {
         throw new AmplifyError('BucketNotFoundError', {
           message: e.message,
-          stack: e.stack,
           resolution: `Check that bucket name is correct: ${bucketName}`,
         }, e);
       }
 
       throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
         message: e.message,
-        stack: e.stack,
       }, e);
     }
   }
@@ -382,7 +380,6 @@ export class S3 {
 
       throw amplifyFaultWithTroubleshootingLink('UnexpectedS3Fault', {
         message: e.message,
-        stack: e.stack,
       }, e);
     }
   };

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts
@@ -7,7 +7,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import {
-  $TSAny, $TSContext, AmplifyError, amplifyErrorWithTroubleshootingLink, amplifyFaultWithTroubleshootingLink, stateManager,
+  $TSAny, $TSContext, AmplifyError, AmplifyFault, stateManager,
 } from 'amplify-cli-core';
 
 import _ from 'lodash';
@@ -186,7 +186,7 @@ export class S3 {
       await this.s3.waitFor('bucketExists', params).promise();
       this.context.print.success('S3 bucket successfully created');
     } else if (throwIfExists) {
-      throw amplifyErrorWithTroubleshootingLink('BucketAlreadyExistsError', {
+      throw new AmplifyError('BucketAlreadyExistsError', {
         message: `Bucket ${bucketName} already exists`,
       });
     }
@@ -351,7 +351,7 @@ export class S3 {
         }, e);
       }
 
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw new AmplifyFault('UnknownFault', {
         message: e.message,
       }, e);
     }
@@ -378,7 +378,7 @@ export class S3 {
         return undefined;
       }
 
-      throw amplifyFaultWithTroubleshootingLink('UnexpectedS3Fault', {
+      throw new AmplifyFault('UnexpectedS3Fault', {
         message: e.message,
       }, e);
     }

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -38,9 +38,6 @@ interface ProjectConfig {
   config?: AwsConfig;
 }
 
-/**
- *
- */
 export interface AwsSecrets {
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -52,9 +49,6 @@ const defaultAWSConfig: AwsConfig = {
   profileName: 'default',
 };
 
-/**
- *
- */
 export async function init(context: $TSContext) {
   if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend || (!context.exeInfo.isNewProject && doesAwsConfigExists(context))) {
     return context;
@@ -88,9 +82,6 @@ export async function init(context: $TSContext) {
   return await initialize(context, authTypeConfig);
 }
 
-/**
- *
- */
 export async function configure(context: $TSContext) {
   context.exeInfo = context.exeInfo || context.amplify.getProjectDetails();
   normalizeInputParams(context);
@@ -276,9 +267,6 @@ async function initialize(context: $TSContext, authConfig?: AuthFlowConfig) {
   return context;
 }
 
-/**
- *
- */
 export function onInitSuccessful(context: $TSContext) {
   if (context.exeInfo.isNewEnv || !doesAwsConfigExists(context)) {
     persistLocalEnvConfig(context);
@@ -606,9 +594,6 @@ function removeProjectConfig(envName: string) {
   }
 }
 
-/**
- *
- */
 export async function loadConfiguration(context: $TSContext): Promise<AwsSecrets> {
   const { envName } = context.amplify.getEnvInfo();
   const config = await loadConfigurationForEnv(context, envName);
@@ -627,9 +612,6 @@ function loadConfigFromPath(profilePath: string): AwsSdkConfig {
   });
 }
 
-/**
- *
- */
 export async function loadConfigurationForEnv(context: $TSContext, env: string, appId?: string): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo || {};
 
@@ -672,9 +654,6 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
   return awsConfig;
 }
 
-/**
- *
- */
 export async function resetCache(context: $TSContext) {
   const projectConfigInfo = getCurrentConfig(context);
   if (projectConfigInfo.configLevel === 'project') {
@@ -685,9 +664,6 @@ export async function resetCache(context: $TSContext) {
   }
 }
 
-/**
- *
- */
 export function resolveRegion(): string {
   // For details of how aws region is set, check the following link
   // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
@@ -790,9 +766,6 @@ function getConfigLevel(context: $TSContext): ProjectType {
   return configLevel;
 }
 
-/**
- *
- */
 export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -1,5 +1,5 @@
 import {
-  exitOnNextTick, JSONUtilities, pathManager, stateManager, $TSAny, $TSContext, amplifyErrorWithTroubleshootingLink,
+  exitOnNextTick, JSONUtilities, pathManager, stateManager, $TSAny, $TSContext, AmplifyError,
 } from 'amplify-cli-core';
 import fs from 'fs-extra';
 import chalk from 'chalk';
@@ -38,6 +38,9 @@ interface ProjectConfig {
   config?: AwsConfig;
 }
 
+/**
+ *
+ */
 export interface AwsSecrets {
   accessKeyId?: string;
   secretAccessKey?: string;
@@ -49,6 +52,9 @@ const defaultAWSConfig: AwsConfig = {
   profileName: 'default',
 };
 
+/**
+ *
+ */
 export async function init(context: $TSContext) {
   if (context.exeInfo.existingLocalEnvInfo?.noUpdateBackend || (!context.exeInfo.isNewProject && doesAwsConfigExists(context))) {
     return context;
@@ -82,6 +88,9 @@ export async function init(context: $TSContext) {
   return await initialize(context, authTypeConfig);
 }
 
+/**
+ *
+ */
 export async function configure(context: $TSContext) {
   context.exeInfo = context.exeInfo || context.amplify.getProjectDetails();
   normalizeInputParams(context);
@@ -180,7 +189,7 @@ function normalizeInputParams(context: $TSContext) {
         }
       }
       if (errorMessage) {
-        throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+        throw new AmplifyError('ConfigurationError', {
           message: 'Error in the command line parameter for awscloudformation configuration.',
           details: errorMessage,
         });
@@ -267,6 +276,9 @@ async function initialize(context: $TSContext, authConfig?: AuthFlowConfig) {
   return context;
 }
 
+/**
+ *
+ */
 export function onInitSuccessful(context: $TSContext) {
   if (context.exeInfo.isNewEnv || !doesAwsConfigExists(context)) {
     persistLocalEnvConfig(context);
@@ -287,7 +299,7 @@ async function create(context: $TSContext) {
   if (awsConfigInfo.configValidated) {
     persistLocalEnvConfig(context);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Invalid configuration settings.',
     });
   }
@@ -306,7 +318,7 @@ async function update(context: $TSContext) {
   if (awsConfigInfo.configValidated) {
     updateProjectConfig(context);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Invalid configuration settings.',
     });
   }
@@ -559,7 +571,7 @@ function getConfigForEnv(context: $TSContext, envName: string) {
         projectConfigInfo.config.secretAccessKey = awsSecrets.secretAccessKey;
         projectConfigInfo.config.region = awsSecrets.region;
       } else {
-        throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+        throw new AmplifyError('ConfigurationError', {
           message: `Corrupt file contents in ${configInfoFilePath}`,
         });
       }
@@ -594,6 +606,9 @@ function removeProjectConfig(envName: string) {
   }
 }
 
+/**
+ *
+ */
 export async function loadConfiguration(context: $TSContext): Promise<AwsSecrets> {
   const { envName } = context.amplify.getEnvInfo();
   const config = await loadConfigurationForEnv(context, envName);
@@ -607,11 +622,14 @@ function loadConfigFromPath(profilePath: string): AwsSdkConfig {
       return config;
     }
   }
-  throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+  throw new AmplifyError('ConfigurationError', {
     message: `Invalid config ${profilePath}`,
   });
 }
 
+/**
+ *
+ */
 export async function loadConfigurationForEnv(context: $TSContext, env: string, appId?: string): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo || {};
 
@@ -654,6 +672,9 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
   return awsConfig;
 }
 
+/**
+ *
+ */
 export async function resetCache(context: $TSContext) {
   const projectConfigInfo = getCurrentConfig(context);
   if (projectConfigInfo.configLevel === 'project') {
@@ -664,6 +685,9 @@ export async function resetCache(context: $TSContext) {
   }
 }
 
+/**
+ *
+ */
 export function resolveRegion(): string {
   // For details of how aws region is set, check the following link
   // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
@@ -694,7 +718,7 @@ async function newUserCheck(context: $TSContext) {
       }
     }
     if (context.exeInfo.inputParams.yes) {
-      throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+      throw new AmplifyError('ConfigurationError', {
         message: 'AWS access credentials can not be found.',
       });
     } else {
@@ -766,6 +790,9 @@ function getConfigLevel(context: $TSContext): ProjectType {
   return configLevel;
 }
 
+/**
+ *
+ */
 export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
   const { awsConfigInfo } = context.exeInfo;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
@@ -794,7 +821,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
     try {
       resultAWSConfigInfo = await getTempCredsWithAdminTokens(context, appId);
     } catch (err) {
-      throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+      throw new AmplifyError('AmplifyStudioLoginError', {
         message: 'Failed to fetch Amplify Studio credentials',
         details: err.message,
       }, err);

--- a/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
+++ b/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
@@ -1,7 +1,7 @@
 // @ts-check
 import chalk from 'chalk';
 import {
-  BannerMessage, stateManager, FeatureFlags, ApiCategoryFacade, amplifyFaultWithTroubleshootingLink, $TSAny,
+  BannerMessage, stateManager, FeatureFlags, ApiCategoryFacade, AmplifyFault, $TSAny,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { fileLogger } from './utils/aws-logger';
@@ -259,7 +259,7 @@ export const showSMSSandboxWarning = async (context) : Promise<void> => {
       // Network error. Sandbox status is for informational purpose and should not stop deployment
       log(e);
     } else {
-      throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+      throw new AmplifyFault('DeploymentFault', {
         message: e.message,
       }, e);
     }

--- a/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
+++ b/packages/amplify-provider-awscloudformation/src/display-helpful-urls.ts
@@ -260,7 +260,6 @@ export const showSMSSandboxWarning = async (context) : Promise<void> => {
       log(e);
     } else {
       throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
-        stack: e.stack,
         message: e.message,
       }, e);
     }

--- a/packages/amplify-provider-awscloudformation/src/download-api-models.ts
+++ b/packages/amplify-provider-awscloudformation/src/download-api-models.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, $TSObject, amplifyErrorWithTroubleshootingLink, pathManager,
+  $TSAny, $TSContext, $TSObject, AmplifyError, pathManager,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import extract from 'extract-zip';
@@ -89,7 +89,7 @@ const copyFilesToSrc = (context: $TSContext, apiName: string, framework: string)
       }
       break;
     default:
-      throw amplifyErrorWithTroubleshootingLink('FrameworkNotSupportedError', {
+      throw new AmplifyError('FrameworkNotSupportedError', {
         message: `Unsupported framework. ${framework}`,
       });
   }
@@ -129,7 +129,7 @@ const getAPIGWRequestParams = (resource: $TSObject, framework: string): $TSAny =
       };
 
     default:
-      throw amplifyErrorWithTroubleshootingLink('FrameworkNotSupportedError', {
+      throw new AmplifyError('FrameworkNotSupportedError', {
         message: `Unsupported framework. ${framework}`,
       });
   }

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -72,7 +72,6 @@ export const run = async (context: $TSContext, resourceDefinition: $TSAny[], exp
     revertToBackup(amplifyExportFolder);
     spinner.fail();
     throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
-      stack: ex.stack,
       message: ex.message,
     }, ex);
   } finally {

--- a/packages/amplify-provider-awscloudformation/src/export-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-resources.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, amplifyFaultWithTroubleshootingLink, JSONUtilities, PathConstants, spinner, stateManager, validateExportDirectoryPath,
+  $TSAny, $TSContext, AmplifyFault, JSONUtilities, PathConstants, spinner, stateManager, validateExportDirectoryPath,
 } from 'amplify-cli-core';
 import { printer, prompter } from 'amplify-prompts';
 import * as fs from 'fs-extra';
@@ -71,7 +71,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSAny[], exp
   } catch (ex) {
     revertToBackup(amplifyExportFolder);
     spinner.fail();
-    throw amplifyFaultWithTroubleshootingLink('ResourceNotReadyFault', {
+    throw new AmplifyFault('ResourceNotReadyFault', {
       message: ex.message,
     }, ex);
   } finally {

--- a/packages/amplify-provider-awscloudformation/src/export-update-amplify-meta.ts
+++ b/packages/amplify-provider-awscloudformation/src/export-update-amplify-meta.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue */
 import {
-  $TSContext, amplifyErrorWithTroubleshootingLink,
+  $TSContext, AmplifyError,
 } from 'amplify-cli-core';
 import * as _ from 'lodash';
 import Cloudformation from './aws-utils/aws-cfn';
@@ -38,7 +38,7 @@ export const run = async (context: $TSContext, stackName: string): Promise<void>
 
   // if stack isn't found mostly because the stack isn't accessible by the credentials
   if (!rootStack) {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw new AmplifyError('StackNotFoundError', {
       message: `${stackName} could not be found.`,
       resolution: 'Please check the stack name and credentials.',
     });
@@ -46,7 +46,7 @@ export const run = async (context: $TSContext, stackName: string): Promise<void>
 
   // if the stack is found and is not in valid state
   if (rootStack.StackStatus !== 'UPDATE_COMPLETE' && rootStack.StackStatus !== 'CREATE_COMPLETE') {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw new AmplifyError('StackNotFoundError', {
       message: `${stackName} not in UPDATE_COMPLETE or CREATE_COMPLETE state`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -125,7 +125,6 @@ export class GraphQLResourceManager {
     } catch (err) {
       if (err.name !== 'InvalidGSIMigrationError') {
         throw new AmplifyFault('UnknownFault', {
-          stack: err.stack,
           message: err.message,
           link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,
         }, err);

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
@@ -2,7 +2,7 @@ import { AttributeDefinition, GlobalSecondaryIndex, KeySchema } from 'cloudform-
 import { DynamoDB, IntrinsicFunction } from 'cloudform';
 
 import _ from 'lodash';
-import { AmplifyError, amplifyErrorWithTroubleshootingLink, AMPLIFY_SUPPORT_DOCS } from 'amplify-cli-core';
+import { AmplifyError, AMPLIFY_SUPPORT_DOCS } from 'amplify-cli-core';
 import { GSIRecord } from '../utils/amplify-resource-state-utils';
 
 export const MAX_GSI_PER_TABLE = 20;
@@ -54,7 +54,7 @@ export const addGSI = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table 
   const existingIndices = getExistingIndexNames(table);
 
   if (existingIndices.length + 1 > MAX_GSI_PER_TABLE) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: `DynamoDB ${table.Properties.TableName || '{UnNamedTable}'} can have max of ${MAX_GSI_PER_TABLE} GSIs`,
     });
   }
@@ -63,7 +63,7 @@ export const addGSI = (index: GSIRecord, table: DynamoDB.Table): DynamoDB.Table 
   assertNotIntrinsicFunction(indexName);
 
   if (existingIndices.includes(indexName)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: `An index with name ${indexName} already exists`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -5,8 +5,8 @@
 import {
   $TSContext,
   $TSObject,
-  amplifyErrorWithTroubleshootingLink,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyError,
+  AmplifyFault,
   JSONUtilities,
   PathConstants,
   pathManager,
@@ -201,7 +201,7 @@ const processStackCreationData = (context: $TSContext, amplifyAppId: string | un
 
     setCloudFormationOutputInContext(context, metadata);
   } else {
-    throw amplifyErrorWithTroubleshootingLink('StackNotFoundError', {
+    throw new AmplifyError('StackNotFoundError', {
       message: 'No stack data present',
     });
   }
@@ -321,7 +321,7 @@ const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
     })
     .catch(ex => {
       spinner.stop('Deployment state save failed.', false);
-      throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+      throw new AmplifyFault('DeploymentFault', {
         message: ex.message,
       }, ex);
     })

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -304,7 +304,6 @@ const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
   const zipFilePath = path.normalize(path.join(tempDir, zipFilename));
   const spinner = new AmplifySpinner();
 
-
   return archiver
     .run(currentCloudBackendDir, zipFilePath, undefined, cliJSONFiles)
     .then(result => {
@@ -324,7 +323,6 @@ const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
       spinner.stop('Deployment state save failed.', false);
       throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
         message: ex.message,
-        stack: ex.stack,
       }, ex);
     })
     .then(() => {

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -95,8 +95,6 @@ export class DeploymentManager {
     } catch (e) {
       throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
         message: 'Could not load configuration',
-        stack: e.stack,
-        details: e.message,
       }, e);
     }
   };
@@ -371,7 +369,6 @@ export class DeploymentManager {
           ? `The cloudformation template ${templatePath} was not found in deployment bucket ${this.deploymentBucket}`
           : e.message,
         details: e.message,
-        stack: e.stack,
       }, e);
     }
   };
@@ -392,7 +389,6 @@ export class DeploymentManager {
       }
       throw amplifyFaultWithTroubleshootingLink('ServiceCallFault', {
         message: err.message,
-        stack: err.stack,
       }, err);
     }
   };

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, amplifyErrorWithTroubleshootingLink, amplifyFaultWithTroubleshootingLink, IDeploymentStateManager,
+  $TSContext, AmplifyError, AmplifyFault, IDeploymentStateManager,
 } from 'amplify-cli-core';
 import { AmplifySpinner, printer as promptsPrinter } from 'amplify-prompts';
 import assert from 'assert';
@@ -93,7 +93,7 @@ export class DeploymentManager {
       assert(cred.region);
       return new DeploymentManager(cred, cred.region, deploymentBucket, eventMap, options);
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: 'Could not load configuration',
       }, e);
     }
@@ -364,7 +364,7 @@ export class DeploymentManager {
       await this.s3Client.headObject({ Bucket: this.deploymentBucket, Key: bucketKey }).promise();
       return true;
     } catch (e) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: e.code === 'NotFound'
           ? `The cloudformation template ${templatePath} was not found in deployment bucket ${this.deploymentBucket}`
           : e.message,
@@ -387,7 +387,7 @@ export class DeploymentManager {
       if (err?.code === 'ResourceNotFoundException') {
         return true; // in the case of an iterative update that recreates a table, non-existence means the table has been fully removed
       }
-      throw amplifyFaultWithTroubleshootingLink('ServiceCallFault', {
+      throw new AmplifyFault('ServiceCallFault', {
         message: err.message,
       }, err);
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-state-manager.ts
@@ -8,7 +8,7 @@ import {
   IDeploymentStateManager,
   JSONUtilities,
   stateManager,
-  amplifyErrorWithTroubleshootingLink,
+  AmplifyError,
 } from 'amplify-cli-core';
 import { S3 } from '../aws-utils/aws-s3';
 import { ProviderName } from '../constants';
@@ -98,7 +98,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
   public startCurrentStep = async (params?: StepStatusParameters): Promise<void> => {
     if (this.direction === 1) {
       if (this.getCurrentStep().status !== DeploymentStepStatus.WAITING_FOR_DEPLOYMENT) {
-        throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+        throw new AmplifyError('DeploymentError', {
           message: `Cannot start step when the current step is in ${this.getCurrentStep().status} status.`,
         });
       }
@@ -107,7 +107,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
       if (params?.previousMetaKey) currentStep.previousMetaKey = params.previousMetaKey;
     } else if (this.direction === -1) {
       if (this.getCurrentStep().status !== DeploymentStepStatus.WAITING_FOR_ROLLBACK) {
-        throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+        throw new AmplifyError('DeploymentError', {
           message: `Cannot start step when the current step is in ${this.getCurrentStep().status} status.`,
         });
       }
@@ -119,17 +119,17 @@ export class DeploymentStateManager implements IDeploymentStateManager {
 
   public advanceStep = async (): Promise<void> => {
     if (!this.isDeploymentInProgress()) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: `Cannot advance a deployment when it was not started.`,
       });
     }
 
     if (this.direction === 1 && this.getCurrentStep().status !== DeploymentStepStatus.DEPLOYING) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: `Cannot advance step when the current step is in ${this.getCurrentStep().status} status.`,
       });
     } else if (this.direction === -1 && this.getCurrentStep().status !== DeploymentStepStatus.ROLLING_BACK) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: `Cannot advance step when the current step is in ${this.getCurrentStep().status} status.`,
       });
     }
@@ -170,7 +170,7 @@ export class DeploymentStateManager implements IDeploymentStateManager {
 
   public startRollback = async (): Promise<void> => {
     if (!this.isDeploymentInProgress() || this.direction !== 1) {
-      throw amplifyErrorWithTroubleshootingLink('DeploymentError', {
+      throw new AmplifyError('DeploymentError', {
         message: 'To rollback a deployment, the deployment must be in progress and not already rolling back.',
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/iterative-rollback.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/iterative-rollback.ts
@@ -2,7 +2,7 @@ import {
   $TSAny,
   $TSContext,
   $TSMeta,
-  amplifyErrorWithTroubleshootingLink,
+  AmplifyError,
   DeploymentState,
   DeploymentStepStatus,
   IDeploymentStateManager,
@@ -25,7 +25,7 @@ const loadDeploymentMeta = async (s3: S3, bucketName: string, metaKey: string): 
     return JSONUtilities.parse<DeploymentOp>(metaDeploymentContent);
   }
 
-  throw amplifyErrorWithTroubleshootingLink('IterativeRollbackError', {
+  throw new AmplifyError('IterativeRollbackError', {
     message: `Could not find deployment meta file: ${metaKey}`,
   });
 };
@@ -65,7 +65,7 @@ export const runIterativeRollback = async (
   const stateFiles: string[] = [];
   for (const step of deployedSteps) {
     if (!step.previousMetaKey) {
-      throw amplifyErrorWithTroubleshootingLink('IterativeRollbackError', {
+      throw new AmplifyError('IterativeRollbackError', {
         message: `Cannot iteratively rollback as the following step does not contain a previousMetaKey: ${JSON.stringify(step)}`,
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -1,12 +1,18 @@
 import { StackEvent } from 'aws-sdk/clients/cloudformation';
 import * as aws from 'aws-sdk';
-import { amplifyFaultWithTroubleshootingLink } from 'amplify-cli-core';
+import { AmplifyFault } from 'amplify-cli-core';
 import { fileLogger, Logger } from '../utils/aws-logger';
 
+/**
+ *
+ */
 export interface StackEventMonitorOptions {
   pollDelay: number;
 }
 
+/**
+ *
+ */
 export interface IStackProgressPrinter {
   addActivity: (activity: StackEvent) => void;
   print: () => void;
@@ -18,6 +24,9 @@ export interface IStackProgressPrinter {
   isRunning: () => boolean;
 }
 
+/**
+ *
+ */
 export class StackEventMonitor {
   private active = false;
   private tickTimer?: NodeJS.Timeout;
@@ -42,12 +51,18 @@ export class StackEventMonitor {
     this.printerFn = printerFn;
   }
 
+  /**
+   *
+   */
   public start(): StackEventMonitor {
     this.active = true;
     this.scheduleNextTick();
     return this;
   }
 
+  /**
+   *
+   */
   public async stop(): Promise<void> {
     this.active = false;
     if (this.tickTimer) {
@@ -147,7 +162,7 @@ export class StackEventMonitor {
         return;
       }
       if (e.code !== 'Throttling') {
-        throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+        throw new AmplifyFault('NotImplementedFault', {
           message: e.message,
         }, e);
       }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -149,7 +149,6 @@ export class StackEventMonitor {
       if (e.code !== 'Throttling') {
         throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
           message: e.message,
-          stack: e.stack,
         }, e);
       }
     }

--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -3,16 +3,10 @@ import * as aws from 'aws-sdk';
 import { AmplifyFault } from 'amplify-cli-core';
 import { fileLogger, Logger } from '../utils/aws-logger';
 
-/**
- *
- */
 export interface StackEventMonitorOptions {
   pollDelay: number;
 }
 
-/**
- *
- */
 export interface IStackProgressPrinter {
   addActivity: (activity: StackEvent) => void;
   print: () => void;
@@ -24,9 +18,6 @@ export interface IStackProgressPrinter {
   isRunning: () => boolean;
 }
 
-/**
- *
- */
 export class StackEventMonitor {
   private active = false;
   private tickTimer?: NodeJS.Timeout;
@@ -51,18 +42,12 @@ export class StackEventMonitor {
     this.printerFn = printerFn;
   }
 
-  /**
-   *
-   */
   public start(): StackEventMonitor {
     this.active = true;
     this.scheduleNextTick();
     return this;
   }
 
-  /**
-   *
-   */
   public async stop(): Promise<void> {
     this.active = false;
     if (this.tickTimer) {

--- a/packages/amplify-provider-awscloudformation/src/network/environment-info.ts
+++ b/packages/amplify-provider-awscloudformation/src/network/environment-info.ts
@@ -1,4 +1,4 @@
-import { amplifyErrorWithTroubleshootingLink, JSONUtilities } from 'amplify-cli-core';
+import { AmplifyError, JSONUtilities } from 'amplify-cli-core';
 import { EC2 } from 'aws-sdk';
 import { Netmask } from 'netmask';
 import { loadConfiguration } from '../configuration-manager';
@@ -38,7 +38,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
     const subnets = subnetsCount;
     const AZs = AvailabilityZones.length;
 
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: `The requested number of subnets exceeds the number of AZs for the region. ${JSONUtilities.stringify({ subnets, azs: AZs })}`,
     });
   }
@@ -63,7 +63,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
   const { VpcId: vpcId } = vpc;
 
   if (vpcId && !vpc.CidrBlock.endsWith(vpcMask)) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Not the right mask',
     });
   }
@@ -84,7 +84,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
     .promise();
 
   if (vpcId && InternetGateways.length === 0) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: `No attached and available Internet Gateway in VPC ${vpcId}`,
     });
   }
@@ -144,7 +144,7 @@ export async function getEnvironmentNetworkInfo(context, params: GetEnvironmentN
   }
 
   if (envCidrs.size < subnetsCount) {
-    throw amplifyErrorWithTroubleshootingLink('ConfigurationError', {
+    throw new AmplifyError('ConfigurationError', {
       message: 'Not enough CIDRs available in VPC',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -36,8 +36,8 @@ import {
   readCFNTemplate,
   Template,
   ApiCategoryFacade,
-  amplifyErrorWithTroubleshootingLink,
-  amplifyFaultWithTroubleshootingLink,
+  AmplifyError,
+  AmplifyFault,
 } from 'amplify-cli-core';
 import { Fn } from 'cloudform-types';
 import { getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
@@ -466,7 +466,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
       await deploymentStateManager.failDeployment();
     }
     rollbackLambdaLayers(layerResources);
-    throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
+    throw new AmplifyFault('DeploymentFault', {
       message: error.message,
     }, error);
   }
@@ -654,7 +654,7 @@ const prepareResource = async (context: $TSContext, resource: $TSAny) => {
   });
 
   if (cfnFiles.length !== 1) {
-    throw amplifyErrorWithTroubleshootingLink('CloudFormationTemplateError', {
+    throw new AmplifyError('CloudFormationTemplateError', {
       message: cfnFiles.length > 1 ? 'Only one CloudFormation template is allowed in the resource directory' : 'No CloudFormation template found in the resource directory',
       details: `Resource directory: ${resourceDir}`,
     });
@@ -1113,7 +1113,7 @@ export const formNestedStack = async (
               const dependentResource = _.get(amplifyMeta, [dependsOn[i].category, dependsOn[i].resourceName], undefined);
 
               if (!dependentResource && dependsOn[i].category) {
-                throw amplifyErrorWithTroubleshootingLink('PushResourcesError', {
+                throw new AmplifyError('PushResourcesError', {
                   message: `Cannot get resource: ${dependsOn[i].resourceName} from '${dependsOn[i].category}' category.`,
                 });
               }
@@ -1122,7 +1122,7 @@ export const formNestedStack = async (
                 const outputAttributeValue = _.get(dependentResource, ['output', attribute], undefined);
 
                 if (!outputAttributeValue) {
-                  throw amplifyErrorWithTroubleshootingLink('PushResourcesError', {
+                  throw new AmplifyError('PushResourcesError', {
                     message: `Cannot read the '${attribute}' dependent attribute value from the output section of resource: '${dependsOn[i].resourceName}'.`,
                   });
                 }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -336,7 +336,6 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
             return;
           }
           throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
-            stack: err.stack,
             message: err.message,
           }, err);
         }
@@ -470,7 +469,6 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
     }
     rollbackLambdaLayers(layerResources);
     throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
-      stack: error.stack,
       message: error.message,
     }, error);
   }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -335,9 +335,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
           if (err?.name === 'ValidationError' && err?.message === 'No updates are to be performed.') {
             return;
           }
-          throw amplifyFaultWithTroubleshootingLink('DeploymentFault', {
-            message: err.message,
-          }, err);
+          throw err;
         }
       }
       context.usageData.stopCodePathTimer('pushDeployment');

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -3,15 +3,21 @@ import * as s3 from '@aws-cdk/aws-s3';
 import * as iam from '@aws-cdk/aws-iam';
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 import { IStackSynthesizer, ISynthesisSession } from '@aws-cdk/core';
-import { amplifyErrorWithTroubleshootingLink, amplifyFaultWithTroubleshootingLink, JSONUtilities } from 'amplify-cli-core';
+import { AmplifyError, AmplifyFault, JSONUtilities } from 'amplify-cli-core';
 
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
 
+/**
+ *
+ */
 export type AmplifyRootStackProps = {
   synthesizer: IStackSynthesizer;
 };
 
+/**
+ *
+ */
 export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTemplate {
   _scope: cdk.Construct;
   deploymentBucket: s3.CfnBucket;
@@ -69,18 +75,21 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
    */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
     if (this._cfnParameterMap.has(logicalId)) {
-      throw amplifyErrorWithTroubleshootingLink('DuplicateLogicalIdError', {
+      throw new AmplifyError('DuplicateLogicalIdError', {
         message: `Logical Id already exists: ${logicalId}.`,
       });
     }
     this._cfnParameterMap.set(logicalId, new cdk.CfnParameter(this, logicalId, props));
   }
 
+  /**
+   *
+   */
   getCfnParameter(logicalId: string): cdk.CfnParameter {
     if (this._cfnParameterMap.has(logicalId)) {
       return this._cfnParameterMap.get(logicalId);
     }
-    throw amplifyErrorWithTroubleshootingLink('ParameterNotFoundError', {
+    throw new AmplifyError('ParameterNotFoundError', {
       message: `Cfn Parameter with LogicalId ${logicalId} doesn't exist`,
     });
   }
@@ -147,30 +156,45 @@ export class AmplifyRootStackOutputs extends cdk.Stack implements AmplifyRootSta
   authRole?: iam.CfnRole;
   unauthRole?: iam.CfnRole;
 
+  /**
+   *
+   */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void {
     new cdk.CfnOutput(this, logicalId, props);
   }
 
+  /**
+   *
+   */
   addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
+  /**
+   *
+   */
   addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void {
-    throw amplifyFaultWithTroubleshootingLink('NotImplementedFault', {
+    throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -8,16 +8,10 @@ import { AmplifyError, AmplifyFault, JSONUtilities } from 'amplify-cli-core';
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
 
-/**
- *
- */
 export type AmplifyRootStackProps = {
   synthesizer: IStackSynthesizer;
 };
 
-/**
- *
- */
 export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTemplate {
   _scope: cdk.Construct;
   deploymentBucket: s3.CfnBucket;
@@ -82,9 +76,6 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
     this._cfnParameterMap.set(logicalId, new cdk.CfnParameter(this, logicalId, props));
   }
 
-  /**
-   *
-   */
   getCfnParameter(logicalId: string): cdk.CfnParameter {
     if (this._cfnParameterMap.has(logicalId)) {
       return this._cfnParameterMap.get(logicalId);
@@ -156,43 +147,28 @@ export class AmplifyRootStackOutputs extends cdk.Stack implements AmplifyRootSta
   authRole?: iam.CfnRole;
   unauthRole?: iam.CfnRole;
 
-  /**
-   *
-   */
   addCfnParameter(props: cdk.CfnParameterProps, logicalId: string): void {
     throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
-  /**
-   *
-   */
   addCfnOutput(props: cdk.CfnOutputProps, logicalId: string): void {
     new cdk.CfnOutput(this, logicalId, props);
   }
 
-  /**
-   *
-   */
   addCfnMapping(props: cdk.CfnMappingProps, logicalId: string): void {
     throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
-  /**
-   *
-   */
   addCfnCondition(props: cdk.CfnConditionProps, logicalId: string): void {
     throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',
     });
   }
 
-  /**
-   *
-   */
   addCfnResource(props: cdk.CfnResourceProps, logicalId: string): void {
     throw new AmplifyFault('NotImplementedFault', {
       message: 'Method not implemented.',

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -1,7 +1,7 @@
 import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from '@aws-cdk/core';
 import {
-  $TSContext, amplifyFaultWithTroubleshootingLink, buildOverrideDir, CFNTemplateFormat, pathManager, Template, writeCFNTemplate,
+  $TSContext, AmplifyFault, buildOverrideDir, CFNTemplateFormat, pathManager, Template, writeCFNTemplate,
 } from 'amplify-cli-core';
 import { formatter } from 'amplify-prompts';
 import * as fs from 'fs-extra';
@@ -213,7 +213,7 @@ export class AmplifyRootStackTransform {
       return this._rootTemplateObj;
     }
 
-    throw amplifyFaultWithTroubleshootingLink('RootStackNotFoundFault', {
+    throw new AmplifyFault('RootStackNotFoundFault', {
       message: `Root Stack Template doesn't exist.`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/stack-synthesizer.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/stack-synthesizer.ts
@@ -1,5 +1,5 @@
 import { ISynthesisSession, LegacyStackSynthesizer, Stack } from '@aws-cdk/core';
-import { amplifyFaultWithTroubleshootingLink, JSONUtilities, Template } from 'amplify-cli-core';
+import { AmplifyFault, JSONUtilities, Template } from 'amplify-cli-core';
 import { AmplifyRootStack, AmplifyRootStackOutputs } from './root-stack-builder';
 
 /**
@@ -16,7 +16,7 @@ export class RootStackSynthesizer extends LegacyStackSynthesizer {
       const templateName = stack.node.id;
       this.setStackAsset(templateName, template);
     } else {
-      throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+      throw new AmplifyFault('UnknownFault', {
         message: 'Error synthesizing the template. Expected Stack to be either instance of AmplifyRootStack',
       });
     }
@@ -46,7 +46,7 @@ export class RootStackSynthesizer extends LegacyStackSynthesizer {
       return this.stacks.get(stackName)!;
     }
 
-    throw amplifyFaultWithTroubleshootingLink('UnknownFault', {
+    throw new AmplifyFault('UnknownFault', {
       message: `Stack ${stackName} is not created`,
     });
   };

--- a/packages/amplify-provider-awscloudformation/src/setup-new-user.ts
+++ b/packages/amplify-provider-awscloudformation/src/setup-new-user.ts
@@ -1,4 +1,4 @@
-import { amplifyErrorWithTroubleshootingLink, open } from 'amplify-cli-core';
+import { AmplifyError, open } from 'amplify-cli-core';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import isOnWsl from 'is-wsl';
@@ -125,7 +125,7 @@ export const run = async (context): Promise<string> => {
     return profileName;
   }
 
-  throw amplifyErrorWithTroubleshootingLink('InputValidationError', {
+  throw new AmplifyError('InputValidationError', {
     message: 'Invalid AWS credentials',
     resolution: 'Please check your AWS credentials',
   });

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, amplifyErrorWithTroubleshootingLink, JSONUtilities, pathManager, SecretFileMode, spinner,
+  $TSAny, $TSContext, AmplifyError, JSONUtilities, pathManager, SecretFileMode, spinner,
 } from 'amplify-cli-core';
 
 import * as aws from 'aws-sdk';
@@ -106,7 +106,7 @@ export const getProfiledAwsConfig = async (context: $TSContext, profileName: str
       validateCredentials(awsConfigInfo, profileName);
     }
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ProfileConfigurationError', {
+    throw new AmplifyError('ProfileConfigurationError', {
       message: `Profile configuration is missing for: ${profileName}`,
     });
   }
@@ -332,7 +332,7 @@ const validateCredentials = (credentials: $TSAny, profileName: string): void => 
     missingKeys.push('aws_secret_access_key');
   }
   if (missingKeys.length > 0) {
-    throw amplifyErrorWithTroubleshootingLink('ProfileConfigurationError', {
+    throw new AmplifyError('ProfileConfigurationError', {
       message: `Profile configuration for '${profileName}' is invalid: missing ${missingKeys.join(', ')}`,
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/src/utility-functions.js
@@ -1,4 +1,4 @@
-const { ApiCategoryFacade, amplifyFaultWithTroubleshootingLink } = require('amplify-cli-core');
+const { ApiCategoryFacade, AmplifyFault } = require('amplify-cli-core');
 const awsRegions = require('./aws-regions');
 const { Lambda } = require('./aws-utils/aws-lambda');
 const DynamoDB = require('./aws-utils/aws-dynamodb');
@@ -136,7 +136,7 @@ module.exports = {
       const { code } = error;
 
       if (code !== 'ResourceNotFoundException') {
-        throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+        throw new AmplifyFault('ResourceNotFoundFault', {
           message: error.message,
         }, error);
       }
@@ -184,7 +184,7 @@ module.exports = {
   getTransformerDirectives: async (context, options) => {
     const { resourceDir } = options;
     if (!resourceDir) {
-      throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
+      throw new AmplifyFault('ResourceNotFoundFault', {
         message: 'Missing resource directory.',
       });
     }

--- a/packages/amplify-provider-awscloudformation/src/utility-functions.js
+++ b/packages/amplify-provider-awscloudformation/src/utility-functions.js
@@ -138,7 +138,6 @@ module.exports = {
       if (code !== 'ResourceNotFoundException') {
         throw amplifyFaultWithTroubleshootingLink('ResourceNotFoundFault', {
           message: error.message,
-          stack: error.stack,
         }, error);
       }
     }
@@ -427,5 +426,5 @@ module.exports = {
   /**
    * Provides the same AWS config used to push the amplify project
    */
-  retrieveAwsConfig: async (context) => getAwsConfig(context),
+  retrieveAwsConfig: async context => getAwsConfig(context),
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -1,5 +1,5 @@
 import {
-  stateManager, $TSContext, amplifyErrorWithTroubleshootingLink,
+  stateManager, $TSContext, AmplifyError,
 } from 'amplify-cli-core';
 import aws from 'aws-sdk';
 import _ from 'lodash';
@@ -10,23 +10,32 @@ import {
   AdminAuthConfig, AwsSdkConfig, CognitoAccessToken, CognitoIdToken,
 } from './auth-types';
 
+/**
+ *
+ */
 export const adminVerifyUrl = (appId: string, envName: string, region: string): string => {
   const baseUrl = process.env.AMPLIFY_CLI_ADMINUI_BASE_URL ?? adminBackendMap[region]?.amplifyAdminUrl;
   return `${baseUrl}/admin/${appId}/${envName}/verify/?loginVersion=1`;
 };
 
+/**
+ *
+ */
 export function doAdminTokensExist(appId: string): boolean {
   if (!appId) {
-    throw amplifyErrorWithTroubleshootingLink('AmplifyStudioError', {
+    throw new AmplifyError('AmplifyStudioError', {
       message: `Failed to check if admin credentials exist: appId is undefined`,
     });
   }
   return !!stateManager.getAmplifyAdminConfigEntry(appId);
 }
 
+/**
+ *
+ */
 export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string; userPoolID: string }> {
   if (!appId) {
-    throw amplifyErrorWithTroubleshootingLink('AmplifyStudioError', {
+    throw new AmplifyError('AmplifyStudioError', {
       message: `Failed to check if Amplify Studio is enabled: appId is undefined`,
     });
   }
@@ -38,6 +47,9 @@ export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: bo
   return { isAdminApp: !!appState.appId, region: appState.region, userPoolID };
 }
 
+/**
+ *
+ */
 export async function getTempCredsWithAdminTokens(context: $TSContext, appId: string): Promise<AwsSdkConfig> {
   if (!doAdminTokensExist(appId)) {
     await adminLoginFlow(context, appId);

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
@@ -1,4 +1,4 @@
-import { amplifyErrorWithTroubleshootingLink, stateManager } from 'amplify-cli-core';
+import { AmplifyError, stateManager } from 'amplify-cli-core';
 import * as assert from 'assert';
 import { CognitoIdentity } from 'aws-sdk';
 import bodyParser from 'body-parser'; // eslint-disable-line
@@ -72,7 +72,7 @@ export class AdminLoginServer {
       })
       .promise();
     if (!IdentityId) {
-      throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+      throw new AmplifyError('AmplifyStudioLoginError', {
         message: 'IdentityId not defined. Amplify CLI was unable to retrieve credentials.',
       });
     }
@@ -87,7 +87,7 @@ export class AdminLoginServer {
           this.print.info('Login canceled');
           process.exit(0);
         }
-        throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+        throw new AmplifyError('AmplifyStudioLoginError', {
           message: 'Failed to receive expected authentication tokens.',
         });
       }
@@ -97,7 +97,7 @@ export class AdminLoginServer {
         res.sendStatus(200);
       } catch (err) {
         res.sendStatus(500);
-        throw amplifyErrorWithTroubleshootingLink('AmplifyStudioLoginError', {
+        throw new AmplifyError('AmplifyStudioLoginError', {
           message: `Failed to receive expected authentication tokens. Error: [${err}]`,
         }, err);
       }

--- a/packages/amplify-provider-awscloudformation/src/utils/resolve-appId.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/resolve-appId.ts
@@ -1,5 +1,5 @@
 import {
-  stateManager, $TSContext, amplifyErrorWithTroubleshootingLink,
+  stateManager, $TSContext, AmplifyError,
 } from 'amplify-cli-core';
 
 /**
@@ -11,13 +11,13 @@ export const resolveAppId = (context: $TSContext): string => {
     if (meta?.providers?.awscloudformation?.AmplifyAppId) {
       return meta.providers.awscloudformation.AmplifyAppId;
     }
-    throw amplifyErrorWithTroubleshootingLink('ProjectAppIdResolveError', {
+    throw new AmplifyError('ProjectAppIdResolveError', {
       message: 'Could not find AmplifyAppId in amplify-meta.json.',
     });
   } else if (context?.exeInfo?.inputParams?.amplify?.appId) {
     return context.exeInfo.inputParams.amplify.appId;
   } else {
-    throw amplifyErrorWithTroubleshootingLink('ProjectAppIdResolveError', {
+    throw new AmplifyError('ProjectAppIdResolveError', {
       message: 'Failed to resolve appId.',
     });
   }

--- a/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/upload-auth-trigger-template.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, amplifyErrorWithTroubleshootingLink, FeatureFlags, JSONUtilities, pathManager, stateManager,
+  $TSContext, AmplifyError, FeatureFlags, JSONUtilities, pathManager, stateManager,
 } from 'amplify-cli-core';
 import * as path from 'path';
 import _ from 'lodash';
@@ -38,7 +38,7 @@ export const uploadAuthTriggerTemplate = async (context: $TSContext): Promise<{ 
 
   // This should not happen, so throw
   if (!deploymentBucketName) {
-    throw amplifyErrorWithTroubleshootingLink('BucketNotFoundError', {
+    throw new AmplifyError('BucketNotFoundError', {
       message: 'DeploymentBucket was not found in amplify-meta.json',
     });
   }


### PR DESCRIPTION
#### Description of changes
- stores downstream exception and prints if debug flag is set
- sends the exception message to the usage data
- removes `*WithTroubleshootingLink` helper functions

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
