### PR TITLE
test(amplify-e2e-core): account for Windows only params in nexpect

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -713,7 +713,7 @@ export function nspawn(command: string | string[], params: string[] = [], option
   // For push operations in E2E we have to explicitly disable the Amplify Console App creation
   // as for the tests that need it, it is already enabled for init, setting the env var here
   // disables the post push check we have in the CLI.
-  if (params.length > 0 && params[0].toLowerCase() === 'push') {
+  if (params.length > 0 && params.find((param: string) => param.toLowerCase() === 'push')) {
     pushEnv = {
       CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
     };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed an issue where an environment parameter was not correctly injected on Windows. This is not currently affecting any e2e tests, but it caused failures in this closed [PR](https://github.com/aws-amplify/amplify-cli/pull/11226).

The reason the original code doesn't work is because of these lines, [here](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-core/src/utils/nexpect.ts#L701) and [here](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-core/src/utils/nexpect.ts#L706), that `unshift` a parameter on Windows environments.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
e2e passed in another PR targeting a feature branch: https://github.com/aws-amplify/amplify-cli/pull/11223

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
