### PR TITLE
fix: iterative gsi deployment - incorrect AttributeDefinitions

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/dynamodb-gsi-utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/dynamodb-gsi-utils.test.ts
@@ -239,6 +239,10 @@ describe('DynamoDB GSI Utils', () => {
               name: 'title',
               type: 'S',
             },
+            sort: {
+              name: 'id',
+              type: 'S',
+            },
           },
         },
       ],
@@ -326,6 +330,22 @@ describe('DynamoDB GSI Utils', () => {
           AttributeName: 'updatedAt',
           AttributeType: 'N',
         },
+      ]);
+    });
+
+    it('should keep the attributes that are in table KeySchema even if the same is used in removed index', () => {
+      const tableWitGSI = makeTableWithGSI({
+        ...tableDefinition
+      });
+      const updatedTable = gsiUtils.removeGSI('byTitle', tableWitGSI);
+
+      expect(updatedTable).not.toEqual(tableWitGSI);
+      expect(updatedTable.Properties?.GlobalSecondaryIndexes).toBeUndefined();
+      expect(updatedTable.Properties.AttributeDefinitions).toEqual([
+        {
+          AttributeName: 'id',
+          AttributeType: 'S',
+        }
       ]);
     });
   });

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
@@ -108,10 +108,13 @@ export const removeGSI = (indexName: string, table: DynamoDB.Table): DynamoDB.Ta
 
   const removedIndices = _.remove(gsis, { IndexName: indexName });
   assertNotIntrinsicFunction(removedIndices);
-  const currentKeySchemas = gsis.reduce((acc, gsi) => {
+  const gsiKeySchemas: Array<KeySchema> = gsis.reduce((acc, gsi) => {
     acc.push(...(gsi.KeySchema as Array<KeySchema>));
     return acc;
   }, []);
+
+  // Add the KeySchema property on table to the currentKeySchemas
+  const currentKeySchemas = _.union(gsiKeySchemas, updatedTable?.Properties?.KeySchema as Array<KeySchema> || []);
 
   // Remove the property as it does not have any child
   if (gsis.length == 0) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
**Given** that a sort key is specified on an index that is already part of the primary key of the model type, for example,
```
type Todo @model {
  id: ID!
  createdDate: AWSDateTime! @index(name : "byCreatedDate", sortKeyFields: ["id"])
}
```
**When** a Customer deletes the index and pushes their change with the `enableIterativeGSIUpdates` feature flag set to `true`,
**Then Currently** in the process of deleting the GSI and associated Attribute Definitions, we also delete the Attribute Definition of the primary key from the Table definition.
** With this fix** we add a check that the attributes referenced in the key schema of the Table do not get removed when deleting the GSI related configuration.

#### Issue #, if available
Internally Tracked

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit test and success iterative deploy from a sample app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
