### PR TITLE
fix(amplify-util-uibuilder): update codegen-ui to 2.7.0

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -13,8 +13,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.5",
-    "@aws-amplify/codegen-ui-react": "2.5.5",
+    "@aws-amplify/codegen-ui": "2.7.0",
+    "@aws-amplify/codegen-ui-react": "2.7.0",
     "amplify-cli-core": "3.4.0",
     "amplify-prompts": "2.6.1",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/utils.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/utils.ts
@@ -4,6 +4,7 @@ export const exampleSchema: GenericDataSchema = {
   dataSourceType: 'DataStore',
   models: {
     Author: {
+      primaryKeys: ['id'],
       fields: {
         id: {
           dataType: 'ID',
@@ -50,6 +51,7 @@ export const exampleSchema: GenericDataSchema = {
       },
     },
     JoinTable: {
+      primaryKeys: ['id'],
       fields: {
         id: {
           dataType: 'ID',
@@ -61,6 +63,7 @@ export const exampleSchema: GenericDataSchema = {
       isJoinTable: true
     },
     EmptyModel: {
+      primaryKeys: ['id'],
       fields: {
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.5.5":
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.5.tgz#804e0c69258eb337fe23e06aa60c4779f377affb"
-  integrity sha512-5A6+ztnEudXQhjwuDLRykEfQWhk1CxnKVWM05wT5pD2peXEhfb/mmKpcZ4CtWh34ilDHk1QdpP+mM8QPuAd1xA==
+"@aws-amplify/codegen-ui-react@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.7.0.tgz#09d1e8439dfe16e88dedf21d9843b10f494cd9cc"
+  integrity sha512-fw7DWdUKsS+/NEMmwHTwSU9nMeAoPcpN4i0hwIY1+KRA3QiTGe89aH2suYGpxZRjyX9pTpjr6nCVTgdSXxQm3Q==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.5.5"
+    "@aws-amplify/codegen-ui" "2.7.0"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.5.5":
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.5.tgz#33b31b52240878590dcf230ea7c8a92261143f89"
-  integrity sha512-7OnjqnMVD0AnlcrEmKyu9IL7s5+zPhj5lAH+z6OFCuGYCONGTZgJJkR7RGs48bmayzm9jvpAPMVLwPSQENcqSQ==
+"@aws-amplify/codegen-ui@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.7.0.tgz#9fdbfa1900a0d5e80681b7c609255460a8ef1cd0"
+  integrity sha512-auvWvA3mzxnfYLy2Pw9UXfVVZrrelIeJDprIj7TkJirdmeXwgwxngtgk33UXtMVowk0mljiCg2WiaVDBYk4Jtg==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Recent upgrades in `amplify-codegen` in the CLI as well as the major version bump for `@aws-amplify/datastore` has introduced regressions in UI Builder functionality:

* Collection generation for models with relationships is broken
* Accessing `hasOne` and `belongsTo` related records is broken in collections

We have several customers reporting issues in Github. Issue: https://github.com/aws-amplify/amplify-studio/issues/763

The new version of `codegen-ui` addresses the above issues.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit & e2e tests in `codegen-ui`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
