### PR TITLE
fix(category-auth): prevent overwriting local changes to backend on amplify upd…

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
@@ -345,46 +345,46 @@ const createAdminAuthFunction = async (
     lambdaGroupVar = 'NONE';
   }
 
-  const functionProps = {
-    functionName: `${functionName}`,
-    roleName: `${functionName}LambdaRole`,
-    dependsOn,
-    authResourceName,
-    lambdaGroupVar,
-  };
-
-  const copyJobs = [
-    {
-      dir: adminAuthAssetRoot,
-      template: 'admin-auth-app.js',
-      target: path.join(targetDir, 'src/app.js'),
-    },
-    {
-      dir: adminAuthAssetRoot,
-      template: 'admin-auth-cognitoActions.js',
-      target: path.join(targetDir, 'src/cognitoActions.js'),
-    },
-    {
-      dir: adminAuthAssetRoot,
-      template: 'admin-auth-index.js',
-      target: path.join(targetDir, 'src/index.js'),
-    },
-    {
-      dir: adminAuthAssetRoot,
-      template: 'admin-auth-package.json',
-      target: path.join(targetDir, 'src/package.json'),
-    },
-    {
-      dir: adminAuthAssetRoot,
-      template: 'admin-queries-function-template.json.ejs',
-      target: path.join(targetDir, `${functionName}-cloudformation-template.json`),
-    },
-  ];
-
-  // copy over the files
-  await context.amplify.copyBatch(context, copyJobs, functionProps, true);
-
   if (operation === 'add') {
+    const functionProps = {
+      functionName: `${functionName}`,
+      roleName: `${functionName}LambdaRole`,
+      dependsOn,
+      authResourceName,
+      lambdaGroupVar,
+    };
+  
+    const copyJobs = [
+      {
+        dir: adminAuthAssetRoot,
+        template: 'admin-auth-app.js',
+        target: path.join(targetDir, 'src/app.js'),
+      },
+      {
+        dir: adminAuthAssetRoot,
+        template: 'admin-auth-cognitoActions.js',
+        target: path.join(targetDir, 'src/cognitoActions.js'),
+      },
+      {
+        dir: adminAuthAssetRoot,
+        template: 'admin-auth-index.js',
+        target: path.join(targetDir, 'src/index.js'),
+      },
+      {
+        dir: adminAuthAssetRoot,
+        template: 'admin-auth-package.json',
+        target: path.join(targetDir, 'src/package.json'),
+      },
+      {
+        dir: adminAuthAssetRoot,
+        template: 'admin-queries-function-template.json.ejs',
+        target: path.join(targetDir, `${functionName}-cloudformation-template.json`),
+      },
+    ];
+  
+    // copy over the files
+    await context.amplify.copyBatch(context, copyJobs, functionProps, true);
+
     // add amplify-meta and backend-config
     const backendConfigs = {
       service: AmplifySupportedService.LAMBDA,

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/synthesize-resources.ts
@@ -323,7 +323,7 @@ const addAdminAuth = async (
   }
 };
 
-const createAdminAuthFunction = async (
+export const createAdminAuthFunction = async (
   context: $TSContext,
   authResourceName: string,
   functionName: string,


### PR DESCRIPTION
…ate auth

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Moved logic that creates/overwrites lambda function template into if statement that is only entered when preforming 'add auth'. This prevents the files from being overwritten on 'update auth.'

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#11515

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
