### PR TITLE
fix: do not overload NODE_ENV env parameter for usage data filtering

### DIFF
--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
 // this file should be a duplicate of amplify.production.template except for the CLI_ENV value
-process.env.CLI_ENV = "development";
+process.env.CLI_ENV = 'development';
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
-// this file should be a duplicate of amplify.production.template except for the CLI_DEV value
-process.env.CLI_DEV = true;
+// this file should be a duplicate of amplify.production.template except for the CLI_ENV value
+process.env.CLI_ENV = "development";
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
-// this file should be a duplicate of amplify.production.template except for the NODE_ENV value
-process.env.NODE_ENV = 'development';
+// this file should be a duplicate of amplify.production.template except for the CLI_DEV value
+process.env.CLI_DEV = true;
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/bin/amplify.production.template
+++ b/packages/amplify-cli/bin/amplify.production.template
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
-// this file should be a duplicate of amplify.production.template except for the NODE_ENV value
-process.env.NODE_ENV = 'production';
+// this file should be a duplicate of amplify.production.template except for the CLI_DEV value
+process.env.CLI_DEV = false;
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/bin/amplify.production.template
+++ b/packages/amplify-cli/bin/amplify.production.template
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
-// this file should be a duplicate of amplify.production.template except for the CLI_DEV value
-process.env.CLI_DEV = false;
+// this file should be a duplicate of amplify.production.template except for the CLI_ENV value
+process.env.CLI_ENV = "production";
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/bin/amplify.production.template
+++ b/packages/amplify-cli/bin/amplify.production.template
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, global-require */
 
-// this file should be a duplicate of amplify.production.template except for the CLI_ENV value
-process.env.CLI_ENV = "production";
+// this file should be a duplicate of amplify except for the CLI_ENV value
+process.env.CLI_ENV = 'production';
 
 const startTime = Date.now();
 if (process.pkg) {

--- a/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
@@ -25,5 +25,6 @@ const getParsedUrl = (): UrlWithStringQuery => {
   return url.parse(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL || '');
 };
 
-const isProduction = (): boolean => process.env.NODE_ENV === 'production';
-const useBetaUrl = (): boolean => !!(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL && typeof process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL === 'string');
+const isProduction = (): boolean => process.env.CLI_DEV === false;
+const useBetaUrl = (): boolean =>
+  !!(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL && typeof process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL === 'string');

--- a/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/getUsageDataUrl.ts
@@ -25,6 +25,6 @@ const getParsedUrl = (): UrlWithStringQuery => {
   return url.parse(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL || '');
 };
 
-const isProduction = (): boolean => process.env.CLI_DEV === false;
+const isProduction = (): boolean => process.env.CLI_ENV === 'production';
 const useBetaUrl = (): boolean =>
   !!(process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL && typeof process.env.AMPLIFY_CLI_BETA_USAGE_TRACKING_URL === 'string');

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -24,7 +24,13 @@ export const buildResource = async (request: BuildRequest): Promise<BuildResult>
 const runBuildScriptHook = (resourceName: string, projectRoot: string): void => {
   const scriptName = `amplify:${resourceName}`;
   if (scriptExists(projectRoot, scriptName)) {
-    runPackageManager(projectRoot, undefined, scriptName);
+    const nodeEnv = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      runPackageManager(projectRoot, undefined, scriptName);
+    } finally {
+      process.env.NODE_ENV = nodeEnv;
+    }
   }
 };
 

--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -24,13 +24,7 @@ export const buildResource = async (request: BuildRequest): Promise<BuildResult>
 const runBuildScriptHook = (resourceName: string, projectRoot: string): void => {
   const scriptName = `amplify:${resourceName}`;
   if (scriptExists(projectRoot, scriptName)) {
-    const nodeEnv = process.env.NODE_ENV;
-    try {
-      delete process.env.NODE_ENV;
-      runPackageManager(projectRoot, undefined, scriptName);
-    } finally {
-      process.env.NODE_ENV = nodeEnv;
-    }
+    runPackageManager(projectRoot, undefined, scriptName);
   }
 };
 


### PR DESCRIPTION
#### Description of changes
- uses CLI_DEV variable to filter usage data instead of NODE_ENV

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
