### PR TITLE
fix: add version bumps logic to changelog creation

### DIFF
--- a/scripts/unified-changelog.ts
+++ b/scripts/unified-changelog.ts
@@ -56,16 +56,19 @@ const extractChangelogInfo = async (changelogPath: string): Promise<ChangelogInf
 
 const formatUnifiedChangelog = (infos: ChangelogInfo[]): string => {
   console.log('Formatting all changes into single changelog');
-  const formattedChangelog = infos
+  var formattedChangelogComponents = infos
     .filter(info => info.latestChanges)
-    .filter(info => !info.latestChanges.includes('Version bump only for package'))
     .filter(info => info.latestChanges.includes('\n')) // if the latestChanges string doesn't contain a newline it's only a version bump
     .sort((a, b) => a.packageName.localeCompare(b.packageName))
     .map(info => {
       const latestChanges = info.latestChanges.replace(/^#+\s+/, ''); // strip off any leading markdown headers
       return `# ${info.packageName} ${latestChanges}`;
-    })
-    .join('\n\n');
+    });
+    // only include version bump sections if the release is all version bumps to avoid an empty change log
+    if (!formattedChangelogComponents.every(component => component.includes('Version bump only for package'))) {
+      formattedChangelogComponents = formattedChangelogComponents.filter(component => !component.includes('Version bump only for package'));
+    }
+    const formattedChangelog = formattedChangelogComponents.join('\n\n');
   return `# Change Log\n\n${formattedChangelog}`;
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
I added logic to `unified-changelog.ts` that checks if a release is comprised of all version bumps and, if so, includes version bumps in the changelog. If there are changes in the changelog that are not version bumps, then all version bumps are omitted from the changelog. This is to avoid release notes from ever being completely empty, as happened with 10.5.1.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
