### PR TITLE
fix: correct name for opensearch simulator in copy pkg assets method

### DIFF
--- a/packages/amplify-cli/src/utils/post-install-initialization.ts
+++ b/packages/amplify-cli/src/utils/post-install-initialization.ts
@@ -49,6 +49,6 @@ const copyPkgAssetRegistry = [
   'amplify-frontend-ios',
   'amplify-go-function-runtime-provider',
   'amplify-java-function-runtime-provider',
-  'amplify-opensearch-simulator',
+  '@aws-amplify/amplify-opensearch-simulator',
   'amplify-python-function-runtime-provider',
 ];


### PR DESCRIPTION
- fix opensearch package name in copyPkgAssetRegistry method

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
