### PR TITLE
chore: filter out usage data from dev instances

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -64,6 +64,9 @@ function generatePkgCli {
   # Restore .d.ts files required by @aws-amplify/codegen-ui at runtime
   cp ../node_modules/typescript/lib/*.d.ts node_modules/typescript/lib/
 
+  # Set NODE_ENV to production
+  sed -i "2s/^/process.env.NODE_ENV = 'production';\n/" node_modules/@aws-amplify/cli-internal/bin/amplify
+
   # Transpile code for packaging
   npx babel node_modules --extensions '.js,.jsx,.es6,.es,.ts' --copy-files --include-dotfiles -d ../build/node_modules
 

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -64,8 +64,8 @@ function generatePkgCli {
   # Restore .d.ts files required by @aws-amplify/codegen-ui at runtime
   cp ../node_modules/typescript/lib/*.d.ts node_modules/typescript/lib/
 
-  # Set NODE_ENV to production
-  sed -i "2s/^/process.env.NODE_ENV = 'production';\n/" node_modules/@aws-amplify/cli-internal/bin/amplify
+  # replace DEV binary entry point with production one
+  cp ../node_modules/@aws-amplify/cli-internal/bin/amplify.production.template node_modules/@aws-amplify/cli-internal/bin/amplify
 
   # Transpile code for packaging
   npx babel node_modules --extensions '.js,.jsx,.es6,.es,.ts' --copy-files --include-dotfiles -d ../build/node_modules

--- a/packages/amplify-cli/bin/amplify.production.template
+++ b/packages/amplify-cli/bin/amplify.production.template
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
 // this file should be a duplicate of amplify.production.template except for the NODE_ENV value
-process.env.NODE_ENV = 'development';
+process.env.NODE_ENV = 'production';
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
@@ -7,8 +7,12 @@ export const prodUrl = `https://api.cli.amplify.aws/${version}/metrics`;
  *  Usage data tracking service URL
  */
 export const getUrl = (): UrlWithStringQuery => {
-  if (process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL && typeof process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL === 'string') {
-    return url.parse(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL || '');
+  if (isProduction() && !useBetaUrl()) {
+    return url.parse(prodUrl);
   }
-  return url.parse(prodUrl);
+
+  return url.parse(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL || '');
 };
+
+const isProduction = (): boolean => process.env.NODE_ENV === 'production';
+const useBetaUrl = (): boolean => !!(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL && typeof process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL === 'string');

--- a/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
@@ -1,12 +1,23 @@
 import url, { UrlWithStringQuery } from 'url';
 import { getLatestApiVersion } from './VersionManager';
 
+let parsedUrl: UrlWithStringQuery;
+
 const version = getLatestApiVersion();
 export const prodUrl = `https://api.cli.amplify.aws/${version}/metrics`;
+
 /**
  *  Usage data tracking service URL
  */
 export const getUrl = (): UrlWithStringQuery => {
+  if (!parsedUrl) {
+    parsedUrl = getParsedUrl();
+  }
+
+  return parsedUrl;
+};
+
+const getParsedUrl = (): UrlWithStringQuery => {
   if (isProduction() && !useBetaUrl()) {
     return url.parse(prodUrl);
   }


### PR DESCRIPTION
#### Description of changes
- injects `production` into the `process.env.NODE_ENV` value in our build
- filters out the usage data for non production builds

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
