### PR TITLE
chore: refactor all bridge calls to codegen and api to use a facade

### DIFF
--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -233,6 +233,10 @@ export class AngularConfigNotFoundError extends Error {
 // @public (undocumented)
 export class ApiCategoryFacade {
     // (undocumented)
+    static addGraphQLAuthorizationMode(context: $TSContext, authType: string): Promise<void>;
+    // (undocumented)
+    static generateContainersArtifacts(context: $TSContext, resource: $TSAny): Promise<$TSObject>;
+    // (undocumented)
     static getDirectiveDefinitions(context: $TSContext, resourceDir: string): Promise<string>;
     // (undocumented)
     static getTransformerVersion(context: $TSContext): Promise<number>;
@@ -403,6 +407,14 @@ export class CloudformationProviderFacade {
     }>;
     // (undocumented)
     static prePushCfnTemplateModifier(context: $TSContext, template: Template_2): Promise<(template: Template_2) => Promise<void>>;
+}
+
+// @public (undocumented)
+export class CodegenUtilityFacade {
+    // (undocumented)
+    static generateModelIntrospection(context: $TSContext, outputDir: string): Promise<void>;
+    // (undocumented)
+    static generateModels(context: $TSContext): Promise<void>;
 }
 
 // @public (undocumented)

--- a/packages/amplify-cli-core/src/plugin-facade/api-category-facade.ts
+++ b/packages/amplify-cli-core/src/plugin-facade/api-category-facade.ts
@@ -4,6 +4,7 @@ import { DeploymentResources as DeploymentResourcesV1 } from 'graphql-transforme
 import {
   $TSAny,
   $TSContext,
+  $TSObject,
 } from '..';
 
 const API_CATEGORY_NAME = 'api';
@@ -35,5 +36,28 @@ export class ApiCategoryFacade {
     options: $TSAny,
   ): Promise<DeploymentResourcesV2 | DeploymentResourcesV1 | undefined> {
     return context.amplify.invokePluginMethod(context, API_CATEGORY_NAME, undefined, 'transformGraphQLSchema', [context, options]);
+  }
+
+  /**
+   * Add a new auth mode to the API.
+   */
+  static async addGraphQLAuthorizationMode(
+    context: $TSContext,
+    authType: string,
+  ): Promise<void> {
+    return context.amplify.invokePluginMethod(context, API_CATEGORY_NAME, undefined, 'addGraphQLAuthorizationMode', [
+      context,
+      { authType, printLeadText: true, authSettings: undefined },
+    ]);
+  }
+
+  /**
+   * Generates an ECS Stack and metadata for the given resource object.
+   */
+  static async generateContainersArtifacts(
+    context: $TSContext,
+    resource: $TSAny,
+  ): Promise<$TSObject> {
+    return context.amplify.invokePluginMethod(context, 'api', undefined, 'generateContainersArtifacts', [context, resource]);
   }
 }

--- a/packages/amplify-cli-core/src/plugin-facade/api-category-facade.ts
+++ b/packages/amplify-cli-core/src/plugin-facade/api-category-facade.ts
@@ -58,6 +58,6 @@ export class ApiCategoryFacade {
     context: $TSContext,
     resource: $TSAny,
   ): Promise<$TSObject> {
-    return context.amplify.invokePluginMethod(context, 'api', undefined, 'generateContainersArtifacts', [context, resource]);
+    return context.amplify.invokePluginMethod(context, API_CATEGORY_NAME, undefined, 'generateContainersArtifacts', [context, resource]);
   }
 }

--- a/packages/amplify-cli-core/src/plugin-facade/codegen-utility-facade.ts
+++ b/packages/amplify-cli-core/src/plugin-facade/codegen-utility-facade.ts
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+// eslint-disable-next-line import/no-cycle
+import { $TSContext } from '..';
+
+const CODEGEN_PLUGIN_NAME = 'codegen';
+
+/**
+ * Facade for the Codegen Utility, to facilitate typed requests against some of the plugin methods exposed.
+ */
+export class CodegenUtilityFacade {
+  /**
+   * Invoke the codegen model generation process, will generate output values for datastore.
+   */
+  static async generateModels(context: $TSContext): Promise<void> {
+    return context.amplify.invokePluginMethod(context, CODEGEN_PLUGIN_NAME, undefined, 'generateModels', [context]);
+  }
+
+  /**
+   * Invoke the codegen model generation process, will generate the model introspection schema in the provided outputDir location.
+   */
+  static async generateModelIntrospection(context: $TSContext, outputDir: string): Promise<void> {
+    // generateModelIntrospection expects --output-dir option to be set
+    _.set(context, ['parameters', 'options', 'output-dir'], outputDir);
+
+    return context.amplify.invokePluginMethod(context, CODEGEN_PLUGIN_NAME, undefined, 'generateModelIntrospection', [context]);
+  }
+}

--- a/packages/amplify-cli-core/src/plugin-facade/index.ts
+++ b/packages/amplify-cli-core/src/plugin-facade/index.ts
@@ -1,2 +1,3 @@
 export * from './api-category-facade';
+export * from './codegen-utility-facade';
 export * from './cloudformation-provider-facade';

--- a/packages/amplify-cli/src/amplify-service-helper.ts
+++ b/packages/amplify-cli/src/amplify-service-helper.ts
@@ -1,5 +1,5 @@
 import {
-  $TSObject, $TSContext, pathManager, stateManager,
+  $TSObject, $TSContext, pathManager, stateManager, CodegenUtilityFacade,
 } from 'amplify-cli-core';
 import { isDataStoreEnabled } from 'graphql-transformer-core';
 import * as path from 'path';
@@ -44,6 +44,6 @@ export const postPullCodegen = async (context: $TSContext): Promise<void> => {
     return;
   }
   if (await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', gqlApiName))) {
-    await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModels', [context]);
+    await CodegenUtilityFacade.generateModels(context);
   }
 };

--- a/packages/amplify-cli/src/extensions/amplify-helpers/apply-auth-mode.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/apply-auth-mode.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { $TSContext, ApiCategoryFacade } from 'amplify-cli-core';
 import { getProjectMeta } from './get-project-meta';
 
 const errAuthMissingIAM = `@auth directive with 'iam' provider found, but the project has no IAM authentication provider configured.`;
@@ -19,42 +19,32 @@ export const isValidGraphQLAuthError = (message: string): boolean => [
  */
 export const handleValidGraphQLAuthError = async (context: $TSContext, message: string): Promise<boolean> => {
   if (message === errAuthMissingIAM) {
-    await addGraphQLAuthRequirement(context, 'AWS_IAM');
+    await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'AWS_IAM');
     return true;
   }
 
   if (checkIfAuthExists() && message === errAuthMissingUserPools) {
-    await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
+    await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'AMAZON_COGNITO_USER_POOLS');
     return true;
   }
 
   if (!context?.parameters?.options?.yes) {
     if (message === errAuthMissingUserPools) {
-      await addGraphQLAuthRequirement(context, 'AMAZON_COGNITO_USER_POOLS');
+      await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'AMAZON_COGNITO_USER_POOLS');
       return true;
     } if (message === errAuthMissingOIDC) {
-      await addGraphQLAuthRequirement(context, 'OPENID_CONNECT');
+      await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'OPENID_CONNECT');
       return true;
     } if (message === errAuthMissingApiKey) {
-      await addGraphQLAuthRequirement(context, 'API_KEY');
+      await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'API_KEY');
       return true;
     } if (message === errAuthMissingLambda) {
-      await addGraphQLAuthRequirement(context, 'AWS_LAMBDA');
+      await ApiCategoryFacade.addGraphQLAuthorizationMode(context, 'AWS_LAMBDA');
       return true;
     }
   }
   return false;
 };
-
-const addGraphQLAuthRequirement = async (context, authType)
-  : Promise<$TSAny> => context.amplify.invokePluginMethod(context, 'api', undefined, 'addGraphQLAuthorizationMode', [
-  context,
-  {
-    authType,
-    printLeadText: true,
-    authSettings: undefined,
-  },
-]);
 
 /**
  * Query Amplify Meta file and check if Auth is configured

--- a/packages/amplify-cli/src/pre-deployment-pull.ts
+++ b/packages/amplify-cli/src/pre-deployment-pull.ts
@@ -1,6 +1,6 @@
 import { run } from 'amplify-app';
 import {
-  $TSContext, AmplifyError, AMPLIFY_SUPPORT_DOCS, pathManager,
+  $TSContext, AmplifyError, AMPLIFY_SUPPORT_DOCS, CodegenUtilityFacade, pathManager,
 } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
 import fetch from 'node-fetch';
@@ -52,7 +52,7 @@ export const preDeployPullBackend = async (context: $TSContext, sandboxId: strin
   replaceSchema(resJson.schema);
 
   // Generate models
-  await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModels', [context]);
+  await CodegenUtilityFacade.generateModels(context);
 };
 
 const replaceSchema = (schema: string): void => {

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,5 +1,5 @@
 import {
-  $TSAny, $TSContext, pathManager, stateManager,
+  $TSAny, $TSContext, CodegenUtilityFacade, pathManager, stateManager,
 } from 'amplify-cli-core';
 import * as fs from 'fs-extra';
 import { isDataStoreEnabled } from 'graphql-transformer-core';
@@ -65,13 +65,10 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     process.stdout.write = tempStdoutWrite.write.bind(tempStdoutWrite);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/models.js#L60
-    await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModels', [context]);
-
-    // generateModelIntrospection expects --output-dir option to be set
-    _.set(context, ['parameters', 'options', 'output-dir'], relativeTempOutputDir);
+    await CodegenUtilityFacade.generateModels(context);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/model-intropection.js#L8
-    await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModelIntrospection', [context]);
+    await CodegenUtilityFacade.generateModelIntrospection(context, relativeTempOutputDir);
 
     const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
     const localSchemaJsPath = path.join(absoluteTempOutputDir, 'models', 'schema.js');

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -155,7 +155,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
         const {
           exposedContainer,
           pipelineInfo: { consoleUrl },
-        }: $TSObject = await context.amplify.invokePluginMethod(context, 'api', undefined, 'generateContainersArtifacts', [context, resource]);
+        }: $TSObject = await ApiCategoryFacade.generateContainersArtifacts(context, resource);
         await context.amplify.updateamplifyMetaAfterResourceUpdate('api', resource.resourceName, 'exposedContainer', exposedContainer);
 
         printer.blankLine();


### PR DESCRIPTION
#### Description of changes
Migrate all API and Codegen bridge requests to use facades.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + [e2e tests](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/13101/workflows/b9c1480b-2bfa-451a-b6f7-e26b8751847d)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
