### PR TITLE
chore: update initializer logic to perform checks on override files

### DIFF
--- a/packages/amplify-e2e-tests/overrides/override-js-error.txt
+++ b/packages/amplify-e2e-tests/overrides/override-js-error.txt
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.override = void 0;
+function override(props) {
+    // this is an intentional compilation error here
+    compilation error
+}
+exports.override = override;

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -65,5 +65,12 @@ describe('amplify init e', () => {
     await addEnvironment(projRoot, { envName: 'envb' });
     const newestEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newestEnvMeta.AuthRoleName).toContain('mockRole');
+
+    // test special scenario where override.js is manually edited by customer & is invalid
+    // this should throw when creating a new environment
+    const destOverrideJSFilePath = path.join(projRoot, 'amplify', 'backend', 'awscloudformation', 'build', 'override.js');
+    const srcInvalidOverrideJSRuntimeError = path.join(__dirname, '..', '..', 'overrides', 'override-js-error.txt');
+    fs.copyFileSync(srcInvalidOverrideJSRuntimeError, destOverrideJSFilePath);
+    await expect(addEnvironment(projRoot, { envName: 'envc' })).rejects.toThrowError();
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -14,7 +14,7 @@ import {
   Tag,
   Template,
 } from 'amplify-cli-core';
-import { AmplifySpinner, printer } from 'amplify-prompts';
+import { AmplifySpinner } from 'amplify-prompts';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import * as vm from 'vm2';
@@ -92,26 +92,41 @@ export const run = async (context: $TSContext): Promise<void> => {
       },
     };
 
+    let projectInitialized = false;
+    let overrideFilePath = '';
     try {
       const backendDir = pathManager.getBackendDirPath();
-      const overrideFilePath = path.join(backendDir, 'awscloudformation', 'build', 'override.js');
-      const overrideCode: string = await fs.readFile(overrideFilePath, 'utf-8');
-      if (overrideCode) {
-        const sandboxNode = new vm.NodeVM({
-          console: 'inherit',
-          timeout: 5000,
-          sandbox: {},
-          require: {
-            context: 'sandbox',
-            builtin: ['path'],
-            external: true,
-          },
-        });
-        await sandboxNode.run(overrideCode).override(configuration);
-      }
+      overrideFilePath = path.join(backendDir, 'awscloudformation', 'build', 'override.js');
+      projectInitialized = true;
     } catch (e) {
-      // TODO: this always throws, and likely needs re-written
-      printer.debug(`Unable to apply auth role overrides: ${e.message}`);
+      // project not initialized
+    }
+    // when a new environment is created, init is called, and we must apply overrides for the auth/unauth roles
+    // not sure why we only do this for auth...
+    if (projectInitialized && fs.existsSync(overrideFilePath)) {
+      try {
+        const overrideCode: string = await fs.readFile(overrideFilePath, 'utf-8');
+        if (overrideCode) {
+          const sandboxNode = new vm.NodeVM({
+            console: 'inherit',
+            timeout: 5000,
+            sandbox: {},
+            require: {
+              context: 'sandbox',
+              builtin: ['path'],
+              external: true,
+            },
+          });
+          await sandboxNode.run(overrideCode).override(configuration);
+        }
+      } catch (err) {
+        // absolutely want to throw if there is a compile or runtime error
+        throw new AmplifyError('InvalidOverrideError', {
+          message: `Executing overrides failed.`,
+          details: err.message,
+          resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
+        }, err);
+      }
     }
 
     const rootStack = JSONUtilities.readJson<Template>(initTemplateFilePath);

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -101,8 +101,6 @@ export const run = async (context: $TSContext): Promise<void> => {
     } catch (e) {
       // project not initialized
     }
-    // when a new environment is created, init is called, and we must apply overrides for the auth/unauth roles
-    // not sure why we only do this for auth...
     if (projectInitialized && fs.existsSync(overrideFilePath)) {
       try {
         const overrideCode: string = await fs.readFile(overrideFilePath, 'utf-8');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This update ensures that we check if the overrides.js file exist before trying to execute override logic, so that it doens't throw all the time, and we can now throw if there is a runtime error.

E2E run: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/12371/workflows/33547174-f9dc-415c-9e47-b8d918e2bfc9

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
