### PR TITLE
chore: update codegen-ui to 2.5.5

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.4",
-    "@aws-amplify/codegen-ui-react": "2.5.4",
+    "@aws-amplify/codegen-ui": "2.5.5",
+    "@aws-amplify/codegen-ui-react": "2.5.5",
     "amplify-cli-core": "3.4.0",
     "amplify-prompts": "2.6.1",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/notifyMissingPackages.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/notifyMissingPackages.test.ts
@@ -52,13 +52,13 @@ describe('should notify when packages are missing', () => {
       },
     };
     notifyMissingPackages(context as JSONUtilitiesDependency.$TSContext);
-    expect(printerDependency.printer.warn).toBeCalledTimes(1);
+    expect(printerDependency.printer.warn).toBeCalledTimes(2);
   });
 
   it('notifies for partial missing dependencies', async () => {
     JSONUtilitiesDependency.JSONUtilities.readJson = jest.fn().mockImplementation(() => ({
       projectPath: __dirname,
-      dependencies: { '@aws-amplify/ui-react': '1.2.0' },
+      dependencies: { '@aws-amplify/ui-react': '4.2.0' },
     }));
     const context = {
       input: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.4.tgz#216dc54b56926043976016ecf1c2e28349676f60"
-  integrity sha512-75rjC7TJ9NCMjPbNd8y4VJlC50H+NKVEoAsDb8IG8UZk6Sf3TOqclvfaDQxf+V916qSOCgc6GjLSohQbS0V6iw==
+"@aws-amplify/codegen-ui-react@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.5.tgz#804e0c69258eb337fe23e06aa60c4779f377affb"
+  integrity sha512-5A6+ztnEudXQhjwuDLRykEfQWhk1CxnKVWM05wT5pD2peXEhfb/mmKpcZ4CtWh34ilDHk1QdpP+mM8QPuAd1xA==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.5.4"
+    "@aws-amplify/codegen-ui" "2.5.5"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.5.4.tgz#9042f861bff7bafa0897a9faeb2ac91a857933a9"
-  integrity sha512-k6HUHiGAB49R6UdTM0rDhPf+PAWpzP/E8s0Gt9HJODMoO8kvIBwlSIIrCVRZizhB2wzO7CjHm/cPQL4OlXPudw==
+"@aws-amplify/codegen-ui@2.5.5":
+  version "2.5.5"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.5.tgz#33b31b52240878590dcf230ea7c8a92261143f89"
+  integrity sha512-7OnjqnMVD0AnlcrEmKyu9IL7s5+zPhj5lAH+z6OFCuGYCONGTZgJJkR7RGs48bmayzm9jvpAPMVLwPSQENcqSQ==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
#### Description of changes
UI Builder is updating the `@aws-amplify/codegen-ui` and `@aws-amplify/codegen-ui-react` version it uses to `2.5.5` to address the following issues:
* fix checkbox to reflect correct state
* Fix [object Object] displayed for AWSJSON field
* Fix array of JSONs crashing render
* fix “less than char” validation
* recommend versions of ui-react and aws-amplify that will fix predicates
* allow style-related overrides to be passed in
* address model names colliding with component types
* support nested arrays
* allow empty string for URL field

#### Description of how you validated changes
- team bug bash
- `yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
