### PR TITLE
fix(amplify-util-uibuilder): tester codegen-ui update to 2.6.0 do not…

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.6",
-    "@aws-amplify/codegen-ui-react": "2.5.6",
+    "@aws-amplify/codegen-ui": "2.6.0",
+    "@aws-amplify/codegen-ui-react": "2.6.0",
     "amplify-cli-core": "3.5.0",
     "amplify-prompts": "2.6.2",
     "aws-sdk": "^2.1233.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.5.6":
-  version "2.5.6"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.6.tgz#d70416c1f35c0c8fd8d8f7ef70a6fb40a46d9822"
-  integrity sha512-RScybJUc+hUp0z+IXkUecsy0tMPNu0YjKO3eCEDrJZyv31aHGdsbadElgVU61p6l3iYig6SwA9mE+SrKw86ALg==
+"@aws-amplify/codegen-ui-react@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.6.0.tgz#7b7421b92c23a9d9675e81b81f48fcc1220f4072"
+  integrity sha512-EbAiDCgcedtGmNWr8LHXRQ6coxa/G7dt/q3wQ+BSazzRLsSAkl6oCikowv3ENFuRoHeOpc0F6kos0ojoicyNCQ==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.5.6"
+    "@aws-amplify/codegen-ui" "2.6.0"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.5.6":
-  version "2.5.6"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.6.tgz#af61c36c12c19880914cae1601b3387579e87d02"
-  integrity sha512-xbe7Hw5boVzT1aSwrDwIQvZ85pNz25zJDIL4xvt1JyjWt2u5flY2DqxMAutltKmY2EGfDFWEzsz7ze/+NCWBtA==
+"@aws-amplify/codegen-ui@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.6.0.tgz#9406a396ca46a4c57f8bde79c989dac616b21f5c"
+  integrity sha512-+N9hROHQxApfo5M/wmY3J7uWx11kFxoVELNXwVpTU6gzW1G9nT19agTvAWOCanxnKjGyDmfpfJRD8+6DmyjxAA==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
This is a test PR to troubleshoot failing e2e tests for https://github.com/aws-amplify/amplify-cli/pull/11701
Please run e2e tests against this but do not merge.