### PR TITLE
chore: delegate cleanup script

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1245,7 +1245,7 @@ commands:
     steps:
       - run:
           name: Scan E2E artifacts
-          no_output_timeout: 90m
+          no_output_timeout: 2m
           command: |
             if ! yarn ts-node .circleci/scan_artifacts.ts; then
               echo "Cleaning the repository"

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -9,9 +9,6 @@ parameters:
   nightly_console_integration_tests:
     type: boolean
     default: false
-  e2e_resource_cleanup:
-    type: boolean
-    default: false
   setup:
     type: boolean
     default: true
@@ -70,14 +67,6 @@ defaults: &defaults
       type: executor
       default: l_medium
   executor: << parameters.os >>
-
-clean_e2e_resources: &clean_e2e_resources
-  name: Cleanup resources
-  command: |
-    pwd
-    cd packages/amplify-e2e-tests
-    yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
-  working_directory: ~/repo
 
 scan_e2e_test_artifacts: &scan_e2e_test_artifacts
   name: Scan And Cleanup E2E Test Artifacts
@@ -461,8 +450,6 @@ jobs:
           path: ~/repo/packages/amplify-e2e-tests/
       - store_artifacts:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
-      # - clean_e2e_resources:
-      #     os: << parameters.os >>
 
   amplify_migration_tests_v5:
     parameters:
@@ -819,23 +806,18 @@ jobs:
           path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
     working_directory: ~/repo
 
-  cleanup_resources_after_e2e_runs:
-    <<: *linux-e2e-executor-large
+  trigger_e2e_workflow_cleanup:
+    <<: *linux-e2e-executor-medium
     steps:
-      - restore_cache:
-          key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
-          name: 'Run cleanup script'
+          name: 'Trigger Cleanup for this Workflow'
           command: |
-            cd packages/amplify-e2e-tests
-            yarn clean-e2e-resources workflow ${CIRCLE_WORKFLOW_ID}
-          no_output_timeout: 90m
-      - run: *scan_e2e_test_artifacts
-      - store_artifacts:
-          path: ~/repo/packages/amplify-e2e-tests/amplify-e2e-reports
-    working_directory: ~/repo
+            echo "Triggering cleanup for Workflow $CIRCLE_WORKFLOW_ID"
+            curl --request POST \
+              --url https://circleci.com/api/v2/project/github/aws-amplify/amplify-cli/pipeline \
+              --header 'Circle-Token: $CIRCLECI_TOKEN' \
+              --header 'content-type: application/json' \
+              --data '{"branch":"'${CIRCLE_BRANCH}'","parameters":{"e2e_workflow_cleanup":true, "e2e_workflow_cleanup_workflow_id":$CIRCLE_WORKFLOW_ID}}'
 
   wait_for_all:
     <<: *linux-e2e-executor-medium
@@ -1110,12 +1092,10 @@ workflows:
                 - /tagged-release\/.*/
                 - /run-e2e\/.*/
 
-      - cleanup_resources_after_e2e_runs:
+      - trigger_e2e_workflow_cleanup:
           context:
             - cleanup-resources
             - e2e-test-context
-          requires:
-            - wait_for_all
           filters:
             branches:
               only:
@@ -1270,18 +1250,4 @@ commands:
               git clean -fdx
               exit 1
             fi
-          when: always
-  clean_e2e_resources:
-    description: Cleanup resources
-    parameters:
-      os:
-        type: executor
-        default: l_large
-    steps:
-      - run:
-          name: Clean job resources
-          command: |
-            pwd
-            cd packages/amplify-e2e-tests
-            yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
           when: always

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -815,9 +815,9 @@ jobs:
             echo "Triggering cleanup for Workflow $CIRCLE_WORKFLOW_ID"
             curl --request POST \
               --url https://circleci.com/api/v2/project/gh/aws-amplify/amplify-cli/pipeline \
-              --header 'Circle-Token: $AMPLIFY_CLI_CIRCLECI_TRIGGER_TOKEN' \
-              --header 'content-type: application/json' \
-              --data '{"branch":"'$CIRCLE_BRANCH'","parameters":{"e2e_workflow_cleanup":true, "e2e_workflow_cleanup_workflow_id":"'$CIRCLE_WORKFLOW_ID'"}}'
+              --header "Circle-Token: $AMPLIFY_CLI_CIRCLECI_TRIGGER_TOKEN" \
+              --header "content-type: application/json" \
+              --data '{"branch":"'$CIRCLE_BRANCH'","parameters":{"e2e_workflow_cleanup":true,"setup":false,"e2e_workflow_cleanup_workflow_id":"'$CIRCLE_WORKFLOW_ID'"}}'
 
   wait_for_all:
     <<: *linux-e2e-executor-medium

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -814,10 +814,10 @@ jobs:
           command: |
             echo "Triggering cleanup for Workflow $CIRCLE_WORKFLOW_ID"
             curl --request POST \
-              --url https://circleci.com/api/v2/project/github/aws-amplify/amplify-cli/pipeline \
-              --header 'Circle-Token: $CIRCLECI_TOKEN' \
+              --url https://circleci.com/api/v2/project/gh/aws-amplify/amplify-cli/pipeline \
+              --header 'Circle-Token: $AMPLIFY_CLI_CIRCLECI_TRIGGER_TOKEN' \
               --header 'content-type: application/json' \
-              --data '{"branch":"'${CIRCLE_BRANCH}'","parameters":{"e2e_workflow_cleanup":true, "e2e_workflow_cleanup_workflow_id":$CIRCLE_WORKFLOW_ID}}'
+              --data '{"branch":"'$CIRCLE_BRANCH'","parameters":{"e2e_workflow_cleanup":true, "e2e_workflow_cleanup_workflow_id":"'$CIRCLE_WORKFLOW_ID'"}}'
 
   wait_for_all:
     <<: *linux-e2e-executor-medium

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1096,6 +1096,8 @@ workflows:
           context:
             - cleanup-resources
             - e2e-test-context
+          requires:
+            - wait_for_all
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,12 @@ parameters:
   e2e_resource_cleanup:
     type: boolean
     default: false
+  e2e_workflow_cleanup:
+    type: boolean
+    default: false
+  e2e_workflow_cleanup_workflow_id:
+    type: integer
+    default: 0
   setup:
     type: boolean
     default: true
@@ -181,12 +187,25 @@ jobs:
       - restore_cache:
           key: >-
             amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - run:
-          name: Run cleanup script
-          command: |
-            cd packages/amplify-e2e-tests
-            yarn clean-e2e-resources
-          no_output_timeout: 90m
+      - when: 
+          condition: << pipeline.parameters.e2e_workflow_cleanup >>
+          steps:
+            - run:
+                name: Run cleanup script for specific workflow
+                command: |
+                  echo "Cleaning up for Workflow << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>"
+                  cd packages/amplify-e2e-tests
+                  yarn clean-e2e-resources job << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>
+              no_output_timeout: 90m
+      - when: 
+          condition: << pipeline.parameters.e2e_resource_cleanup >>
+          steps:
+            - run:
+                name: Run cleanup script
+                command: |
+                  cd packages/amplify-e2e-tests
+                  yarn clean-e2e-resources
+              no_output_timeout: 90m
       - run:
           name: Scan And Cleanup E2E Test Artifacts
           command: |
@@ -221,7 +240,10 @@ workflows:
             - build
             - publish_to_local_registry
   e2e_resource_cleanup:
-    when: << pipeline.parameters.e2e_resource_cleanup >>
+    when: 
+      or:
+        - equal: [true, << pipeline.parameters.e2e_resource_cleanup >>]
+        - equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
     jobs:
       - build
       - cleanup_resources:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
                 command: |
                   echo "Cleaning up for Workflow << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>"
                   cd packages/amplify-e2e-tests
-                  yarn clean-e2e-resources job << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>
+                  yarn clean-e2e-resources workflow << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>
                 no_output_timeout: 90m
       - when: 
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ parameters:
     type: boolean
     default: false
   e2e_workflow_cleanup_workflow_id:
-    type: integer
-    default: 0
+    type: string
   setup:
     type: boolean
     default: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,8 @@ jobs:
           key: >-
             amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - when: 
-          condition: << pipeline.parameters.e2e_workflow_cleanup >>
+          condition:
+            equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
           steps:
             - run:
                 name: Run cleanup script for specific workflow
@@ -196,16 +197,17 @@ jobs:
                   echo "Cleaning up for Workflow << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>"
                   cd packages/amplify-e2e-tests
                   yarn clean-e2e-resources job << pipeline.parameters.e2e_workflow_cleanup_workflow_id >>
-              no_output_timeout: 90m
+                no_output_timeout: 90m
       - when: 
-          condition: << pipeline.parameters.e2e_resource_cleanup >>
+          condition:
+            equal: [true, << pipeline.parameters.e2e_resource_cleanup >>]
           steps:
             - run:
                 name: Run cleanup script
                 command: |
                   cd packages/amplify-e2e-tests
                   yarn clean-e2e-resources
-              no_output_timeout: 90m
+                no_output_timeout: 90m
       - run:
           name: Scan And Cleanup E2E Test Artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ parameters:
     default: false
   e2e_workflow_cleanup_workflow_id:
     type: string
+    default: ''
   setup:
     type: boolean
     default: true

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -198,7 +198,7 @@ function useChildAccountCredentials {
 }
 
 function retry {
-    MAX_ATTEMPTS=2
+    MAX_ATTEMPTS=1
     SLEEP_DURATION=5
     FIRST_RUN=true
     n=0

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -198,7 +198,7 @@ function useChildAccountCredentials {
 }
 
 function retry {
-    MAX_ATTEMPTS=1
+    MAX_ATTEMPTS=2
     SLEEP_DURATION=5
     FIRST_RUN=true
     n=0

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -263,13 +263,18 @@ function splitTests(
           } else {
             // for the most up-to-date list of executors for e2e, see the config.base.yml file
             let linuxVMSize = JOBS_RUNNING_ON_LINUX_LARGE_VM.includes(newJobName) ? 'l_large' : 'l_medium';
+            let requiredJobs = workflowJob[jobName].requires || [];
+            const allowWindows = WINDOWS_TEST_ALLOWLIST.includes(newJobName);
+            if(!allowWindows) {
+              requiredJobs = requiredJobs.filter(j => j !== 'build_windows_workspace_for_e2e');
+            }
             return {
               [newJobName]: {
                 ...Object.values(workflowJob)[0],
-                requires: workflowJob[jobName].requires || [],
+                requires: requiredJobs,
                 matrix: {
                   parameters: {
-                    os: WINDOWS_TEST_ALLOWLIST.includes(newJobName) ? [linuxVMSize, 'w_medium'] : [linuxVMSize],
+                    os: allowWindows ? [linuxVMSize, 'w_medium'] : [linuxVMSize],
                   },
                 },
               },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, our e2e-cleanup script that runs after each e2e workflow takes about 10-20 minutes to run, but we can't trigger a new job or re-run without cancelling the entire workflow.
Cancelling the workflow prevents the cleanup script from running to completion, and we don't want to do that.

As shown below, 95% of cleanup jobs run 36 minutes or less (P95 metric), this will bring the P95 down to ~40 seconds.
![image](https://user-images.githubusercontent.com/110861985/206769336-7641afa4-70ef-4a53-a159-e559aec1230d.png)


This change **delegates the cleanup step to a separate job, that can run independent of the E2E run**, so that we can allocate time to our cleanup script without preventing re-runs of E2E.
This will also allow us to expand on our cleanup script without compromising due to how long it takes to run the cleanup.

Additionally, **tests that don't run on windows no longer depend on the windows job**. This allows linux tests to start whenever the binaries are ready without having to wait for the windows build to finish. This should help reduce hotspots/throttling during the start of testing.

Here is the update workflow:
![image](https://user-images.githubusercontent.com/110861985/206766690-e437e7a5-4f91-4d43-8351-ddcb5723f3a2.png)

That triggers the e2e_resource_cleanup job:
![image](https://user-images.githubusercontent.com/110861985/206766836-5e56afd8-d259-4ae5-a00d-7e1732afd222.png)

Here is an example of being able to re-run while the e2e cleanup is still running for the last workflow:
![image](https://user-images.githubusercontent.com/110861985/206780392-66652f25-ed60-4979-b0ae-fca2362bf7ce.png)


Additional details on how this works:
1. The trigger is an API call to CircleCI that triggers the pipeline with some parameters.
2. The pipeline reads those parameters, including the workflow ID, and can delete resources specific to that workflow.
3. The Token used for triggering the pipeline has been added to the cleanup e2e context, this can be any personal CCI token; it will not work with the current 'project' token.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
