### PR TITLE
chore: Handle rejected promises that weren't caught or awaited anywhere in the code

### DIFF
--- a/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
+++ b/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
@@ -2,7 +2,7 @@ import { AmplifyError } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts'; // eslint-disable-line import/no-extraneous-dependencies
 import { reportError } from '../commands/diagnose';
 import { Context } from '../domain/context';
-import { init, handleException } from '../amplify-exception-handler';
+import { init, handleException, handleUnhandledRejection } from '../amplify-exception-handler';
 
 const printerMock = printer as any;
 
@@ -109,5 +109,39 @@ describe('test exception handler', () => {
     expect(printerMock.info).toHaveBeenCalledWith(amplifyError.details);
     expect(printerMock.debug).toHaveBeenCalledWith(amplifyError.stack);
     expect(printerMock.error).toHaveBeenCalledWith('Failed to report error: MockTestError');
+  });
+});
+
+describe('test unhandled rejection handler', () => {
+  it('should return error with message when unhandled promise rejected with string', async () => {
+    const testString = 'test';
+    const testError = new Error(testString);
+    expect(() => {
+      handleUnhandledRejection(testString);
+    }).toThrowError(testError);
+  });
+
+  it('should return error with message when unhandled promise rejected with an object', async () => {
+    const testObject = { error: 'test' };
+    const testError = new Error(JSON.stringify(testObject));
+    expect(() => {
+      handleUnhandledRejection(testObject);
+    }).toThrowError(testError);
+  });
+
+  it('should return error with message when unhandled promise rejected with an error', async () => {
+    const testString = 'test';
+    const testError = new Error(testString);
+    expect(() => {
+      handleUnhandledRejection(testError);
+    }).toThrowError(testError);
+  });
+
+  it('should return error with unknown message when unhandled promise rejected with null', async () => {
+    const testString = 'Unhandled promise rejection';
+    const testError = new Error(testString);
+    expect(() => {
+      handleUnhandledRejection(null);
+    }).toThrowError(testError);
   });
 });

--- a/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
+++ b/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
@@ -137,6 +137,14 @@ describe('test unhandled rejection handler', () => {
     }).toThrowError(testError);
   });
 
+  it('should return error with message when unhandled promise rejected with a number', async () => {
+    const testNumber = 1;
+    const testError = new Error(testNumber.toString());
+    expect(() => {
+      handleUnhandledRejection(testNumber);
+    }).toThrowError(testError);
+  });
+
   it('should return error with unknown message when unhandled promise rejected with null', async () => {
     const testString = 'Unhandled promise rejection';
     const testError = new Error(testString);

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -79,6 +79,21 @@ export const handleException = async (exception: unknown): Promise<void> => {
   process.exit(1);
 };
 
+/**
+ * Handle rejected promises that weren't caught or awaited anywhere in the code.
+ */
+export const handleUnhandledRejection = (reason: Error | $TSAny): void => {
+  if (reason instanceof Error) {
+    throw reason;
+  } else if (reason !== null && typeof reason === 'string') {
+    throw new Error(reason);
+  } else if (reason !== null && typeof reason === 'object') {
+    throw new Error(JSON.stringify(reason));
+  } else {
+    throw new Error('Unhandled promise rejection');
+  }
+};
+
 const getDeepestAmplifyException = (amplifyException: AmplifyException): AmplifyException => {
   let deepestAmplifyException = amplifyException;
   while (deepestAmplifyException.downstreamException && deepestAmplifyException.downstreamException instanceof AmplifyException) {

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -87,7 +87,7 @@ export const handleUnhandledRejection = (reason: Error | $TSAny): void => {
     throw reason;
   } else if (reason !== null && typeof reason === 'string') {
     throw new Error(reason);
-  } else if (reason !== null && typeof reason === 'object') {
+  } else if (reason !== null) {
     throw new Error(JSON.stringify(reason));
   } else {
     throw new Error('Unhandled promise rejection');


### PR DESCRIPTION
#### Description of changes

As per https://nodejs.org/api/process.html#event-unhandledrejection the event `unhandledRejection` is emitted whenever a Promise is rejected and no error handler is attached to the promise. However the promise can be rejected with just a simple message as well like `Promise.reject("message")` instead of an Error object like `Promise.reject(new Error("message")`.

This PR fixes that such that rejection with any message will yield the right message in `AmplifyError` instead of `UnknownFault`

#### Issue #, if available N/A

#### Description of how you validated changes

Unit tests for the new method.

However testing the unhandledRejection event handler is blocked on https://github.com/facebook/jest/issues/5620
#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
