### PR TITLE
test(cli): multienv e2e tests revisions

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1229,7 +1229,7 @@ commands:
                   source .circleci/local_publish_helpers.sh
                   cd packages/amplify-e2e-tests
                   retry yarn run e2e --force-exit --detectOpenHandles --maxWorkers=3 $TEST_SUITE
-                no_output_timeout: 45m
+                no_output_timeout: 60m
       - when:
           condition:
             or:
@@ -1243,7 +1243,7 @@ commands:
                   source $BASH_ENV
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 45m
+                no_output_timeout: 60m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,4 +1,4 @@
-name: Bug report
+name: Bug Report
 description: Create a report to help us improve Amplify CLI
 labels: ["pending-triage"]
 
@@ -35,7 +35,7 @@ body:
   - type: input
     attributes:
       label: How did you install the Amplify CLI?
-      description: 'For example: npm, yarn, curl, etc.'
+      description: "For example: npm, yarn, curl, etc."
   - type: input
     attributes:
       label: If applicable, what version of Node.js are you using?
@@ -49,7 +49,7 @@ body:
   - type: input
     attributes:
       label: What operating system are you using?
-      description: 'For example: Mac, Windows, Ubuntu.'
+      description: "For example: Mac, Windows, Ubuntu."
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature request
+name: Feature Request
 description: Suggest an idea for the CLI
 labels: ["pending-triage"]
 

--- a/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
@@ -59,7 +59,7 @@ import {
       const appId = getAppId(projRoot);
       await amplifyPull(projRoot2, { override: false, noUpdateBackend: true, emptyDir: true, appId });
       await listEnvironment(projRoot2, {});
-      await pullEnvironment(projRoot2, { noUpdateBackend: true, appId, envName: 'dir' });
+      await pullEnvironment(projRoot2, { appId, envName: 'dir' });
       await listEnvironment(projRoot2, { numEnv: 2 });
     });
   
@@ -71,7 +71,7 @@ import {
   
       var failed = false;
       try {
-        await pullEnvironment(projRoot, { noUpdateBackend: true, appId, envName: 'doesnotexist' });
+        await pullEnvironment(projRoot, { appId, envName: 'doesnotexist' });
       } catch (e) {
         failed = true;
       }

--- a/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable spellcheck/spell-checker */
+/* eslint-disable import/no-extraneous-dependencies */
+
+import {
+    addAuthWithDefault,
+    amplifyPull,
+    checkIfBucketExists,
+    createNewProjectDir,
+    deleteProject,
+    deleteProjectDir,
+    getProjectMeta,
+    initJSProjectWithProfile,
+    getAppId,
+  } from '@aws-amplify/amplify-e2e-core';
+  import {
+    listEnvironment,
+    pullEnvironment
+  } from '../environment/env';
+    
+  const validate = async (meta: any) : Promise<void> => {
+    expect(meta.providers.awscloudformation).toBeDefined();
+    const {
+      AuthRoleArn: authRoleArn, DeploymentBucketName: bucketName, Region: region, StackId: stackId,
+    } = meta.providers.awscloudformation;
+  
+    expect(authRoleArn).toBeDefined();
+    expect(region).toBeDefined();
+    expect(stackId).toBeDefined();
+    const bucketExists = await checkIfBucketExists(bucketName, region);
+    expect(bucketExists).toMatchObject({});
+  };
+    
+  describe('pull env and answer no to changes', () => {
+    let projRoot: string;
+    let projRoot2: string;
+    beforeEach(async () => {
+      projRoot = await createNewProjectDir('pull-answer-no-test');
+      projRoot2 = await createNewProjectDir('pull-answer-no-test-2');
+    });
+  
+    afterEach(async () => {
+      await deleteProject(projRoot);
+      deleteProjectDir(projRoot);
+      deleteProjectDir(projRoot2);
+    });
+  
+    it('init a project, change to empty dir, pull and answer no', async () => {
+      await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false });
+      const appId = getAppId(projRoot);
+      await amplifyPull(projRoot2, { override: false, noUpdateBackend: true, emptyDir: true, appId: appId });
+      const meta = getProjectMeta(projRoot);
+      await validate(meta);
+    });
+  
+    it('init a project, change to empty dir, env list, env pull and answer no', async () => {
+      await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false });
+      const meta = getProjectMeta(projRoot);
+      await validate(meta);
+      const appId = getAppId(projRoot);
+      await amplifyPull(projRoot2, { override: false, noUpdateBackend: true, emptyDir: true, appId });
+      await listEnvironment(projRoot2, {});
+      await pullEnvironment(projRoot2, { noUpdateBackend: true, appId, envName: 'dir' });
+      await listEnvironment(projRoot2, { numEnv: 2 });
+    });
+  
+    it('init a project, pull env that does not exist', async () => {
+      await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false });
+      const meta = getProjectMeta(projRoot);
+      await validate(meta);
+      const appId = getAppId(projRoot);
+  
+      var failed = false;
+      try {
+        await pullEnvironment(projRoot, { noUpdateBackend: true, appId, envName: 'doesnotexist' });
+      } catch (e) {
+        failed = true;
+      }
+  
+      expect(failed).toBe(true);
+    });
+  });

--- a/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-unmodified-backend.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable spellcheck/spell-checker */
-/* eslint-disable import/no-extraneous-dependencies */
-
 import {
     addAuthWithDefault,
     amplifyPull,

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-4.test.ts
@@ -36,6 +36,8 @@ describe('Schema iterative update - create update and delete', () => {
 
     const finalSchema = path.join('iterative-push', 'add-remove-and-update-key', 'final-schema.graphql');
     await updateApiSchema(projectDir, apiName, finalSchema);
+    console.log("starting iterative updates");
     await amplifyPushUpdate(projectDir);
+    console.log("done with iterative updates");
   });
 });

--- a/packages/amplify-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-e2e-tests/src/environment/env.ts
@@ -150,7 +150,6 @@ export function getEnvironment(cwd: string, settings: { envName: string }): Prom
 */
 
 const defaultPullEnvironmentSettings = {
-  noUpdateBackend: true,
   appId: EOL,
   envName: EOL,
 };
@@ -160,15 +159,15 @@ export function pullEnvironment(
   settings?: Partial<typeof defaultPullEnvironmentSettings>,
   testingWithLatestCodebase = false,
 ): Promise<void> {
-  const s = { ...defaultPullEnvironmentSettings, ...settings };
+  const { appId, envName } = { ...defaultPullEnvironmentSettings, ...settings };
   const args = ['env', 'pull'];
 
-  if (s.appId) {
-    args.push('--appId', s.appId);
+  if (appId) {
+    args.push('--appId', appId);
   }
 
-  if (s.envName) {
-    args.push('--envName', s.envName);
+  if (envName) {
+    args.push('--envName', envName);
   }
 
   const chain = spawn(getCLIPath(testingWithLatestCodebase), args, { cwd, stripColors: true });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Changed pullEnvironment test function so that it accepts appId and envName paramaters.

Added 3 E2E tests to test fixes that will be made for Github issues #11372 and #11487.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
