### PR TITLE
fix: handle lambda permissions for notifications category

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -1,5 +1,6 @@
 import { $TSAny, $TSContext, AmplifyError, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
 import { FunctionDependency, FunctionParameters } from 'amplify-function-plugin-interface';
+import { printer } from 'amplify-prompts';
 import * as TransformPackage from 'graphql-transformer-core';
 import inquirer, { CheckboxQuestion, DistinctChoice } from 'inquirer';
 import _ from 'lodash';
@@ -97,7 +98,7 @@ export const askExecRolePermissionsQuestions = async (
     }
 
     if (_.isEmpty(resourcesList)) {
-      context.print.warning(`No resources found for ${selectedCategory}`);
+      printer.warn(`No resources found for ${selectedCategory}`);
       continue;
     }
 
@@ -130,7 +131,7 @@ export const askExecRolePermissionsQuestions = async (
         // In case of some resources they are not in the meta file so check for resource existence as well
         const isMobileHubImportedResource = _.get(amplifyMeta, [selectedCategory, resourceName, 'mobileHubMigrated'], false);
         if (isMobileHubImportedResource) {
-          context.print.warning(
+          printer.warn(
             `Policies cannot be added for ${selectedCategory}/${resourceName}, since it is a MobileHub imported resource.`,
           );
           continue;
@@ -156,8 +157,7 @@ export const askExecRolePermissionsQuestions = async (
       }
     } catch (e) {
       if (e.name === 'PluginMethodNotFoundError') {
-        context.print.warning(`${selectedCategory} category does not support resource policies yet.`);
-        context.usageData.emitError(e);
+        printer.warn(`${selectedCategory} category does not support resource policies yet.`);
       } else {
         throw new AmplifyError('PluginPolicyAddError', {
           message: `Policies cannot be added for ${selectedCategory}`,
@@ -316,7 +316,7 @@ export async function generateEnvVariablesForCfn(context: $TSContext, resources:
   const envVarStringList = Array.from(envVars).sort().join('\n\t');
 
   if (envVarStringList) {
-    context.print.info(`${envVarPrintoutPrefix}${envVarStringList}`);
+    printer.info(`${envVarPrintoutPrefix}${envVarStringList}`);
   }
   return { environmentMap, dependsOn, envVarStringList };
 }

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -127,6 +127,7 @@ export type AmplifyErrorType =
   | 'PermissionsError'
   | 'PluginMethodNotFoundError'
   | 'PluginNotFoundError'
+  | 'PluginPolicyAddError'
   | 'ProfileConfigurationError'
   | 'ProjectAppIdResolveError'
   | 'ProjectInitError'

--- a/packages/amplify-e2e-tests/src/__tests__/function-permissions.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function-permissions.test.ts
@@ -1,0 +1,45 @@
+import {
+  addNotificationChannel,
+  addFunction,
+  amplifyPushUpdate,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+} from '@aws-amplify/amplify-e2e-core';
+import { getShortId } from '../import-helpers';
+
+describe('amplify add function with permissions', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('function-permissions');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('add notifications and function permissions', async () => {
+    await initJSProjectWithProfile(projRoot, {});
+
+    const settings = { resourceName: `notifications${getShortId()}` };
+    await addNotificationChannel(projRoot, settings, 'SMS');
+    await addFunction(
+      projRoot,
+      {
+        name: 'testFunction',
+        functionTemplate: 'Hello World',
+        additionalPermissions: {
+          permissions: ['notifications'],
+          resources: [settings.resourceName],
+          choices: ['auth', 'analytics', 'notifications'],
+          operations: ['create', 'read'],
+        },
+      },
+      'nodejs',
+    );
+    await amplifyPushUpdate(projRoot);
+  });
+});


### PR DESCRIPTION
#### Description of changes
- fixed regression introduced by error name changed for resource policy method not found

#### Issue #11320

#### Description of how you validated changes
- manual testing
- e2e test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
