### PR TITLE
chore: truncate long file names to fix dev build

### DIFF
--- a/packages/amplify-e2e-core/src/nexpect-reporter.js
+++ b/packages/amplify-e2e-core/src/nexpect-reporter.js
@@ -84,7 +84,10 @@ class AmplifyCLIExecutionReporter {
               // this ensures only alphanumeric values are in the file name
               sanitizedSections.push(section.replace(/[^a-z0-9]/gi, '_').toLowerCase());
             }
-            const suffix = sanitizedSections.join('_');
+            let suffix = sanitizedSections.join('_');
+            if(suffix.length > 30){
+              suffix = suffix.substring(0, 30);
+            }
             const castFile = `${new Date().getTime()}_${index}_${suffix}.cast`;
             const castFilePath = path.join(publicPath, castFile);
             fs.writeFileSync(castFilePath, r.recording);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Tests are passing in dev, but they show an error due to some jobs having very long artifact names.
This truncates the suffix appended to artifacts to ensure names don't get too long.

Here is the e2e run for this fix: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/aluja/fix-dev-build-long-names

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/110861985/202362270-08a47dda-6261-43ed-bc17-82c55d1b22c2.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
