### PR TITLE
fix: make upload_pkg_binaries depend on verify-versions-match in circ…

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -994,6 +994,7 @@ workflows:
             - build_pkg_binaries_macos
             - build_pkg_binaries_win
             - build_pkg_binaries_arm
+            - verify-versions-match
       - build_pkg_binaries_linux:
           requires:
             - publish_to_local_registry


### PR DESCRIPTION
…leci

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change makes the upload_pkg_binaries step in CircleCI depend on the verify-versions-match step. This prevents tests from running if the versions do not match.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
