### PR TITLE
fix: back off on cfn event pull

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1306,7 +1306,7 @@ commands:
                   source $BASH_ENV
                   amplify version
                   retry runE2eTest
-                no_output_timeout: 60m
+                no_output_timeout: 90m
   scan_e2e_test_artifacts:
     description: 'Scan And Cleanup E2E Test Artifacts'
     parameters:

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/searchable-migration.test.ts
@@ -13,6 +13,8 @@ import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
 
 (global as any).fetch = require('node-fetch');
 
+jest.setTimeout(120 * 60 * 1000); // Set timeout to 2 hour because of creating/deleting searchable instance
+
 describe('transformer model searchable migration test', () => {
   let projRoot: string;
   let projectName: string;

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -157,7 +157,7 @@ class CloudFormation {
     const self = this;
     let delay = CFN_POLL_TIME;
     let readStackEventsCalls = 0;
-    let invoker = function() {
+    const invoker = () => {
       self.addToPollQueue(stackName, 3);
       if (delay < CFN_POLL_TIME_MAX) {
         delay = Math.min(Math.pow(2, readStackEventsCalls) * CFN_POLL_TIME, CFN_POLL_TIME_MAX);

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -22,6 +22,7 @@ const { printer } = require('amplify-prompts');
 
 const CFN_MAX_CONCURRENT_REQUEST = 5;
 const CFN_POLL_TIME = 5 * 1000; // 5 secs wait to check if  new stacks are created by root stack
+const CFN_POLL_TIME_MAX = 30 * 1000; // 30 seconds
 let CFNLOG = [];
 const CFN_SUCCESS_STATUS = ['UPDATE_COMPLETE', 'CREATE_COMPLETE', 'DELETE_COMPLETE', 'DELETE_SKIPPED'];
 
@@ -85,7 +86,7 @@ class CloudFormation {
         }
         cfnModel.waitFor(cfnCompleteStatus, cfnStackCheckParams, async (completeErr, waitForStackdata) => {
           if (self.pollForEvents) {
-            clearInterval(self.pollForEvents);
+            clearTimeout(self.pollForEvents);
           }
 
           this.progressBar?.stop();
@@ -124,7 +125,7 @@ class CloudFormation {
           Promise.reject(e);
         } finally {
           if (this.pollForEvents) {
-            clearInterval(this.pollForEvents);
+            clearTimeout(this.pollForEvents);
           }
         }
       });
@@ -153,7 +154,20 @@ class CloudFormation {
   }
 
   readStackEvents(stackName) {
-    this.pollForEvents = setInterval(() => this.addToPollQueue(stackName, 3), CFN_POLL_TIME);
+    const self = this;
+    let delay = CFN_POLL_TIME;
+    let readStackEventsCalls = 0;
+    let invoker = function() {
+      self.addToPollQueue(stackName, 3);
+      if (delay < CFN_POLL_TIME_MAX) {
+        delay = Math.min(Math.pow(2, readStackEventsCalls) * CFN_POLL_TIME, CFN_POLL_TIME_MAX);
+      }
+      self.pollForEvents = setTimeout(invoker, delay);
+      readStackEventsCalls++;
+    }
+
+    // start it off
+    self.pollForEvents = setTimeout(invoker, delay);
   }
 
   pollStack(stackName) {
@@ -357,13 +371,13 @@ class CloudFormation {
                   const cfnCompleteStatus = 'stackUpdateComplete';
                   if (updateErr) {
                     if (self.pollForEvents) {
-                      clearInterval(self.pollForEvents);
+                      clearTimeout(self.pollForEvents);
                     }
                     return reject(updateErr);
                   }
                   cfnModel.waitFor(cfnCompleteStatus, cfnStackCheckParams, completeErr => {
                     if (self.pollForEvents) {
-                      clearInterval(self.pollForEvents);
+                      clearTimeout(self.pollForEvents);
                     }
                     this.progressBar?.stop();
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Implement exponential backoff at polling cfn events (inspired by https://github.com/aws-amplify/amplify-cli/pull/10959 and https://stackoverflow.com/questions/14969657/setinterval-with-exponential-time-decrease )
- Increase test timeout to accommodate for searchable-migration test duration.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I injected `console.log('Delay ' + delay + ' Attempt ' + readStackEventsCalls);` into `readStackEvents` and ran one of the e2e tests. Below is outcome.
<img width="433" alt="image" src="https://user-images.githubusercontent.com/5849952/208283146-10e754a4-1cc2-4e3e-959d-f1109d4d0c14.png">

E2E test run.

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/13698/workflows/634b1e55-3c58-49fe-b88e-db161cafb298

<img width="847" alt="image" src="https://user-images.githubusercontent.com/5849952/208343349-a267ee59-277e-47ef-9916-f97b408d61fd.png">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
