### PR TITLE
chore: cleanup orphan appsync apis

### DIFF
--- a/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
+++ b/packages/amplify-e2e-core/src/utils/add-circleci-tags.ts
@@ -32,6 +32,7 @@ export const addCircleCITags = (projectPath: string): void => {
     addTagIfNotExist('circleci:build_id', sanitizeTagValue(process.env['CIRCLE_BUILD_NUM'] || 'N/A'));
     addTagIfNotExist('circleci:build_url', sanitizeTagValue(process.env['CIRCLE_BUILD_URL'] || 'N/A'));
     addTagIfNotExist('circleci:job', sanitizeTagValue(process.env['CIRCLE_JOB'] || 'N/A'));
+    addTagIfNotExist('circleci:create_time', new Date().toISOString());
     // exposed by custom CLI test environment
     if (global.getTestName) {
       addTagIfNotExist('jest:test_name', sanitizeTagValue(global.getTestName().substr(0, 255) || 'N/A'));

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -76,6 +76,13 @@ type IamRoleInfo = {
   createTime: Date;
 };
 
+type AppSyncApiInfo = {
+  apiId: string;
+  name: string;
+  region: string;
+  cciInfo?: CircleCIJobDetails;
+};
+
 type ReportEntry = {
   jobId?: string;
   workflowId?: string;
@@ -86,6 +93,7 @@ type ReportEntry = {
   buckets: Record<string, S3BucketInfo>;
   roles: Record<string, IamRoleInfo>;
   pinpointApps: Record<string, PinpointAppInfo>;
+  appSyncApis: Record<string, AppSyncApiInfo>;
 };
 
 type JobFilterPredicate = (job: ReportEntry) => boolean;
@@ -105,6 +113,7 @@ type AWSAccountInfo = {
 };
 
 const PINPOINT_TEST_REGEX = /integtest/;
+const APPSYNC_TEST_REGEX = /integtest/;
 const BUCKET_TEST_REGEX = /test/;
 const IAM_TEST_REGEX = /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-/;
 const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
@@ -129,6 +138,17 @@ const testBucketStalenessFilter = (resource: aws.S3.Bucket): boolean => {
 const testRoleStalenessFilter = (resource: aws.IAM.Role): boolean => {
   const isTestResource = resource.RoleName.match(IAM_TEST_REGEX);
   const isStaleResource = (new Date().getUTCMilliseconds() - resource.CreateDate.getUTCMilliseconds()) > STALE_DURATION_MS;
+  return isTestResource && isStaleResource;
+};
+
+const testAppSyncApiStalenessFilter = (resource: aws.AppSync.GraphqlApi): boolean => {
+  const isTestResource = resource.name.match(APPSYNC_TEST_REGEX);
+  const createTimeTagValue = resource.tags['circleci:create_time'];
+  let isStaleResource = true;
+  if (createTimeTagValue) {
+    const createTime = new Date(createTimeTagValue);
+    isStaleResource = (new Date().getUTCMilliseconds() - createTime.getUTCMilliseconds()) > STALE_DURATION_MS;
+  }
   return isTestResource && isStaleResource;
 };
 
@@ -175,6 +195,16 @@ const getOrphanPinpointApplications = async (account: AWSAccountInfo, region: st
   } while (nextToken);
 
   return apps;
+};
+
+/**
+ * Get all AppSync Apis in the account, and filter down to the ones we consider stale.
+ */
+const getOrphanAppSyncApis = async (account: AWSAccountInfo, region: string): Promise<AppSyncApiInfo[]> => {
+  const appSyncClient = new aws.AppSync(getAWSConfig(account, region));
+  const listApisResponse = await appSyncClient.listGraphqlApis({ maxResults: 1000 }).promise();
+  const staleApis = listApisResponse.graphqlApis.filter(testAppSyncApiStalenessFilter);
+  return staleApis.map(it => ({ apiId: it.apiId, name: it.name, region }));
 };
 
 /**
@@ -384,6 +414,7 @@ const mergeResourcesByCCIJob = (
   orphanS3Buckets: S3BucketInfo[],
   orphanIamRoles: IamRoleInfo[],
   orphanPinpointApplications: PinpointAppInfo[],
+  orphanAppSyncApis: AppSyncApiInfo[],
 ): Record<string, ReportEntry> => {
   const result: Record<string, ReportEntry> = {};
 
@@ -463,6 +494,18 @@ const mergeResourcesByCCIJob = (
     jobId: key,
     pinpointApps: src,
   }));
+
+  _.mergeWith(
+    result,
+    {
+      [ORPHAN]: orphanAppSyncApis,
+    },
+    (val, src, key) => ({
+      ...val,
+      jobId: key,
+      appSyncApis: src,
+    }),
+  );
 
   return result;
 };
@@ -599,6 +642,23 @@ const deletePinpointApp = async (account: AWSAccountInfo, accountIndex: number, 
   }
 };
 
+const deleteAppSyncApis = async (account: AWSAccountInfo, accountIndex: number, apis: AppSyncApiInfo[]): Promise<void> => {
+  await Promise.all(apis.map(api => deleteAppSyncApi(account, accountIndex, api)));
+};
+
+const deleteAppSyncApi = async (account: AWSAccountInfo, accountIndex: number, api: AppSyncApiInfo): Promise<void> => {
+  const {
+    apiId, name, region,
+  } = api;
+  try {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting AppSync Api ${name}`);
+    const appSync = new aws.AppSync(getAWSConfig(account, region));
+    await appSync.deleteGraphqlApi({ apiId }).promise();
+  } catch (e) {
+    console.log(`[ACCOUNT ${accountIndex}] Deleting AppSync Api ${name} failed with error ${e.message}`);
+  }
+};
+
 const deleteCfnStacks = async (account: AWSAccountInfo, accountIndex: number, stacks: StackInfo[]): Promise<void> => {
   await Promise.all(stacks.map(stack => deleteCfnStack(account, accountIndex, stack)));
 };
@@ -654,6 +714,10 @@ const deleteResources = async (
 
     if (resources.pinpointApps) {
       await deletePinpointApps(account, accountIndex, Object.values(resources.pinpointApps));
+    }
+
+    if (resources.appSyncApis) {
+      await deleteAppSyncApis(account, accountIndex, Object.values(resources.appSyncApis));
     }
   }
 };
@@ -752,6 +816,7 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
   const orphanPinpointApplicationsPromise = AWS_REGIONS_TO_RUN_TESTS.map(region => getOrphanPinpointApplications(account, region));
   const orphanBucketPromise = getOrphanS3TestBuckets(account);
   const orphanIamRolesPromise = getOrphanTestIamRoles(account);
+  const orphanAppSyncApisPromise = AWS_REGIONS_TO_RUN_TESTS.map(region => getOrphanAppSyncApis(account, region));
 
   const apps = (await Promise.all(appPromises)).flat();
   const stacks = (await Promise.all(stackPromises)).flat();
@@ -759,8 +824,11 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
   const orphanBuckets = await orphanBucketPromise;
   const orphanIamRoles = await orphanIamRolesPromise;
   const orphanPinpointApplications = (await Promise.all(orphanPinpointApplicationsPromise)).flat();
+  const orphanAppSyncApis = (await Promise.all(orphanAppSyncApisPromise)).flat();
 
-  const allResources = mergeResourcesByCCIJob(apps, stacks, buckets, orphanBuckets, orphanIamRoles, orphanPinpointApplications);
+  const allResources = mergeResourcesByCCIJob(
+    apps, stacks, buckets, orphanBuckets, orphanIamRoles, orphanPinpointApplications, orphanAppSyncApis,
+  );
   const staleResources = _.pickBy(allResources, filterPredicate);
 
   generateReport(staleResources);

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -202,7 +202,7 @@ const getOrphanPinpointApplications = async (account: AWSAccountInfo, region: st
  */
 const getOrphanAppSyncApis = async (account: AWSAccountInfo, region: string): Promise<AppSyncApiInfo[]> => {
   const appSyncClient = new aws.AppSync(getAWSConfig(account, region));
-  const listApisResponse = await appSyncClient.listGraphqlApis({ maxResults: 50 }).promise();
+  const listApisResponse = await appSyncClient.listGraphqlApis({ maxResults: 25 }).promise();
   const staleApis = listApisResponse.graphqlApis.filter(testAppSyncApiStalenessFilter);
   return staleApis.map(it => ({ apiId: it.apiId, name: it.name, region }));
 };

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -202,7 +202,7 @@ const getOrphanPinpointApplications = async (account: AWSAccountInfo, region: st
  */
 const getOrphanAppSyncApis = async (account: AWSAccountInfo, region: string): Promise<AppSyncApiInfo[]> => {
   const appSyncClient = new aws.AppSync(getAWSConfig(account, region));
-  const listApisResponse = await appSyncClient.listGraphqlApis({ maxResults: 1000 }).promise();
+  const listApisResponse = await appSyncClient.listGraphqlApis({ maxResults: 50 }).promise();
   const staleApis = listApisResponse.graphqlApis.filter(testAppSyncApiStalenessFilter);
   return staleApis.map(it => ({ apiId: it.apiId, name: it.name, region }));
 };

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -827,7 +827,7 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
   const orphanAppSyncApis = (await Promise.all(orphanAppSyncApisPromise)).flat();
 
   const allResources = mergeResourcesByCCIJob(
-    apps, stacks, buckets, orphanBuckets, orphanIamRoles, orphanPinpointApplications, orphanAppSyncApis,
+    apps, stacks, buckets, orphanBuckets, orphanIamRoles, orphanPinpointApplications, orphanAppSyncApis
   );
   const staleResources = _.pickBy(allResources, filterPredicate);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This cleans up orphan App Sync apis  that led to quota exhaustion.

App Sync apis don't carry creation time, so we're adding a tag to track this.

![image](https://user-images.githubusercontent.com/5849952/209722642-c20fa1d0-bb64-4931-9cca-4bbf6a48ed51.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
