### PR TITLE
fix: enforce cli-internal and cli-npm package are always on the same …

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -186,11 +186,16 @@ jobs:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run:
           name: verify versions match
           command: |
             source .circleci/local_publish_helpers.sh
-            verifyVersionsMatch
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            setNpmRegistryUrlToLocal
+            changeNpmGlobalPath
+            checkPackageVersionsInLocalNpmRegistry
 
   mock_e2e_tests:
     <<: *linux-e2e-executor-large

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -179,6 +179,19 @@ jobs:
           command: |
             yarn verify-api-extract
 
+  verify-versions-match:
+    <<: *linux-e2e-executor-medium
+    steps:
+      - restore_cache:
+          key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_cache:
+          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: verify versions match
+          command: |
+            source .circleci/local_publish_helpers.sh
+            verifyVersionsMatch
+
   mock_e2e_tests:
     <<: *linux-e2e-executor-large
     steps:
@@ -874,6 +887,16 @@ workflows:
                 - /release_rc\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
       - verify-api-extract:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - beta
+                - release
+                - /release_rc\/.*/
+                - /tagged-release-without-e2e-tests\/.*/
+      - verify-versions-match:
           requires:
             - build
           filters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -898,14 +898,7 @@ workflows:
                 - /tagged-release-without-e2e-tests\/.*/
       - verify-versions-match:
           requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - beta
-                - release
-                - /release_rc\/.*/
-                - /tagged-release-without-e2e-tests\/.*/
+            - publish_to_local_registry
       - test:
           requires:
             - build

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -280,17 +280,16 @@ function runE2eTest {
     fi
 }
 
-function verifyVersionsMatch {
-  internal_cli_package_json_path="./packages/amplify-cli/package.json"
-  npm_cli_package_json_path="./packages/amplify-cli-npm/package.json"
+function checkPackageVersionsInLocalNpmRegistry {
+    cli_internal_version=$(npm view @aws-amplify/cli-internal version)
+    cli_version=$(npm view @aws-amplify/cli version)
 
-  internal_cli_version=$(jq '.version' $internal_cli_package_json_path)
-  npm_cli_version=$(jq '.version' $npm_cli_package_json_path)
-
-  if [[ $internal_cli_version != $npm_cli_version ]]; then
-    echo "Versions did not match."
-    echo "amplify-cli version: $internal_cli_version"
-    echo "amplify-cli-npm version: $npm_cli_version"
-    exit 1
-  fi
+    if [[ $cli_internal_version != $cli_version ]]; then
+        echo "Versions did not match."
+        echo "@aws-amplify/cli-internal version: $cli_internal_version"
+        echo "@aws-amplify/cli version: $cli_version"
+        exit 1
+    else
+        echo "Versions matched ($cli_internal_version)"
+    fi
 }

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -289,6 +289,7 @@ function checkPackageVersionsInLocalNpmRegistry {
 
     if [[ $cli_internal_version != $cli_version ]]; then
         echo "Versions did not match."
+        echo "Manual fix: add a commit with a 'feat' prefix that touches the cli-npm package to bump its version."
         exit 1
     else
         echo "Versions matched."

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -279,3 +279,18 @@ function runE2eTest {
         yarn run e2e --force-exit --detectOpenHandles --maxWorkers=3 $TEST_SUITE
     fi
 }
+
+function verifyVersionsMatch {
+  internal_cli_package_json_path="./packages/amplify-cli/package.json"
+  npm_cli_package_json_path="./packages/amplify-cli-npm/package.json"
+
+  internal_cli_version=$(jq '.version' $internal_cli_package_json_path)
+  npm_cli_version=$(jq '.version' $npm_cli_package_json_path)
+
+  if [[ $internal_cli_version != $npm_cli_version ]]; then
+    echo "Versions did not match."
+    echo "amplify-cli version: $internal_cli_version"
+    echo "amplify-cli-npm version: $npm_cli_version"
+    exit 1
+  fi
+}

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -284,12 +284,13 @@ function checkPackageVersionsInLocalNpmRegistry {
     cli_internal_version=$(npm view @aws-amplify/cli-internal version)
     cli_version=$(npm view @aws-amplify/cli version)
 
+    echo "@aws-amplify/cli-internal version: $cli_internal_version"
+    echo "@aws-amplify/cli version: $cli_version"
+
     if [[ $cli_internal_version != $cli_version ]]; then
         echo "Versions did not match."
-        echo "@aws-amplify/cli-internal version: $cli_internal_version"
-        echo "@aws-amplify/cli version: $cli_version"
         exit 1
     else
-        echo "Versions matched ($cli_internal_version)"
+        echo "Versions matched."
     fi
 }

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -289,7 +289,7 @@ function checkPackageVersionsInLocalNpmRegistry {
 
     if [[ $cli_internal_version != $cli_version ]]; then
         echo "Versions did not match."
-        echo "Manual fix: add a commit with a 'feat' prefix that touches the cli-npm package to bump its version."
+        echo "Manual fix: add a proper conventional commit that touches the amplify-cli-npm package to correct its version bump. For example https://github.com/aws-amplify/amplify-cli/commit/6f14792d1db424aa428ec4836fed7d6dd5cccfd0"
         exit 1
     else
         echo "Versions matched."

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -85,6 +85,19 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
   # create release commit and release tags
   npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" $(echo $force_publish_local_args) --no-commit-hooks
 
+  internal_cli_package_json_path="../packages/amplify-cli/package.json"
+  npm_cli_package_json_path="../packages/amplify-cli-npm/package.json"
+
+  internal_cli_version=$(jq '.version' $internal_cli_package_json_path)
+  npm_cli_version=$(jq '.version' $npm_cli_package_json_path)
+
+  if [[ $internal_cli_version != $npm_cli_version ]]; then
+    echo "Versions did not match."
+    echo "amplify-cli version: $internal_cli_version"
+    echo "amplify-cli-npm version: $npm_cli_version"
+    exit 1
+  fi
+
   # if publishing locally to verdaccio
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     # publish to verdaccio with no dist tag (default to latest)

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -85,19 +85,6 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
   # create release commit and release tags
   npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" $(echo $force_publish_local_args) --no-commit-hooks
 
-  internal_cli_package_json_path="../packages/amplify-cli/package.json"
-  npm_cli_package_json_path="../packages/amplify-cli-npm/package.json"
-
-  internal_cli_version=$(jq '.version' $internal_cli_package_json_path)
-  npm_cli_version=$(jq '.version' $npm_cli_package_json_path)
-
-  if [[ $internal_cli_version != $npm_cli_version ]]; then
-    echo "Versions did not match."
-    echo "amplify-cli version: $internal_cli_version"
-    echo "amplify-cli-npm version: $npm_cli_version"
-    exit 1
-  fi
-
   # if publishing locally to verdaccio
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     # publish to verdaccio with no dist tag (default to latest)


### PR DESCRIPTION
…version

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
I added logic to the publish.sh script that checks the versions of the cli-internal and cli-npm packages in their respective package.json files. If these versions do not match, then the script fails before anything is published to verdaccio.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
I ran the added block of code on from the .circleci directory with matching versions and non-matching versions in the package.json files and ensured that it worked as intended.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
