### PR TITLE
fix: address UI Builder component generation errors

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.5",
-    "@aws-amplify/codegen-ui-react": "2.5.5",
+    "@aws-amplify/codegen-ui": "2.5.6",
+    "@aws-amplify/codegen-ui-react": "2.5.6",
     "amplify-cli-core": "3.4.0",
     "amplify-prompts": "2.6.1",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
@@ -69,6 +69,10 @@ describe('can create a ui builder component', () => {
     generateAmplifyUiBuilderIndexFile(context, [schema]);
     expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).toBeCalled();
   });
+  it('does not call renderSchemaToTemplate for index file if no schema', () => {
+    generateAmplifyUiBuilderIndexFile(context, []);
+    expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).not.toBeCalled();
+  })
   it('calls the renderManager for utils file w/ validation, formatter, and fetchByPath helpers if there is a form', () => {
     generateAmplifyUiBuilderUtilFile(context, { hasForms: true, hasViews: false });
     expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).toBeCalledWith(expect.arrayContaining(['validation', 'formatter', 'fetchByPath']));

--- a/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
@@ -145,7 +145,9 @@ export const generateAmplifyUiBuilderIndexFile = (context: $TSContext, schemas: 
   });
 
   try {
-    rendererManager.renderSchemaToTemplate(schemas);
+    if(schemas.length) {
+      rendererManager.renderSchemaToTemplate(schemas);
+    }
   } catch (e) {
     printer.debug(e);
     printer.debug('Failed to generate component index file');

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.5.5":
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.5.tgz#804e0c69258eb337fe23e06aa60c4779f377affb"
-  integrity sha512-5A6+ztnEudXQhjwuDLRykEfQWhk1CxnKVWM05wT5pD2peXEhfb/mmKpcZ4CtWh34ilDHk1QdpP+mM8QPuAd1xA==
+"@aws-amplify/codegen-ui-react@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.6.tgz#d70416c1f35c0c8fd8d8f7ef70a6fb40a46d9822"
+  integrity sha512-RScybJUc+hUp0z+IXkUecsy0tMPNu0YjKO3eCEDrJZyv31aHGdsbadElgVU61p6l3iYig6SwA9mE+SrKw86ALg==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.5.5"
+    "@aws-amplify/codegen-ui" "2.5.6"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.5.5":
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.5.tgz#33b31b52240878590dcf230ea7c8a92261143f89"
-  integrity sha512-7OnjqnMVD0AnlcrEmKyu9IL7s5+zPhj5lAH+z6OFCuGYCONGTZgJJkR7RGs48bmayzm9jvpAPMVLwPSQENcqSQ==
+"@aws-amplify/codegen-ui@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.6.tgz#af61c36c12c19880914cae1601b3387579e87d02"
+  integrity sha512-xbe7Hw5boVzT1aSwrDwIQvZ85pNz25zJDIL4xvt1JyjWt2u5flY2DqxMAutltKmY2EGfDFWEzsz7ze/+NCWBtA==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Update codegen packages to 2.5.6 to address the following issue:
  - misconfiguring the toggle field component for nested boolean values.
- Update index file generating logic to not render when no valid schemas passed. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
