### PR TITLE
chore: add `pending-triage` to new bug, feature, question issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Create a report to help us improve Amplify CLI
+labels: ["pending-triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yaml
@@ -1,5 +1,6 @@
 name: Feature request
 description: Suggest an idea for the CLI
+labels: ["pending-triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/3.usage-question.md
+++ b/.github/ISSUE_TEMPLATE/3.usage-question.md
@@ -2,7 +2,7 @@
 name: Usage Question
 about: Ask a question about AWS Amplify CLI usage
 title: ''
-labels: question
+labels: question,pending-triage
 assignees: ''
 ---
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Adds `pending-triage` to all new bug and feature request issue submissions. This will help automate the triage workflow and reduce overhead of manually assigning this label by converging on using `pending-triage` as the triage entrypoint rather than both "no label" and "pending-triage"

**UPDATE:** 
also adds `pending-triage` to new question submissions, further consolidating the triage entrypoint

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
