### PR TITLE
chore: migrate notifications category to amplify-prompter

### DIFF
--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -27,13 +27,9 @@
     "amplify-prompts": "2.6.0",
     "chalk": "^4.1.1",
     "fs-extra": "^8.1.0",
-    "inquirer": "^7.3.3",
     "lodash": "^4.17.21",
     "ora": "^4.0.3",
     "promise-sequential": "^1.1.1"
-  },
-  "devDependencies": {
-    "mockirer": "^2.0.1"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/amplify-category-notifications/src/__tests__/apns-cert-config.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/apns-cert-config.test.ts
@@ -1,12 +1,7 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable spellcheck/spell-checker */
+import { prompter } from 'amplify-prompts';
 import * as apnsCertConfig from '../apns-cert-config';
 import * as p12decoder from '../apns-cert-p12decoder';
 import { ICertificateInfo } from '../apns-cert-p12decoder';
-
-const inquirer = require('inquirer');
-const mockirer = require('mockirer');
 
 jest.mock('../apns-cert-p12decoder');
 
@@ -21,14 +16,16 @@ describe('apns-cert-config', () => {
   const mockP12DecoderReturn = {};
 
   beforeAll(() => {
-    mockirer(inquirer, mockAnswers);
     const p12DecoderMock = p12decoder as jest.Mocked<typeof p12decoder>;
     p12DecoderMock.run.mockReturnValue(mockP12DecoderReturn as unknown as ICertificateInfo);
   });
 
-  beforeEach(() => {});
-
   test('p12decoder invoked', async () => {
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce(mockFilePath)
+      .mockResolvedValueOnce(mockPassword);
+
     const result = await apnsCertConfig.run(undefined);
     expect(p12decoder.run).toBeCalledWith(mockAnswers);
     expect(result).toBe(mockP12DecoderReturn);

--- a/packages/amplify-category-notifications/src/__tests__/apns-cert-config.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/apns-cert-config.test.ts
@@ -4,6 +4,8 @@ import * as p12decoder from '../apns-cert-p12decoder';
 import { ICertificateInfo } from '../apns-cert-p12decoder';
 
 jest.mock('../apns-cert-p12decoder');
+jest.mock('amplify-prompts');
+const prompterMock = prompter as jest.Mocked<typeof prompter>;
 
 describe('apns-cert-config', () => {
   const mockFilePath = 'mock_p12_file_path';
@@ -21,8 +23,7 @@ describe('apns-cert-config', () => {
   });
 
   test('p12decoder invoked', async () => {
-    prompter.input = jest
-      .fn()
+    prompterMock.input
       .mockResolvedValueOnce(mockFilePath)
       .mockResolvedValueOnce(mockPassword);
 

--- a/packages/amplify-category-notifications/src/__tests__/apns-key-config.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/apns-key-config.test.ts
@@ -3,6 +3,9 @@ import * as p8decoder from '../apns-cert-p8decoder';
 import * as apnsKeyConfig from '../apns-key-config';
 
 jest.mock('../apns-cert-p8decoder');
+jest.mock('amplify-prompts');
+const prompterMock = prompter as jest.Mocked<typeof prompter>;
+
 describe('apns-key-config', () => {
   const mockBundleId = 'mockBundleId';
   const mockTeamId = 'mockTeamId';
@@ -22,8 +25,7 @@ describe('apns-key-config', () => {
   });
 
   test('p8decoder invoked', async () => {
-    prompter.input = jest
-      .fn()
+    prompterMock.input
       .mockResolvedValueOnce(mockBundleId)
       .mockResolvedValueOnce(mockTeamId)
       .mockResolvedValueOnce(mockTokenKeyId)

--- a/packages/amplify-category-notifications/src/__tests__/apns-key-config.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/apns-key-config.test.ts
@@ -1,11 +1,6 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable spellcheck/spell-checker */
+import { prompter } from 'amplify-prompts';
 import * as p8decoder from '../apns-cert-p8decoder';
 import * as apnsKeyConfig from '../apns-key-config';
-
-const inquirer = require('inquirer');
-const mockirer = require('mockirer');
 
 jest.mock('../apns-cert-p8decoder');
 describe('apns-key-config', () => {
@@ -13,25 +8,29 @@ describe('apns-key-config', () => {
   const mockTeamId = 'mockTeamId';
   const mockTokenKeyId = 'mockTokenKeyId';
   const mockFilePath = 'mock_p8_file_path';
+  const mockP8DecoderReturn = 'mockP8DecoderReturn';
   const mockKeyConfig = {
     BundleId: mockBundleId,
     TeamId: mockTeamId,
     TokenKeyId: mockTokenKeyId,
-    P8FilePath: mockFilePath,
+    TokenKey: mockP8DecoderReturn,
   };
-  const mockP8DecoderReturn = 'mockP8DecoderReturn';
 
   beforeAll(() => {
-    mockirer(inquirer, mockKeyConfig);
     const p8DecoderMock = p8decoder as jest.Mocked<typeof p8decoder>;
     p8DecoderMock.run.mockReturnValue(mockP8DecoderReturn);
   });
 
-  beforeEach(() => {});
-
   test('p8decoder invoked', async () => {
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce(mockBundleId)
+      .mockResolvedValueOnce(mockTeamId)
+      .mockResolvedValueOnce(mockTokenKeyId)
+      .mockResolvedValueOnce(mockFilePath);
+
     const result = await apnsKeyConfig.run(undefined);
     expect(p8decoder.run).toBeCalledWith(mockFilePath);
-    expect(result).toBe(mockKeyConfig);
+    expect(result).toMatchObject(mockKeyConfig);
   });
 });

--- a/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
@@ -1,25 +1,22 @@
 /* eslint-disable spellcheck/spell-checker */
 import {
-  $TSContext, $TSAny, AmplifyCategories, AmplifySupportedService,
+  $TSContext, $TSAny, AmplifyCategories, AmplifySupportedService, AmplifyFault,
 } from 'amplify-cli-core';
-import inquirer from 'inquirer';
+import { prompter } from 'amplify-prompts';
 import * as channelFCM from '../channel-fcm';
 import { ChannelAction, ChannelConfigDeploymentType, IChannelAPIResponse } from '../channel-types';
 import { ChannelType } from '../notifications-backend-cfg-channel-api';
 
-const channelName = 'FCM';
-
-const mockInquirer = (answers : $TSAny): $TSAny => {
-  (inquirer as any).prompt = async (prompts:$TSAny):Promise<$TSAny> => {
-    [].concat(prompts).forEach(prompt => {
-      if (!((prompt as unknown as any).name in answers) && typeof (prompt as unknown as any).default !== 'undefined') {
-        // eslint-disable-next-line no-param-reassign
-        answers[(prompt as unknown as any).name] = (prompt as unknown as any).default;
-      }
-    });
-    return answers;
-  };
+class NoErrorThrownError extends Error {}
+const getError = async <TError>(call: () => unknown): Promise<TError> => {
+  try {
+    await call();
+    throw new NoErrorThrownError();
+  } catch (error: unknown) {
+    return error as TError;
+  }
 };
+const channelName = 'FCM';
 
 const mockPinpointResponseData = (status: boolean, action : ChannelAction): IChannelAPIResponse => ({
   action,
@@ -48,7 +45,7 @@ const mockContext = (output: $TSAny, client: $TSAny): $TSContext => ({
   },
 }) as unknown as $TSContext;
 
-const mockContextReject = (output:$TSAny, clientReject:$TSAny):$TSAny => ({
+const mockContextReject = (output: $TSAny, clientReject: $TSAny): $TSAny => ({
   exeInfo: {
     serviceMeta: {
       output,
@@ -84,27 +81,39 @@ describe('channel-FCM', () => {
 
   test('configure', async () => {
     mockChannelEnabledOutput.Enabled = true;
-    mockInquirer({ disableChannel: true });
+    prompter.yesOrNo = jest
+      .fn()
+      .mockResolvedValueOnce(true);
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce('ApiKey-abc123');
+
     const mockContextObj = mockContext(mockChannelEnabledOutput, mockPinpointClient);
     await channelFCM.configure(mockContextObj).then(() => {
       expect(mockPinpointClient.updateGcmChannel).toBeCalled();
     });
 
     mockChannelEnabledOutput.Enabled = true;
-    mockInquirer({ disableChannel: false });
+    prompter.yesOrNo = jest
+      .fn()
+      .mockResolvedValueOnce(false);
     await channelFCM.configure(mockContext(mockChannelEnabledOutput, mockPinpointClient)).then(() => {
       expect(mockPinpointClient.updateGcmChannel).toBeCalled();
     });
 
     mockChannelEnabledOutput.Enabled = false;
-    mockInquirer({ enableChannel: true });
+    prompter.yesOrNo = jest
+      .fn()
+      .mockResolvedValueOnce(true);
     await channelFCM.configure(mockContext(mockChannelEnabledOutput, mockPinpointClient)).then(() => {
       expect(mockPinpointClient.updateGcmChannel).toBeCalled();
     });
   });
 
   test('enable', async () => {
-    mockInquirer({ ApiKey: 'ApiKey-abc123' });
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce('ApiKey-abc123');
     const mockContextObj = mockContext(mockChannelEnabledOutput, mockPinpointClient);
     const data = await channelFCM.enable(mockContextObj, 'successMessage');
     expect(mockPinpointClient.updateGcmChannel).toBeCalled();
@@ -112,7 +121,9 @@ describe('channel-FCM', () => {
   });
 
   test('enable with newline', async () => {
-    mockInquirer({ ApiKey: 'ApiKey-abc123\n' });
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce('ApiKey-abc123\n');
     const data = await channelFCM.enable(mockContext(mockChannelEnabledOutput, mockPinpointClient), 'successMessage');
     expect(mockPinpointClient.updateGcmChannel).toBeCalledWith(
       {
@@ -127,9 +138,14 @@ describe('channel-FCM', () => {
   });
 
   test('enable unsuccessful', async () => {
-    mockInquirer({ ApiKey: 'ApiKey-abc123' });
-    await expect(channelFCM.enable(mockContextReject(mockServiceOutput, mockPinpointClientReject), 'successMessage')).rejects.toThrowError('Failed to enable the FCM channel');
-    expect(mockPinpointClient.updateGcmChannel).toBeCalled();
+    prompter.input = jest
+      .fn()
+      .mockResolvedValueOnce('ApiKey-abc123');
+
+    const context = mockContextReject(mockServiceOutput, mockPinpointClientReject);
+    const errCert: AmplifyFault = await getError(async () => channelFCM.enable(context as unknown as $TSContext, 'successMessage'));
+    expect(context.exeInfo.pinpointClient.updateGcmChannel).toBeCalled();
+    expect(errCert?.downstreamException?.message).toContain(mockPinpointResponseErr.message);
   });
 
   test('disable', async () => {

--- a/packages/amplify-category-notifications/src/apns-cert-config.ts
+++ b/packages/amplify-category-notifications/src/apns-cert-config.ts
@@ -1,5 +1,5 @@
 import { $TSAny } from 'amplify-cli-core';
-import inquirer from 'inquirer';
+import { prompter } from 'amplify-prompts';
 import { run as p12decoderRun, ICertificateInfo } from './apns-cert-p12decoder';
 import { validateFilePath } from './validate-filepath';
 
@@ -11,20 +11,12 @@ export const run = async (channelInput: $TSAny): Promise<ICertificateInfo> => {
     return p12decoderRun(channelInput);
   }
 
-  const questions = [
-    {
-      name: 'P12FilePath',
-      type: 'input',
-      message: 'The certificate file path (.p12): ',
-      validate: validateFilePath,
-    },
-    {
-      name: 'P12FilePassword',
-      type: 'input',
-      message: 'The certificate password (if any): ',
-    },
-  ];
+  const p12FilePath = await prompter.input('The certificate file path (.p12): ', { validate: validateFilePath });
+  const p12FilePassword = await prompter.input('The certificate password (if any): ');
+  const answers = {
+    P12FilePath: p12FilePath,
+    P12FilePassword: p12FilePassword,
+  };
 
-  const answers = await inquirer.prompt(questions);
   return p12decoderRun(answers);
 };

--- a/packages/amplify-category-notifications/src/apns-key-config.ts
+++ b/packages/amplify-category-notifications/src/apns-key-config.ts
@@ -1,5 +1,5 @@
 import { $TSAny } from 'amplify-cli-core';
-import inquirer from 'inquirer';
+import { prompter } from 'amplify-prompts';
 import { validateFilePath } from './validate-filepath';
 import { run as p8decoderRun } from './apns-cert-p8decoder';
 /**
@@ -7,33 +7,21 @@ import { run as p8decoderRun } from './apns-cert-p8decoder';
  */
 export const run = async (channelInput: $TSAny) : Promise<$TSAny> => {
   let keyConfig;
+
   if (channelInput) {
     keyConfig = channelInput;
   } else {
-    const questions = [
-      {
-        name: 'BundleId',
-        type: 'input',
-        message: 'The bundle id used for APNs Tokens: ',
-      },
-      {
-        name: 'TeamId',
-        type: 'input',
-        message: 'The team id used for APNs Tokens: ',
-      },
-      {
-        name: 'TokenKeyId',
-        type: 'input',
-        message: 'The key id used for APNs Tokens: ',
-      },
-      {
-        name: 'P8FilePath',
-        type: 'input',
-        message: 'The key file path (.p8): ',
-        validate: validateFilePath,
-      },
-    ];
-    keyConfig = await inquirer.prompt(questions);
+    const bundleId = await prompter.input('The bundle id used for APNs Tokens: ');
+    const teamId = await prompter.input('The team id used for APNs Tokens: ');
+    const tokenKeyId = await prompter.input('The key id used for APNs Tokens: ');
+    const p8FilePath = await prompter.input('The key file path (.p8): ', { validate: validateFilePath });
+
+    keyConfig = {
+      BundleId: bundleId,
+      TeamId: teamId,
+      TokenKeyId: tokenKeyId,
+      P8FilePath: p8FilePath,
+    };
   }
 
   keyConfig.TokenKey = p8decoderRun(keyConfig.P8FilePath);

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -1,13 +1,11 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable spellcheck/spell-checker */
-import inquirer, { QuestionCollection } from 'inquirer';
 import ora from 'ora';
 import fs from 'fs-extra';
 import {
   $TSAny, $TSContext, AmplifyFault,
 } from 'amplify-cli-core';
 
-import { printer } from 'amplify-prompts';
+import { printer, prompter } from 'amplify-prompts';
 import * as configureKey from './apns-key-config';
 import * as configureCertificate from './apns-cert-config';
 import { ChannelAction, IChannelAPIResponse, ChannelConfigDeploymentType } from './channel-types';
@@ -26,26 +24,16 @@ export const configure = async (context: $TSContext): Promise<IChannelAPIRespons
   let response: IChannelAPIResponse|undefined;
   if (isChannelEnabled) {
     printer.info(`The ${channelName} channel is currently enabled`);
-    const answer = await inquirer.prompt({
-      name: 'disableChannel',
-      type: 'confirm',
-      message: `Do you want to disable the ${channelName} channel`,
-      default: false,
-    });
-    if (answer.disableChannel) {
+    const disableChannel = await prompter.yesOrNo(`Do you want to disable the ${channelName} channel`, false);
+    if (disableChannel) {
       response = await disable(context);
     } else {
       const successMessage = `The ${channelName} channel has been successfully updated.`;
       response = await enable(context, successMessage);
     }
   } else {
-    const answer = await inquirer.prompt({
-      name: 'enableChannel',
-      type: 'confirm',
-      message: `Do you want to enable the ${channelName} channel`,
-      default: true,
-    });
-    if (answer.enableChannel) {
+    const enableChannel = await prompter.yesOrNo(`Do you want to enable the ${channelName} channel`, true);
+    if (enableChannel) {
       response = await enable(context, undefined);
     }
   }
@@ -73,14 +61,10 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const question: QuestionCollection<{ [x: string]: unknown; }> = {
-      name: 'DefaultAuthenticationMethod',
-      type: 'list',
-      message: 'Choose authentication method used for APNs',
-      choices: ['Certificate', 'Key'],
-      default: channelOutput.DefaultAuthenticationMethod || 'Certificate',
+    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], channelOutput.DefaultAuthenticationMethod || 'Certificate');
+    answers = {
+      DefaultAuthenticationMethod: authMethod,
     };
-    answers = await inquirer.prompt(question);
   }
 
   if (answers.DefaultAuthenticationMethod === 'Key') {

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -61,7 +61,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], channelOutput.DefaultAuthenticationMethod || 'Certificate');
+    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], { initial: channelOutput.DefaultAuthenticationMethod || 'Certificate' });
     answers = {
       DefaultAuthenticationMethod: authMethod,
     };

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -61,7 +61,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], { initial: channelOutput.DefaultAuthenticationMethod || 'Certificate' });
+    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], { initial: byValue(channelOutput.DefaultAuthenticationMethod || 'Certificate') });
     answers = {
       DefaultAuthenticationMethod: authMethod,
     };

--- a/packages/amplify-category-notifications/src/channel-apns.ts
+++ b/packages/amplify-category-notifications/src/channel-apns.ts
@@ -5,7 +5,7 @@ import {
   $TSAny, $TSContext, AmplifyFault,
 } from 'amplify-cli-core';
 
-import { printer, prompter } from 'amplify-prompts';
+import { byValue, printer, prompter } from 'amplify-prompts';
 import * as configureKey from './apns-key-config';
 import * as configureCertificate from './apns-cert-config';
 import { ChannelAction, IChannelAPIResponse, ChannelConfigDeploymentType } from './channel-types';
@@ -61,7 +61,11 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const authMethod = await prompter.pick('Select the authentication method for the APNS channel', ['Certificate', 'Key'], { initial: byValue(channelOutput.DefaultAuthenticationMethod || 'Certificate') });
+    const authMethod = await prompter.pick(
+      'Select the authentication method for the APNS channel',
+      ['Certificate', 'Key'],
+      { initial: byValue(channelOutput.DefaultAuthenticationMethod || 'Certificate') },
+    );
     answers = {
       DefaultAuthenticationMethod: authMethod,
     };

--- a/packages/amplify-category-notifications/src/channel-email.ts
+++ b/packages/amplify-category-notifications/src/channel-email.ts
@@ -1,10 +1,9 @@
 import {
   $TSAny, $TSContext, AmplifyError, AmplifyFault,
 } from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
+import { printer, prompter } from 'amplify-prompts';
 
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import inquirer from 'inquirer';
 import ora from 'ora';
 import { ChannelAction, ChannelConfigDeploymentType } from './channel-types';
 import { buildPinpointChannelResponseSuccess } from './pinpoint-helper';
@@ -22,26 +21,16 @@ export const configure = async (context: $TSContext):Promise<void> => {
 
   if (isChannelEnabled) {
     printer.info(`The ${channelName} channel is currently enabled`);
-    const answer = await inquirer.prompt({
-      name: 'disableChannel',
-      type: 'confirm',
-      message: `Do you want to disable the ${channelName} channel`,
-      default: false,
-    });
-    if (answer.disableChannel) {
+    const disableChannel = await prompter.yesOrNo(`Do you want to disable the ${channelName} channel`, false);
+    if (disableChannel) {
       await disable(context);
     } else {
       const successMessage = `The ${channelName} channel has been successfully updated.`;
       await enable(context, successMessage);
     }
   } else {
-    const answer = await inquirer.prompt({
-      name: 'enableChannel',
-      type: 'confirm',
-      message: `Do you want to enable the ${channelName} channel`,
-      default: true,
-    });
-    if (answer.enableChannel) {
+    const enableChannel = await prompter.yesOrNo(`Do you want to enable the ${channelName} channel`, true);
+    if (enableChannel) {
       await enable(context, undefined);
     }
   }
@@ -61,27 +50,11 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const questions = [
-      {
-        name: 'FromAddress',
-        type: 'input',
-        message: "The 'From' Email address used to send emails",
-        default: channelOutput.FromAddress,
-      },
-      {
-        name: 'Identity',
-        type: 'input',
-        message: 'The ARN of an identity verified with SES',
-        default: channelOutput.Identity,
-      },
-      {
-        name: 'RoleArn',
-        type: 'input',
-        message: "The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service",
-        default: channelOutput.RoleArn,
-      },
-    ];
-    answers = await inquirer.prompt(questions);
+    answers = {
+      FromAddress: await prompter.input(`The 'From' Email address used to send emails`, channelOutput.FromAddress),
+      Identity: await prompter.input('The ARN of an identity verified with SES', channelOutput.Identity),
+      RoleArn: await prompter.input(`The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service`, channelOutput.RoleArn),
+    };
   }
 
   const params = {

--- a/packages/amplify-category-notifications/src/channel-email.ts
+++ b/packages/amplify-category-notifications/src/channel-email.ts
@@ -46,14 +46,14 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
   if (context.exeInfo.pinpointInputParams?.[channelName]) {
     answers = validateInputParams(context.exeInfo.pinpointInputParams[channelName]);
   } else {
-    let channelOutput:$TSAny = {};
+    let channelOutput: $TSAny = {};
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
     answers = {
-      FromAddress: await prompter.input(`The 'From' Email address used to send emails`, channelOutput.FromAddress),
-      Identity: await prompter.input('The ARN of an identity verified with SES', channelOutput.Identity),
-      RoleArn: await prompter.input(`The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service`, channelOutput.RoleArn),
+      FromAddress: await prompter.input(`The 'From' Email address used to send emails`, { initial: channelOutput.FromAddress }),
+      Identity: await prompter.input('The ARN of an identity verified with SES', { initial: channelOutput.Identity }),
+      RoleArn: await prompter.input(`The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service`, { initial: channelOutput.RoleArn }),
     };
   }
 

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -1,8 +1,7 @@
 import {
   $TSAny, $TSContext, AmplifyError, AmplifyFault,
 } from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
-import inquirer from 'inquirer';
+import { printer, prompter } from 'amplify-prompts';
 import ora from 'ora';
 import { ChannelAction, ChannelConfigDeploymentType, IChannelAPIResponse } from './channel-types';
 import { buildPinpointChannelResponseSuccess } from './pinpoint-helper';
@@ -20,26 +19,16 @@ export const configure = async (context: $TSContext): Promise<void> => {
 
   if (isChannelEnabled) {
     printer.info(`The ${channelName} channel is currently enabled`);
-    const answer = await inquirer.prompt({
-      name: 'disableChannel',
-      type: 'confirm',
-      message: `Do you want to disable the ${channelName} channel`,
-      default: false,
-    });
-    if (answer.disableChannel) {
+    const disableChannel = await prompter.yesOrNo(`Do you want to disable the ${channelName} channel`, false);
+    if (disableChannel) {
       await disable(context);
     } else {
       const successMessage = `The ${channelName} channel has been successfully updated.`;
       await enable(context, successMessage);
     }
   } else {
-    const answer = await inquirer.prompt({
-      name: 'enableChannel',
-      type: 'confirm',
-      message: `Do you want to enable the ${channelName} channel`,
-      default: true,
-    });
-    if (answer.enableChannel) {
+    const enableChannel = await prompter.yesOrNo(`Do you want to enable the ${channelName} channel`, true);
+    if (enableChannel) {
       await enable(context, undefined);
     }
   }
@@ -59,15 +48,10 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const questions = [
-      {
-        name: 'ApiKey',
-        type: 'input',
-        message: 'ApiKey',
-        default: channelOutput.ApiKey,
-      },
-    ];
-    answers = trimAnswers(await inquirer.prompt(questions));
+    answers = {
+      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey }),
+    };
+    answers = trimAnswers(answers);
   }
 
   const params = {
@@ -121,15 +105,10 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     if (context.exeInfo.serviceMeta.output[channelName]) {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
-    const questions = [
-      {
-        name: 'ApiKey',
-        type: 'input',
-        message: 'ApiKey',
-        default: channelOutput.ApiKey,
-      },
-    ];
-    answers = trimAnswers(await inquirer.prompt(questions));
+    answers = {
+      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey }),
+    };
+    answers = trimAnswers(answers);
   }
 
   const params = {

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -49,9 +49,8 @@ export const enable = async (context: $TSContext, successMessage: string | undef
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
     answers = {
-      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey }),
+      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey, transform: input => input.trim() }),
     };
-    answers = trimAnswers(answers);
   }
 
   const params = {
@@ -106,9 +105,8 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
     answers = {
-      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey }),
+      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey, transform: input => input.trim() }),
     };
-    answers = trimAnswers(answers);
   }
 
   const params = {

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -160,13 +160,3 @@ export const pull = async (context: $TSContext, pinpointApp: $TSAny):Promise<$TS
     return undefined;
   }
 };
-
-const trimAnswers = (answers: Record<string, $TSAny>): Record<string, $TSAny> => {
-  for (const [key, value] of Object.entries(answers)) {
-    if (typeof answers[key] === 'string') {
-      // eslint-disable-next-line no-param-reassign
-      answers[key] = value.trim();
-    }
-  }
-  return answers;
-};

--- a/packages/amplify-category-notifications/src/channel-sms.ts
+++ b/packages/amplify-category-notifications/src/channel-sms.ts
@@ -1,7 +1,6 @@
 import { $TSAny, $TSContext, AmplifyFault } from 'amplify-cli-core';
-import inquirer from 'inquirer';
 import ora from 'ora';
-import { printer } from 'amplify-prompts';
+import { printer, prompter } from 'amplify-prompts';
 import { ChannelAction, ChannelConfigDeploymentType } from './channel-types';
 import { buildPinpointChannelResponseSuccess } from './pinpoint-helper';
 
@@ -18,23 +17,13 @@ export const configure = async (context : $TSContext):Promise<void> => {
 
   if (isChannelEnabled) {
     printer.info(`The ${channelName} channel is currently enabled`);
-    const answer = await inquirer.prompt({
-      name: 'disableChannel',
-      type: 'confirm',
-      message: `Do you want to disable the ${channelName} channel`,
-      default: false,
-    });
-    if (answer.disableChannel) {
+    const disableChannel = await prompter.yesOrNo(`Do you want to disable the ${channelName} channel`, false);
+    if (disableChannel) {
       await disable(context);
     }
   } else {
-    const answer = await inquirer.prompt({
-      name: 'enableChannel',
-      type: 'confirm',
-      message: `Do you want to enable the ${channelName} channel`,
-      default: true,
-    });
-    if (answer.enableChannel) {
+    const enableChannel = await prompter.yesOrNo(`Do you want to enable the ${channelName} channel`, true);
+    if (enableChannel) {
       await enable(context);
     }
   }

--- a/packages/amplify-category-notifications/src/validate-filepath.ts
+++ b/packages/amplify-category-notifications/src/validate-filepath.ts
@@ -5,10 +5,9 @@ import * as fs from 'fs-extra';
  * @param filePath - path to file
  * @returns true on success
  */
-export const validateFilePath = (filePath: string): boolean|string => {
-  let result = false;
-  if (filePath) {
-    result = fs.existsSync(filePath);
+export const validateFilePath = (filePath: string): string | true => {
+  if (filePath && fs.existsSync(filePath)) {
+    return true;
   }
-  return result || 'file path must be valid';
+  return 'file path must be valid';
 };


### PR DESCRIPTION
#### Description of changes
- migrates notifications category to use amplify-prompter library instead of inquirer

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
