### PR TITLE
chore: migrate issue templates name to Title Case

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,4 +1,4 @@
-name: Bug report
+name: Bug Report
 description: Create a report to help us improve Amplify CLI
 labels: ["pending-triage"]
 
@@ -35,7 +35,7 @@ body:
   - type: input
     attributes:
       label: How did you install the Amplify CLI?
-      description: 'For example: npm, yarn, curl, etc.'
+      description: "For example: npm, yarn, curl, etc."
   - type: input
     attributes:
       label: If applicable, what version of Node.js are you using?
@@ -49,7 +49,7 @@ body:
   - type: input
     attributes:
       label: What operating system are you using?
-      description: 'For example: Mac, Windows, Ubuntu.'
+      description: "For example: Mac, Windows, Ubuntu."
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature request
+name: Feature Request
 description: Suggest an idea for the CLI
 labels: ["pending-triage"]
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

aligns usage of Title Case issue template names
- migrates `Bug report` -> `Bug Report`
- migrates `Feature request` -> `Feature Request`

I'm also open to migrating "Usage Question" to "Usage question". I don't have strong opinions but would prefer consistency

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

n/a

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
