### PR TITLE
fix: suppress CDK deprecation warning in CLI base level

### DIFF
--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -50,6 +50,16 @@ process.on('unhandledRejection', error => {
   throw error;
 });
 
+/**
+ * Disable the CDK deprecation warning in production but not in CI/debug mode
+ */
+const disableCDKDeprecationWarning = () => {
+  const isDebug = process.argv.includes('--debug') || process.env.AMPLIFY_ENABLE_DEBUG_OUTPUT === 'true';
+  if (!isDebug) {
+    process.env.JSII_DEPRECATED = 'quiet';
+  }
+}
+
 const convertKeysToLowerCase = <T>(obj: Record<string, T>): Record<string, T> => {
   const newObj = {};
   Object.entries(obj).forEach(([key, value]) => { newObj[key.toLowerCase()] = value; });
@@ -99,6 +109,12 @@ const normalizeStatusCommandOptions = (input: Input): Input => {
  */
 export const run = async (startTime: number): Promise<void> => {
   deleteOldVersion();
+
+  //TODO: This is a temporary suppression for CDK deprecation warnings, which should be removed after the migration is complete
+  // Most of these warning messages are targetting searchable directive, which needs to migrate from elastic search to open search
+  // This is not diabled in debug mode
+  disableCDKDeprecationWarning();
+
   let pluginPlatform = await getPluginPlatform();
   let input = getCommandLineInput(pluginPlatform);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a follow-up of api PR https://github.com/aws-amplify/amplify-category-api/pull/931 for suppressing the CDK warning msgs to the CLI level to prevent the output in commands other than `api` category.

These warning msgs are only populated when the debug mode is on.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
By running `amplify-dev status api -acm <modelName>` and `amplify-dev mock`
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
