### PR TITLE
fix: print table summary on verbose status

### DIFF
--- a/packages/amplify-cli-core/src/cliViewAPI.ts
+++ b/packages/amplify-cli-core/src/cliViewAPI.ts
@@ -34,7 +34,7 @@ export class ViewResourceTableParams {
   getCategoryFromCLIOptions(cliOptions: object) {
     if (cliOptions) {
       return Object.keys(cliOptions)
-        .filter(key => key != 'verbose' && key !== 'yes')
+        .filter(key => key !== 'verbose' && key !== 'yes')
         .map(category => category.toLowerCase());
     } else {
       return [];

--- a/packages/amplify-cli/src/__tests__/input-validation.test.ts
+++ b/packages/amplify-cli/src/__tests__/input-validation.test.ts
@@ -1,0 +1,14 @@
+import { Input } from '../domain/input';
+import { verifyInput } from '../input-manager';
+import { PluginPlatform } from '../domain/plugin-platform';
+
+describe('input validation tests', () => {
+  it('status -v option should be treated as verbose', () => {
+    const input = new Input(['status', '-v']);
+    input.command = 'status';
+    input.options = { v: true };
+
+    verifyInput(new PluginPlatform(), input);
+    expect(input?.options?.verbose).toBe(true);
+  });
+});


### PR DESCRIPTION
#### Description of changes
- fix status summary when -v flag is used

#### Description of how you validated changes
- manual test and unit test added

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
