### PR TITLE
fix: update override templates use extensibility helper with CDK v2

### DIFF
--- a/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-category-custom/resources/package.json
+++ b/packages/amplify-category-custom/resources/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0",
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2",
     "aws-cdk-lib": "~2.44.0",
     "constructs": "^10.0.5"
   },

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-cli-core/resources/overrides-resource/package.json
+++ b/packages/amplify-cli-core/resources/overrides-resource/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+    "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
   },
   "devDependencies": {
     "typescript": "^4.2.4"

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/package.json
@@ -8,10 +8,9 @@
       "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-      "@aws-amplify/cli-extensibility-helper": "^2.0.0"
+      "@aws-amplify/cli-extensibility-helper": "^3.0.0-cdkv2.2"
     },
     "devDependencies": {
       "typescript": "^4.2.4"
     }
   }
-  


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Update `@aws-amplify/cli-extensibility-helper` to correct version that's based on CDK v2 in override templates.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [ x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
