### PR TITLE
fix: fallback to tpi for amplify app when no backend dir

### DIFF
--- a/packages/amplify-cli/src/__tests__/attach-backend.test.ts
+++ b/packages/amplify-cli/src/__tests__/attach-backend.test.ts
@@ -1,0 +1,55 @@
+import { $TSContext, stateManager } from 'amplify-cli-core';
+import { attachBackend } from '../attach-backend';
+
+jest.mock('../amplify-service-helper');
+jest.mock('../attach-backend-steps/a10-queryProvider');
+jest.mock('../attach-backend-steps/a20-analyzeProject');
+jest.mock('../attach-backend-steps/a30-initFrontend');
+jest.mock('../attach-backend-steps/a40-generateFiles');
+jest.mock('../initialize-env');
+jest.mock('amplify-prompts');
+
+jest.mock('amplify-cli-core');
+jest.mock('fs-extra');
+const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+
+const testAppId = 'testAppId';
+
+stateManagerMock.getTeamProviderInfo.mockReturnValue({
+  test: {
+    awscloudformation: {
+      AmplifyAppId: testAppId,
+    },
+  },
+});
+
+stateManagerMock.getLocalEnvInfo.mockReturnValue({
+  noUpdateBackend: true,
+  envName: 'test',
+});
+stateManagerMock.getLocalAWSInfo.mockReturnValue({
+  test: {},
+});
+
+describe('attachBackend', () => {
+  it('sets input params appId to team provider app id if not already present', async () => {
+    const inputParams = {
+      yes: true,
+      test: {},
+      amplify: {
+        defaultEditor: 'test',
+        projectName: 'test',
+        envName: 'test',
+        frontend: 'test',
+        noOverride: false,
+      },
+    };
+    const contextStub = {
+      exeInfo: {
+        awsConfigInfo: {},
+      },
+    } as unknown as $TSContext;
+    await attachBackend(contextStub, inputParams);
+    expect(contextStub.exeInfo.inputParams.amplify.appId).toBe(testAppId);
+  });
+});

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -14,7 +14,6 @@ import { queryProvider } from './attach-backend-steps/a10-queryProvider';
 import { analyzeProject } from './attach-backend-steps/a20-analyzeProject';
 import { initFrontend } from './attach-backend-steps/a30-initFrontend';
 import { generateFiles } from './attach-backend-steps/a40-generateFiles';
-import { getAmplifyAppId } from './extensions/amplify-helpers/get-amplify-appId';
 import { initializeEnv } from './initialize-env';
 
 const backupAmplifyDirName = 'amplify-backup';
@@ -225,7 +224,8 @@ const updateContextForNoUpdateBackendProjects = (context: $TSContext): void => {
     context.exeInfo.inputParams.amplify.envName = context.exeInfo.inputParams.amplify.envName || envName;
     context.exeInfo.inputParams.amplify.frontend = context.exeInfo.inputParams.amplify.frontend
     || context.exeInfo.existingProjectConfig.frontend;
-    context.exeInfo.inputParams.amplify.appId = context.exeInfo.inputParams.amplify.appId || getAmplifyAppId();
+    context.exeInfo.inputParams.amplify.appId = context.exeInfo.inputParams.amplify.appId
+      || context.exeInfo.existingTeamProviderInfo[envName].awscloudformation?.AmplifyAppId;
     // eslint-disable-next-line max-len
     context.exeInfo.inputParams[context.exeInfo.inputParams.amplify.frontend] = context.exeInfo.inputParams[context.exeInfo.inputParams.amplify.frontend]
       || context.exeInfo.existingProjectConfig[context.exeInfo.inputParams.amplify.frontend];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes an issue where pull when selecting "no" to "do you want to modify this backend" would fail because it was looking for the Amplify AppId in the backend/amplify-meta.json file. This change switches back to using the team-provider-info.json file.

#### Issue #, if available

Fixes: https://github.com/aws-amplify/amplify-cli/issues/11415

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
manually tested, added a unit test and running e2e here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/foyleef/no-backend-app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
