### PR TITLE
fix: Typescript -> TypeScript in customer-facing errors

### DIFF
--- a/packages/amplify-category-custom/src/utils/build-custom-resources.ts
+++ b/packages/amplify-category-custom/src/utils/build-custom-resources.ts
@@ -101,7 +101,10 @@ const buildResource = async (context: $TSContext, resource: ResourceMeta): Promi
   const localTscExecutablePath = path.join(targetDir, 'node_modules', '.bin', 'tsc');
 
   if (!fs.existsSync(localTscExecutablePath)) {
-    throw new Error('TypeScript executable not found. Please add it as a dev-dependency in the package.json file for this resource.');
+    throw new AmplifyError('MissingOverridesInstallationRequirementsError', {
+      message: 'TypeScript executable not found.',
+      resolution: 'Please add it as a dev-dependency in the package.json file for this resource.',
+    });
   }
 
   try {

--- a/packages/amplify-category-custom/src/utils/build-custom-resources.ts
+++ b/packages/amplify-category-custom/src/utils/build-custom-resources.ts
@@ -101,7 +101,7 @@ const buildResource = async (context: $TSContext, resource: ResourceMeta): Promi
   const localTscExecutablePath = path.join(targetDir, 'node_modules', '.bin', 'tsc');
 
   if (!fs.existsSync(localTscExecutablePath)) {
-    throw new Error('Typescript executable not found. Please add it as a dev-dependency in the package.json file for this resource.');
+    throw new Error('TypeScript executable not found. Please add it as a dev-dependency in the package.json file for this resource.');
   }
 
   try {

--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -90,7 +90,7 @@ export const buildOverrideDir = async (cwd: string, destDirPath: string): Promis
 
     if (!fs.existsSync(localTscExecutablePath)) {
       throw new AmplifyError('MissingOverridesInstallationRequirementsError', {
-        message: 'Typescript executable not found.',
+        message: 'TypeScript executable not found.',
         resolution: 'Please add it as a dev-dependency in the package.json file for this resource.',
       });
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

teeny tiny change to fix the casing for `TypeScript` in customer-facing error messages

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

n/a

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
