### PR TITLE
fix: check java_home variable before starting opensearch emulator

### DIFF
--- a/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { describe } from 'jest-circus';
-import { _isUnsupportedJavaVersion } from '../../utils';
+import { _isUnsupportedJavaVersion, checkJavaHome } from '../../utils';
 import { fail } from 'assert';
 import semver = require('semver/preload');
 
@@ -90,5 +90,16 @@ LibericaJDK 64-Bit Server VM (build 11.0.3-BellSoft+12, mixed mode)`,
       const actual = _isUnsupportedJavaVersion(stderr === '' ? null : stderr);
       expect(actual).toBe(java.unsupported);
     });
+  });
+});
+
+describe('Check JAVA_HOME variable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
+  it('Should not throw when JAVA_HOME is set', () => {
+    process.env.JAVA_HOME = 'pathtojdk';
+    expect( () => { checkJavaHome() }).not.toThrow();
   });
 });

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import fetch from 'node-fetch';
 
 import { getAmplifyMeta, getMockDataDirectory, getMockSearchableTriggerDirectory } from '../utils';
-import { checkJavaVersion } from '../utils/index';
+import { checkJavaVersion, checkJavaHome } from '../utils/index';
 import { runTransformer } from './run-graphql-transformer';
 import { processAppSyncResources } from '../CFNParser';
 import { ResolverOverrides } from './resolver-overrides';
@@ -396,6 +396,7 @@ export class APITest {
     try {
       const mockConfig = await getMockConfig(context);
       await this.createMockSearchableArtifacts(context);
+      checkJavaHome();
       this.opensearchEmulator = await opensearchEmulator.launch(
         getMockOpenseachDataDirectory(context), 
         {

--- a/packages/amplify-util-mock/src/utils/index.ts
+++ b/packages/amplify-util-mock/src/utils/index.ts
@@ -8,6 +8,9 @@ export async function getAmplifyMeta(context: any) {
 import * as which from 'which';
 import * as execa from 'execa';
 import * as semver from 'semver';
+import _ from 'lodash';
+import { AmplifyFault } from 'amplify-cli-core';
+import { printer } from 'amplify-prompts';
 
 const minJavaVersion = '>=1.8 <= 2.0 ||  >=8.0';
 
@@ -45,3 +48,15 @@ function isUnsupportedJavaVersion(stderr: string | null): boolean {
 }
 
 export const _isUnsupportedJavaVersion: (stderr: string | null) => boolean = isUnsupportedJavaVersion;
+
+export const checkJavaHome = () => {
+  const javaHomeValue = process?.env?.JAVA_HOME;
+  if(_.isEmpty(javaHomeValue)) {
+    const resolutionMessage = 'Set the JAVA_HOME environment variable to point to the installed JDK directory and retry';
+    printer.info(resolutionMessage);
+    throw new AmplifyFault('MockProcessFault', {
+      message: 'JAVA_HOME variable not set',
+      resolution: resolutionMessage
+    });
+  }
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds check for `JAVA_HOME` variable which needs to be set for successful startup of OpenSearch emulator and prints out useful warning to the customer.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
