### PR TITLE
chore: fix unit tests parallelization

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -151,7 +151,7 @@ jobs:
                   - .cache
                   - .ssh
   test:
-    <<: *linux-e2e-executor-large
+    <<: *linux-e2e-executor-xlarge
     steps:
       - restore_cache:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}

--- a/nx.json
+++ b/nx.json
@@ -21,11 +21,17 @@
     "default": [
       "{projectRoot}/**/*",
       "!{projectRoot}/**/*.md"
+    ],
+    "production": [
+      "default",
+      "!{projectRoot}/coverage/**",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.tsbuildinfo"
     ]
   },
   "targetDefaults": {
     "build": {
-      "inputs": [ "default", "^default" ],
+      "inputs": [ "default", "^production" ],
       "dependsOn": [ "^build" ]
     },
     "prepare": {
@@ -37,7 +43,7 @@
       "dependsOn": [ "^package" ]
     },
     "test": {
-      "inputs": [ "default", "^default" ],
+      "inputs": [ "default", "^production" ],
       "dependsOn": [ "build" ]
     },
     "extract-api": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "addwords": "node ./scripts/add-to-dict.js",
     "test-changed": "nx affected --target=test",
     "test": "nx run-many --target=test --all",
-    "test-ci": "nx run-many --target=test --all -- --ci",
+    "test-ci": "nx run-many --target=test --all -- --ci -i",
     "e2e": "nx run e2e",
     "cloud-e2e": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=$UPSTREAM_BRANCH\"",
     "cloud-e2e-with-rc": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e-with-rc/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=$UPSTREAM_BRANCH\"",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "addwords": "node ./scripts/add-to-dict.js",
     "test-changed": "nx affected --target=test",
     "test": "nx run-many --target=test --all",
-    "test-ci": "nx run-many --target=test --all --parallel=1 -- --ci -i",
+    "test-ci": "nx run-many --target=test --all -- --ci",
     "e2e": "nx run e2e",
     "cloud-e2e": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=$UPSTREAM_BRANCH\"",
     "cloud-e2e-with-rc": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e-with-rc/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=$UPSTREAM_BRANCH\"",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR fixes how sources sets are used to determine changes for build and test steps.
Testing in parallel was causing pretty long and non deterministic spin-locks between packages in dependency graph.
I.e. package that was testing itself was writing files that re-triggered build in parallel execution.

Based on https://github.com/nrwl/nx-examples/blob/master/nx.json
and https://nx.dev/more-concepts/customizing-inputs

Before:
![image](https://user-images.githubusercontent.com/5849952/206603748-707a9b2e-4b8e-490a-9898-08f2b654b953.png)

After:
![image](https://user-images.githubusercontent.com/5849952/206603772-f0a9940d-0d6c-48ae-b848-1858ccdf330f.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
