### PR TITLE
chore: update to match new executor naming

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -166,7 +166,7 @@ jobs:
       - run: chmod +x .circleci/lint_pr.sh && ./.circleci/lint_pr.sh
 
   verify-api-extract:
-    <<: *linux-e2e-executor
+    <<: *linux-e2e-executor-medium
     steps:
       - restore_cache:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Recently, executor names were updated to be more specific:
linux-e2e-executor -> linux-e2e-executor-medium

A recent addition to the config file did not get this update; this fixes that.

Setup succeeded: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/aluja/update-executor-name-to-fix-build

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
