### PR TITLE
fix: include arm64 in github release

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -598,6 +598,7 @@ jobs:
             mv amplify-pkg-win-x64.exe amplify-pkg-win.exe
             tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos
             tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux
+            tar zcvf amplify-pkg-linux-arm64.tgz amplify-pkg-linux-arm64
             tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win.exe
       - run:
           name: Publish Amplify CLI GitHub prerelease

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -598,7 +598,6 @@ jobs:
             mv amplify-pkg-win-x64.exe amplify-pkg-win.exe
             tar zcvf amplify-pkg-macos.tgz amplify-pkg-macos
             tar zcvf amplify-pkg-linux.tgz amplify-pkg-linux
-            tar zcvf amplify-pkg-linux-arm64.tgz amplify-pkg-linux-arm64
             tar zcvf amplify-pkg-win.exe.tgz amplify-pkg-win.exe
       - run:
           name: Publish Amplify CLI GitHub prerelease

--- a/scripts/github-prerelease.ts
+++ b/scripts/github-prerelease.ts
@@ -9,7 +9,7 @@ import { unifiedChangelogPath } from './constants';
  */
 const binariesDir = join(__dirname, '..', 'out');
 const binaryNamePrefix = 'amplify-pkg-';
-const platformSuffixes = ['linux', 'macos', 'win.exe'];
+const platformSuffixes = ['linux', 'linux-arm64', 'macos', 'win.exe'];
 
 const validateVersion = async (version: string) => {
   if (!valid(version)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Make release upload arm binary to github.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
