### PR TITLE
fix: parse true and false strings from env vars

### DIFF
--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -30,7 +30,7 @@ export * from './git-operations';
 /**
  * Whether the current environment is CircleCI or not
  */
-export const isCI = (): boolean => process.env.CI && process.env.CIRCLECI;
+export const isCI = (): boolean => JSON.parse(process.env.CI) && JSON.parse(process.env.CIRCLECI);
 
 // eslint-disable-next-line spellcheck/spell-checker
 export const TEST_PROFILE_NAME = isCI() ? 'amplify-integ-test-user' : 'default';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixes type mismatch in the `amplify-e2e-core` module. Introduced in https://github.com/aws-amplify/amplify-cli/pull/11365.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
