### PR TITLE
chore: migrate hosting category from inquirer to prompter library

### DIFF
--- a/packages/amplify-category-hosting/__tests__/index.test.js
+++ b/packages/amplify-category-hosting/__tests__/index.test.js
@@ -1,12 +1,11 @@
 jest.mock('../lib/category-manager');
 
-const inquirer = require('inquirer');
-const mockirer = require('mockirer');
 const fs = require('fs-extra');
-
 const categoryManager = require('../lib/category-manager');
-
 const indexModule = require('../index');
+
+const prompter = require('amplify-prompts');
+jest.mock('amplify-prompts');
 
 describe('index', () => {
   const mockContext = {
@@ -57,8 +56,8 @@ describe('index', () => {
     mockAvailableServices.push(ANOTHERSERVICE);
     mockDisabledServices.push(S3ANDCLOUDFRONT);
     mockDisabledServices.push(ANOTHERSERVICE);
-    mockAnswers.selectedServices.push(S3ANDCLOUDFRONT);
-    mockirer(inquirer, mockAnswers);
+
+    prompter.pick = jest.fn().mockImplementationOnce('S3ANDCLOUDFRONT');
     await indexModule.add(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
   });
@@ -92,7 +91,7 @@ describe('index', () => {
     mockEnabledServices.push(S3ANDCLOUDFRONT);
     mockEnabledServices.push(ANOTHERSERVICE);
     mockAnswers.selectedServices.push(S3ANDCLOUDFRONT);
-    mockirer(inquirer, mockAnswers);
+    prompter.pick = jest.fn().mockImplementationOnce('S3ANDCLOUDFRONT');
     await indexModule.configure(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
   });
@@ -156,7 +155,7 @@ describe('index', () => {
     mockEnabledServices.push(S3ANDCLOUDFRONT);
     mockEnabledServices.push(ANOTHERSERVICE);
     mockAnswers.selectedService = mockEnabledServices[0];
-    mockirer(inquirer, mockAnswers);
+    prompter.pick = jest.fn().mockImplementationOnce(ockEnabledServices[0]);
     await indexModule.console(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
     expect(categoryManager.runServiceAction.mock.calls[0][0]).toBe(mockContext);

--- a/packages/amplify-category-hosting/__tests__/index.test.js
+++ b/packages/amplify-category-hosting/__tests__/index.test.js
@@ -3,9 +3,16 @@ jest.mock('../lib/category-manager');
 const fs = require('fs-extra');
 const categoryManager = require('../lib/category-manager');
 const indexModule = require('../index');
+const amplifyPrompts = require('amplify-prompts');
 
-const prompter = require('amplify-prompts');
-jest.mock('amplify-prompts');
+jest.mock('amplify-prompts', () => ({
+  prompter: {
+    input: jest.fn(),
+    yesOrNo: jest.fn(),
+    pick: jest.fn(),
+  },
+  byValue: jest.fn(),
+}));
 
 describe('index', () => {
   const mockContext = {
@@ -57,7 +64,7 @@ describe('index', () => {
     mockDisabledServices.push(S3ANDCLOUDFRONT);
     mockDisabledServices.push(ANOTHERSERVICE);
 
-    prompter.pick = jest.fn().mockImplementationOnce('S3ANDCLOUDFRONT');
+    amplifyPrompts.prompter.pick.mockReturnValueOnce(['S3ANDCLOUDFRONT']);
     await indexModule.add(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
   });
@@ -91,7 +98,7 @@ describe('index', () => {
     mockEnabledServices.push(S3ANDCLOUDFRONT);
     mockEnabledServices.push(ANOTHERSERVICE);
     mockAnswers.selectedServices.push(S3ANDCLOUDFRONT);
-    prompter.pick = jest.fn().mockImplementationOnce('S3ANDCLOUDFRONT');
+    amplifyPrompts.prompter.pick.mockReturnValueOnce(['S3ANDCLOUDFRONT']);
     await indexModule.configure(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
   });
@@ -155,7 +162,7 @@ describe('index', () => {
     mockEnabledServices.push(S3ANDCLOUDFRONT);
     mockEnabledServices.push(ANOTHERSERVICE);
     mockAnswers.selectedService = mockEnabledServices[0];
-    prompter.pick = jest.fn().mockImplementationOnce(ockEnabledServices[0]);
+    amplifyPrompts.prompter.pick.mockReturnValueOnce(mockEnabledServices[0]);
     await indexModule.console(mockContext);
     expect(categoryManager.runServiceAction).toBeCalled();
     expect(categoryManager.runServiceAction.mock.calls[0][0]).toBe(mockContext);

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/configuration-manager.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/configuration-manager.test.js
@@ -1,5 +1,13 @@
-const prompter = require('amplify-prompts');
-jest.mock('amplify-prompts');
+const amplifyPrompts = require('amplify-prompts');
+
+jest.mock('amplify-prompts', () => ({
+  prompter: {
+    input: jest.fn(),
+    yesOrNo: jest.fn(),
+    pick: jest.fn(),
+  },
+  byValue: jest.fn(),
+}));
 
 jest.mock('../../../lib/S3AndCloudFront/helpers/configure-Website');
 const configureWebsite = require('../../../lib/S3AndCloudFront/helpers/configure-Website');
@@ -73,14 +81,15 @@ describe('configuration-manager', () => {
   });
 
   test('init', async () => {
-    prompter.input = jest.fn().mockReturnValue('mockHostingBucketName');
+    amplifyPrompts.prompter.input.mockReturnValue('mockHostingBucketName');
     await configurationManager.init(mockContext);
     expect(mockContext.exeInfo.parameters.bucketName).toBeDefined();
     expect(configureWebsite.configure).toBeCalledWith(mockContext);
   });
 
   test('configure', async () => {
-    prompter.input = jest.fn()
+    amplifyPrompts.byValue.mockReturnValue(0);
+    amplifyPrompts.prompter.pick
       .mockReturnValueOnce('Website')
       .mockReturnValueOnce('CloudFront')
       .mockReturnValueOnce('Publish')

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/configuration-manager.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/configuration-manager.test.js
@@ -1,5 +1,5 @@
-jest.mock('inquirer');
-const inquirer = require('inquirer');
+const prompter = require('amplify-prompts');
+jest.mock('amplify-prompts');
 
 jest.mock('../../../lib/S3AndCloudFront/helpers/configure-Website');
 const configureWebsite = require('../../../lib/S3AndCloudFront/helpers/configure-Website');
@@ -73,17 +73,19 @@ describe('configuration-manager', () => {
   });
 
   test('init', async () => {
-    inquirer.prompt.mockResolvedValueOnce({ HostingBucketName: 'mockHostingBucketName' });
+    prompter.input = jest.fn().mockReturnValue('mockHostingBucketName');
     await configurationManager.init(mockContext);
     expect(mockContext.exeInfo.parameters.bucketName).toBeDefined();
     expect(configureWebsite.configure).toBeCalledWith(mockContext);
   });
 
   test('configure', async () => {
-    inquirer.prompt.mockResolvedValueOnce({ section: 'Website' });
-    inquirer.prompt.mockResolvedValueOnce({ section: 'CloudFront' });
-    inquirer.prompt.mockResolvedValueOnce({ section: 'Publish' });
-    inquirer.prompt.mockResolvedValueOnce({ section: 'exit' });
+    prompter.input = jest.fn()
+      .mockReturnValueOnce('Website')
+      .mockReturnValueOnce('CloudFront')
+      .mockReturnValueOnce('Publish')
+      .mockReturnValueOnce('exit');
+
     await configurationManager.configure(mockContext);
     expect(configureWebsite.configure).toBeCalledWith(mockContext);
     expect(configureCloudFront.configure).toBeCalledWith(mockContext);

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-CloudFront.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-CloudFront.test.js
@@ -1,8 +1,16 @@
 const fs = require('fs-extra');
 const path = require('path');
 const configureCloudFront = require('../../../../lib/S3AndCloudFront/helpers/configure-CloudFront');
-const prompter = require('amplify-prompts');
-jest.mock('amplify-prompts');
+const amplifyPrompts = require('amplify-prompts');
+
+jest.mock('amplify-prompts', () => ({
+  prompter: {
+    input: jest.fn(),
+    yesOrNo: jest.fn(),
+    pick: jest.fn(),
+  },
+  byValue: jest.fn(),
+}));
 
 describe('configure-CloudFront', () => {
   const configActions = {
@@ -50,11 +58,11 @@ describe('configure-CloudFront', () => {
     const mockTemplatePath = path.join(__dirname, '../../../../__mocks__/mockTemplate.json');
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.prompter.yesOrNo
       .mockResolvedValueOnce(false) // Remove CloudFront from hosting
       .mockResolvedValueOnce(false); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
@@ -81,9 +89,9 @@ describe('configure-CloudFront', () => {
     const mockTemplatePath = path.join(__dirname, '../../../../__mocks__/mockTemplate.json');
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
-    prompter.yesOrNo = jest.fn()
-      .mockResolvedValueOnce(true) // Remove CloudFront from hosting
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.yesOrNo = jest.fn().mockResolvedValueOnce(true); // Remove CloudFront from hosting
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce('index.html')
       .mockResolvedValueOnce('error.html');
 
@@ -103,11 +111,13 @@ describe('configure-CloudFront', () => {
     const mockTemplatePath = path.join(__dirname, '../../../../__mocks__/mockTemplate-noCloudFront.json');
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
       .mockResolvedValueOnce(true) // Add CloudFront to hosting
       .mockResolvedValueOnce(false); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
@@ -134,17 +144,21 @@ describe('configure-CloudFront', () => {
     const mockTemplatePath = path.join(__dirname, '../../../../__mocks__/mockTemplate.json');
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.byValue = jest.fn().mockReturnValue('list');
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
       .mockResolvedValueOnce(false) // Remove CloudFront from hosting
       .mockResolvedValueOnce(true); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
       .mockResolvedValueOnce(mockDefaultCacheMinTTL);
 
-    prompter.pick = jest.fn()
+    amplifyPrompts.prompter.pick = jest
+      .fn()
       .mockResolvedValueOnce(configActions.list)
       .mockResolvedValueOnce(configActions.done);
 
@@ -165,27 +179,27 @@ describe('configure-CloudFront', () => {
       ResponsePagePath: '/',
       ErrorCachingMinTTL: 300,
     };
-
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.byValue = jest.fn().mockReturnValue('list');
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
       .mockResolvedValueOnce(false) // Remove CloudFront from hosting
-      .mockResolvedValueOnce(true) // Configure Custom Error Responses
-      ;
+      .mockResolvedValueOnce(true); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
       .mockResolvedValueOnce(mockDefaultCacheMinTTL)
       .mockResolvedValueOnce(mockCustomErrorResponses.ResponseCode)
       .mockResolvedValueOnce(mockCustomErrorResponses.ResponsePagePath)
-      .mockResolvedValueOnce(mockCustomErrorResponses.ErrorCachingMinTTL)
-      ;
+      .mockResolvedValueOnce(mockCustomErrorResponses.ErrorCachingMinTTL);
 
-    prompter.pick = jest.fn()
+    amplifyPrompts.prompter.pick = jest
+      .fn()
       .mockResolvedValueOnce(configActions.add)
       .mockResolvedValueOnce(mockErrorCode.ErrorCode)
-      .mockResolvedValueOnce(configActions.done)
-      ;
+      .mockResolvedValueOnce(configActions.done);
 
     const { DistributionConfig } = mockContext.exeInfo.template.Resources.CloudFrontDistribution.Properties;
     let result = await configureCloudFront.configure(mockContext);
@@ -210,26 +224,28 @@ describe('configure-CloudFront', () => {
       ResponsePagePath: '/mockPack',
       ErrorCachingMinTTL: 333,
     };
-    prompter.yesOrNo = jest.fn()
-      .mockResolvedValueOnce(false) // Remove CloudFront from hosting
-      .mockResolvedValueOnce(true) // Configure Custom Error Responses
-      ;
 
-    prompter.input = jest.fn()
+    amplifyPrompts.byValue = jest.fn().mockReturnValue('list');
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
+      .mockResolvedValueOnce(false) // Remove CloudFront from hosting
+      .mockResolvedValueOnce(true); // Configure Custom Error Responses
+
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
       .mockResolvedValueOnce(mockDefaultCacheMinTTL)
       .mockResolvedValueOnce(mockCustomErrorResponses.ResponseCode)
       .mockResolvedValueOnce(mockCustomErrorResponses.ResponsePagePath)
-      .mockResolvedValueOnce(mockCustomErrorResponses.ErrorCachingMinTTL)
-      ;
+      .mockResolvedValueOnce(mockCustomErrorResponses.ErrorCachingMinTTL);
 
-    prompter.pick = jest.fn()
+    amplifyPrompts.prompter.pick = jest
+      .fn()
       .mockResolvedValueOnce(configActions.edit)
       .mockResolvedValueOnce(mockErrorCode.ErrorCode)
-      .mockResolvedValueOnce(configActions.done)
-      ;
+      .mockResolvedValueOnce(configActions.done);
 
     let result = await configureCloudFront.configure(mockContext);
     expect(result).toEqual(mockContext);
@@ -245,33 +261,34 @@ describe('configure-CloudFront', () => {
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
     const { DistributionConfig } = mockContext.exeInfo.template.Resources.CloudFrontDistribution.Properties;
-    const mockCustomReponseToRemove = DistributionConfig.CustomErrorResponses[0];
+    const mockCustomResponseToRemove = DistributionConfig.CustomErrorResponses[0];
     const mockErrorCode = {
-      ErrorCode: mockCustomReponseToRemove.ErrorCode,
+      ErrorCode: mockCustomResponseToRemove.ErrorCode,
     };
 
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.byValue = jest.fn().mockReturnValue('list');
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
       .mockResolvedValueOnce(false) // Remove CloudFront from hosting
-      .mockResolvedValueOnce(true) // Configure Custom Error Responses
-      ;
+      .mockResolvedValueOnce(true); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
-      .mockResolvedValueOnce(mockDefaultCacheMinTTL)
-      ;
+      .mockResolvedValueOnce(mockDefaultCacheMinTTL);
 
-    prompter.pick = jest.fn()
+    amplifyPrompts.prompter.pick = jest
+      .fn()
       .mockResolvedValueOnce(configActions.remove)
       .mockResolvedValueOnce(mockErrorCode.ErrorCode)
-      .mockResolvedValueOnce(configActions.done)
-      ;
+      .mockResolvedValueOnce(configActions.done);
 
     let result = await configureCloudFront.configure(mockContext);
     expect(result).toEqual(mockContext);
     expect(Array.isArray(DistributionConfig.CustomErrorResponses)).toBeTruthy();
-    expect(DistributionConfig.CustomErrorResponses).not.toContainEqual(mockCustomReponseToRemove);
+    expect(DistributionConfig.CustomErrorResponses).not.toContainEqual(mockCustomResponseToRemove);
   });
 
   test('configure: customError remove all', async () => {
@@ -279,23 +296,22 @@ describe('configure-CloudFront', () => {
     const mockTemplate = mockContext.amplify.readJsonFile(mockTemplatePath);
     mockContext.exeInfo.template = mockTemplate;
 
-    prompter.yesOrNo = jest.fn()
+    amplifyPrompts.prompter.yesOrNo = jest
+      .fn()
       .mockResolvedValueOnce(false) // Remove CloudFront from hosting
-      .mockResolvedValueOnce(true) // Configure Custom Error Responses
-      ;
+      .mockResolvedValueOnce(true); // Configure Custom Error Responses
 
-    prompter.input = jest.fn()
+    amplifyPrompts.prompter.input = jest
+      .fn()
       .mockResolvedValueOnce(mockDefaultRootObject)
       .mockResolvedValueOnce(mockDefaultCacheDefaultTTL)
       .mockResolvedValueOnce(mockDefaultCacheMaxTTL)
-      .mockResolvedValueOnce(mockDefaultCacheMinTTL)
-      ;
+      .mockResolvedValueOnce(mockDefaultCacheMinTTL);
 
-    prompter.pick = jest.fn()
+    amplifyPrompts.prompter.pick = jest
+      .fn()
       .mockResolvedValueOnce(configActions.removeAll)
-      .mockResolvedValueOnce(mockErrorCode.ErrorCode)
-      .mockResolvedValueOnce(configActions.done)
-      ;
+      .mockResolvedValueOnce(configActions.done);
 
     const { DistributionConfig } = mockContext.exeInfo.template.Resources.CloudFrontDistribution.Properties;
     let result = await configureCloudFront.configure(mockContext);

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Publish.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Publish.test.js
@@ -1,9 +1,17 @@
 const fs = require('fs-extra');
 const path = require('path');
 const configurePublish = require('../../../../lib/S3AndCloudFront/helpers/configure-Publish');
+const amplifyPrompts = require('amplify-prompts');
 
-const prompter = require('amplify-prompts');
-jest.mock('amplify-prompts');
+jest.mock('amplify-prompts', () => ({
+  prompter: {
+    input: jest.fn(),
+    yesOrNo: jest.fn(),
+    pick: jest.fn(),
+  },
+  byValue: jest.fn(),
+}));
+
 
 describe('configure-Publish', () => {
   const DONE = 'exit';
@@ -50,17 +58,18 @@ describe('configure-Publish', () => {
   });
 
   test('configure, flow1', async () => {
-    prompter.pick = jest.fn
+    amplifyPrompts.byValue.mockResolvedValueOnce('list');
+    amplifyPrompts.prompter.pick
       .mockResolvedValueOnce(configActions.list)
       .mockResolvedValueOnce(configActions.add)
       .mockResolvedValueOnce(configActions.add)
       .mockResolvedValueOnce(configActions.remove)
+      .mockResolvedValueOnce('mockPattern1')
       .mockResolvedValueOnce(configActions.done);
 
-    prompter.input = jest.fn
+    amplifyPrompts.prompter.input
       .mockResolvedValueOnce('mockPattern1')
-      .mockResolvedValueOnce('mockPattern2')
-      .mockResolvedValueOnce('mockPattern1');
+      .mockResolvedValueOnce('mockPattern2');
 
     const result = await configurePublish.configure(mockContext);
     expect(mockContext.print.info).toBeCalled();
@@ -71,13 +80,14 @@ describe('configure-Publish', () => {
   });
 
   test('configure, flow2', async () => {
-    prompter.pick = jest.fn
+    amplifyPrompts.byValue.mockResolvedValueOnce('list');
+    amplifyPrompts.prompter.pick
       .mockResolvedValueOnce(configActions.add)
       .mockResolvedValueOnce(configActions.add)
       .mockResolvedValueOnce(configActions.removeAll)
       .mockResolvedValueOnce(configActions.done);
 
-    prompter.input = jest.fn
+    amplifyPrompts.prompter.input
       .mockResolvedValueOnce('mockPattern1')
       .mockResolvedValueOnce('mockPattern2');
 

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Publish.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Publish.test.js
@@ -1,9 +1,9 @@
-jest.mock('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
-const inquirer = require('inquirer');
-
 const configurePublish = require('../../../../lib/S3AndCloudFront/helpers/configure-Publish');
+
+const prompter = require('amplify-prompts');
+jest.mock('amplify-prompts');
 
 describe('configure-Publish', () => {
   const DONE = 'exit';
@@ -45,20 +45,23 @@ describe('configure-Publish', () => {
   });
 
   beforeEach(() => {
-    inquirer.prompt.mockClear();
     fs.existsSync.mockClear();
     fs.writeFileSync.mockClear();
   });
 
   test('configure, flow1', async () => {
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.list });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
-    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern1' });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
-    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern2' });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.remove });
-    inquirer.prompt.mockResolvedValueOnce({ patternToRemove: 'mockPattern1' });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.done });
+    prompter.pick = jest.fn
+      .mockResolvedValueOnce(configActions.list)
+      .mockResolvedValueOnce(configActions.add)
+      .mockResolvedValueOnce(configActions.add)
+      .mockResolvedValueOnce(configActions.remove)
+      .mockResolvedValueOnce(configActions.done);
+
+    prompter.input = jest.fn
+      .mockResolvedValueOnce('mockPattern1')
+      .mockResolvedValueOnce('mockPattern2')
+      .mockResolvedValueOnce('mockPattern1');
+
     const result = await configurePublish.configure(mockContext);
     expect(mockContext.print.info).toBeCalled();
     expect(fs.writeFileSync).toBeCalled();
@@ -68,12 +71,16 @@ describe('configure-Publish', () => {
   });
 
   test('configure, flow2', async () => {
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
-    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern1' });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.add });
-    inquirer.prompt.mockResolvedValueOnce({ patternToAdd: 'mockPattern2' });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.removeAll });
-    inquirer.prompt.mockResolvedValueOnce({ action: configActions.done });
+    prompter.pick = jest.fn
+      .mockResolvedValueOnce(configActions.add)
+      .mockResolvedValueOnce(configActions.add)
+      .mockResolvedValueOnce(configActions.removeAll)
+      .mockResolvedValueOnce(configActions.done);
+
+    prompter.input = jest.fn
+      .mockResolvedValueOnce('mockPattern1')
+      .mockResolvedValueOnce('mockPattern2');
+
     const result = await configurePublish.configure(mockContext);
     expect(mockContext.print.info).toBeCalled();
     expect(fs.writeFileSync).toBeCalled();

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Website.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Website.test.js
@@ -1,4 +1,4 @@
-const prompter = require('amplify-prompts');
+const { prompter } = require('amplify-prompts');
 const mockTemplate = require('../../../../__mocks__/mockTemplate-noCloudFront');
 const configureWebsite = require('../../../../lib/S3AndCloudFront/helpers/configure-Website');
 

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Website.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/configure-Website.test.js
@@ -1,9 +1,8 @@
-const inquirer = require('inquirer');
-const mockirer = require('mockirer');
-
+const prompter = require('amplify-prompts');
 const mockTemplate = require('../../../../__mocks__/mockTemplate-noCloudFront');
-
 const configureWebsite = require('../../../../lib/S3AndCloudFront/helpers/configure-Website');
+
+jest.mock('amplify-prompts');
 
 describe('configure-Website', () => {
   const mockContext = {
@@ -18,10 +17,9 @@ describe('configure-Website', () => {
   const indexDoc = 'index.html';
   const errorDoc = 'error.html';
   beforeAll(() => {
-    mockirer(inquirer, {
-      IndexDocument: indexDoc,
-      ErrorDocument: errorDoc,
-    });
+    prompter.input = jest.fn()
+      .mockReturnValueOnce(indexDoc)
+      .mockReturnValueOnce(errorDoc);
   });
 
   test('configure', async () => {

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
@@ -24,7 +24,6 @@ const parametersFileName = 'parameters.json';
 
 const DEV = 'DEV (S3 only with HTTP)';
 const PROD = 'PROD (S3 with CloudFront using HTTPS)';
-const Environments = [DEV, PROD];
 
 const s3IndexModule = require('../../../lib/S3AndCloudFront/index');
 

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
@@ -28,8 +28,16 @@ const Environments = [DEV, PROD];
 
 const s3IndexModule = require('../../../lib/S3AndCloudFront/index');
 
-const prompter = require('amplify-prompts');
-jest.mock('amplify-prompts');
+const amplifyPrompts = require('amplify-prompts');
+
+jest.mock('amplify-prompts', () => ({
+  prompter: {
+    input: jest.fn(),
+    yesOrNo: jest.fn(),
+    pick: jest.fn(),
+  },
+  byValue: jest.fn(),
+}));
 
 describe('s3IndexModule', () => {
   const INTERNAL_TEMPLATE_FILE_PATH = path.normalize(path.join(__dirname, '../../../lib/', templateFileName));
@@ -103,7 +111,7 @@ describe('s3IndexModule', () => {
   };
 
   beforeAll(() => {
-    prompter.pick = jest.fn().mockReturnValue(mockAnswers.environment);
+    amplifyPrompts.prompter.pick.mockReturnValue(mockAnswers.environment);
     fs.ensureDirSync = jest.fn();
     fs.existsSync = jest.fn(() => {
       return true;

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/s3Index.test.js
@@ -9,8 +9,6 @@ jest.mock('../../../lib/S3AndCloudFront/helpers/cloudfront-manager');
 const fs = require('fs-extra');
 const path = require('path');
 const { open } = require('amplify-cli-core');
-const inquirer = require('inquirer');
-const mockirer = require('mockirer');
 
 const configManager = require('../../../lib/S3AndCloudFront/configuration-manager');
 const fileUPloader = require('../../../lib/S3AndCloudFront/helpers/file-uploader');
@@ -29,6 +27,9 @@ const PROD = 'PROD (S3 with CloudFront using HTTPS)';
 const Environments = [DEV, PROD];
 
 const s3IndexModule = require('../../../lib/S3AndCloudFront/index');
+
+const prompter = require('amplify-prompts');
+jest.mock('amplify-prompts');
 
 describe('s3IndexModule', () => {
   const INTERNAL_TEMPLATE_FILE_PATH = path.normalize(path.join(__dirname, '../../../lib/', templateFileName));
@@ -102,7 +103,7 @@ describe('s3IndexModule', () => {
   };
 
   beforeAll(() => {
-    mockirer(inquirer, mockAnswers);
+    prompter.pick = jest.fn().mockReturnValue(mockAnswers.environment);
     fs.ensureDirSync = jest.fn();
     fs.existsSync = jest.fn(() => {
       return true;

--- a/packages/amplify-category-hosting/commands/hosting/remove.js
+++ b/packages/amplify-category-hosting/commands/hosting/remove.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const prompter = require('amplify-prompts');
+const { prompter } = require('amplify-prompts');
 
 const subcommand = 'remove';
 const category = 'hosting';
@@ -65,7 +65,7 @@ async function chooseResource(context, inputResourceName) {
         if (inputResourceName) {
           resourceName = inputResourceName;
         } else if (enabledResources.length > 0) {
-          resourceName = await prompter.pick('Choose the resource you would want to remove', enabledResources, { returnSize: 1 });
+          resourceName = await prompter.pick('Choose the resource you would want to remove', enabledResources);
         } else {
           context.print.error(`You have not added any resources managed by the ${displayName} hosting plugin module.`);
         }

--- a/packages/amplify-category-hosting/commands/hosting/remove.js
+++ b/packages/amplify-category-hosting/commands/hosting/remove.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra');
-const path = require('path');
-const inquirer = require('inquirer');
+const prompter = require('amplify-prompts');
 
 const subcommand = 'remove';
 const category = 'hosting';
@@ -66,16 +65,7 @@ async function chooseResource(context, inputResourceName) {
         if (inputResourceName) {
           resourceName = inputResourceName;
         } else if (enabledResources.length > 0) {
-          const question = [
-            {
-              name: 'resource',
-              type: 'list',
-              message: 'Choose the resource you would want to remove',
-              choices: enabledResources,
-            },
-          ];
-          const answer = await inquirer.prompt(question);
-          resourceName = answer.resource;
+          resourceName = await prompter.pick('Choose the resource you would want to remove', enabledResources, { returnSize: 1 });
         } else {
           context.print.error(`You have not added any resources managed by the ${displayName} hosting plugin module.`);
         }

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -1,4 +1,4 @@
-const inquirer = require('inquirer');
+const { prompter, byValues, byValue } = require('amplify-prompts');
 const sequential = require('promise-sequential');
 const path = require('path');
 const categoryManager = require('./lib/category-manager');
@@ -11,15 +11,15 @@ async function add(context) {
 
   if (availableServices.length > 0) {
     if (disabledServices.length > 1) {
-      const answers = await inquirer.prompt({
-        type: 'checkbox',
-        name: 'selectedServices',
-        message: 'Please select the service(s) to add.',
-        choices: disabledServices,
-        default: disabledServices[0],
-      });
+      const selectedServices = await prompter.pick(
+        'Please select the service(s) to add.',
+        disabledServices,
+        {
+          initial: byValues([disabledServices[0]])
+        },
+      );
       const tasks = [];
-      answers.selectedServices.forEach(service => {
+      selectedServices.forEach(service => {
         tasks.push(() => categoryManager.runServiceAction(context, service, 'enable'));
       });
       return sequential(tasks);
@@ -41,15 +41,15 @@ async function configure(context) {
 
   if (availableServices.length > 0) {
     if (enabledServices.length > 1) {
-      const answers = await inquirer.prompt({
-        type: 'checkbox',
-        name: 'selectedServices',
-        message: 'Please select the service(s) to configure.',
-        choices: enabledServices,
-        default: enabledServices[0],
-      });
+      const selectedServices = await prompter.pick(
+        'Please select the service(s) to configure.',
+        enabledServices,
+        {
+          initial: byValues([enabledServices[0]])
+        }
+      );
       const tasks = [];
-      answers.selectedServices.forEach(service => {
+      selectedServices.forEach(service => {
         tasks.push(() => categoryManager.runServiceAction(context, service, 'configure'));
       });
       return sequential(tasks);
@@ -80,14 +80,12 @@ async function console(context) {
 
   if (availableServices.length > 0) {
     if (enabledServices.length > 1) {
-      const answer = await inquirer.prompt({
-        type: 'list',
-        name: 'selectedService',
-        message: 'Please select the service.',
-        choices: enabledServices,
-        default: enabledServices[0],
-      });
-      return categoryManager.runServiceAction(context, answer.selectedService, 'console');
+      const selectedService = await prompter.pick(
+        'Please select the service.',
+        enabledServices,
+        { initial: byValue([enabledServices[0]]) }
+      );
+      return categoryManager.runServiceAction(context, selectedService, 'console');
     } else if (enabledServices.length === 1) {
       return categoryManager.runServiceAction(context, enabledServices[0], 'console');
     }

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -1,4 +1,4 @@
-const { prompter, byValues, byValue } = require('amplify-prompts');
+const { prompter } = require('amplify-prompts');
 const sequential = require('promise-sequential');
 const path = require('path');
 const categoryManager = require('./lib/category-manager');
@@ -15,7 +15,8 @@ async function add(context) {
         'Please select the service(s) to add.',
         disabledServices,
         {
-          initial: byValues([disabledServices[0]])
+          initial: 0,
+          returnSize: 'many'
         },
       );
       const tasks = [];
@@ -45,7 +46,8 @@ async function configure(context) {
         'Please select the service(s) to configure.',
         enabledServices,
         {
-          initial: byValues([enabledServices[0]])
+          initial: 0,
+          returnSize: 'many'
         }
       );
       const tasks = [];
@@ -83,7 +85,7 @@ async function console(context) {
       const selectedService = await prompter.pick(
         'Please select the service.',
         enabledServices,
-        { initial: byValue([enabledServices[0]]) }
+        { initial: 0 }
       );
       return categoryManager.runServiceAction(context, selectedService, 'console');
     } else if (enabledServices.length === 1) {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
@@ -46,7 +46,7 @@ async function configureHostingComponents(context, lastConfiguredSection) {
     }
   }
 
-  const section = await prompter.pick('Specify the section to configure', options, { initial: byValue(defaultSection), returnSize: 1 });
+  const section = await prompter.pick('Specify the section to configure', options, { initial: byValue(defaultSection) });
   if (section !== done) {
     const configureModule = require(configurables[section]);
     await configureModule.configure(context);

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
@@ -62,9 +62,7 @@ async function setBucketName(context, bucketName) {
   }
 
   bucketName = bucketName.replace(/[^-a-z0-9]/g, '');
-  const answer = await prompter.input('hosting bucket name', { initial: bucketName, validate: validateBucketName });
-
-  context.exeInfo.parameters.bucketName = answer;
+  context.exeInfo.parameters.bucketName = await prompter.input('hosting bucket name', { initial: bucketName, validate: validateBucketName });
 }
 
 module.exports = {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/configuration-manager.js
@@ -1,6 +1,6 @@
-const inquirer = require('inquirer');
 const moment = require('moment');
 const validateBucketName = require('./helpers/validate-bucket-name');
+const { prompter, byValue } = require('amplify-prompts');
 
 const configurables = {
   Website: './helpers/configure-Website',
@@ -46,18 +46,11 @@ async function configureHostingComponents(context, lastConfiguredSection) {
     }
   }
 
-  const answer = await inquirer.prompt({
-    type: 'list',
-    name: 'section',
-    message: 'Specify the section to configure',
-    choices: options,
-    default: defaultSection,
-  });
-
-  if (answer.section !== done) {
-    const configureModule = require(configurables[answer.section]);
+  const section = await prompter.pick('Specify the section to configure', options, { initial: byValue(defaultSection), returnSize: 1 });
+  if (section !== done) {
+    const configureModule = require(configurables[section]);
     await configureModule.configure(context);
-    await configureHostingComponents(context, answer.section);
+    await configureHostingComponents(context, section);
   }
 }
 
@@ -69,20 +62,9 @@ async function setBucketName(context, bucketName) {
   }
 
   bucketName = bucketName.replace(/[^-a-z0-9]/g, '');
+  const answer = await prompter.input('hosting bucket name', { initial: bucketName, validate: validateBucketName });
 
-  const questions = [
-    {
-      name: 'HostingBucketName',
-      type: 'input',
-      message: 'hosting bucket name',
-      default: bucketName,
-      validate: validateBucketName,
-    },
-  ];
-
-  const answers = await inquirer.prompt(questions);
-
-  context.exeInfo.parameters.bucketName = answers.HostingBucketName;
+  context.exeInfo.parameters.bucketName = answer;
 }
 
 module.exports = {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -1,12 +1,12 @@
 const path = require('path');
-const inquirer = require('inquirer');
 const configureWebsite = require('./configure-Website');
+const { prompter, byValue } = require('amplify-prompts');
 
 const originErrorCodes = {
   400: 'Bad Request',
   403: 'Forbidden',
   404: 'Not Found',
-  405: 'Mothod Not Allowed',
+  405: 'Method Not Allowed',
   414: 'Request-URI Too Long',
   416: 'Requested Range Not Satisfiable',
   500: 'Internal Server Error',
@@ -21,13 +21,8 @@ async function configure(context) {
   const originalTemplate = context.amplify.readJsonFile(templateFilePath);
   if (!context.exeInfo.template.Resources.CloudFrontDistribution) {
     context.print.info('CloudFront is NOT in the current hosting');
-    const answer = await inquirer.prompt({
-      name: 'AddCloudFront',
-      type: 'confirm',
-      message: 'Add CloudFront to hosting',
-      default: false,
-    });
-    if (answer.AddCloudFront) {
+    const addCloudFront = await prompter.yesOrNo('Add CloudFront to hosting', false);
+    if (addCloudFront) {
       const { CloudFrontDistribution, OriginAccessIdentity, PrivateBucketPolicy } = originalTemplate.Resources;
       const { Outputs } = originalTemplate;
       context.exeInfo.template.Resources.OriginAccessIdentity = OriginAccessIdentity;
@@ -44,13 +39,8 @@ async function configure(context) {
       delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;
     }
   } else {
-    const answer = await inquirer.prompt({
-      name: 'RemoveCloudFront',
-      type: 'confirm',
-      message: 'Remove CloudFront from hosting',
-      default: false,
-    });
-    if (answer.RemoveCloudFront) {
+    const removeCloudFront = await prompter.yesOrNo('Remove CloudFront from hosting', false);
+    if (removeCloudFront) {
       delete context.exeInfo.template.Resources.OriginAccessIdentity;
       delete context.exeInfo.template.Resources.CloudFrontDistribution;
       // Don't remove the following line,
@@ -75,46 +65,12 @@ async function configure(context) {
   if (context.exeInfo.template.Resources.CloudFrontDistribution) {
     const { DistributionConfig } = context.exeInfo.template.Resources.CloudFrontDistribution.Properties;
 
-    const questions = [
-      {
-        name: 'DefaultRootObject',
-        type: 'input',
-        message: 'default object to return from origin',
-        default: DistributionConfig.DefaultRootObject,
-      },
-      {
-        name: 'DefaultCacheDefaultTTL',
-        type: 'input',
-        message: 'Default TTL for the default cache behavior',
-        default: DistributionConfig.DefaultCacheBehavior.DefaultTTL,
-      },
-      {
-        name: 'DefaultCacheMaxTTL',
-        type: 'input',
-        message: 'Max TTL for the default cache behavior',
-        default: DistributionConfig.DefaultCacheBehavior.MaxTTL,
-      },
-      {
-        name: 'DefaultCacheMinTTL',
-        type: 'input',
-        message: 'Min TTL for the default cache behavior',
-        default: DistributionConfig.DefaultCacheBehavior.MinTTL,
-      },
-      {
-        name: 'ConfigCustomError',
-        type: 'confirm',
-        message: 'Configure Custom Error Responses',
-        default: true,
-      },
-    ];
+    DistributionConfig.DefaultRootObject = await prompter.input('default object to return from origin', { initial: DistributionConfig.DefaultRootObject });
+    DistributionConfig.DefaultCacheBehavior.DefaultTTL = await prompter.input('Default TTL for the default cache behavior', { initial: DistributionConfig.DefaultCacheBehavior.DefaultTTL });
+    DistributionConfig.DefaultCacheBehavior.MaxTTL = await prompter.input('Max TTL for the default cache behavior', { initial: DistributionConfig.DefaultCacheBehavior.MaxTTL });
+    DistributionConfig.DefaultCacheBehavior.MinTTL = await prompter.input('Min TTL for the default cache behavior', { initial: DistributionConfig.DefaultCacheBehavior.MinTTL });
 
-    const answers = await inquirer.prompt(questions);
-    DistributionConfig.DefaultRootObject = answers.DefaultRootObject;
-    DistributionConfig.DefaultCacheBehavior.DefaultTTL = answers.DefaultCacheDefaultTTL;
-    DistributionConfig.DefaultCacheBehavior.MaxTTL = answers.DefaultCacheMaxTTL;
-    DistributionConfig.DefaultCacheBehavior.MinTTL = answers.DefaultCacheMinTTL;
-
-    if (answers.ConfigCustomError) {
+    if (await prompter.yesOrNo('Configure Custom Error Responses', true)) {
       await configureCustomErrorResponse(context, DistributionConfig);
     }
   }
@@ -128,15 +84,8 @@ async function configureCustomErrorResponse(context, DistributionConfig) {
   }
   const done = 'exit';
   const configActions = ['list', 'add', 'edit', 'remove', 'remove all', done];
-  const answer = await inquirer.prompt({
-    name: 'action',
-    type: 'list',
-    message: 'Please select the action on Custom Error Responses.',
-    choices: configActions,
-    default: configActions[0],
-  });
-
-  switch (answer.action) {
+  const action = await prompter.pick('Please select the action on Custom Error Responses.', configActions, { initial: byValue(configActions[0]), returnSize: 1 });
+  switch (action) {
     case 'list':
       listCustomErrorResponses(context, DistributionConfig.CustomErrorResponses);
       break;
@@ -157,7 +106,7 @@ async function configureCustomErrorResponse(context, DistributionConfig) {
       break;
   }
 
-  if (answer.action !== done) {
+  if (action !== done) {
     await configureCustomErrorResponse(context, DistributionConfig);
   }
 }
@@ -171,40 +120,11 @@ function listCustomErrorResponses(context, CustomErrorResponses) {
 async function addCER(context, CustomErrorResponses) {
   const unConfiguredCodes = getUnConfiguredErrorCodes(CustomErrorResponses);
   if (unConfiguredCodes.length > 0) {
-    const selection = await inquirer.prompt({
-      name: 'ErrorCode',
-      type: 'list',
-      message: 'Please select the error code to add custom error response.',
-      choices: unConfiguredCodes,
-      default: unConfiguredCodes[0],
-    });
-
-    const questions = [
-      {
-        name: 'ResponseCode',
-        type: 'input',
-        message: 'Response code',
-        default: 200,
-      },
-      {
-        name: 'ResponsePagePath',
-        type: 'input',
-        message: 'Response page path',
-        default: '/',
-      },
-      {
-        name: 'ErrorCachingMinTTL',
-        type: 'input',
-        message: 'Error caching Min TTL in seconds',
-        default: 300,
-      },
-    ];
-    const answers = await await inquirer.prompt(questions);
     CustomErrorResponses.push({
-      ErrorCachingMinTTL: parseInt(answers.ErrorCachingMinTTL, 10),
-      ErrorCode: parseInt(selection.ErrorCode, 10),
-      ResponseCode: parseInt(answers.ResponseCode, 10),
-      ResponsePagePath: answers.ResponsePagePath,
+      ErrorCode: await prompter.pick('Please select the error code to add custom error response.', unConfiguredCodes, { initial: byValue(unConfiguredCodes[0]), returnSize: 1, transform: input => parseInt(input, 10) }),
+      ResponseCode: await prompter.input('Response code', { initial: 200, transform: input => parseInt(input, 10) }),
+      ResponsePagePath: await prompter.input('Response page path', { initial: '/' }),
+      ErrorCachingMinTTL: await prompter.input('Error caching Min TTL in seconds', { initial: 300, transform: input => parseInt(input, 10) }),
     });
   } else {
     context.print.info('All configurable error codes from the origin have been mapped.');
@@ -215,41 +135,12 @@ async function addCER(context, CustomErrorResponses) {
 async function editCER(context, CustomErrorResponses) {
   const configuredCodes = getConfiguredErrorCodes(CustomErrorResponses);
   if (configuredCodes.length > 0) {
-    const selection = await inquirer.prompt({
-      name: 'ErrorCode',
-      type: 'list',
-      message: 'Please select the error code to edit its custom error response.',
-      choices: configuredCodes,
-      default: configuredCodes[0],
-    });
-
-    const i = getCerIndex(selection.ErrorCode, CustomErrorResponses);
-    const questions = [
-      {
-        name: 'ResponseCode',
-        type: 'input',
-        message: 'Response code',
-        default: CustomErrorResponses[i].ResponseCode,
-      },
-      {
-        name: 'ResponsePagePath',
-        type: 'input',
-        message: 'Response page path',
-        default: CustomErrorResponses[i].ResponsePagePath,
-      },
-      {
-        name: 'ErrorCachingMinTTL',
-        type: 'input',
-        message: 'Error caching Min TTL in seconds',
-        default: CustomErrorResponses[i].ErrorCachingMinTTL,
-      },
-    ];
-    const answers = await await inquirer.prompt(questions);
-    Object.assign(CustomErrorResponses[i], answers);
-    CustomErrorResponses[i].ErrorCachingMinTTL = parseInt(answers.ErrorCachingMinTTL, 10);
-    CustomErrorResponses[i].ErrorCode = parseInt(selection.ErrorCode, 10);
-    CustomErrorResponses[i].ResponseCode = parseInt(answers.ResponseCode, 10);
-    CustomErrorResponses[i].ResponsePagePath = answers.ResponsePagePath;
+    const errorCode = await prompter.pick('Please select the error code to edit its custom error response.', configuredCodes, { initial: byValue(configuredCodes[0]), returnSize: 1, transform: input => parseInt(input, 10) });
+    const i = getCerIndex(errorCode, CustomErrorResponses);
+    CustomErrorResponses[i].ErrorCode = errorCode;
+    CustomErrorResponses[i].ResponseCode = await prompter.input('Response code', { initial: CustomErrorResponses[i].ResponseCode, transform: input => parseInt(input, 10) });
+    CustomErrorResponses[i].ResponsePagePath = await prompter.input('Response page path', { initial: CustomErrorResponses[i].ResponsePagePath });
+    CustomErrorResponses[i].ErrorCachingMinTTL = await prompter.input('Error caching Min TTL in seconds', { initial: CustomErrorResponses[i].ErrorCachingMinTTL, transform: input => parseInt(input, 10) });
   } else {
     context.print.info('No configurable error code from the origin has been mapped.');
     context.print.info('You can select to add custom error responses.');
@@ -259,15 +150,13 @@ async function editCER(context, CustomErrorResponses) {
 async function removeCER(context, CustomErrorResponses) {
   const configuredCodes = getConfiguredErrorCodes(CustomErrorResponses);
   if (configuredCodes.length > 0) {
-    const selection = await inquirer.prompt({
-      name: 'ErrorCode',
-      type: 'list',
-      message: 'Please select the error code to remove its custom error response.',
-      choices: configuredCodes,
-      default: configuredCodes[0],
-    });
+    const selection = await prompter.pick(
+      'Please select the error code to remove its custom error response.',
+      configuredCodes,
+      { initial: configuredCodes[0], returnSize: 1 }
+    );
 
-    const i = getCerIndex(selection.ErrorCode, CustomErrorResponses);
+    const i = getCerIndex(selection, CustomErrorResponses);
     CustomErrorResponses.splice(i, 1);
   } else {
     context.print.info('No configurable error code from the origin has been mapped.');

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -84,7 +84,7 @@ async function configureCustomErrorResponse(context, DistributionConfig) {
   }
   const done = 'exit';
   const configActions = ['list', 'add', 'edit', 'remove', 'remove all', done];
-  const action = await prompter.pick('Please select the action on Custom Error Responses.', configActions, { initial: byValue(configActions[0]), returnSize: 1 });
+  const action = await prompter.pick('Please select the action on Custom Error Responses.', configActions, { initial: byValue(configActions[0]) });
   switch (action) {
     case 'list':
       listCustomErrorResponses(context, DistributionConfig.CustomErrorResponses);

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-CloudFront.js
@@ -121,7 +121,7 @@ async function addCER(context, CustomErrorResponses) {
   const unConfiguredCodes = getUnConfiguredErrorCodes(CustomErrorResponses);
   if (unConfiguredCodes.length > 0) {
     CustomErrorResponses.push({
-      ErrorCode: await prompter.pick('Please select the error code to add custom error response.', unConfiguredCodes, { initial: byValue(unConfiguredCodes[0]), returnSize: 1, transform: input => parseInt(input, 10) }),
+      ErrorCode: await prompter.pick('Please select the error code to add custom error response.', unConfiguredCodes, { initial: byValue(unConfiguredCodes[0]), transform: input => parseInt(input, 10) }),
       ResponseCode: await prompter.input('Response code', { initial: 200, transform: input => parseInt(input, 10) }),
       ResponsePagePath: await prompter.input('Response page path', { initial: '/' }),
       ErrorCachingMinTTL: await prompter.input('Error caching Min TTL in seconds', { initial: 300, transform: input => parseInt(input, 10) }),
@@ -135,7 +135,7 @@ async function addCER(context, CustomErrorResponses) {
 async function editCER(context, CustomErrorResponses) {
   const configuredCodes = getConfiguredErrorCodes(CustomErrorResponses);
   if (configuredCodes.length > 0) {
-    const errorCode = await prompter.pick('Please select the error code to edit its custom error response.', configuredCodes, { initial: byValue(configuredCodes[0]), returnSize: 1, transform: input => parseInt(input, 10) });
+    const errorCode = await prompter.pick('Please select the error code to edit its custom error response.', configuredCodes, { initial: byValue(configuredCodes[0]), transform: input => parseInt(input, 10) });
     const i = getCerIndex(errorCode, CustomErrorResponses);
     CustomErrorResponses[i].ErrorCode = errorCode;
     CustomErrorResponses[i].ResponseCode = await prompter.input('Response code', { initial: CustomErrorResponses[i].ResponseCode, transform: input => parseInt(input, 10) });
@@ -153,7 +153,7 @@ async function removeCER(context, CustomErrorResponses) {
     const selection = await prompter.pick(
       'Please select the error code to remove its custom error response.',
       configuredCodes,
-      { initial: configuredCodes[0], returnSize: 1 }
+      { initial: configuredCodes[0] }
     );
 
     const i = getCerIndex(selection, CustomErrorResponses);

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Publish.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const minimatch = require('minimatch');
 const fs = require('fs-extra');
-const prompter = require('amplify-prompts');
+const { prompter, byValue } = require('amplify-prompts');
 
 const PublishIgnoreFileName = 'amplifyPublishIgnore.json';
 
@@ -54,7 +54,7 @@ async function configurePublishIgnore(context, publishIgnore) {
   const action = await prompter.pick(
     'Please select the configuration action on the publish ignore.',
     configActions,
-    { initial: configActions[0], returnSize: 1 },
+    { initial: byValue(configActions[0]) },
   );
 
   switch (action) {
@@ -112,7 +112,7 @@ async function removeIgnore(context, publishIgnore) {
   } else {
     const patternToRemove = await prompter.pick('', [...publishIgnore, CANCEL]);
     if (patternToRemove && patternToRemove !== CANCEL) {
-      publishIgnore = publishIgnore.filter(ignore => answer.patternToRemove !== ignore);
+      publishIgnore = publishIgnore.filter(ignore => patternToRemove !== ignore);
     }
   }
   return publishIgnore;

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Website.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Website.js
@@ -1,36 +1,17 @@
-const inquirer = require('inquirer');
-
+const prompter = require('amplify-prompts');
 const validateDocName = require('./validate-website-doc-name');
 
 async function configure(context) {
   if (!context.exeInfo.template.Resources.CloudFrontDistribution) {
     const { WebsiteConfiguration } = context.exeInfo.template.Resources.S3Bucket.Properties;
-    const questions = [
-      {
-        name: 'IndexDocument',
-        type: 'input',
-        message: 'index doc for the website',
-        default: WebsiteConfiguration.IndexDocument,
-        validate: validateDocName,
-      },
-      {
-        name: 'ErrorDocument',
-        type: 'input',
-        message: 'error doc for the website',
-        default: WebsiteConfiguration.ErrorDocument,
-        validate: validateDocName,
-      },
-    ];
-
-    const answers = await inquirer.prompt(questions);
-    WebsiteConfiguration.IndexDocument = answers.IndexDocument.trim();
-    WebsiteConfiguration.ErrorDocument = answers.ErrorDocument.trim();
+    WebsiteConfiguration.IndexDocument = await prompter.input('index doc for the website', { initial: WebsiteConfiguration.IndexDocument, validate: validateDocName, transform: input => input.trim() });
+    WebsiteConfiguration.ErrorDocument = await prompter.input('error doc for the website', { initial: WebsiteConfiguration.ErrorDocument, validate: validateDocName, transform: input => input.trim() });
   } else {
     context.print.warning('Static webhosting is disabled for the hosting bucket when CloudFront Distribution is enabled.');
   }
   return context;
 }
 
-module.exports = {
+export default {
   configure,
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Website.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/configure-Website.js
@@ -1,4 +1,4 @@
-const prompter = require('amplify-prompts');
+const { prompter } = require('amplify-prompts');
 const validateDocName = require('./validate-website-doc-name');
 
 async function configure(context) {
@@ -12,6 +12,6 @@ async function configure(context) {
   return context;
 }
 
-export default {
+module.exports = {
   configure,
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/validate-website-doc-name.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/validate-website-doc-name.js
@@ -8,7 +8,7 @@ module.exports = value => {
 
   isValid = !/\//.test(value);
   if (!isValid) {
-    return 'The slash charactor is not allowed.';
+    return 'The slash character is not allowed.';
   }
   return true;
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -1,5 +1,4 @@
 const fs = require('fs-extra');
-const inquirer = require('inquirer');
 const path = require('path');
 const chalk = require('chalk');
 const { open } = require('amplify-cli-core');
@@ -7,6 +6,7 @@ const configManager = require('./configuration-manager');
 const fileUPloader = require('./helpers/file-uploader');
 const cloudFrontManager = require('./helpers/cloudfront-manager');
 const constants = require('../constants');
+const { prompter, byValue } = require('amplify-prompts');
 
 const serviceName = 'S3AndCloudFront';
 const providerPlugin = 'awscloudformation';
@@ -53,14 +53,7 @@ async function enable(context) {
 }
 
 async function checkCDN(context) {
-  const selectEnvironment = {
-    type: 'list',
-    name: 'environment',
-    message: 'Select the environment setup:',
-    choices: Environments,
-    default: DEV,
-  };
-  const answer = await inquirer.prompt(selectEnvironment);
+  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(DEV), returnSize: 1 });
   if (answer.environment === DEV) {
     removeCDN(context);
   } else {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -53,8 +53,8 @@ async function enable(context) {
 }
 
 async function checkCDN(context) {
-  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(DEV), returnSize: 1 });
-  if (answer.environment === DEV) {
+  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(DEV) });
+  if (answer === DEV) {
     removeCDN(context);
   } else {
     makeBucketPrivate(context);

--- a/packages/amplify-category-hosting/package.json
+++ b/packages/amplify-category-hosting/package.json
@@ -19,17 +19,14 @@
   },
   "dependencies": {
     "amplify-cli-core": "3.5.1",
+    "amplify-prompts": "2.6.2",
     "chalk": "^4.1.1",
     "fs-extra": "^8.1.0",
-    "inquirer": "^7.3.3",
     "mime-types": "^2.1.26",
     "minimatch": "^3.0.4",
     "moment": "^2.24.0",
     "ora": "^4.0.3",
     "promise-sequential": "^1.1.1"
-  },
-  "devDependencies": {
-    "mockirer": "^2.0.1"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
#### Description of changes
- migrate hosting category from inquirer to prompter library

#### Checklist
- [x] PR description included
- [x] `yarn test` passes 
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
