### PR TITLE
chore: fix npx pkg arm64 binary creation

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -72,7 +72,7 @@ function generatePkgCli {
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
     # This will generate a file our arm64 binary
-    npx pkg --no-bytecode --no-bytecode --public-packages "*" --public -t node14-linux-arm64 ../build/node_modules -o ../out/amplify-pkg-linux-arm64
+    npx pkg --no-bytecode --public-packages "*" --public -t node14-linux-arm64 ../build/node_modules -o ../out/amplify-pkg-linux-arm64
     # This will generate files for our x64 binaries.
     npx pkg -t node14-macos-x64 ../build/node_modules -o ../out/amplify-pkg-macos-x64
     npx pkg -t node14-linux-x64 ../build/node_modules -o ../out/amplify-pkg-linux-x64

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -72,7 +72,7 @@ function generatePkgCli {
   cp package.json ../build/node_modules/package.json
   if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
     # This will generate a file our arm64 binary
-    npx pkg --no-bytecode -t node14-linux-arm64 ../build/node_modules -o ../out/amplify-pkg-linux-arm64
+    npx pkg --no-bytecode --no-bytecode --public-packages "*" --public -t node14-linux-arm64 ../build/node_modules -o ../out/amplify-pkg-linux-arm64
     # This will generate files for our x64 binaries.
     npx pkg -t node14-macos-x64 ../build/node_modules -o ../out/amplify-pkg-macos-x64
     npx pkg -t node14-linux-x64 ../build/node_modules -o ../out/amplify-pkg-linux-x64


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
-  fix for arm64 binary pkg fail from tagged release branch : https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/12428/workflows/c68e39e3-441d-4f14-923e-953a2a51fa62/jobs/476066
- Inspired from this : https://github.com/vercel/pkg#other-considerations 




<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/12428/workflows/c68e39e3-441d-4f14-923e-953a2a51fa62/jobs/476066

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- fix tested on tagged-release branch : https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/12445/workflows/302d61c1-9c93-45f3-adb6-f41f64f77d4a
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
