### PR TITLE
fix(mock): topo sort for resource in mock

### DIFF
--- a/packages/amplify-util-mock/src/CFNParser/stack/index.ts
+++ b/packages/amplify-util-mock/src/CFNParser/stack/index.ts
@@ -11,7 +11,7 @@ import {
   CloudFormationResource,
   CloudFormationResources,
   CloudFormationTemplate,
-  CloudFormationTemplateFetcher
+  CloudFormationTemplateFetcher,
 } from './types';
 
 export const CFN_PSEUDO_PARAMS = {
@@ -19,14 +19,14 @@ export const CFN_PSEUDO_PARAMS = {
   'AWS::AccountId': '12345678910',
   'AWS::StackId': 'fake-stackId',
   'AWS::StackName': 'local-testing',
-  'AWS::URLSuffix': 'amazonaws.com'
+  'AWS::URLSuffix': 'amazonaws.com',
 };
 
 export function nestedStackHandler(
   resourceName: string,
   resource: CloudFormationResource,
   cfnContext: CloudFormationParseContext,
-  cfnTemplateFetcher: CloudFormationTemplateFetcher
+  cfnTemplateFetcher: CloudFormationTemplateFetcher,
 ) {
   if (typeof resource.Properties.TemplateURL === 'undefined') {
     throw new Error(`Error in parsing Nested stack ${resourceName}. Stack is missing required property TemplateURL`);
@@ -37,7 +37,7 @@ export function nestedStackHandler(
   const processedParameters = Object.entries(parameters).reduce((acc, [parameterName, parameterValue]) => {
     return {
       ...acc,
-      [parameterName]: parseValue(parameterValue, cfnContext)
+      [parameterName]: parseValue(parameterValue, cfnContext),
     };
   }, {});
 
@@ -75,7 +75,7 @@ export function processConditions(conditions: CloudFormationConditions, processe
       params: processedParams,
       conditions: { ...conditions },
       resources: {},
-      exports: {}
+      exports: {},
     });
   });
   return processedConditions;
@@ -87,22 +87,24 @@ export function getDependencyResources(node: object | any[], params: Record<stri
     return [];
   }
 
-  if (isPlainObject(node) && Object.keys(node).length === 1) {
-    const fnName = Object.keys(node)[0];
-    const fnArgs = node[fnName];
-    if ('Ref' === fnName) {
-      const resourceName = fnArgs;
-      if (!Object.keys(params).includes(resourceName)) {
+  if (isPlainObject(node)) {
+    const nodeKeys = Object.keys(node);
+    if (nodeKeys.length === 1) {
+      const fnName = Object.keys(node)[0];
+      const fnArgs = node[fnName];
+      if ('Ref' === fnName) {
+        const resourceName = fnArgs;
+        if (!Object.keys(params).includes(resourceName)) {
+          result.push(resourceName);
+          return result;
+        }
+      } else if ('Fn::GetAtt' === fnName) {
+        const resourceName = fnArgs[0];
         result.push(resourceName);
-      }
-    } else if ('Fn::GetAtt' === fnName) {
-      const resourceName = fnArgs[0];
-      result.push(resourceName);
-    } else if (typeof fnArgs !== 'string') {
-      for (let i = 0; i < fnArgs.length; i++) {
-        result = [...result, ...getDependencyResources(fnArgs[i], params)];
+        return result;
       }
     }
+    return nodeKeys.map(key => getDependencyResources(node[key], params)).reduce((sum, val) => [...sum, ...val], []);
   } else if (Array.isArray(node)) {
     return node.reduce((acc, item) => [...acc, ...getDependencyResources(item, params)], []);
   }
@@ -158,7 +160,7 @@ export function sortResources(resources: CloudFormationResources, params: Record
 
 export function filterResourcesBasedOnConditions(
   resources: CloudFormationResources,
-  conditions: Record<string, boolean>
+  conditions: Record<string, boolean>,
 ): CloudFormationResources {
   const filteredResources: CloudFormationResources = {};
   Object.entries(resources)
@@ -183,7 +185,7 @@ export function processResources(
   conditions: Record<string, boolean>,
   resources: CloudFormationResources,
   cfnExports: Record<string, any>,
-  cfnTemplateFetcher: CloudFormationTemplateFetcher
+  cfnTemplateFetcher: CloudFormationTemplateFetcher,
 ): { resources: Record<string, any>; stackExports: Record<string, any> } {
   const filteredResources = filterResourcesBasedOnConditions(resources, conditions);
   const sortedResourceNames = sortResources(filteredResources, parameters);
@@ -195,7 +197,7 @@ export function processResources(
       params: { ...parameters },
       conditions: { ...conditions },
       resources: { ...processedResources },
-      exports: { ...cfnExports }
+      exports: { ...cfnExports },
     };
 
     if (resourceType === 'AWS::CloudFormation::Stack') {
@@ -213,7 +215,7 @@ export function processResources(
           throw e;
         } else {
           console.log(
-            `Mock does not handle CloudFormation resource of type ${resourceType}. Skipping processing resource ${resourceName}.`
+            `Mock does not handle CloudFormation resource of type ${resourceType}. Skipping processing resource ${resourceName}.`,
           );
         }
       }
@@ -227,7 +229,7 @@ export function processExports(
   parameters: Record<string, any>,
   conditions: Record<string, boolean>,
   resources: Record<string, any>,
-  cfnExports: Record<string, any> = {}
+  cfnExports: Record<string, any> = {},
 ): Record<string, any> {
   const stackExports = {};
   const cfnContext = { params: parameters, conditions, resources, exports: cfnExports };
@@ -256,7 +258,7 @@ export function processOutputs(
   parameters: Record<string, any>,
   conditions: Record<string, boolean>,
   resources: Record<string, any>,
-  cfnExports: Record<string, any> = {}
+  cfnExports: Record<string, any> = {},
 ): Record<string, any> {
   const outputs = {};
   const cfnContext = { params: parameters, conditions, resources, exports: cfnExports };
@@ -270,7 +272,7 @@ export function processCloudFormationStack(
   template: CloudFormationTemplate,
   parameters: Record<string, any>,
   cfnExports: Record<string, any>,
-  cfnTemplateFetcher: CloudFormationTemplateFetcher
+  cfnTemplateFetcher: CloudFormationTemplateFetcher,
 ): { resources: Record<string, any>; stackExports: Record<string, any>; outputs: Record<string, any> } {
   const mergedParameters = mergeParameters(template.Parameters || {}, parameters || {});
   const processedConditions = processConditions(template.Conditions || {}, mergedParameters);
@@ -280,18 +282,18 @@ export function processCloudFormationStack(
     mergedParameters,
     processedConditions,
     processedResources.resources,
-    processedResources.stackExports
+    processedResources.stackExports,
   );
   const processedExports = processExports(
     template.Outputs || {},
     mergedParameters,
     processedConditions,
     processedResources.resources,
-    processedResources.stackExports
+    processedResources.stackExports,
   );
   return {
     resources: processedResources.resources,
     stackExports: processedExports,
-    outputs: processedOutput
+    outputs: processedOutput,
   };
 }

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/stack/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/stack/index.test.ts
@@ -697,5 +697,20 @@ describe('CloudFormation stack', () => {
       };
       expect(getDependencyResources(propValue, {})).toEqual(['Fn1', 'Fn2']);
     });
+    it('should get Fn::GetAtt resource name inside resource parameters as a dependency', () => {
+      const propValue = {
+        Parameters: {
+          Functions: [
+            {
+              'Fn::GetAtt': ['Fn1', 'FunctionId'],
+            },
+            {
+              'Fn::GetAtt': ['Fn2', 'FunctionId'],
+            },
+          ],
+        }
+      };
+      expect(getDependencyResources(propValue, {})).toEqual(['Fn1', 'Fn2']);
+    })
   });
 });

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/stack/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/stack/index.test.ts
@@ -57,8 +57,8 @@ describe('CloudFormation stack', () => {
       ).toEqual({ ...CFN_PSEUDO_PARAMS, test: 'default test value' }); // ?
     });
     it('should throw an error when the input is missing default value', () => {
-      expect(
-        () => mergeParameters(
+      expect(() =>
+        mergeParameters(
           {
             test: {
               Type: 'String',
@@ -226,16 +226,18 @@ describe('CloudFormation stack', () => {
     });
 
     it('should throw an error when condition is non-existent condition', () => {
-      expect(() => filterResourcesBasedOnConditions(
-        {
-          resource1: {
-            Properties: {},
-            Condition: 'non-existent-condition',
-            Type: 'resource1type',
+      expect(() =>
+        filterResourcesBasedOnConditions(
+          {
+            resource1: {
+              Properties: {},
+              Condition: 'non-existent-condition',
+              Type: 'resource1type',
+            },
           },
-        },
-        {},
-      )).toThrowError('not defined in Condition block');
+          {},
+        ),
+      ).toThrowError('not defined in Condition block');
     });
   });
 
@@ -571,7 +573,10 @@ describe('CloudFormation stack', () => {
         'nestedStack',
         resource,
         {
-          conditions: {}, exports: {}, params: {}, resources: {},
+          conditions: {},
+          exports: {},
+          params: {},
+          resources: {},
         },
         cfnResourceFetcher,
       );
@@ -589,14 +594,19 @@ describe('CloudFormation stack', () => {
           TemplateURL: 'https://s3.amazonaws.com/${S3DeploymentBucket}/${S3DeploymentRootKey}/stacks/stack1',
         },
       };
-      expect(() => nestedStackHandler(
-        'nestedStack',
-        resource,
-        {
-          conditions: {}, exports: { 'NestedStack:FooValue': 'Existing value' }, params: {}, resources: {},
-        },
-        cfnResourceFetcher,
-      )).toThrowError('is already exported in a different stack');
+      expect(() =>
+        nestedStackHandler(
+          'nestedStack',
+          resource,
+          {
+            conditions: {},
+            exports: { 'NestedStack:FooValue': 'Existing value' },
+            params: {},
+            resources: {},
+          },
+          cfnResourceFetcher,
+        ),
+      ).toThrowError('is already exported in a different stack');
     });
 
     it('should throw error if the nested stack resource does not have TemplateURL', () => {
@@ -604,9 +614,19 @@ describe('CloudFormation stack', () => {
         Type: 'AWS::CloudFormation::Stack',
         Properties: {},
       };
-      expect(() => nestedStackHandler('nestedStack', resource, {
-        conditions: {}, exports: {}, params: {}, resources: {},
-      }, cfnResourceFetcher)).toThrowError('Stack is missing required property TemplateURL');
+      expect(() =>
+        nestedStackHandler(
+          'nestedStack',
+          resource,
+          {
+            conditions: {},
+            exports: {},
+            params: {},
+            resources: {},
+          },
+          cfnResourceFetcher,
+        ),
+      ).toThrowError('Stack is missing required property TemplateURL');
     });
   });
 
@@ -697,7 +717,7 @@ describe('CloudFormation stack', () => {
       };
       expect(getDependencyResources(propValue, {})).toEqual(['Fn1', 'Fn2']);
     });
-    it('should get Fn::GetAtt resource name inside resource parameters as a dependency', () => {
+    it('should get Fn::GetAtt resource name inside resource parameters (more than 1 key) as a dependency', () => {
       const propValue = {
         Parameters: {
           Functions: [
@@ -708,9 +728,12 @@ describe('CloudFormation stack', () => {
               'Fn::GetAtt': ['Fn2', 'FunctionId'],
             },
           ],
-        }
+          referencetonestedstack: {
+            'Fn::GetAtt': ['Fn3', 'FunctionId'],
+          },
+        },
       };
-      expect(getDependencyResources(propValue, {})).toEqual(['Fn1', 'Fn2']);
-    })
+      expect(getDependencyResources(propValue, {})).toEqual(['Fn1', 'Fn2', 'Fn3']);
+    });
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
When traversing the resource attribute for intrinsic dependencies, the previous method will stop at node with more than 1 attributes, which means attribute such as  `Properties.Parameters` will never be visited for finding the dependencies. The PR is to fix this bug.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fix https://github.com/aws-amplify/amplify-category-api/issues/1014
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
