### PR TITLE
fix: update s3 bucket policies to enable secure transport for storage category

### DIFF
--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
@@ -219,6 +219,85 @@ Object {
     },
   },
   "Resources": Object {
+    "DeploymentBucketBlockHTTP": Object {
+      "DependsOn": Array [
+        "S3Bucket",
+      ],
+      "Properties": Object {
+        "Bucket": Object {
+          "Fn::If": Array [
+            "ShouldNotCreateEnvResources",
+            Object {
+              "Ref": "bucketName",
+            },
+            Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Ref": "bucketName",
+                  },
+                  Object {
+                    "Fn::Select": Array [
+                      3,
+                      Object {
+                        "Fn::Split": Array [
+                          "-",
+                          Object {
+                            "Ref": "AWS::StackName",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "-",
+                  Object {
+                    "Ref": "env",
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "S3Bucket",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "S3Bucket",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "S3AuthPrivatePolicy": Object {
       "Condition": "CreateAuthPrivate",
       "DependsOn": Array [

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/__snapshots__/s3-stack-builder.test.ts.snap
@@ -220,9 +220,6 @@ Object {
   },
   "Resources": Object {
     "DeploymentBucketBlockHTTP": Object {
-      "DependsOn": Array [
-        "S3Bucket",
-      ],
       "Properties": Object {
         "Bucket": Object {
           "Fn::If": Array [
@@ -269,6 +266,7 @@ Object {
                 },
               },
               "Effect": "Deny",
+              "Principal": "*",
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.ts
@@ -177,11 +177,11 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
       bucketName: this.s3BucketName,
       corsConfiguration: this.buildCORSRules(),
     });
-    const cfnBucketPolicy = new s3Cdk.CfnBucketPolicy(this, 'DeploymentBucketBlockHTTP', {
+    // eslint-disable-next-line no-new
+    new s3Cdk.CfnBucketPolicy(this, 'DeploymentBucketBlockHTTP', {
       bucket: this.s3BucketName,
       policyDocument: this.addSecureTransportPolicyDocument(),
     });
-    cfnBucketPolicy.addDependsOn(this.s3Bucket);
 
     this.s3Bucket.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
     // 2. Configure Notifications on the S3 bucket.
@@ -260,6 +260,7 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
     const policyStatementList: Array<iamCdk.PolicyStatement> = [];
     policyStatementList.push(
       new iamCdk.PolicyStatement({
+        principals: [new iamCdk.StarPrincipal()],
         resources: [this.s3Bucket.attrArn, `${this.s3Bucket.attrArn}/*`],
         actions: [`s3:*`],
         effect: iamCdk.Effect.DENY,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Attaches a bucket policy that blocks all unencrypted traffic to the storage category generated S3 buckets. This is to adhere to best practices for private buckets.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
updated unit tests and snapshot

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/akz/blocks_unencrypted_traffic

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
