### PR TITLE
chore: Persist downstream exceptions in usage metrics

### DIFF
--- a/packages/amplify-cli/src/__tests__/usage-data.test.ts
+++ b/packages/amplify-cli/src/__tests__/usage-data.test.ts
@@ -190,20 +190,20 @@ describe('test usageData calls', () => {
 describe('test usage data payload generation', () => {
   it('when no error', async () => {
     expect(UsageData.Instance.getUsageDataPayload(null, '').error).toBeUndefined();
-    expect(UsageData.Instance.getUsageDataPayload(null, '').downStreamException).toBeUndefined();
+    expect(UsageData.Instance.getUsageDataPayload(null, '').downstreamException).toBeUndefined();
   });
   it('when error without downstream exception', async () => {
     const amplifyError = new AmplifyError('NotImplementedError', { message: 'test error message' });
     const usageData = UsageData.Instance.getUsageDataPayload(amplifyError, '');
     expect(usageData.error).toEqual(new SerializableError(amplifyError));
-    expect(usageData.downStreamException).toBeUndefined();
+    expect(usageData.downstreamException).toBeUndefined();
   });
   it('when error with downstream exception', async () => {
-    const downStreamException = new Error('DownStreamException');
-    const amplifyError = new AmplifyError('NotImplementedError', { message: 'test error message' }, downStreamException);
+    const downstreamException = new Error('DownStreamException');
+    const amplifyError = new AmplifyError('NotImplementedError', { message: 'test error message' }, downstreamException);
     const usageData = UsageData.Instance.getUsageDataPayload(amplifyError, '');
     expect(usageData.error).toEqual(new SerializableError(amplifyError));
-    expect(usageData.downStreamException).toEqual(new SerializableError(downStreamException));
+    expect(usageData.downstreamException).toEqual(new SerializableError(downstreamException));
   });
 });
 

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
@@ -19,7 +19,7 @@ export class UsageDataPayload implements IUsageDataPayload {
   inputOptions: InputOptions;
   timestamp: string;
   error!: SerializableError;
-  downStreamException!: SerializableError;
+  downstreamException!: SerializableError;
   payloadVersion: string;
   osPlatform: string;
   osRelease: string;
@@ -64,7 +64,7 @@ export class UsageDataPayload implements IUsageDataPayload {
     if (error) {
       this.error = new SerializableError(error);
       if ('downstreamException' in error && (error as $TSAny).downstreamException) {
-        this.downStreamException = new SerializableError((error as $TSAny).downstreamException as Error);
+        this.downstreamException = new SerializableError((error as $TSAny).downstreamException as Error);
       }
     }
   }

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataPayload.ts
@@ -1,4 +1,4 @@
-import { isCI } from 'amplify-cli-core';
+import { $TSAny, isCI } from 'amplify-cli-core';
 import { IFlowReport } from 'amplify-cli-shared-interfaces';
 import * as os from 'os';
 import { Input } from '../input';
@@ -19,6 +19,7 @@ export class UsageDataPayload implements IUsageDataPayload {
   inputOptions: InputOptions;
   timestamp: string;
   error!: SerializableError;
+  downStreamException!: SerializableError;
   payloadVersion: string;
   osPlatform: string;
   osRelease: string;
@@ -62,6 +63,9 @@ export class UsageDataPayload implements IUsageDataPayload {
     this.flowReport = flowReport;
     if (error) {
       this.error = new SerializableError(error);
+      if ('downstreamException' in error && (error as $TSAny).downstreamException) {
+        this.downStreamException = new SerializableError((error as $TSAny).downstreamException as Error);
+      }
     }
   }
 }

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataTypes.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataTypes.ts
@@ -35,7 +35,7 @@ export interface IUsageDataPayload {
   inputOptions: InputOptions;
   timestamp: string;
   error: SerializableError;
-  downStreamException: SerializableError;
+  downstreamException: SerializableError;
   payloadVersion: string;
   osPlatform: string;
   osRelease: string;

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageDataTypes.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageDataTypes.ts
@@ -35,6 +35,7 @@ export interface IUsageDataPayload {
   inputOptions: InputOptions;
   timestamp: string;
   error: SerializableError;
+  downStreamException: SerializableError;
   payloadVersion: string;
   osPlatform: string;
   osRelease: string;


### PR DESCRIPTION
#### Description of changes

Persist downstream exceptions in usage metrics that are not of type 'AmplifyException`

Pending items:
- [ ] Update transformation lambda function to handle the new field similar to `error` [In progress]
- [ ] Update db with the new columns generated by lambda 

#### Description of how you validated changes

unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
