### PR TITLE
fix: broken windows build due to cp command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ This section should get you running with **Amplify CLI** and get you familiar wi
 
    # Windows
    yarn setup-dev-win
+   ## Must be run in Powershell
    ```
 
 > NOTE: Make sure to always [sync your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) with _dev_ branch of amplify-cli

--- a/packages/amplify-environment-parameters/package.json
+++ b/packages/amplify-environment-parameters/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib tsconfig.tsbuildinfo node_modules src/schemas",
     "test": "jest --logHeapUsage",
     "extract-api": "ts-node ../../scripts/extract-api.ts",
-    "generate-schemas": "mkdirp lib/schemas src/schemas && ts-json-schema-generator --path 'src/backend-parameters.d.ts' --type 'BackendParameters' --no-type-check --out lib/schemas/BackendParameters.schema.json && cp lib/schemas/BackendParameters.schema.json src/schemas/BackendParameters.schema.json"
+    "generate-schemas": "mkdirp lib/schemas src/schemas && ts-json-schema-generator --path src/backend-parameters.d.ts --type BackendParameters --no-type-check --out lib/schemas/BackendParameters.schema.json && copyfiles --flat lib/schemas/BackendParameters.schema.json src/schemas"
   },
   "dependencies": {
     "amplify-cli-core": "3.4.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Replaced the `cp` command in the `generate-schemas` script of the `amplify-environment-parameters` package. The `cp` command was causing the build to fail on windows.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
On windows:
1. Ran `yarn cache clean`
2. `yarn setup-dev-win`

The build script successfully ran.

On mac:
1. Ran `yarn cache clean`
2. `yarn clean`
3. `yarn setup-dev`

The build was successful.

Not validated on Linux.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
