### PR TITLE
chore: install dotnet 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,10 @@ RUN sudo apt-get update
 RUN sudo apt-get install apt-transport-https
 RUN sudo apt-get update
 RUN sudo apt-get install dotnet-sdk-3.1
+RUN sudo apt-get install dotnet-sdk-6.0
 RUN dotnet --version
+RUN dotnet --list-sdks
 RUN dotnet tool install -g amazon.lambda.tools
 RUN dotnet tool install -g amazon.lambda.testtool-3.1
+RUN dotnet tool install -g amazon.lambda.testtool-6.0
 ENV PATH=${PATH}:/home/circleci/.dotnet/tools


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Pre-requisite for https://github.com/aws-amplify/amplify-cli/issues/11510 . 
This installs .NET 6 in addition to .NET Core 3.1.
.NET Core 3.1 is kept for CLI test runs that still target that runtime.

.NET supports side by side installation. The right version of SDK is picked by declaration in csproj files, for example here https://github.com/aws-amplify/amplify-cli/blob/2fc42cce2b6622426ed81d9a4582fc1121ad399b/packages/amplify-dotnet-function-template-provider/resources/lambda/HelloWorld/Function.csproj.ejs#L3 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I have run `function_3` tests in SSH session with both runtimes installed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
