### PR TITLE
fix(amplify-util-uibuilder): update codegen-ui to 2.7.2

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.5.6",
-    "@aws-amplify/codegen-ui-react": "2.5.6",
+    "@aws-amplify/codegen-ui": "2.7.2",
+    "@aws-amplify/codegen-ui-react": "2.7.2",
     "amplify-cli-core": "3.5.0",
     "amplify-prompts": "2.6.2",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/utils.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/utils.ts
@@ -4,6 +4,7 @@ export const exampleSchema: GenericDataSchema = {
   dataSourceType: 'DataStore',
   models: {
     Author: {
+      primaryKeys: ['id'],
       fields: {
         id: {
           dataType: 'ID',
@@ -50,6 +51,7 @@ export const exampleSchema: GenericDataSchema = {
       },
     },
     JoinTable: {
+      primaryKeys: ['id'],
       fields: {
         id: {
           dataType: 'ID',
@@ -61,6 +63,7 @@ export const exampleSchema: GenericDataSchema = {
       isJoinTable: true
     },
     EmptyModel: {
+      primaryKeys: ['id'],
       fields: {
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.5.6":
-  version "2.5.6"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.5.6.tgz#d70416c1f35c0c8fd8d8f7ef70a6fb40a46d9822"
-  integrity sha512-RScybJUc+hUp0z+IXkUecsy0tMPNu0YjKO3eCEDrJZyv31aHGdsbadElgVU61p6l3iYig6SwA9mE+SrKw86ALg==
+"@aws-amplify/codegen-ui-react@2.7.2":
+  version "2.7.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.7.2.tgz#3789a9f0e989aff6009f27d15106f979fa752898"
+  integrity sha512-glUu6mNY/z8NwBe9D+MauyKENguujlPgnHZYbVouqAa+y4KTwLnXF6valkg6pOFI2bed7eBRzTtIdmo29BVJvA==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.5.6"
+    "@aws-amplify/codegen-ui" "2.7.2"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.5.6":
-  version "2.5.6"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.5.6.tgz#af61c36c12c19880914cae1601b3387579e87d02"
-  integrity sha512-xbe7Hw5boVzT1aSwrDwIQvZ85pNz25zJDIL4xvt1JyjWt2u5flY2DqxMAutltKmY2EGfDFWEzsz7ze/+NCWBtA==
+"@aws-amplify/codegen-ui@2.7.2":
+  version "2.7.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.7.2.tgz#aa4ca4f21162e7b6badf49e71987eb3507177906"
+  integrity sha512-nAVfanYejH0HB9wIbfObFZLo73Uec5MeUlH5CfUMWyZP2MF59BgAp+zy3IStiJxq+kpH4xVitAdKLNAz6ubqhQ==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Recent upgrades in `amplify-codegen` in the CLI as well as the major version bump for `@aws-amplify/datastore` has introduced regressions in UI Builder functionality:

* Collection generation for models with relationships is broken
* Accessing `hasOne` and `belongsTo` related records is broken in collections

We have several customers reporting issues in Github. Issue: https://github.com/aws-amplify/amplify-studio/issues/763

The new version of `codegen-ui` addresses the above issues.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit & e2e tests in `codegen-ui`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
