### PR TITLE
chore: remove datastore Schema type dependency

### DIFF
--- a/packages/amplify-util-uibuilder/src/__tests__/prePushHandler.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/prePushHandler.test.ts
@@ -24,7 +24,7 @@ describe('handlePrePush', () => {
   beforeEach(() => {
     context = {
       amplify: {
-        invokePluginMethod: () => ({ models: { Comment: {} } }),
+        invokePluginMethod: jest.fn().mockResolvedValue({ models: { Comment: {} } }),
       },
       input: {
         options: {
@@ -87,17 +87,15 @@ describe('handlePrePush', () => {
   });
 
   it('runs handlePrePush', async () => {
-    utilsMock.isFormDetachedFromModel = jest.fn().mockImplementation(() => true);
-    utilsMock.isFormSchemaCustomized = jest.fn().mockImplementation(() => true);
+    utilsMock.isFormDetachedFromModel = jest.fn().mockReturnValue(true);
+    utilsMock.isFormSchemaCustomized = jest.fn().mockReturnValue(true);
     const spy = jest.spyOn(printer, 'warn');
     await prePushHandler(context);
     expect(spy).toHaveBeenCalledWith('The following forms will no longer be available because the connected data model no longer exists: BlogCreateForm, BlogUpdateForm');
   });
 
   it('runs handlePrePush without schema', async () => {
-    context.amplify.invokePluginMethod = jest.fn()
-      .mockImplementation(() => ({ models: { Comment: {} } }))
-      .mockImplementation(() => (null));
+    context.amplify.invokePluginMethod = jest.fn().mockResolvedValue(null);
     const spy = jest.spyOn(printer, 'debug');
     await prePushHandler(context);
     expect(spy).toHaveBeenCalledWith('Local schema not found');

--- a/packages/amplify-util-uibuilder/src/utils/prePushHandler.ts
+++ b/packages/amplify-util-uibuilder/src/utils/prePushHandler.ts
@@ -1,9 +1,13 @@
 import { $TSContext } from 'amplify-cli-core';
-import type { Schema } from '@aws-amplify/datastore';
 import { printer } from 'amplify-prompts';
 import AmplifyUIBuilder from 'aws-sdk/clients/amplifyuibuilder';
 import { AmplifyStudioClient } from '../clients';
 import { isFormDetachedFromModel, isFormSchemaCustomized, shouldRenderComponents } from '../commands/utils';
+
+// TODO: replace this type when amplify-codegen package export official types
+type Schema = {
+  models: Record<string, unknown>
+};
 
 /**
  * Handles showing a warning for detached forms pre-push.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Update code to remove the datastore type. We will use the type from codegen when it's exported in the future. As for now, there's no need to use datastore and we'd like to remove the import.

This also removes the datastore dependency.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
