### PR TITLE
fix: adding new environment when having a project with notifications

### DIFF
--- a/packages/amplify-category-analytics/src/analytics-resource-api.ts
+++ b/packages/amplify-category-analytics/src/analytics-resource-api.ts
@@ -132,11 +132,8 @@ export const analyticsPluginAPIPush = async (
     pushResponse.reasonMsg = `No Resources of ${resourceProviderServiceName} found for ${AmplifyCategories.ANALYTICS} category`;
   } else {
     try {
-      context.parameters.options.yes = true;
-      context.exeInfo.inputParams = (context.exeInfo.inputParams) || {};
-      context.exeInfo.inputParams.yes = true;
       await invokeAuthPush(context);
-      await analyticsPush(context);
+      await analyticsPushYes(context);
     } catch (err) {
       pushResponse.status = false;
       pushResponse.errorCode = PluginAPIError.E_PUSH_FAILED;
@@ -144,6 +141,27 @@ export const analyticsPluginAPIPush = async (
     }
   }
   return pushResponse;
+};
+
+/**
+ * Execute analytics push command with force yes
+ * @param {Object} context - The amplify context.
+ */
+export const analyticsPushYes = async (context: $TSContext): Promise<void> => {
+  const exeInfoClone = { ...context?.exeInfo };
+  const parametersClone = { ...context?.parameters };
+  try {
+    context.exeInfo = (context.exeInfo) || {};
+    context.exeInfo.inputParams = (context.exeInfo.inputParams) || {};
+    context.exeInfo.inputParams.yes = true; // force yes to avoid prompts
+    context.parameters = (context.parameters) || {};
+    context.parameters.options.yes = true;
+    context.parameters.first = undefined;
+    await analyticsPush(context);
+  } finally {
+    context.exeInfo = exeInfoClone;
+    context.parameters = parametersClone;
+  }
 };
 
 /**
@@ -171,6 +189,7 @@ export const analyticsPluginAPIPostPush = async (context: $TSContext) : Promise<
       pinpointNotificationsMeta.Id = analyticsResource.output.Id;
       pinpointNotificationsMeta.Region = analyticsResource.output.Region;
       // Update Notifications output and channel metadata
+      pinpointNotificationsMeta.output = pinpointNotificationsMeta.output || {};
       pinpointNotificationsMeta.output.Id = analyticsResource.output.Id;
       pinpointNotificationsMeta.output.regulatedResourceName = analyticsResource.resourceName; // without the env suffix
       pinpointNotificationsMeta.output.region = analyticsResource.output.Region;

--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -531,10 +531,10 @@ const authPushYes = async context => {
   const exeInfoClone = { ...context?.exeInfo };
   const parametersClone = { ...context?.parameters };
   try {
-    context.exeInfo ??= {};
-    context.exeInfo.inputParams ??= {};
+    context.exeInfo = (context.exeInfo) || {};
+    context.exeInfo.inputParams = (context.exeInfo.inputParams) || {};
     context.exeInfo.inputParams.yes = true; // force yes to avoid prompts
-    context.parameters ??= {};
+    context.parameters = (context.parameters) || {};
     context.parameters.options.yes = true;
     context.parameters.first = undefined;
     await authRunPush(context);

--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -531,10 +531,10 @@ const authPushYes = async context => {
   const exeInfoClone = { ...context?.exeInfo };
   const parametersClone = { ...context?.parameters };
   try {
-    context.exeInfo = (context.exeInfo) || {};
-    context.exeInfo.inputParams = (context.exeInfo.inputParams) || {};
+    context.exeInfo ??= {};
+    context.exeInfo.inputParams ??= {};
     context.exeInfo.inputParams.yes = true; // force yes to avoid prompts
-    context.parameters = (context.parameters) || {};
+    context.parameters ??= {};
     context.parameters.options.yes = true;
     context.parameters.first = undefined;
     await authRunPush(context);

--- a/packages/amplify-category-auth/src/index.js
+++ b/packages/amplify-category-auth/src/index.js
@@ -529,16 +529,20 @@ async function isSMSWorkflowEnabled(context, resourceName) {
  */
 const authPushYes = async context => {
   const exeInfoClone = { ...context?.exeInfo };
+  const parametersClone = { ...context?.parameters };
   try {
     context.exeInfo = (context.exeInfo) || {};
     context.exeInfo.inputParams = (context.exeInfo.inputParams) || {};
     context.exeInfo.inputParams.yes = true; // force yes to avoid prompts
+    context.parameters = (context.parameters) || {};
+    context.parameters.options.yes = true;
+    context.parameters.first = undefined;
     await authRunPush(context);
   } finally {
     context.exeInfo = exeInfoClone;
+    context.parameters = parametersClone;
   }
 };
-
 
 module.exports = {
   externalAuthEnable,

--- a/packages/amplify-category-notifications/src/channel-sms.ts
+++ b/packages/amplify-category-notifications/src/channel-sms.ts
@@ -52,7 +52,7 @@ export const enable = async (context:$TSContext):Promise<$TSAny> => {
     return buildPinpointChannelResponseSuccess(ChannelAction.ENABLE, deploymentType, channelName, data.SMSChannelResponse);
   } catch (e) {
     spinner.stop();
-    throw new AmplifyFault('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelSmsFault', {
       message: `Failed to enable the ${channelName} channel.`,
     }, e);
   }
@@ -81,7 +81,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     return buildPinpointChannelResponseSuccess(ChannelAction.DISABLE, deploymentType, channelName, data.SMSChannelResponse);
   } catch (e) {
     spinner.fail(`Failed to disable the ${channelName} channel.`);
-    throw new AmplifyFault('NotificationsChannelEmailFault', {
+    throw new AmplifyFault('NotificationsChannelSmsFault', {
       message: `Failed to disable the ${channelName} channel.`,
     }, e);
   }

--- a/packages/amplify-category-notifications/src/commands/notifications/add.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/add.ts
@@ -6,7 +6,7 @@ import {
 } from '../../pinpoint-helper';
 import { enableChannel } from '../../notifications-manager';
 
-import { ChannelConfigDeploymentType, IChannelAPIResponse } from '../../channel-types';
+import { ChannelConfigDeploymentType } from '../../channel-types';
 import { writeData } from '../../multi-env-manager-utils';
 import {
   viewShowAllChannelsEnabledWarning,

--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -43,8 +43,6 @@ export const run = async (context:$TSContext): Promise<$TSContext> => {
           resolution: 'Deploy Auth and Pinpoint resources manually.',
         }, err);
       }
-      // eslint-disable-next-line no-param-reassign
-      context = pinpointAppStatus.context;
     }
     if (isPinpointAppDeployed(pinpointAppStatus.status) || isChannelDeploymentDeferred(selectedChannel)) {
       const channelAPIResponse : IChannelAPIResponse|undefined = await notificationManager.configureChannel(context, selectedChannel);

--- a/packages/amplify-category-notifications/src/multi-env-manager.ts
+++ b/packages/amplify-category-notifications/src/multi-env-manager.ts
@@ -359,8 +359,6 @@ export const checkAndCreatePinpointApp = async (
         resolution: 'Deploy the Auth and Pinpoint resources manually.',
       }, err);
     }
-    // eslint-disable-next-line no-param-reassign
-    context = pinpointAppStatus.context;
   }
 
   return updatedPinpointAppStatus;

--- a/packages/amplify-category-notifications/src/multi-env-manager.ts
+++ b/packages/amplify-category-notifications/src/multi-env-manager.ts
@@ -9,7 +9,7 @@ import {
   getPinpointAppFromAnalyticsOutput,
   getPinpointAppStatus,
   getPinpointClient,
-  isPinpointAppDeployed,
+  IPinpointAppStatus,
   isPinpointDeploymentRequired,
   pushAuthAndAnalyticsPinpointResources,
   scanCategoryMetaForPinpoint,
@@ -21,7 +21,7 @@ import { ICategoryMeta } from './notifications-amplify-meta-types';
 import { PinpointName } from './pinpoint-name';
 import { writeData } from './multi-env-manager-utils';
 import { viewShowInlineModeInstructionsFail, viewShowInlineModeInstructionsStart, viewShowInlineModeInstructionsStop } from './display-utils';
-import { getAvailableChannels, isChannelDeploymentDeferred } from './notifications-backend-cfg-channel-api';
+import { getAvailableChannels } from './notifications-backend-cfg-channel-api';
 
 /**
  * Create Pinpoint resource in Analytics, Create Pinpoint Meta for Notifications category and
@@ -338,15 +338,18 @@ const getEnabledDisabledChannelsFromConfigAndMeta = (
  * @param channelName channel to be enabled
  * @param pinpointAppStatus Deployment status of the Pinpoint resource
  */
-export const checkAndCreatePinpointApp = async (context: $TSContext, channelName: string, pinpointAppStatus: $TSAny) : Promise<$TSAny> => {
+export const checkAndCreatePinpointApp = async (
+  context: $TSContext,
+  channelName: string,
+  pinpointAppStatus: IPinpointAppStatus,
+) : Promise<IPinpointAppStatus> => {
+  let updatedPinpointAppStatus = pinpointAppStatus;
   if (isPinpointDeploymentRequired(channelName, pinpointAppStatus)) {
     await viewShowInlineModeInstructionsStart(channelName);
     try {
       // updates the pinpoint app status
-      // eslint-disable-next-line no-param-reassign
-      pinpointAppStatus = await pushAuthAndAnalyticsPinpointResources(context, pinpointAppStatus);
-      // eslint-disable-next-line no-param-reassign
-      pinpointAppStatus = await ensurePinpointApp(context, pinpointAppStatus);
+      updatedPinpointAppStatus = await pushAuthAndAnalyticsPinpointResources(context, pinpointAppStatus);
+      updatedPinpointAppStatus = await ensurePinpointApp(context, updatedPinpointAppStatus);
       await viewShowInlineModeInstructionsStop(channelName);
     } catch (err) {
       // if the push fails, the user will be prompted to deploy the resource manually
@@ -360,13 +363,10 @@ export const checkAndCreatePinpointApp = async (context: $TSContext, channelName
     context = pinpointAppStatus.context;
   }
 
-  if (isPinpointAppDeployed(pinpointAppStatus.status) || isChannelDeploymentDeferred(channelName)) {
-    const channelAPIResponse = await notificationManager.enableChannel(context, channelName);
-    await writeData(context, channelAPIResponse);
-  }
+  return updatedPinpointAppStatus;
 };
 
-const pushChanges = async (context: $TSContext, pinpointNotificationsMeta: $TSAny):Promise<Array<IChannelAPIResponse|undefined>> => {
+const pushChanges = async (context: $TSContext, pinpointNotificationsMeta: $TSAny): Promise<Array<IChannelAPIResponse|undefined>> => {
   let pinpointInputParams : $TSAny;
 
   if (context?.exeInfo?.inputParams?.categories?.[AmplifyCategories.NOTIFICATIONS]?.[AmplifySupportedService.PINPOINT]
@@ -399,10 +399,12 @@ const pushChanges = async (context: $TSContext, pinpointNotificationsMeta: $TSAn
   );
 
   for (const channel of channelsToEnable) {
+    await checkAndCreatePinpointApp(context, channel, pinpointAppStatus);
     results.push(await notificationManager.enableChannel(context, channel));
   }
 
   for (const channel of channelsToDisable) {
+    await checkAndCreatePinpointApp(context, channel, pinpointAppStatus);
     results.push(await notificationManager.disableChannel(context, channel));
   }
 

--- a/packages/amplify-e2e-tests/src/__tests__/notifications-multi-env.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/notifications-multi-env.test.ts
@@ -1,0 +1,59 @@
+import {
+  addNotificationChannel,
+  amplifyStatus,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getAppId,
+  initJSProjectWithProfile,
+} from '@aws-amplify/amplify-e2e-core';
+import { addEnvironment, listEnvironment } from '../environment/env';
+import {
+  getShortId,
+} from '../import-helpers';
+
+describe('notification category test - SMS', () => {
+  const testChannel = 'SMS';
+  const testChannelSelection = 'SMS';
+  const projectPrefix = `notification${testChannel}`.substring(0, 19);
+  const projectSettings = {
+    name: projectPrefix,
+    disableAmplifyAppCreation: false,
+  };
+
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await createNewProjectDir(projectPrefix);
+  });
+
+  afterEach(async () => {
+    await deleteProject(projectRoot);
+    deleteProjectDir(projectRoot);
+  });
+
+  // inline channels
+  it(`should add and remove the ${testChannel} channel correctly when no pinpoint is configured`, async () => {
+    await initJSProjectWithProfile(projectRoot, projectSettings);
+
+    // add sms channel
+    const settings = { resourceName: `${projectPrefix}${getShortId()}` };
+    await addNotificationChannel(projectRoot, settings, testChannelSelection);
+
+    const appId = getAppId(projectRoot);
+    expect(appId).toBeDefined();
+
+    // expect that Notifications, Analytics, and Auth categories are shown
+    await amplifyStatus(projectRoot, 'Notifications');
+    await amplifyStatus(projectRoot, 'Analytics');
+    await amplifyStatus(projectRoot, 'Auth');
+
+    await addEnvironment(projectRoot, { envName: 'prod' });
+    await listEnvironment(projectRoot, { numEnv: 2 });
+
+    // expect that Notifications, Analytics, and Auth categories are shown in the new env
+    await amplifyStatus(projectRoot, 'Notifications');
+    await amplifyStatus(projectRoot, 'Analytics');
+    await amplifyStatus(projectRoot, 'Auth');
+  });
+});


### PR DESCRIPTION
#### Description of changes
- since notifications requires pinpoint analytics and auth to be in the cloud changing env should force a push for the required resources
- fixes the undefined exception when setting the Id to the output section
- small refactoring to remove duplicate code

#### Issue #11432

#### Description of how you validated changes
- e2e test added and manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
