### PR TITLE
fix: 🐛 Added virtual file system support to prevent out of sync

### DIFF
--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -24,7 +24,6 @@ export const PathConstants = {
 
   // resource level
   BuildDirName: 'build',
-  SchemaSnapshot: '.snapshot',
   // 2nd Level
   OverrideDirName: 'overrides',
   ProviderName: 'awscloudformation',
@@ -111,7 +110,7 @@ export class PathManager {
   );
 
   getBackendSnapshotVFSPath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.SchemaSnapshot],
+    projectPath, [PathConstants.AmplifyDirName, '.snapshot'],
   );
 
   getCurrentCloudBackendDirPath = (projectPath?: string): string => this.constructPath(

--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -24,6 +24,7 @@ export const PathConstants = {
 
   // resource level
   BuildDirName: 'build',
+  SchemaSnapshot: '.snapshot',
   // 2nd Level
   OverrideDirName: 'overrides',
   ProviderName: 'awscloudformation',
@@ -107,6 +108,10 @@ export class PathManager {
 
   getBackendDirPath = (projectPath?: string): string => this.constructPath(
     projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName],
+  );
+
+  getBackendSnapshotVFSPath = (projectPath?: string): string => this.constructPath(
+    projectPath, [PathConstants.AmplifyDirName, PathConstants.SchemaSnapshot],
   );
 
   getCurrentCloudBackendDirPath = (projectPath?: string): string => this.constructPath(

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -81,6 +81,7 @@
     "jose": "^4.3.7",
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
+    "memfs": "^3.4.12",
     "moment": "^2.24.0",
     "netmask": "^2.0.2",
     "node-fetch": "^2.6.7",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/vfs-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/vfs-helpers.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable spellcheck/spell-checker */
+import * as fs from 'fs-extra';
+import { fs as vfs } from 'memfs';
+import {
+  existsVFSSync, copyFromVFStoFSSync, deleteBackendSnapshotVFS, takeBackendSnapshotVFS,
+} from '../../utils/vfs-helpers';
+
+const fsMock = fs as jest.Mocked<typeof fs>;
+const vfsMock = vfs as jest.Mocked<typeof vfs>;
+
+jest.mock('amplify-cli-core', () => ({
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('mockBackendDirPath'),
+    getBackendSnapshotVFSPath: jest.fn().mockReturnValue('.mock_snapshot'),
+  },
+}));
+
+describe('VFSHelperFunctions', () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+
+    fsMock.mkdirSync('mockBackendDirPath', { recursive: true });
+    fsMock.mkdirSync('mockBackendDirPath/mockDir', { recursive: true });
+    fsMock.mkdirSync('mockCloudCurrentResourcesPath', { recursive: true });
+    fsMock.writeFileSync('mockBackendDirPath/file1.txt', 'file1');
+    fsMock.writeFileSync('mockBackendDirPath/file2.txt', 'file2');
+    fsMock.writeFileSync('mockBackendDirPath/file3.txt', 'file3');
+    fsMock.writeFileSync('mockBackendDirPath/mockDir/file1.txt', 'file1');
+  });
+
+  it('should take a snapshot of the directory and place it in the vfs', () => {
+    takeBackendSnapshotVFS();
+    expect(vfsMock.readFileSync('.mock_snapshot/file1.txt', 'utf8')).toBe('file1');
+    expect(vfsMock.readFileSync('.mock_snapshot/file2.txt', 'utf8')).toBe('file2');
+    expect(vfsMock.readFileSync('.mock_snapshot/file3.txt', 'utf8')).toBe('file3');
+    expect(vfsMock.readFileSync('.mock_snapshot/mockDir/file1.txt', 'utf8')).toBe('file1');
+    deleteBackendSnapshotVFS();
+  });
+
+  it('should copy files from the VFS to the file system', () => {
+    takeBackendSnapshotVFS();
+    copyFromVFStoFSSync('.mock_snapshot', 'mockCloudCurrentResourcesPath');
+    expect(fsMock.readFileSync('mockCloudCurrentResourcesPath/file1.txt', 'utf8')).toBe('file1');
+    expect(fsMock.readFileSync('mockCloudCurrentResourcesPath/file2.txt', 'utf8')).toBe('file2');
+    expect(fsMock.readFileSync('mockCloudCurrentResourcesPath/file3.txt', 'utf8')).toBe('file3');
+    expect(fsMock.readFileSync('mockCloudCurrentResourcesPath/mockDir/file1.txt', 'utf8')).toBe('file1');
+  });
+
+  it('should delete the snapshot from the vfs', () => {
+    takeBackendSnapshotVFS();
+    deleteBackendSnapshotVFS();
+    expect(vfsMock.existsSync('.mock_snapshot')).toBe(false);
+  });
+
+  it('should assert the existance of a file in the vfs', () => {
+    takeBackendSnapshotVFS();
+    expect(existsVFSSync('.mock_snapshot/file1.txt')).toBe(true);
+    expect(existsVFSSync('.mock_snapshot/nonExistant.txt')).toBe(false);
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/vfs-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/vfs-helpers.test.ts
@@ -56,5 +56,11 @@ describe('VFSHelperFunctions', () => {
     takeBackendSnapshotVFS();
     expect(existsVFSSync('.mock_snapshot/file1.txt')).toBe(true);
     expect(existsVFSSync('.mock_snapshot/nonExistant.txt')).toBe(false);
+    deleteBackendSnapshotVFS();
+    expect(existsVFSSync('.mock_snapshot/file1.txt')).toBe(false);
+  });
+  afterAll(() => {
+    fsMock.rmdirSync('mockBackendDirPath', { recursive: true });
+    fsMock.rmdirSync('mockCloudCurrentResourcesPath', { recursive: true });
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -32,10 +32,12 @@ import CloudFormation from './aws-utils/aws-cfn';
 import { $TSContext, ApiCategoryFacade } from 'amplify-cli-core';
 import * as resourceExport from './export-resources';
 import * as exportUpdateMeta from './export-update-amplify-meta';
+import { copyFromVFStoFSSync, existsVFSSync } from './utils/vfs-helpers';
 
 export { resolveAppId } from './utils/resolve-appId';
 export { loadConfigurationForEnv } from './configuration-manager';
 export { getLocationSupportedRegion, getLocationRegionMapping } from './aws-utils/aws-location';
+export { copyFromVFStoFSSync, existsVFSSync } from './utils/vfs-helpers';
 import { updateEnv } from './update-env';
 
 export const cfnRootStackFileName = 'root-cloudformation-stack.json';
@@ -198,4 +200,6 @@ module.exports = {
   hashDirectory,
   prePushCfnTemplateModifier,
   getApiKeyConfig,
+  copyFromVFStoFSSync,
+  existsVFSSync,
 };

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -17,6 +17,7 @@
 /* eslint-disable no-await-in-loop */
 import _ from 'lodash';
 import * as fs from 'fs-extra';
+import { fs as vfs } from 'memfs';
 import * as path from 'path';
 import glob from 'glob';
 import {
@@ -274,6 +275,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
       || rebuild
     ) {
       context.usageData.stopCodePathTimer('pushTransform');
+      takeBackendSnapshotVFS();
       context.usageData.startCodePathTimer('pushDeployment');
       // if there are deploymentSteps, need to do an iterative update
       if (deploymentSteps.length > 0) {
@@ -469,6 +471,48 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
     throw new AmplifyFault('DeploymentFault', {
       message: error.message,
     }, error);
+  } finally {
+    deleteBackendSnapshotVFS();
+  }
+};
+
+const takeBackendSnapshotVFS = (): void => {
+  const sourceDir = path.normalize(path.join(pathManager.getBackendDirPath()));
+  const targetDir = path.normalize(path.join(pathManager.getBackendSnapshotVFSPath()));
+  copyFromFStoVFSSync(sourceDir, targetDir);
+};
+
+const deleteBackendSnapshotVFS = (): void => {
+  const targetDir = path.normalize(path.join(pathManager.getBackendSnapshotVFSPath()));
+  if (vfs.existsSync(targetDir)) removeVFSDirRecursive(targetDir);
+};
+
+const copyFromFStoVFSSync = (src: string, dest: string) => {
+  const exists = fs.existsSync(src);
+  const stats = exists && fs.statSync(src);
+  const isDirectory = exists && stats.isDirectory();
+  if (isDirectory) {
+    vfs.mkdirSync(dest, { recursive: true });
+    fs.readdirSync(src).forEach(childItemName => {
+      copyFromFStoVFSSync(path.join(src, childItemName),
+        path.join(dest, childItemName));
+    });
+  } else {
+    vfs.writeFileSync(dest, fs.readFileSync(src));
+  }
+};
+
+const removeVFSDirRecursive = (directoryPath: string) => {
+  if (vfs.existsSync(directoryPath)) {
+    vfs.readdirSync(directoryPath).forEach(file => {
+      const curPath = path.join(directoryPath, file);
+      if (vfs.lstatSync(curPath).isDirectory()) {
+        removeVFSDirRecursive(curPath);
+      } else {
+        vfs.unlinkSync(curPath);
+      }
+    });
+    vfs.rmdirSync(directoryPath);
   }
 };
 

--- a/packages/amplify-provider-awscloudformation/src/utils/vfs-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/vfs-helpers.ts
@@ -1,0 +1,78 @@
+import { Stats } from 'fs';
+/* eslint-disable spellcheck/spell-checker */
+import * as fs from 'fs-extra';
+import { fs as vfs } from 'memfs';
+import * as path from 'path';
+import { pathManager } from 'amplify-cli-core';
+
+/**
+ * Creates a virtual file system snapshot with the contents of the amplify backend project
+ */
+export const takeBackendSnapshotVFS = (): void => {
+  const sourceDir = path.normalize(path.join(pathManager.getBackendDirPath()));
+  const targetDir = path.normalize(path.join(pathManager.getBackendSnapshotVFSPath()));
+  copyFromFStoVFSSync(sourceDir, targetDir);
+};
+
+/**
+ * Copies a directory from the file system to the virtual file system
+ */
+const copyFromFStoVFSSync = (src: string, dest: string): void => {
+  const exists = fs.existsSync(src);
+  const stats = exists && fs.statSync(src);
+  const isDirectory = exists && (stats as Stats).isDirectory();
+  if (isDirectory) {
+    vfs.mkdirSync(dest, { recursive: true });
+    fs.readdirSync(src).forEach(childItemName => {
+      copyFromFStoVFSSync(path.join(src, childItemName),
+        path.join(dest, childItemName));
+    });
+  } else {
+    vfs.writeFileSync(dest, fs.readFileSync(src));
+  }
+};
+
+/**
+ * Deletes the backend snapshot form the virtual file system
+ */
+export const deleteBackendSnapshotVFS = (): void => {
+  const targetDir = path.normalize(path.join(pathManager.getBackendSnapshotVFSPath()));
+  if (vfs.existsSync(targetDir)) { removeVFSDirRecursive(targetDir); }
+};
+
+const removeVFSDirRecursive = (directoryPath: string): void => {
+  if (vfs.existsSync(directoryPath)) {
+    vfs.readdirSync(directoryPath).forEach(file => {
+      const curPath = path.join(directoryPath, file);
+      if (vfs.lstatSync(curPath).isDirectory()) {
+        removeVFSDirRecursive(curPath);
+      } else {
+        vfs.unlinkSync(curPath);
+      }
+    });
+    vfs.rmdirSync(directoryPath);
+  }
+};
+
+/**
+ * Checks for existance of file in the virtual file system
+ */
+export const existsVFSSync = (src: string): boolean => vfs.existsSync(src);
+
+/**
+ * Copies a directory from the virtual file system to the file system
+ */
+export const copyFromVFStoFSSync = (src: string, dest: string): void => {
+  const exists = vfs.existsSync(src);
+  const stats = exists && vfs.statSync(src);
+  const isDirectory = exists && (stats as Stats).isDirectory();
+  if (isDirectory) {
+    fs.mkdirSync(dest, { recursive: true });
+    vfs.readdirSync(src).forEach(childItemName => {
+      copyFromVFStoFSSync(path.join(src, childItemName),
+        path.join(dest, childItemName));
+    });
+  } else {
+    fs.writeFileSync(dest, vfs.readFileSync(src));
+  }
+};


### PR DESCRIPTION
Added virtual file system support to snapshot backend to prevent #current-cloud-backend mismatch with s3 deployment

✅ Closes: aws-amplify/amplify-category-api#88

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

aws-amplify/amplify-category-api#88

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

`yarn test` and sample app deployment with changes  and no issues when modifying schema.graphql during deployment.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
