### PR TITLE
fix: add human readable names to artifact files

### DIFF
--- a/packages/amplify-e2e-core/src/nexpect-reporter.js
+++ b/packages/amplify-e2e-core/src/nexpect-reporter.js
@@ -64,15 +64,28 @@ class AmplifyCLIExecutionReporter {
     fs.ensureDirSync(publicPath);
 
     const processedResults = results.testResults.map(result => {
+      // result is Array of TestResult: https://github.com/facebook/jest/blob/ac57282299c383320845fb9a026719de7ed3ee5e/packages/jest-test-result/src/types.ts#L90
       const resultCopy = { ...result };
       delete resultCopy.CLITestRunner;
       return {
         ...resultCopy,
+        // each test result has an array of 'AssertionResult'
         testResults: result.testResults.map(r => {
           const recordings = mergeCliLog(r, result.CLITestRunner.logs.children, r.ancestorTitles);
 
-          const recordingWithPath = recordings.map(r => {
-            const castFile = `${uuid()}.cast`;
+          const recordingWithPath = recordings.map((r, index) => {
+            // the first command is always 'amplify', but r.cmd is the full path to the cli.. so this is more readable
+            const commandAndParams = ['amplify'];
+            if(r.params){
+              commandAndParams.push(...r.params);
+            }
+            let sanitizedSections = [];
+            for(let section of commandAndParams){
+              // this ensures only alphanumeric values are in the file name
+              sanitizedSections.push(section.replace(/[^a-z0-9]/gi, '_').toLowerCase());
+            }
+            const suffix = sanitizedSections.join('_');
+            const castFile = `${new Date().getTime()}_${index}_${suffix}.cast`;
             const castFilePath = path.join(publicPath, castFile);
             fs.writeFileSync(castFilePath, r.recording);
             const rCopy = { ...r };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
I just created this [same PR](https://github.com/aws-amplify/amplify-category-api/pull/1006) in our API repo for an identical change, here is the summary:

Often, when tests fail we are unable to playback the artifacts, and must scan through a bunch of .cast files to figure out the error trail. This process is very manual and slow, often there are ten files or more, and they currently don't print in-order, so you have to look through each one to find the error.
Instead, we can use labels that use timestamps, & and order indicator, so that it is easier to find the file that contains the error, usually the first file that occurs before the "amplify delete" teardown step.

This is BEFORE, it is not possible to quickly identify the error, or to see any type of ordering/metadata about each file:
![image](https://user-images.githubusercontent.com/110861985/202263987-40218a17-cc92-4d3b-8ad1-75534660ff20.png)

So, what does it look like now?
Take this example.. using this change, I can quickly scan the files to see what commands were executed for each test on the right hand side. I can also see that the .cast files are in order. Additionally, I can quickly go to the file that happens before the teardown step 'amplify api gql compile' and find the error in there.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/110861985/202351463-52e800c1-4599-4801-957b-6e90e98ae584.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
