### PR TITLE
fix: generate default theme if user has no themes

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
@@ -75,7 +75,9 @@ describe('amplify pull with uibuilder', () => {
     expect(fileList).toContain('MyIcon.d.ts');
     expect(fileList).toContain('MyIcon.jsx');
     expect(fileList).toContain('index.js');
-    expect(fileList).toHaveLength(5);
+    expect(fileList).toContain('studioTheme.js');
+    expect(fileList).toContain('studioTheme.js.d.ts');
+    expect(fileList).toHaveLength(7);
 
     spawnSync(
       getNpmPath(),

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.2",
-    "@aws-amplify/codegen-ui-react": "2.5.2",
+    "@aws-amplify/codegen-ui": "2.5.4",
+    "@aws-amplify/codegen-ui-react": "2.5.4",
     "amplify-cli-core": "3.3.0",
     "amplify-prompts": "2.6.0",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 import * as codegen from '@aws-amplify/codegen-ui'; // eslint-disable-line import/no-extraneous-dependencies
 import {
   generateAmplifyUiBuilderIndexFile,
@@ -54,6 +55,10 @@ describe('can create a ui builder component', () => {
   });
   it('calls the renderManager for themes', () => {
     createUiBuilderTheme(context, schema);
+    expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).toBeCalled();
+  });
+  it('calls the renderManager for default theme', () => {
+    createUiBuilderTheme(context, schema, { renderDefaultTheme: true });
     expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).toBeCalled();
   });
   it('calls the renderManager for forms', () => {

--- a/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
@@ -79,6 +79,7 @@ describe('can generate components', () => {
     expect(utilsMock.generateUiBuilderThemes).toBeCalledTimes(1);
     expect(utilsMock.generateUiBuilderForms).toBeCalledTimes(1);
   });
+
   it('does not run generateComponents if not Amplify Admin app', async () => {
     utilsMock.shouldRenderComponents = jest.fn().mockReturnValue(false);
     await run(context);

--- a/packages/amplify-util-uibuilder/src/__tests__/syncAmplifyUiComponents.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/syncAmplifyUiComponents.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable spellcheck/spell-checker */
 import { AmplifyCategories, AmplifySupportedService, stateManager } from 'amplify-cli-core'; // eslint-disable-line import/no-extraneous-dependencies
 import aws from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
 import {
@@ -235,6 +236,18 @@ describe('should sync amplify ui builder components', () => {
       throw new Error('ahh!');
     });
     const themes = generateUiBuilderThemes(context, [{}, {}]);
+    expect(themes.every(theme => theme.resultType === 'FAILURE')).toBeTruthy();
+  });
+  it('can generate ui builder default theme when no themes are passed', async () => {
+    createUiBuilderComponentDependencyMock.createUiBuilderTheme = jest.fn().mockImplementation(() => ({}));
+    const themes = generateUiBuilderThemes(context, []);
+    expect(themes.every(theme => theme.resultType === 'SUCCESS')).toBeTruthy();
+  });
+  it('can handle failed generation generate ui builder default theme when no themes are passed', async () => {
+    createUiBuilderComponentDependencyMock.createUiBuilderTheme = jest.fn().mockImplementation(() => {
+      throw new Error('ahh!');
+    });
+    const themes = generateUiBuilderThemes(context, []);
     expect(themes.every(theme => theme.resultType === 'FAILURE')).toBeTruthy();
   });
   it('can generate ui builder forms', async () => {

--- a/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
@@ -23,6 +23,7 @@ import {
   ScriptKind,
   UtilTemplateType,
   ReactUtilsStudioTemplateRenderer,
+  ReactThemeStudioTemplateRendererOptions,
 } from '@aws-amplify/codegen-ui-react';
 import { printer } from 'amplify-prompts';
 import {
@@ -60,10 +61,14 @@ export const createUiBuilderComponent = (context: $TSContext, schema: StudioComp
 /**
  * Writes theme file to the work space
  */
-export const createUiBuilderTheme = (context: $TSContext, schema: StudioTheme): StudioTheme => {
+export const createUiBuilderTheme = (
+  context: $TSContext,
+  schema: StudioTheme,
+  options?: ReactThemeStudioTemplateRendererOptions,
+): StudioTheme => {
   const uiBuilderComponentsPath = getUiBuilderComponentsPath(context);
   const rendererFactory = new StudioTemplateRendererFactory(
-    (component: StudioTheme) => (new ReactThemeStudioTemplateRenderer(component, config) as unknown) as StudioTemplateRenderer<
+    (component: StudioTheme) => (new ReactThemeStudioTemplateRenderer(component, config, options) as unknown) as StudioTemplateRenderer<
         unknown,
         StudioTheme,
         FrameworkOutputManager<unknown>,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Use the default theme from amplify ui in the users project if they don't own their own themes.

Upgrade codegen-ui in util-uibuilder package

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://app.asana.com/0/1202185248783861/1203287913178604/f

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Unit test

In a new account without a theme, I went through the getting started instructions for Form builder. And the default theme was used and generated instead.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
