### PR TITLE
fix: stop timer on early push resources exit

### DIFF
--- a/packages/amplify-cli/src/__tests__/push-resources.test.ts
+++ b/packages/amplify-cli/src/__tests__/push-resources.test.ts
@@ -1,0 +1,49 @@
+import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { ManuallyTimedCodePath } from '../domain/amplify-usageData/UsageDataTypes';
+import { pushResources } from '../extensions/amplify-helpers/push-resources';
+
+jest.mock('amplify-cli-core', () => ({
+  ...(jest.requireActual('amplify-cli-core') as $TSAny),
+  FeatureFlags: {
+    isInitialized: jest.fn().mockReturnValue(true),
+    getNumber: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+jest.mock('@aws-amplify/amplify-category-custom', () => ({ generateDependentResourcesType: jest.fn() }));
+// this method also returns if there are resources to be created or updated
+jest.mock('../extensions/amplify-helpers/resource-status', () => ({ showResourceTable: jest.fn().mockReturnValue(Promise.resolve(false)) }));
+
+const mockContext = {
+  exeInfo: {
+    forcePush: false,
+  },
+  amplify: {
+    executeProviderUtils: jest.fn(),
+    getResourceStatus: jest.fn().mockResolvedValue({
+      resourcesToBeCreated: [],
+      resourcesToBeUpdated: [],
+    }),
+  },
+  usageData: {
+    startCodePathTimer: jest.fn(),
+    stopCodePathTimer: jest.fn(),
+  },
+  parameters: {
+    options: {},
+  },
+} as unknown as $TSContext;
+
+describe('push resources', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start and stop usage timer if there are no resources to push', async () => {
+    await pushResources(mockContext, 'auth');
+    expect(mockContext.usageData.startCodePathTimer).toBeCalledWith(ManuallyTimedCodePath.PUSH_TRANSFORM);
+    expect(mockContext.usageData.stopCodePathTimer).toBeCalledWith(ManuallyTimedCodePath.PUSH_TRANSFORM);
+    expect(mockContext.usageData.startCodePathTimer).toBeCalledTimes(1);
+    expect(mockContext.usageData.stopCodePathTimer).toBeCalledTimes(1);
+  });
+});

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -78,8 +78,8 @@ export const pushResources = async (
 
   // no changes detected
   if (!hasChanges && !context.exeInfo.forcePush && !rebuild) {
+    context.usageData.stopCodePathTimer(ManuallyTimedCodePath.PUSH_TRANSFORM);
     printer.info('\nNo changes detected');
-
     return false;
   }
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -78,8 +78,8 @@ export const pushResources = async (
 
   // no changes detected
   if (!hasChanges && !context.exeInfo.forcePush && !rebuild) {
-    context.usageData.stopCodePathTimer(ManuallyTimedCodePath.PUSH_TRANSFORM);
     printer.info('\nNo changes detected');
+    context.usageData.stopCodePathTimer(ManuallyTimedCodePath.PUSH_TRANSFORM);
     return false;
   }
 


### PR DESCRIPTION
#### Description of changes
- prevents leaving the usage timer started on early exit from push resources
note: issue was discovered while testing notifications migration which triggers push for auth resource followed up by a push for analytics, if auth was previously pushed, first push will exit early leaving the timer started and followup push for analytics will throw an exception attempting to start a started timer

#### Description of how you validated changes
- manual testing
- unit test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
