### PR TITLE
chore: fix 'no console output' timeout for a long running test

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1229,7 +1229,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --force-exit --detectOpenHandles --maxWorkers=3 $TEST_SUITE
-                no_output_timeout: 45m
+                no_output_timeout: 60m
       - when:
           condition:
             or:
@@ -1243,7 +1243,7 @@ commands:
                   source $BASH_ENV
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 45m
+                no_output_timeout: 60m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
@@ -36,6 +36,8 @@ describe('Schema iterative update - create update and delete', () => {
 
     const finalSchema = path.join('iterative-push', 'add-remove-and-update-key', 'final-schema.graphql');
     await updateApiSchema(projectDir, apiName, finalSchema);
+    console.log("starting iterative updates");
     await amplifyPushUpdate(projectDir);
+    console.log("done with iterative updates");
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, we have a 45 minute timeout in CircleCI that prevents tests from running for extended periods of time without providing any updates/progress; we do this on purpose because we don't want tests to hang forever. 

This works great for every test, except this one, which does an 8 step iterative deployment.

This test takes about 45 minutes to run, and doesn't provide any feedback to the test runner (console output). This simple addition will ensure that the test runner knows that progress is being made, and prevent the test from being terminated.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
