### PR TITLE
feat: enable auto-naming indexes for new project

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -644,7 +644,7 @@ export class FeatureFlags {
         name: 'enableAutoIndexQueryNames',
         type: 'boolean',
         defaultValueForExistingProjects: false,
-        defaultValueForNewProjects: false,
+        defaultValueForNewProjects: true,
       },
       {
         name: 'respectPrimaryKeyAttributesOnConnectionField',


### PR DESCRIPTION
#### Description of changes

* Enable the feature flag by default to auto-set `@index` names.
* Relevant Docs Update: https://github.com/aws-amplify/docs/pull/4801

#### Issue #, if available
N/A

#### Description of how you validated changes
Running e2e suite with feature flag enabled by default. Verified docs examples, and verified a few `@hasMany` relationship examples to verify that custom indexes work in relationships, and codegen is consistent with `gql-compile` output.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
