### PR TITLE
fix: fallback to empty array there is an error fetching resources for account cleanup

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -131,13 +131,13 @@ const handleExpiredTokenException = (): void => {
  */
 const testBucketStalenessFilter = (resource: aws.S3.Bucket): boolean => {
   const isTestResource = resource.Name.match(BUCKET_TEST_REGEX);
-  const isStaleResource = (new Date().getUTCMilliseconds() - resource.CreationDate.getUTCMilliseconds()) > STALE_DURATION_MS;
+  const isStaleResource = new Date().getUTCMilliseconds() - resource.CreationDate.getUTCMilliseconds() > STALE_DURATION_MS;
   return isTestResource && isStaleResource;
 };
 
 const testRoleStalenessFilter = (resource: aws.IAM.Role): boolean => {
   const isTestResource = resource.RoleName.match(IAM_TEST_REGEX);
-  const isStaleResource = (new Date().getUTCMilliseconds() - resource.CreateDate.getUTCMilliseconds()) > STALE_DURATION_MS;
+  const isStaleResource = new Date().getUTCMilliseconds() - resource.CreateDate.getUTCMilliseconds() > STALE_DURATION_MS;
   return isTestResource && isStaleResource;
 };
 
@@ -147,14 +147,14 @@ const testAppSyncApiStalenessFilter = (resource: aws.AppSync.GraphqlApi): boolea
   let isStaleResource = true;
   if (createTimeTagValue) {
     const createTime = new Date(createTimeTagValue);
-    isStaleResource = (new Date().getUTCMilliseconds() - createTime.getUTCMilliseconds()) > STALE_DURATION_MS;
+    isStaleResource = new Date().getUTCMilliseconds() - createTime.getUTCMilliseconds() > STALE_DURATION_MS;
   }
   return isTestResource && isStaleResource;
 };
 
 const testPinpointAppStalenessFilter = (resource: aws.Pinpoint.ApplicationResponse): boolean => {
   const isTestResource = resource.Name.match(PINPOINT_TEST_REGEX);
-  const isStaleResource = (new Date().getUTCMilliseconds() - new Date(resource.CreationDate).getUTCMilliseconds()) > STALE_DURATION_MS;
+  const isStaleResource = new Date().getUTCMilliseconds() - new Date(resource.CreationDate).getUTCMilliseconds() > STALE_DURATION_MS;
   return isTestResource && isStaleResource;
 };
 
@@ -184,12 +184,20 @@ const getOrphanPinpointApplications = async (account: AWSAccountInfo, region: st
   let nextToken = null;
 
   do {
-    const result = await pinpoint.getApps({
-      Token: nextToken,
-    }).promise();
-    apps.push(...result.ApplicationsResponse.Item.filter(testPinpointAppStalenessFilter).map(it => ({
-      id: it.Id, name: it.Name, arn: it.Arn, region, createTime: new Date(it.CreationDate),
-    })));
+    const result = await pinpoint
+      .getApps({
+        Token: nextToken,
+      })
+      .promise();
+    apps.push(
+      ...result.ApplicationsResponse.Item.filter(testPinpointAppStalenessFilter).map(it => ({
+        id: it.Id,
+        name: it.Name,
+        arn: it.Arn,
+        region,
+        createTime: new Date(it.CreationDate),
+      })),
+    );
 
     nextToken = result.ApplicationsResponse.NextToken;
   } while (nextToken);
@@ -348,7 +356,7 @@ const getJobCircleCIDetails = async (jobId: number): Promise<CircleCIJobDetails>
   const client = getCircleCIClient();
   const result = await client.build(jobId);
 
-  const r = _.pick(result, [
+  const r = (_.pick(result, [
     'build_url',
     'branch',
     'build_num',
@@ -359,7 +367,7 @@ const getJobCircleCIDetails = async (jobId: number): Promise<CircleCIJobDetails>
     'committer_name',
     'workflows.workflow_id',
     'lifecycle',
-  ]) as unknown as CircleCIJobDetails;
+  ]) as unknown) as CircleCIJobDetails;
   return r;
 };
 
@@ -549,11 +557,7 @@ const deleteIamRole = async (account: AWSAccountInfo, accountIndex: number, role
   }
 };
 
-const deleteAttachedRolePolicies = async (
-  account: AWSAccountInfo,
-  accountIndex: number,
-  roleName: string,
-): Promise<void> => {
+const deleteAttachedRolePolicies = async (account: AWSAccountInfo, accountIndex: number, roleName: string): Promise<void> => {
   const iamClient = new aws.IAM(getAWSConfig(account));
   const rolePolicies = await iamClient.listAttachedRolePolicies({ RoleName: roleName }).promise();
   await Promise.all(rolePolicies.AttachedPolicies.map(policy => detachIamAttachedRolePolicy(account, accountIndex, roleName, policy)));
@@ -577,22 +581,13 @@ const detachIamAttachedRolePolicy = async (
   }
 };
 
-const deleteRolePolicies = async (
-  account: AWSAccountInfo,
-  accountIndex: number,
-  roleName: string,
-): Promise<void> => {
+const deleteRolePolicies = async (account: AWSAccountInfo, accountIndex: number, roleName: string): Promise<void> => {
   const iamClient = new aws.IAM(getAWSConfig(account));
   const rolePolicies = await iamClient.listRolePolicies({ RoleName: roleName }).promise();
   await Promise.all(rolePolicies.PolicyNames.map(policy => deleteIamRolePolicy(account, accountIndex, roleName, policy)));
 };
 
-const deleteIamRolePolicy = async (
-  account: AWSAccountInfo,
-  accountIndex: number,
-  roleName: string,
-  policyName: string,
-): Promise<void> => {
+const deleteIamRolePolicy = async (account: AWSAccountInfo, accountIndex: number, roleName: string, policyName: string): Promise<void> => {
   try {
     console.log(`[ACCOUNT ${accountIndex}] Deleting Iam Role Policy ${policyName}`);
     const iamClient = new aws.IAM(getAWSConfig(account));
@@ -629,9 +624,7 @@ const deletePinpointApps = async (account: AWSAccountInfo, accountIndex: number,
 };
 
 const deletePinpointApp = async (account: AWSAccountInfo, accountIndex: number, app: PinpointAppInfo): Promise<void> => {
-  const {
-    id, name, region,
-  } = app;
+  const { id, name, region } = app;
   try {
     console.log(`[ACCOUNT ${accountIndex}] Deleting Pinpoint App ${name}`);
     console.log(`Pinpoint creation time (PST): ${app.createTime.toLocaleTimeString('en-US', { timeZone: 'America/Los_Angeles' })}`);
@@ -647,9 +640,7 @@ const deleteAppSyncApis = async (account: AWSAccountInfo, accountIndex: number, 
 };
 
 const deleteAppSyncApi = async (account: AWSAccountInfo, accountIndex: number, api: AppSyncApiInfo): Promise<void> => {
-  const {
-    apiId, name, region,
-  } = api;
+  const { apiId, name, region } = api;
   try {
     console.log(`[ACCOUNT ${accountIndex}] Deleting AppSync Api ${name}`);
     const appSync = new aws.AppSync(getAWSConfig(account, region));
@@ -798,7 +789,9 @@ const getAccountsToCleanup = async (): Promise<AWSAccountInfo[]> => {
     return await Promise.all(accountCredentialPromises);
   } catch (e) {
     console.error(e);
-    console.log('Error assuming child account role. This could be because the script is already running from within a child account. Running on current AWS account only.');
+    console.log(
+      'Error assuming child account role. This could be because the script is already running from within a child account. Running on current AWS account only.',
+    );
     return [
       {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
@@ -810,24 +803,32 @@ const getAccountsToCleanup = async (): Promise<AWSAccountInfo[]> => {
 };
 
 const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, filterPredicate: JobFilterPredicate): Promise<void> => {
-  const appPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getAmplifyApps(account, region));
-  const stackPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getStacks(account, region));
-  const bucketPromise = getS3Buckets(account);
-  const orphanPinpointApplicationsPromise = AWS_REGIONS_TO_RUN_TESTS.map(region => getOrphanPinpointApplications(account, region));
-  const orphanBucketPromise = getOrphanS3TestBuckets(account);
-  const orphanIamRolesPromise = getOrphanTestIamRoles(account);
-  const orphanAppSyncApisPromise = AWS_REGIONS_TO_RUN_TESTS.map(region => getOrphanAppSyncApis(account, region));
+  const appPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getAmplifyApps(account, region).catch(() => []));
+  const stackPromises = AWS_REGIONS_TO_RUN_TESTS.map(region => getStacks(account, region).catch(() => []));
+  const bucketPromise = getS3Buckets(account).catch(() => []);
+  const orphanPinpointApplicationsPromise = AWS_REGIONS_TO_RUN_TESTS.map(region =>
+    getOrphanPinpointApplications(account, region).catch(() => []),
+  );
+  const orphanBucketPromise = getOrphanS3TestBuckets(account).catch(() => []);
+  const orphanIamRolesPromise = getOrphanTestIamRoles(account).catch(() => []);
+  const orphanAppSyncApisPromise = AWS_REGIONS_TO_RUN_TESTS.map(region => getOrphanAppSyncApis(account, region).catch(() => []));
 
-  const apps = (await Promise.all(appPromises)).flat();
-  const stacks = (await Promise.all(stackPromises)).flat();
-  const buckets = await bucketPromise;
-  const orphanBuckets = await orphanBucketPromise;
-  const orphanIamRoles = await orphanIamRolesPromise;
-  const orphanPinpointApplications = (await Promise.all(orphanPinpointApplicationsPromise)).flat();
-  const orphanAppSyncApis = (await Promise.all(orphanAppSyncApisPromise)).flat();
+  const apps = (await Promise.all(appPromises).catch(() => [])).flat();
+  const stacks = (await Promise.all(stackPromises).catch(() => [])).flat();
+  const buckets = await bucketPromise.catch(() => []);
+  const orphanBuckets = await orphanBucketPromise.catch(() => []);
+  const orphanIamRoles = await orphanIamRolesPromise.catch(() => []);
+  const orphanPinpointApplications = (await Promise.all(orphanPinpointApplicationsPromise).catch(() => [])).flat();
+  const orphanAppSyncApis = (await Promise.all(orphanAppSyncApisPromise).catch(() => [])).flat();
 
   const allResources = mergeResourcesByCCIJob(
-    apps, stacks, buckets, orphanBuckets, orphanIamRoles, orphanPinpointApplications, orphanAppSyncApis
+    apps,
+    stacks,
+    buckets,
+    orphanBuckets,
+    orphanIamRoles,
+    orphanPinpointApplications,
+    orphanAppSyncApis,
   );
   const staleResources = _.pickBy(allResources, filterPredicate);
 


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently, if there is a rejected promise while gathering any of the resources to be cleaned in the e2e cleanup script, none of the resources are cleaned. For example, while attempting to fetch an amplify app with a deleted stack, an error is thrown, and none of the associated resources are cleaned up. Additionally, any timeout, too many requests, etc, will cause the cleanup to fail entirely. This has led to an accumulation of lingering e2e resources.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
