### PR TITLE
chore: migrate xr category from inquirer to prompter library

### DIFF
--- a/packages/amplify-category-xr/package.json
+++ b/packages/amplify-category-xr/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "amplify-cli-core": "3.5.0",
+    "amplify-prompts": "2.6.2",
     "chalk": "^4.1.1",
-    "fs-extra": "^8.1.0",
-    "inquirer": "^7.3.3"
+    "fs-extra": "^8.1.0"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
migrate xr category from inquirer to prompter library


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes:
manually tested
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/akz/inquirer_xr_migration

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
