### PR TITLE
fix: suppress errors when browser launch fails

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
@@ -40,13 +40,13 @@ describe('adminLoginFlow', () => {
     const appId = 'appid';
     const region = 'us-east-2';
 
-    let spinnerStartMock = jest.spyOn(AmplifySpinner.prototype, 'start');
-    let spinnerStopMock = jest.spyOn(AmplifySpinner.prototype, 'stop');
+    const spinnerStartMock = jest.spyOn(AmplifySpinner.prototype, 'start');
+    const spinnerStopMock = jest.spyOn(AmplifySpinner.prototype, 'stop');
 
     await adminLoginFlow(contextStub, appId, undefined, region);
 
     expect(spinnerStartMock).toBeCalledTimes(1);
-    expect(spinnerStartMock).toBeCalledWith('Attempt to open browser failed, please manually paste in your CLI login key:\n');
+    expect(spinnerStartMock).toBeCalledWith('Please manually paste in your CLI login key:\n');
 
     expect(spinnerStopMock).toBeCalledTimes(1);
     expect(spinnerStopMock).toBeCalledWith("Successfully received Amplify Studio tokens.");

--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
@@ -46,7 +46,7 @@ describe('adminLoginFlow', () => {
     await adminLoginFlow(contextStub, appId, undefined, region);
 
     expect(spinnerStartMock).toBeCalledTimes(1);
-    expect(spinnerStartMock).toBeCalledWith('Please manually paste in your CLI login key:\n');
+    expect(spinnerStartMock).toBeCalledWith('Manually enter your CLI login key:\n');
 
     expect(spinnerStopMock).toBeCalledTimes(1);
     expect(spinnerStopMock).toBeCalledWith("Successfully received Amplify Studio tokens.");

--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
@@ -1,0 +1,54 @@
+import { $TSContext } from 'amplify-cli-core';
+import { adminLoginFlow } from '../admin-login';
+import { AmplifySpinner } from 'amplify-prompts';
+
+jest.mock('amplify-cli-core', () => {
+  return {
+    open: jest.fn().mockReturnValue(Promise.reject('some spawn error')),
+  }
+});
+
+jest.mock('../utils/admin-login-server', () => {
+  return {
+    AdminLoginServer: jest.fn().mockReturnValue({
+      startServer: jest.fn().mockImplementation((callback) => {
+        callback();
+      }),
+      shutdown: jest.fn(),
+    })
+  }
+});
+
+describe('adminLoginFlow', () => {
+  let contextStub: $TSContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    contextStub = ({
+      amplify: {
+        getEnvInfo: () => {
+          return {
+            envName: 'dev'
+          }
+        }
+      },
+    } as unknown) as $TSContext;
+  });
+
+  it('catches errors when fails to launch browser', async () => {
+    const appId = 'appid';
+    const region = 'us-east-2';
+
+    let spinnerStartMock = jest.spyOn(AmplifySpinner.prototype, 'start');
+    let spinnerStopMock = jest.spyOn(AmplifySpinner.prototype, 'stop');
+
+    await adminLoginFlow(contextStub, appId, undefined, region);
+
+    expect(spinnerStartMock).toBeCalledTimes(1);
+    expect(spinnerStartMock).toBeCalledWith('Attempt to open browser failed, please manually paste in your CLI login key:\n');
+
+    expect(spinnerStopMock).toBeCalledTimes(1);
+    expect(spinnerStopMock).toBeCalledWith("Successfully received Amplify Studio tokens.");
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -1,11 +1,10 @@
-import ora from 'ora';
 import util from 'util';
 import readline from 'readline';
 import { Writable } from 'stream';
 import {
   $TSContext, AmplifyError, AMPLIFY_DOCS_URL, open,
 } from 'amplify-cli-core';
-import { printer } from 'amplify-prompts';
+import { printer, AmplifySpinner } from 'amplify-prompts';
 import { adminVerifyUrl, adminBackendMap, isAmplifyAdminApp } from './utils/admin-helpers';  // eslint-disable-line
 import { AdminLoginServer } from './utils/admin-login-server';
 import { AdminAuthPayload } from './utils/auth-types';
@@ -27,15 +26,13 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
   }
 
   const url = adminVerifyUrl(appId, envName, region);
-  let spinner: ora.Ora;
+  const spinner = new AmplifySpinner();
 
   await open(url, { wait: false }).then(() => {
     printer.info(`Opening link: ${url}`);
-    spinner = ora('Confirm login in the browser or manually paste in your CLI login key:\n');
-  }).catch(e => {
-    spinner = ora('Attempt to open browser failed, please manually paste in your CLI login key:\n');
-  }).finally(() => {
-    spinner.start();
+    spinner.start('Confirm login in the browser or manually paste in your CLI login key:\n');
+  }).catch(() => {
+    spinner.start('Attempt to open browser failed, please manually paste in your CLI login key:\n');
   });
 
   try {
@@ -127,7 +124,8 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
         cancelGetTokenViaServer();
         cancelGetTokenViaPrompt();
       });
-    spinner.succeed('Successfully received Amplify Studio tokens.');
+
+    spinner.stop('Successfully received Amplify Studio tokens.');
   } catch (e) {
     spinner.stop();
     printer.error(`Failed to authenticate with Amplify Studio: ${e?.message || e}`);

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -28,12 +28,14 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
   const url = adminVerifyUrl(appId, envName, region);
   const spinner = new AmplifySpinner();
 
-  await open(url, { wait: false }).then(() => {
+  try {
+    await open(url, { wait: false });
     printer.info(`Opening link: ${url}`);
     spinner.start('Confirm login in the browser or manually paste in your CLI login key:\n');
-  }).catch(() => {
-    spinner.start('Attempt to open browser failed, please manually paste in your CLI login key:\n');
-  });
+  } catch(_) {
+    printer.info(`Attempt to open the following link failed: ${url}`)
+    spinner.start('Please manually paste in your CLI login key:\n');
+  }
 
   try {
     // spawn express server locally to get credentials

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -33,8 +33,8 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
     printer.info(`Opening link: ${url}`);
     spinner.start('Confirm login in the browser or manually paste in your CLI login key:\n');
   } catch(_) {
-    printer.info(`Attempt to open the following link failed: ${url}`)
-    spinner.start('Please manually paste in your CLI login key:\n');
+    printer.info(`Could not open ${url} in the current environment`)
+    spinner.start('Manually enter your CLI login key:\n');
   }
 
   try {

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -27,11 +27,16 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
   }
 
   const url = adminVerifyUrl(appId, envName, region);
-  printer.info(`Opening link: ${url}`);
-  await open(url, { wait: false }).catch(e => {
-    printer.error(`Failed to open web browser: ${e?.message || e}`);
+  let spinner: ora.Ora;
+
+  await open(url, { wait: false }).then(() => {
+    printer.info(`Opening link: ${url}`);
+    spinner = ora('Confirm login in the browser or manually paste in your CLI login key:\n');
+  }).catch(e => {
+    spinner = ora('Attempt to open browser failed, please manually paste in your CLI login key:\n');
+  }).finally(() => {
+    spinner.start();
   });
-  const spinner = ora('Confirm login in the browser or manually paste in your CLI login key:\n').start();
 
   try {
     // spawn express server locally to get credentials


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This pull request suppresses errors when the browser fails to launch. This might happen if a developer is using a non-GUI machine to run CLI or the user's machine has blocked processes from launching the browser. The fix suppresses the error and prompts the user to manually populate their Amplify login key.

The PR also replaces the `ora` package with the `AmplifySpinner` in the prompt.

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-cli/issues/11240
Fixes: https://github.com/aws-amplify/amplify-cli/issues/11176

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Added a unit test that raises an error when `open` is invoked that tests the spinner successfully starts and stops. Additionally, integration tests will be run to ensure no regressions.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
