### PR TITLE
fix: properly filter cli-inputs

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/handlers/resource-handlers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/handlers/resource-handlers.test.ts
@@ -48,8 +48,9 @@ const removeDeprecatedPropsMock = removeDeprecatedProps as jest.MockedFunction<t
 removeDeprecatedPropsMock.mockImplementation(input => input);
 
 const AuthInputStateMock = AuthInputState as jest.MockedClass<typeof AuthInputState>;
+const saveCLIInputPayloadMock = jest.fn();
 AuthInputStateMock.mockImplementation(() => ({
-  saveCLIInputPayload: jest.fn(),
+  saveCLIInputPayload: saveCLIInputPayloadMock,
 } as unknown as AuthInputState));
 
 describe('getUpdateAuthHandler', () => {
@@ -65,6 +66,7 @@ describe('getUpdateAuthHandler', () => {
     } as unknown as CognitoConfiguration;
 
     await getUpdateAuthHandler(contextStub)(cognitoConfig);
-    expect(saveParamsFn.mock.calls[0][3]).toEqual(testConfig);
+    const actualCliInputsFileContent = saveCLIInputPayloadMock.mock.calls[0][0];
+    expect(Object.keys(actualCliInputsFileContent).includes('hostedUIProviderCreds')).toBe(false);
   });
 });

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/handlers/resource-handlers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/handlers/resource-handlers.test.ts
@@ -1,0 +1,70 @@
+import { $TSContext, stateManager } from 'amplify-cli-core';
+import { getUpdateAuthHandler } from '../../../../provider-utils/awscloudformation/handlers/resource-handlers';
+import { CognitoConfiguration } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/awsCognito-user-input-types';
+import { getSupportedServices } from '../../../../provider-utils/supported-services';
+import { getUpdateAuthDefaultsApplier } from '../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers';
+import { AuthInputState } from '../../../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state';
+import { getPostUpdateAuthMetaUpdater } from '../../../../provider-utils/awscloudformation/utils/amplify-meta-updaters';
+import { getPostUpdateAuthMessagePrinter } from '../../../../provider-utils/awscloudformation/utils/message-printer';
+import { removeDeprecatedProps } from '../../../../provider-utils/awscloudformation/utils/synthesize-resources';
+
+jest.mock('../../../../provider-utils/awscloudformation/utils/synthesize-resources');
+jest.mock('../../../../provider-utils/awscloudformation/utils/auth-defaults-appliers');
+jest.mock('../../../../provider-utils/supported-services');
+jest.mock('../../../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state');
+jest.mock('../../../../provider-utils/awscloudformation/utils/generate-auth-stack-template');
+jest.mock('../../../../provider-utils/awscloudformation/utils/message-printer');
+// eslint-disable-next-line spellcheck/spell-checker
+jest.mock('../../../../provider-utils/awscloudformation/utils/amplify-meta-updaters');
+jest.mock('../../../../provider-utils/awscloudformation/utils/auth-sms-workflow-helper');
+jest.mock('amplify-cli-core');
+
+const getSupportedServicesMock = getSupportedServices as jest.MockedFunction<typeof getSupportedServices>;
+getSupportedServicesMock.mockReturnValue({
+  test: {
+    defaultValuesFilename: 'test',
+  },
+});
+
+const testConfig = {
+  hostedUIProviderCreds: 'testProviderCreds',
+};
+
+const getUpdateAuthDefaultsApplierMock = getUpdateAuthDefaultsApplier as jest.MockedFunction<typeof getUpdateAuthDefaultsApplier>;
+getUpdateAuthDefaultsApplierMock.mockReturnValue(jest.fn().mockReturnValue({ ...testConfig }));
+
+const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+stateManagerMock.getMeta.mockReturnValue({
+  auth: {},
+});
+
+const getPostUpdateAuthMetaUpdaterMock = getPostUpdateAuthMetaUpdater as jest.MockedFunction<typeof getPostUpdateAuthMetaUpdater>;
+getPostUpdateAuthMetaUpdaterMock.mockReturnValue(jest.fn());
+
+const getPostUpdateAuthMessagePrinterMock = getPostUpdateAuthMessagePrinter as jest.MockedFunction<typeof getPostUpdateAuthMessagePrinter>;
+getPostUpdateAuthMessagePrinterMock.mockReturnValue(jest.fn());
+
+const removeDeprecatedPropsMock = removeDeprecatedProps as jest.MockedFunction<typeof removeDeprecatedProps>;
+removeDeprecatedPropsMock.mockImplementation(input => input);
+
+const AuthInputStateMock = AuthInputState as jest.MockedClass<typeof AuthInputState>;
+AuthInputStateMock.mockImplementation(() => ({
+  saveCLIInputPayload: jest.fn(),
+} as unknown as AuthInputState));
+
+describe('getUpdateAuthHandler', () => {
+  it('filters cliInputs on env specific params', async () => {
+    const saveParamsFn = jest.fn();
+    const contextStub = {
+      amplify: {
+        saveEnvResourceParameters: saveParamsFn,
+      },
+    } as unknown as $TSContext;
+    const cognitoConfig: CognitoConfiguration = {
+      serviceName: 'test',
+    } as unknown as CognitoConfiguration;
+
+    await getUpdateAuthHandler(contextStub)(cognitoConfig);
+    expect(saveParamsFn.mock.calls[0][3]).toEqual(testConfig);
+  });
+});

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
@@ -135,7 +135,7 @@ export const getUpdateAuthHandler = (context: $TSContext) => async (request: Ser
   const envSpecificParams: $TSAny = {};
   const cliInputs = { ...sharedParams };
   ENV_SPECIFIC_PARAMS.forEach(paramName => {
-    if (paramName in request) {
+    if (paramName in { ...cliInputs, ...request }) {
       envSpecificParams[paramName] = cliInputs[paramName];
       delete cliInputs[paramName];
     }

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/handlers/resource-handlers.ts
@@ -135,7 +135,7 @@ export const getUpdateAuthHandler = (context: $TSContext) => async (request: Ser
   const envSpecificParams: $TSAny = {};
   const cliInputs = { ...sharedParams };
   ENV_SPECIFIC_PARAMS.forEach(paramName => {
-    if (paramName in { ...cliInputs, ...request }) {
+    if (paramName in cliInputs) {
       envSpecificParams[paramName] = cliInputs[paramName];
       delete cliInputs[paramName];
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
auth config parameters are split into environment-specific parameters and environment-agnostic parameters. This splitting happens based on a known set of keys in the config object. However, we were filtering on a "request" object instead of the cliInputs object, causing some keys to slip through the filter

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested and added a unit test.  E2E is running here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/13359/workflows/c1c5fe14-f1dc-469e-9809-52775cf7b461
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
