### PR TITLE
chore: check uncompressed binary size

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -102,33 +102,35 @@ function verifyPkgCli {
     echo "Sizes in bytes"
     wc -c out/*
 
-    linux_compressed_binary_threshold_in_bytes=$((200 * 1024 * 1024))
-    linux_compressed_binary_size=$(wc -c out/amplify-pkg-linux-x64.tgz | awk '{print $1}')
-    if (( linux_compressed_binary_size > linux_compressed_binary_threshold_in_bytes )); then
-      echo "Linux compressed binary size has grown over $linux_compressed_binary_threshold_in_bytes bytes"
-      exit 1
-    fi
+    function verifySinglePkg {
+      binary_name=$1
+      compressed_binary_name=$2
+      binary_threshold_in_bytes=$3
 
-    macos_compressed_binary_threshold_in_bytes=$((200 * 1024 * 1024))
-    macos_compressed_binary_size=$(wc -c out/amplify-pkg-macos-x64.tgz | awk '{print $1}')
-    if (( macos_compressed_binary_size > macos_compressed_binary_threshold_in_bytes )); then
-      echo "MacOS compressed binary size has grown over $macos_compressed_binary_threshold_in_bytes bytes"
-      exit 1
-    fi
+      # Compressed binary size is not deterministic enough to have stricter threshold.
+      # I.e. it depends on how compression algorithm can compress bytecode and there are cases where compressed size
+      # grows even if uncompressed size drops. We don't have control on bytecode and compression.
+      # Therefore we check if compression gets past half of original size as sanity check.
+      compressed_binary_threshold_in_bytes=$((binary_threshold_in_bytes/2))
 
-    win_compressed_binary_threshold_in_bytes=$((200 * 1024 * 1024))
-    win_compressed_binary_size=$(wc -c out/amplify-pkg-win-x64.tgz | awk '{print $1}')
-    if (( win_compressed_binary_size > win_compressed_binary_threshold_in_bytes )); then
-      echo "Windows compressed binary size has grown over $win_compressed_binary_threshold_in_bytes bytes"
-      exit 1
-    fi
+      binary_size=$(wc -c out/$binary_name | awk '{print $1}')
+      compressed_binary_size=$(wc -c out/$compressed_binary_name | awk '{print $1}')
 
-    arm_compressed_binary_threshold_in_bytes=$((150 * 1024 * 1024))
-    arm_compressed_binary_size=$(wc -c out/amplify-pkg-linux-arm64.tgz | awk '{print $1}')
-    if (( arm_compressed_binary_size > arm_compressed_binary_threshold_in_bytes )); then
-      echo "Windows compressed binary size has grown over $arm_compressed_binary_threshold_in_bytes bytes"
-      exit 1
-    fi
+      if (( binary_size > binary_threshold_in_bytes )); then
+        echo "$binary_name size has grown over $binary_threshold_in_bytes bytes"
+        exit 1
+      fi
+
+      if (( compressed_binary_size > compressed_binary_threshold_in_bytes )); then
+        echo "$compressed_binary_name size has grown over $compressed_binary_threshold_in_bytes bytes"
+        exit 1
+      fi
+    }
+
+    verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((700 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((700 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((700 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((550 * 1024 * 1024))
 }
 
 function unsetNpmRegistryUrl {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This changes how do we gate binary size in such a way that:
- we put strict threshold on uncompressed binary size
- we put more permissive sanity check on compressed binary size because compression is not predictable.

Example when compressed size grew but uncompressed dropped.
Left is dev , right is cdkv2 branch.
![Pasted Graphic](https://user-images.githubusercontent.com/5849952/206002941-a7202ba1-9f9f-41aa-ab94-629dd82b3e6e.png)


The sizes has been based on current state of dev.
![image](https://user-images.githubusercontent.com/5849952/206003039-25424a68-cfed-46ef-ba76-dc4959de7e3f.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
