### PR TITLE
fix: trigger analytics migration on update/configure notifications

### DIFF
--- a/packages/amplify-category-notifications/src/__tests__/notifications.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/notifications.test.ts
@@ -1,0 +1,37 @@
+import { $TSContext } from 'amplify-cli-core';
+import { migrationCheck } from '../migrations/index';
+import * as apiAnalyticsClient from '../plugin-client-api-analytics';
+
+const mockContext = {
+  input: { command: undefined },
+} as unknown as $TSContext;
+
+jest.mock('../plugin-client-api-analytics', () => ({ invokeAnalyticsMigrations: jest.fn() }));
+
+describe('notifications tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('notification migrations calls analytics migration', async () => {
+    mockContext.input.command = 'add';
+    await migrationCheck(mockContext);
+    expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();
+    jest.resetAllMocks();
+
+    mockContext.input.command = 'configure';
+    await migrationCheck(mockContext);
+    expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();
+    jest.resetAllMocks();
+
+    mockContext.input.command = 'push';
+    await migrationCheck(mockContext);
+    expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();
+    jest.resetAllMocks();
+
+    mockContext.input.command = 'remove';
+    await migrationCheck(mockContext);
+    expect(apiAnalyticsClient.invokeAnalyticsMigrations).not.toBeCalled();
+    jest.resetAllMocks();
+  });
+});

--- a/packages/amplify-category-notifications/src/__tests__/notifications.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/notifications.test.ts
@@ -24,6 +24,11 @@ describe('notifications tests', () => {
     expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();
     jest.resetAllMocks();
 
+    mockContext.input.command = 'update';
+    await migrationCheck(mockContext);
+    expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();
+    jest.resetAllMocks();
+
     mockContext.input.command = 'push';
     await migrationCheck(mockContext);
     expect(apiAnalyticsClient.invokeAnalyticsMigrations).toBeCalled();

--- a/packages/amplify-category-notifications/src/migrations/index.ts
+++ b/packages/amplify-category-notifications/src/migrations/index.ts
@@ -5,7 +5,7 @@ import { invokeAnalyticsMigrations } from '../plugin-client-api-analytics';
  * checks if the project has been migrated to the latest version
  */
 export const migrationCheck = async (context: $TSContext): Promise<void> => {
-  if (['add', 'configure', 'push'].includes(context.input.command)) {
+  if (['add', 'configure', 'update', 'push'].includes(context.input.command)) {
     await invokeAnalyticsMigrations(context);
   }
 };

--- a/packages/amplify-category-notifications/src/migrations/index.ts
+++ b/packages/amplify-category-notifications/src/migrations/index.ts
@@ -5,7 +5,7 @@ import { invokeAnalyticsMigrations } from '../plugin-client-api-analytics';
  * checks if the project has been migrated to the latest version
  */
 export const migrationCheck = async (context: $TSContext): Promise<void> => {
-  if (['add', 'update', 'push'].includes(context.input.command)) {
+  if (['add', 'configure', 'push'].includes(context.input.command)) {
     await invokeAnalyticsMigrations(context);
   }
 };


### PR DESCRIPTION
#### Description of changes
- notifications `update` command is just an alias, the migration check should look for `configure`

#### Description of how you validated changes
- manual test
- unit test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
