### PR TITLE
chore: fix dangling bucket bug that triggers alerts

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/hostingPROD.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hostingPROD.test.ts
@@ -21,12 +21,11 @@ describe('amplify add hosting', () => {
     const hostingBucket = projectMeta?.hosting?.S3AndCloudFront?.output?.HostingBucketName;
     await removeHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
-
+    await deleteProject(projRoot);
     if (hostingBucket) {
       // Once the Hosting bucket is removed automatically we should get rid of this.
       await deleteS3Bucket(hostingBucket);
     }
-    await deleteProject(projRoot);
     deleteProjectDir(projRoot);
   });
 

--- a/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
@@ -21,7 +21,16 @@ describe('generated tags test', () => {
   });
 
   afterEach(async () => {
+    const hostingBucket = extractHostingBucketInfo(projRoot);
+    await removeHosting(projRoot);
+    await amplifyPushWithoutCodegen(projRoot);
     await deleteProject(projRoot);
+    if (hostingBucket) {
+      try {
+        await deleteS3Bucket(hostingBucket);
+      // eslint-disable-next-line no-empty
+      } catch {}
+    }
     deleteProjectDir(projRoot);
   });
 
@@ -43,15 +52,7 @@ describe('generated tags test', () => {
     expect(rootStackInfo.Tags.filter(r => r.Key === 'user:Stack')[0].Value).toEqual(envName);
     expect(rootStackInfo.Tags.filter(r => r.Key === 'user:Application')[0].Value).toEqual(projName);
 
-    // clean up
-    const hostingBucket = extractHostingBucketInfo(projRoot);
-    await removeHosting(projRoot);
-    await amplifyPushWithoutCodegen(projRoot);
-    if (hostingBucket) {
-      try {
-        await deleteS3Bucket(hostingBucket);
-      } catch {}
-    }
+    
   });
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Recently, we've been getting alerts due to CloudFront distributions pointing to buckets that don't exist.
This is being caused by a condition where we delete the bucket, and then delete the project afterwards.
The CloudFront distribution momentarily exists without a bucket, and triggers the alert.

If you are curious why we need to manually delete the s3 bucket afterwards, its because of this bug:
https://github.com/aws-amplify/amplify-cli/issues/10478


Here is a successful E2E run with these changes:
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/12047/workflows/11f327a9-4364-4f92-9749-3a70d7b28cb7

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
