### PR TITLE
fix: add check for api repo overrides errors

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
+++ b/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
@@ -66,8 +66,12 @@ export const transformResourceWithOverrides = async (context: $TSContext, resour
       'InvalidOverrideError',
       'InvalidCustomResourceError',
     ];
-    if (err instanceof AmplifyException
-      && overrideOrCustomStackErrorsList.find(v => v === err.name)) {
+    if (
+      (err instanceof AmplifyException
+      && overrideOrCustomStackErrorsList.find(v => v === err.name))
+      // this is a special exception for the API category which would otherwise have a
+      // circular dependency if it imported AmplifyException
+      || err['_amplifyErrorType'] === 'InvalidOverrideError') {
       throw err;
     }
 

--- a/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
+++ b/packages/amplify-provider-awscloudformation/src/override-manager/transform-resource.ts
@@ -1,5 +1,5 @@
 import {
-  $TSContext, AmplifyErrorType, AmplifyException, FeatureFlags, IAmplifyResource, JSONUtilities, pathManager,
+  $TSContext, AmplifyError, AmplifyErrorType, AmplifyException, FeatureFlags, IAmplifyResource, JSONUtilities, pathManager,
 } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as fs from 'fs-extra';
@@ -72,6 +72,17 @@ export const transformResourceWithOverrides = async (context: $TSContext, resour
       // this is a special exception for the API category which would otherwise have a
       // circular dependency if it imported AmplifyException
       || err['_amplifyErrorType'] === 'InvalidOverrideError') {
+      
+      // if the exception is not already an AmplifyException re-throw it as an AmplifyException
+      // so that user's get the appropriate resolution steps that we intended
+      if(err['_amplifyErrorType'] === 'InvalidOverrideError') {
+        throw new AmplifyError('InvalidOverrideError', {
+          message: `Executing overrides failed.`,
+          details: err.message,
+          resolution: 'There may be runtime errors in your overrides file. If so, fix the errors and try again.',
+        }, err);
+      }
+      // otherwise just rethrow the AmplifyException
       throw err;
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a workaround to detect specific override errors coming from the API repository, because if we import AmplifyException in that repo/package it creates a cyclic dependency.
In the meantime, if an error with overrides occurs in the API category, it will throw errors with this special property that we can detect in CLI using this logic.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
