### PR TITLE
fix(api): add null placeholder for nested stack during api rebuild

### DIFF
--- a/packages/amplify-e2e-core/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-core/src/init/deleteProject.ts
@@ -6,7 +6,12 @@ import { getBackendAmplifyMeta } from '../utils';
  * Runs `amplify delete`
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const deleteProject = async (cwd: string, profileConfig?: any, usingLatestCodebase = false): Promise<void> => {
+export const deleteProject = async (
+  cwd: string,
+  profileConfig?: any,
+  usingLatestCodebase = false,
+  noOutputTimeout: number = 1000 * 60 * 20,
+): Promise<void> => {
   // Read the meta from backend otherwise it could fail on non-pushed, just initialized projects
   try {
     const { StackName: stackName, Region: region } = getBackendAmplifyMeta(cwd).providers.awscloudformation;
@@ -15,7 +20,6 @@ export const deleteProject = async (cwd: string, profileConfig?: any, usingLates
       (stack) => stack.StackStatus.endsWith('_COMPLETE') || stack.StackStatus.endsWith('_FAILED'),
     );
 
-    const noOutputTimeout = 1000 * 60 * 20; // 20 minutes;
     await spawn(getCLIPath(usingLatestCodebase), ['delete'], { cwd, stripColors: true, noOutputTimeout })
       .wait('Are you sure you want to continue?')
       .sendYes()
@@ -25,18 +29,3 @@ export const deleteProject = async (cwd: string, profileConfig?: any, usingLates
     console.log('Error on deleting project at:', cwd);
   }
 };
-
-export const amplifyDeleteWithLongerTimeout = (cwd: string, usingLatestCodebase = false): Promise<void> => new Promise((resolve, reject) => {
-  const noOutputTimeout = 1000 * 60 * 30; // 30 minutes;
-  spawn(getCLIPath(usingLatestCodebase), ['delete'], { cwd, stripColors: true, noOutputTimeout })
-    .wait('Are you sure you want to continue?')
-    .sendConfirmYes()
-    .wait('Project deleted locally.')
-    .run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        reject(err);
-      }
-    });
-});

--- a/packages/amplify-e2e-core/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-core/src/init/deleteProject.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-cycle */
 import { nspawn as spawn, retry, getCLIPath, describeCloudFormationStack } from '..';
 import { getBackendAmplifyMeta } from '../utils';
+import { $TSAny } from 'amplify-cli-core';
 
 /**
  * Runs `amplify delete`
@@ -8,7 +9,7 @@ import { getBackendAmplifyMeta } from '../utils';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const deleteProject = async (
   cwd: string,
-  profileConfig?: any,
+  profileConfig?: $TSAny,
   usingLatestCodebase = false,
   noOutputTimeout: number = 1000 * 60 * 20,
 ): Promise<void> => {

--- a/packages/amplify-e2e-core/src/init/deleteProject.ts
+++ b/packages/amplify-e2e-core/src/init/deleteProject.ts
@@ -25,3 +25,18 @@ export const deleteProject = async (cwd: string, profileConfig?: any, usingLates
     console.log('Error on deleting project at:', cwd);
   }
 };
+
+export const amplifyDeleteWithLongerTimeout = (cwd: string, usingLatestCodebase = false): Promise<void> => new Promise((resolve, reject) => {
+  const noOutputTimeout = 1000 * 60 * 30; // 30 minutes;
+  spawn(getCLIPath(usingLatestCodebase), ['delete'], { cwd, stripColors: true, noOutputTimeout })
+    .wait('Are you sure you want to continue?')
+    .sendConfirmYes()
+    .wait('Project deleted locally.')
+    .run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+});

--- a/packages/amplify-e2e-tests/schemas/relational_models_v2.graphql
+++ b/packages/amplify-e2e-tests/schemas/relational_models_v2.graphql
@@ -1,0 +1,18 @@
+input AMPLIFY {
+  globalAuthRule: AuthRule = { allow: public }
+}
+type Todo @model {
+  id: ID!
+  name: String
+  description: String
+  tasks: [Task] @hasMany
+  assignee: Worker @hasOne
+}
+type Task @model {
+  id: ID!
+  todo: Todo @belongsTo
+}
+type Worker @model {
+  id: ID!
+  todo: Todo @belongsTo
+}

--- a/packages/amplify-e2e-tests/schemas/searchable_model_v2.graphql
+++ b/packages/amplify-e2e-tests/schemas/searchable_model_v2.graphql
@@ -1,0 +1,8 @@
+input AMPLIFY {
+  globalAuthRule: AuthRule = { allow: public }
+}
+type Todo @model @searchable {
+  id: ID!
+  name: String
+  description: String
+}

--- a/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
@@ -5,27 +5,13 @@ import {
   amplifyPush,
   deleteProject,
   deleteProjectDir,
-  putItemInTable,
-  scanTable,
   rebuildApi,
   getProjectMeta,
   updateApiSchema,
 } from '@aws-amplify/amplify-e2e-core';
+import { testTableAfterRebuildApi, testTableBeforeRebuildApi } from '../rebuild-test-helpers';
 
 const projName = 'apitest';
-
-export const testTableBeforeRebuildApi = async (apiId: string, region: string, modelName: string) => {
-  const tableName = `${modelName}-${apiId}-integtest`;
-  await putItemInTable(tableName, region, { id: 'this is a test value' });
-  const scanResultBefore = await scanTable(tableName, region);
-  expect(scanResultBefore.Items.length).toBe(1);
-};
-
-export const testTableAfterRebuildApi = async (apiId: string, region: string, modelName: string) => {
-  const tableName = `${modelName}-${apiId}-integtest`;
-  const scanResultAfter = await scanTable(tableName, region);
-  expect(scanResultAfter.Items.length).toBe(0);
-};
 
 let projRoot;
 beforeEach(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
@@ -9,15 +9,27 @@ import {
   scanTable,
   rebuildApi,
   getProjectMeta,
+  updateApiSchema,
 } from '@aws-amplify/amplify-e2e-core';
 
 const projName = 'apitest';
+
+export const testTableBeforeRebuildApi = async (apiId: string, region: string, modelName: string) => {
+  const tableName = `${modelName}-${apiId}-integtest`;
+  await putItemInTable(tableName, region, { id: 'this is a test value' });
+  const scanResultBefore = await scanTable(tableName, region);
+  expect(scanResultBefore.Items.length).toBe(1);
+};
+
+export const testTableAfterRebuildApi = async (apiId: string, region: string, modelName: string) => {
+  const tableName = `${modelName}-${apiId}-integtest`;
+  const scanResultAfter = await scanTable(tableName, region);
+  expect(scanResultAfter.Items.length).toBe(0);
+};
+
 let projRoot;
 beforeEach(async () => {
   projRoot = await createNewProjectDir(projName);
-  await initJSProjectWithProfile(projRoot, { name: projName });
-  await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
-  await amplifyPush(projRoot);
 });
 afterEach(async () => {
   await deleteProject(projRoot);
@@ -25,20 +37,33 @@ afterEach(async () => {
 });
 
 describe('amplify rebuild api', () => {
-  it('recreates all model tables', async () => {
+  it('recreates single table', async () => {
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
+    await amplifyPush(projRoot);
     const projMeta = getProjectMeta(projRoot);
     const apiId = projMeta?.api?.[projName]?.output?.GraphQLAPIIdOutput;
     const region = projMeta?.providers?.awscloudformation?.Region;
     expect(apiId).toBeDefined();
     expect(region).toBeDefined();
-    const tableName = `Todo-${apiId}-integtest`;
-    await putItemInTable(tableName, region, { id: 'this is a test value' });
-    const scanResultBefore = await scanTable(tableName, region);
-    expect(scanResultBefore.Items.length).toBe(1);
-
+    await testTableBeforeRebuildApi(apiId, region, 'Todo');
     await rebuildApi(projRoot, projName);
+    await testTableAfterRebuildApi(apiId, region, 'Todo');
+  });
+  it('recreates tables for relational models', async () => {
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
+    await updateApiSchema(projRoot, projName, 'relational_models_v2.graphql');
+    await amplifyPush(projRoot);
+    const projMeta = getProjectMeta(projRoot);
+    const apiId = projMeta?.api?.[projName]?.output?.GraphQLAPIIdOutput;
+    const region = projMeta?.providers?.awscloudformation?.Region;
+    expect(apiId).toBeDefined();
+    expect(region).toBeDefined();
 
-    const scanResultAfter = await scanTable(tableName, region);
-    expect(scanResultAfter.Items.length).toBe(0);
+    const modelNames = [ 'Todo', 'Task', 'Worker' ];
+    modelNames.forEach(async (modelName) => await testTableBeforeRebuildApi(apiId, region, modelName));
+    await rebuildApi(projRoot, projName);
+    modelNames.forEach(async (modelName) => await testTableAfterRebuildApi(apiId, region, modelName));
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
@@ -45,7 +45,7 @@ describe('amplify rebuild api', () => {
     expect(apiId).toBeDefined();
     expect(region).toBeDefined();
 
-    const modelNames = [ 'Todo', 'Task', 'Worker' ];
+    const modelNames = ['Todo', 'Task', 'Worker'];
     modelNames.forEach(async (modelName) => await testTableBeforeRebuildApi(apiId, region, modelName));
     await rebuildApi(projRoot, projName);
     modelNames.forEach(async (modelName) => await testTableAfterRebuildApi(apiId, region, modelName));

--- a/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
@@ -16,6 +16,8 @@ const projName = 'apitest';
 let projRoot;
 beforeEach(async () => {
   projRoot = await createNewProjectDir(projName);
+  await initJSProjectWithProfile(projRoot, { name: projName });
+  await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
 });
 afterEach(async () => {
   await deleteProject(projRoot);
@@ -24,8 +26,6 @@ afterEach(async () => {
 
 describe('amplify rebuild api', () => {
   it('recreates single table', async () => {
-    await initJSProjectWithProfile(projRoot, { name: projName });
-    await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
     await amplifyPush(projRoot);
     const projMeta = getProjectMeta(projRoot);
     const apiId = projMeta?.api?.[projName]?.output?.GraphQLAPIIdOutput;
@@ -37,8 +37,6 @@ describe('amplify rebuild api', () => {
     await testTableAfterRebuildApi(apiId, region, 'Todo');
   });
   it('recreates tables for relational models', async () => {
-    await initJSProjectWithProfile(projRoot, { name: projName });
-    await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
     await updateApiSchema(projRoot, projName, 'relational_models_v2.graphql');
     await amplifyPush(projRoot);
     const projMeta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
@@ -12,9 +12,6 @@ import {
   amplifyDeleteWithLongerTimeout,
 } from '@aws-amplify/amplify-e2e-core';
 
-// Set longer timeout as the test involves creation and deletion of opensearch domain for twice
-jest.setTimeout(1000 * 60 * 90); // 90 minutes
-
 const projName = 'apitest';
 
 let projRoot;

--- a/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
@@ -1,0 +1,45 @@
+import {
+  createNewProjectDir,
+  initJSProjectWithProfile,
+  addApiWithoutSchema,
+  amplifyPush,
+  deleteProject,
+  deleteProjectDir,
+  putItemInTable,
+  scanTable,
+  rebuildApi,
+  getProjectMeta,
+  updateApiSchema,
+} from '@aws-amplify/amplify-e2e-core';
+import { testTableAfterRebuildApi, testTableBeforeRebuildApi } from './api_6a.test';
+
+// Set longer timeout as the test involves creation and deletion of opensearch domain for twice
+jest.setTimeout(1000 * 60 * 90); // 90 minutes
+
+const projName = 'apitest';
+
+let projRoot;
+beforeEach(async () => {
+  projRoot = await createNewProjectDir(projName);
+});
+afterEach(async () => {
+  await deleteProject(projRoot);
+  deleteProjectDir(projRoot);
+});
+
+describe('amplify rebuild api', () => {
+  it('recreates tables and opensearch service for searchable models', async () => {
+    await initJSProjectWithProfile(projRoot, { name: projName });
+    await addApiWithoutSchema(projRoot, { transformerVersion: 2 });
+    await updateApiSchema(projRoot, projName, 'searchable_model_v2.graphql');
+    await amplifyPush(projRoot);
+    const projMeta = getProjectMeta(projRoot);
+    const apiId = projMeta?.api?.[projName]?.output?.GraphQLAPIIdOutput;
+    const region = projMeta?.providers?.awscloudformation?.Region;
+    expect(apiId).toBeDefined();
+    expect(region).toBeDefined();
+    await testTableBeforeRebuildApi(apiId, region, 'Todo');
+    await rebuildApi(projRoot, projName);
+    await testTableAfterRebuildApi(apiId, region, 'Todo');
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
@@ -7,7 +7,7 @@ import {
   rebuildApi,
   getProjectMeta,
   updateApiSchema,
-  deleteProject
+  deleteProject,
 } from '@aws-amplify/amplify-e2e-core';
 import { testTableAfterRebuildApi, testTableBeforeRebuildApi } from '../rebuild-test-helpers';
 

--- a/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6c.test.ts
@@ -7,7 +7,7 @@ import {
   rebuildApi,
   getProjectMeta,
   updateApiSchema,
-  amplifyDeleteWithLongerTimeout,
+  deleteProject
 } from '@aws-amplify/amplify-e2e-core';
 import { testTableAfterRebuildApi, testTableBeforeRebuildApi } from '../rebuild-test-helpers';
 
@@ -18,7 +18,7 @@ beforeEach(async () => {
   projRoot = await createNewProjectDir(projName);
 });
 afterEach(async () => {
-  await amplifyDeleteWithLongerTimeout(projRoot);
+  await deleteProject(projRoot, undefined, false, 1000 * 60 * 30);
   deleteProjectDir(projRoot);
 });
 

--- a/packages/amplify-e2e-tests/src/rebuild-test-helpers/index.ts
+++ b/packages/amplify-e2e-tests/src/rebuild-test-helpers/index.ts
@@ -1,0 +1,14 @@
+import { putItemInTable, scanTable } from "@aws-amplify/amplify-e2e-core";
+
+export const testTableBeforeRebuildApi = async (apiId: string, region: string, modelName: string) => {
+  const tableName = `${modelName}-${apiId}-integtest`;
+  await putItemInTable(tableName, region, { id: 'this is a test value' });
+  const scanResultBefore = await scanTable(tableName, region);
+  expect(scanResultBefore.Items.length).toBe(1);
+};
+
+export const testTableAfterRebuildApi = async (apiId: string, region: string, modelName: string) => {
+  const tableName = `${modelName}-${apiId}-integtest`;
+  const scanResultAfter = await scanTable(tableName, region);
+  expect(scanResultAfter.Items.length).toBe(0);
+};

--- a/packages/amplify-e2e-tests/src/rebuild-test-helpers/index.ts
+++ b/packages/amplify-e2e-tests/src/rebuild-test-helpers/index.ts
@@ -1,4 +1,4 @@
-import { putItemInTable, scanTable } from "@aws-amplify/amplify-e2e-core";
+import { putItemInTable, scanTable } from '@aws-amplify/amplify-e2e-core';
 
 export const testTableBeforeRebuildApi = async (apiId: string, region: string, modelName: string) => {
   const tableName = `${modelName}-${apiId}-integtest`;

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -22,6 +22,8 @@ import { addGSI, getGSIDetails, removeGSI } from './dynamodb-gsi-helpers';
 import { loadConfiguration } from '../configuration-manager';
 
 const ROOT_LEVEL = 'root';
+const RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME = '_root';
+const CONNECTION_STACK_NAME = 'ConnectionStack';
 
 /**
  * Type for GQLResourceManagerProps
@@ -166,14 +168,24 @@ export class GraphQLResourceManager {
       fs.copySync(previousStepPath, stepPath);
       previousStepPath = stepPath;
 
-      const tables = this.templateState.getKeys();
+      const nestedStacks = this.templateState.getKeys().filter((k) => k !== RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME);
       const tableNames = [];
-      tables.forEach((tableName) => {
-        tableNames.push(tableNameMap.get(tableName));
-        const tableNameStackFilePath = path.join(stepPath, 'stacks', `${tableName}.json`);
-        fs.ensureDirSync(path.dirname(tableNameStackFilePath));
-        JSONUtilities.writeJson(tableNameStackFilePath, this.templateState.pop(tableName));
+      nestedStacks.forEach((stackName) => {
+        if (stackName !== CONNECTION_STACK_NAME) {
+          // Connection stack is not provisioning dynamoDB table and need to be filtered
+          tableNames.push(tableNameMap.get(stackName));
+        }
+        const nestedStackFilePath = path.join(stepPath, 'stacks', `${stackName}.json`);
+        fs.ensureDirSync(path.dirname(nestedStackFilePath));
+        JSONUtilities.writeJson(nestedStackFilePath, this.templateState.pop(stackName));
       });
+
+      // Update the root stack template when it is changed in template state
+      if (this.templateState.has(RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME)) {
+        const rootStackFilePath = path.join(stepPath, 'cloudformation-template.json');
+        fs.ensureDirSync(path.dirname(rootStackFilePath));
+        JSONUtilities.writeJson(rootStackFilePath, this.templateState.pop(RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME));
+      }
 
       const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${buildHash}/states/${stepNumber}`;
       const deploymentStep: DeploymentOp = {
@@ -303,15 +315,59 @@ export class GraphQLResourceManager {
   };
 
   private tableRecreationManagement = (currentState: DiffableProject) => {
-    this.getTablesBeingReplaced().forEach((tableMeta) => {
+    const recreatedTables = this.getTablesBeingReplaced();
+    recreatedTables.forEach((tableMeta) => {
       const ddbStack = this.getStack(tableMeta.stackName, currentState);
       this.dropTemplateResources(ddbStack);
-
       // clear any other states created by GSI updates as dropping and recreating supersedes those changes
       this.clearTemplateState(tableMeta.stackName);
       this.templateState.add(tableMeta.stackName, JSONUtilities.stringify(ddbStack));
     });
+
+    /**
+     * When rebuild api, the root stack needs to change the reference to nested stack output values to temporary null placeholder value
+     * as there will be no output from nested stacks.
+     * Besides, the connection stack also needs to drop the template resources and outputs when the there are relational directives defined
+     */
+    if (this.rebuildAllTables) {
+      const rootStack = this.getStack(ROOT_LEVEL, currentState);
+      const connectionStack = this.getStack(CONNECTION_STACK_NAME, currentState);
+      const allRecreatedNestedStackNames = recreatedTables.map((tableMeta) => tableMeta.stackName);
+      if (connectionStack) {
+        allRecreatedNestedStackNames.push(CONNECTION_STACK_NAME);
+        this.dropTemplateResources(connectionStack);
+        this.templateState.add(CONNECTION_STACK_NAME, JSONUtilities.stringify(connectionStack));
+      }
+      this.replaceRecreatedNestedStackParamsInRootStackTemplate(allRecreatedNestedStackNames, rootStack);
+      this.templateState.add(RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME, JSONUtilities.stringify(rootStack));
+    }
   };
+
+  /**
+   * Set recreated nested stack parameters to 'TemporaryPlaceholderValue' in root stack template
+   * @param recreatedNestedStackNames names of recreated stacks
+   * @param rootStack root stack template
+   */
+  private replaceRecreatedNestedStackParamsInRootStackTemplate(recreatedNestedStackNames: string[], rootStack: Template) {
+    recreatedNestedStackNames.forEach((stackName) => {
+      const stackParamsMap = rootStack.Resources[stackName].Properties.Parameters;
+      Object.keys(stackParamsMap).forEach((stackParamKey) => {
+        const paramObj = stackParamsMap[stackParamKey];
+        const paramObjKeys = Object.keys(paramObj);
+        if (paramObjKeys.length === 1 && paramObjKeys[0] === 'Fn::GetAtt') {
+          const paramObjValue = paramObj[paramObjKeys[0]];
+          if (
+            Array.isArray(paramObjValue) &&
+            paramObjValue.length === 2 &&
+            recreatedNestedStackNames.includes(paramObjValue[0]) &&
+            paramObjValue[1].startsWith('Outputs.')
+          ) {
+            stackParamsMap[stackParamKey] = 'TemporaryPlaceholderValue';
+          }
+        }
+      });
+    });
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getTablesBeingReplaced = (): any => {

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -343,7 +343,7 @@ export class GraphQLResourceManager {
       // Drop resources and outputs for searchable stack if existed
       if (searchableStack) {
         allRecreatedNestedStackNames.push(SEARCHABLE_STACK_NAME);
-        this.dropTemplateResources(searchableStack);
+        this.dropTemplateResourcesForSearchableStack(searchableStack);
         this.templateState.add(SEARCHABLE_STACK_NAME, JSONUtilities.stringify(searchableStack));
       }
       // Update nested stack params in root stack
@@ -446,6 +446,18 @@ export class GraphQLResourceManager {
     template.Resources.PlaceholderNullResource = { Type: 'AWS::CloudFormation::WaitConditionHandle' };
     template.Outputs = {};
   };
+
+  /**
+   * Remove all outputs and resources except for search domain for searchable stack
+   * @param template stack CFN tempalte
+   */
+  private dropTemplateResourcesForSearchableStack = (template: Template): void => {
+    const OpenSearchDomainLogicalID = 'OpenSearchDomain';
+    const searchDomain = template.Resources[OpenSearchDomainLogicalID];
+    template.Resources = {};
+    template.Resources[OpenSearchDomainLogicalID] = searchDomain;
+    template.Outputs = {};
+  }
 
   private clearTemplateState = (stackName: string) => {
     while (this.templateState.has(stackName)) {

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -457,7 +457,7 @@ export class GraphQLResourceManager {
     template.Resources = {};
     template.Resources[OpenSearchDomainLogicalID] = searchDomain;
     template.Outputs = {};
-  }
+  };
 
   private clearTemplateState = (stackName: string) => {
     while (this.templateState.has(stackName)) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixed the failure of `amplify api rebuild` for the following scenarios:

- Multiple models (appsync function dependencies between table stacks)
- Relational models (connection stack)
- Models with `@searchable` defined (searchable stack)

**Note: for `@searchable` rebuild the open search domain will be kept but the other resources (IAM roles, streaming lambda functions) will be removed and regenerated.**

The root cause is that some parameters of nested stack refers to the other nested stacks(including tables, connection and searchable), whereas the `Outputs` of them are dropped during the first stage of deployment. The change is to use null placeholder values to replace the references mentioned above in the api root template.

### Example
Given the following schema
```GraqhQL
input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!

type Todo @model @searchable{
  id: ID!
  name: String!
  description: String
  tasks: [Task] @hasMany
}
type Task @model {
  id: ID!
  todo: Todo @belongsTo
}
```
During the rebuild process, the following stack templates will be generated. The DynamoDB table stack will remain the same behavior as previous.
#### `SearchableStack.json`
```json
{
  "Description": "An auto-generated nested stack for searchable.",
  "AWSTemplateFormatVersion": "2010-09-09",
  "Mappings": {
        ...
  },
  "Conditions": {
      ...
  },
  "Resources": {
    //keep domain only and remove the rest
    "OpenSearchDomain": {
      "Type": "AWS::Elasticsearch::Domain",
      "Properties": {
            ...
       }
    }
  },
  "Outputs": {
    //empty output
  },
  "Parameters": {
    //remain unchanged
    ...
  }
}
```
#### `ConnectionStack.json`
```json
{
  "Resources": {
   //remove all resources but leave one placeholder
    "PlaceholderNullResource": {
        "Type": "AWS::CloudFormation::WaitConditionHandle"
    }
  },
  "Outputs": {
    //remove all outputs
  }
  "Parameters": {
    //remain unchanged
    ...
  }
}
```
#### `cloudformation-template.json` (API root template)
Only `Paramters` referencing the `Outputs` of nested stack will be changed to the placeholder value. The previous behavior will cause null reference error (as outputs are dropped during rebuild)
```json
{
  "Resources": {
    "Task": {
      "Properties": {
        "Parameters": {
          "refertotodonestedstackoutput":
            "Fn::GetAtt": [ "Todo", "Outputs.todoParamOutput"] // this will be replaced by following line
            "TemporaryPlaceholderValue"
        }
      }
    }
  }
}
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fix https://github.com/aws-amplify/amplify-category-api/issues/964
fix https://github.com/aws-amplify/amplify-category-api/issues/56
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
