### PR TITLE
chore: make build faster

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -36,6 +36,14 @@ executors:
     environment:
       AMPLIFY_DIR: C:/home/circleci/repo/out
       AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
+  l_xlarge: &linux-e2e-executor-xlarge
+    docker:
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+    working_directory: ~/repo
+    resource_class: xlarge
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
 # If you update this name, make sure to update it in split-e2e-tests.ts as well
   l_large: &linux-e2e-executor-large
     docker:
@@ -98,8 +106,8 @@ jobs:
     parameters:
       os:
         type: executor
-        default: l_large
-    executor: l_large
+        default: l_xlarge
+    executor: l_xlarge
     steps:
       - checkout
       - run: yarn config set script-shell $(which bash)

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -176,7 +176,7 @@ jobs:
       - run: chmod +x .circleci/lint_pr.sh && ./.circleci/lint_pr.sh
 
   verify-api-extract:
-    <<: *linux-e2e-executor-medium
+    <<: *linux-e2e-executor-xlarge
     steps:
       - restore_cache:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}

--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,8 @@
           "package",
           "prepare",
           "extract-api"
-        ]
+        ],
+        "parallel": 8
       }
     }
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
- sets max parallel to 8 for all nx jobs (instead of default 3)
- bumps linux executor to xlarge for build step to bring more cores.

Other considerations.
Setting parallel to 8 is going to slightly speed up local dev loop as well.
Unfortunatelly NX does not allow dynamic configuration based on number of CPUs. So setting this to 8 seems like a good compromise given how powerful average dev machine is.


Linux build
Before:
![image](https://user-images.githubusercontent.com/5849952/206282965-5ce315f1-9ce7-4d60-beef-c6572d57392c.png)
After:
![image](https://user-images.githubusercontent.com/5849952/206283000-580c844d-59d9-4bf3-bbc7-59c252849179.png)

Windows build
Before:
![image](https://user-images.githubusercontent.com/5849952/206283103-7748cb72-41b0-4625-a5ca-8b40ad88d1d3.png)
After:
![image](https://user-images.githubusercontent.com/5849952/206283870-01c497ac-aa02-41b2-a9a5-1a9b3d099750.png)



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
