### PR TITLE
feat(category-geo): add two new map styles 2022.10

### DIFF
--- a/packages/amplify-category-geo/src/__tests__/service-utils/mapParams.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/mapParams.test.ts
@@ -10,7 +10,9 @@ describe('map style construction works as expected', () => {
         "RasterEsriImagery",
         "VectorHereBerlin",
         "VectorHereExplore",
-        "VectorHereExploreTruck"
+        "VectorHereExploreTruck",
+        "RasterHereExploreSatellite",
+        "HybridHereExploreSatellite"
     ];
 
     it('parses various supported map styles', () => {

--- a/packages/amplify-category-geo/src/service-utils/mapParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapParams.ts
@@ -27,7 +27,9 @@ export enum EsriMapStyleType {
  export enum HereMapStyleType {
    Berlin = "Berlin",
    Explore = "Explore",
-   ExploreTruck = "ExploreTruck"
+   ExploreTruck = "ExploreTruck",
+   RasterSatellite = "RasterSatellite",
+   HybridSatellite = "HybridSatellite"
  }
 
 export type MapStyleType = EsriMapStyleType | HereMapStyleType;
@@ -44,7 +46,9 @@ export enum MapStyle {
     RasterEsriImagery = "RasterEsriImagery",
     VectorHereBerlin = "VectorHereBerlin",
     VectorHereExplore = "VectorHereExplore",
-    VectorHereExploreTruck = "VectorHereExploreTruck"
+    VectorHereExploreTruck = "VectorHereExploreTruck",
+    RasterHereExploreSatellite = "RasterHereExploreSatellite",
+    HybridHereExploreSatellite = "HybridHereExploreSatellite"
 }
 
 /**
@@ -69,6 +73,12 @@ export const convertToCompleteMapParams = (partial: Partial<MapParameters>): Map
 export const getGeoMapStyle = (dataProvider: DataProvider, mapStyleType: MapStyleType) => {
     if (dataProvider === DataProvider.Here) {
       return `VectorHere${mapStyleType}`;
+    }
+    else if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.RasterSatellite) {
+      return MapStyle.RasterHereExploreSatellite;
+    }
+    else if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.HybridSatellite) {
+      return MapStyle.HybridHereExploreSatellite;
     }
     else if (dataProvider === DataProvider.Esri && mapStyleType === EsriMapStyleType.Imagery) {
       return MapStyle.RasterEsriImagery;
@@ -99,6 +109,10 @@ export const getMapStyleComponents = (mapStyle: string): Pick<MapParameters, 'da
             return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.Explore };
         case MapStyle.VectorHereExploreTruck:
             return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.ExploreTruck };
+        case MapStyle.RasterHereExploreSatellite:
+            return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.RasterSatellite };
+        case MapStyle.HybridHereExploreSatellite:
+            return { dataProvider: DataProvider.Here, mapStyleType: HereMapStyleType.HybridSatellite };
         default:
             throw new Error(`Invalid map style ${mapStyle}`);
     }

--- a/packages/amplify-category-geo/src/service-utils/mapParams.ts
+++ b/packages/amplify-category-geo/src/service-utils/mapParams.ts
@@ -71,14 +71,14 @@ export const convertToCompleteMapParams = (partial: Partial<MapParameters>): Map
  * Constructs the Amazon Location Map Style from available map parameters
  */
 export const getGeoMapStyle = (dataProvider: DataProvider, mapStyleType: MapStyleType) => {
-    if (dataProvider === DataProvider.Here) {
-      return `VectorHere${mapStyleType}`;
-    }
-    else if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.RasterSatellite) {
+    if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.RasterSatellite) {
       return MapStyle.RasterHereExploreSatellite;
     }
     else if (dataProvider === DataProvider.Here && mapStyleType === HereMapStyleType.HybridSatellite) {
       return MapStyle.HybridHereExploreSatellite;
+    }
+    else if (dataProvider === DataProvider.Here) {
+      return `VectorHere${mapStyleType}`;
     }
     else if (dataProvider === DataProvider.Esri && mapStyleType === EsriMapStyleType.Imagery) {
       return MapStyle.RasterEsriImagery;

--- a/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
+++ b/packages/amplify-category-geo/src/service-walkthroughs/mapWalkthrough.ts
@@ -86,6 +86,8 @@ export const mapStyleWalkthrough = async (parameters: Partial<MapParameters>): P
         { name: 'Berlin (data provided by HERE)', value: MapStyle.VectorHereBerlin },
         { name: 'Explore (data provided by HERE)', value: MapStyle.VectorHereExplore },
         { name: 'ExploreTruck (data provided by HERE)', value: MapStyle.VectorHereExploreTruck },
+        { name: 'RasterSatellite (data provided by HERE)', value: MapStyle.RasterHereExploreSatellite },
+        { name: 'HybridSatellite (data provided by HERE)', value: MapStyle.HybridHereExploreSatellite },
         { name: 'Topographic (data provided by Esri)', value: MapStyle.VectorEsriTopographic },
         { name: 'Navigation (data provided by Esri)', value: MapStyle.VectorEsriNavigation },
         { name: 'LightGrayCanvas (data provided by Esri)', value: MapStyle.VectorEsriLightGrayCanvas },

--- a/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
+++ b/packages/amplify-headless-interface/schemas/geo/1/AddGeoRequest.schema.json
@@ -94,7 +94,9 @@
                 "RasterEsriImagery",
                 "VectorHereBerlin",
                 "VectorHereExplore",
-                "VectorHereExploreTruck"
+                "VectorHereExploreTruck",
+                "RasterHereExploreSatellite",
+                "HybridHereExploreSatellite"
             ],
             "type": "string"
         }

--- a/packages/amplify-headless-interface/src/interface/geo/add.ts
+++ b/packages/amplify-headless-interface/src/interface/geo/add.ts
@@ -72,5 +72,7 @@ export enum AccessType {
   RasterEsriImagery = "RasterEsriImagery",
   VectorHereBerlin = "VectorHereBerlin",
   VectorHereExplore = "VectorHereExplore",
-  VectorHereExploreTruck = "VectorHereExploreTruck"
+  VectorHereExploreTruck = "VectorHereExploreTruck",
+  RasterHereExploreSatellite = "RasterHereExploreSatellite",
+  HybridHereExploreSatellite = "HybridHereExploreSatellite"
 }


### PR DESCRIPTION
#### Description of changes

- Two new map styles were added.
  - "RasterHereExploreSatellite"
  - "HybridHereExploreSatellite"

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/11261

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
