### PR TITLE
fix: diagnose error if backend not pulled

### DIFF
--- a/packages/amplify-cli/src/commands/diagnose.ts
+++ b/packages/amplify-cli/src/commands/diagnose.ts
@@ -126,7 +126,7 @@ const createZip = async (context: Context, error: Error | undefined): Promise<st
   if (!rootPath) {
     throw projectNotInitializedError();
   }
-  const backend = stateManager.getBackendConfig(rootPath);
+  const backend = stateManager.getBackendConfig(rootPath, { throwIfNotExist: false, default: {} });
   const resources: { category: string; resourceName: string; service: string }[] = [];
   const categoryResources = Object.keys(backend).reduce((array, key) => {
     Object.keys(backend[key]).forEach(resourceKey => {
@@ -240,6 +240,6 @@ const hashedProjectIdentifiers = (): { projectIdentifier: string; projectEnvIden
 };
 
 const getAppId = (): string => {
-  const meta = stateManager.getMeta();
-  return _.get(meta, ['providers', 'awscloudformation', 'AmplifyAppId']);
+  const meta = stateManager.getMeta(undefined, { throwIfNotExist: false });
+  return meta?.providers?.awscloudformation?.AmplifyAppId ?? 'noAppIdFound';
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently when no backend is pulled (Answer No to "Do you plan on modifying this backend?), diagnose flows fail. Either by triggering an error to be thrown, or by running `amplify diagnose`.

The changes remove assumptions that a backend is always present.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/11066

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
