### PR TITLE
fix:  ensure cfn lambda outputs when forcePush flag is used

### DIFF
--- a/packages/amplify-category-function/API.md
+++ b/packages/amplify-category-function/API.md
@@ -40,6 +40,9 @@ const console_2: (context: $TSContext) => Promise<void>;
 export { console_2 as console }
 
 // @public (undocumented)
+export const ensureLambdaExecutionRoleOutputs: () => Promise<void>;
+
+// @public (undocumented)
 export const executeAmplifyCommand: (context: $TSContext) => Promise<void>;
 
 // @public (undocumented)

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.test.ts
@@ -1,0 +1,263 @@
+import { pathManager, stateManager, readCFNTemplate, writeCFNTemplate, CFNTemplateFormat } from 'amplify-cli-core';
+import { ensureLambdaExecutionRoleOutputs } from '../../../../provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
+
+jest.mock('amplify-cli-core');
+const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;
+const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+const readCFNTemplateMock = readCFNTemplate as jest.MockedFunction<typeof readCFNTemplate>;
+const writeCFNTemplateMock = writeCFNTemplate as jest.MockedFunction<typeof writeCFNTemplate>;
+
+describe('test ensureLambdaExecutionRoleOutputs function', () => {
+  beforeEach(() => {
+    pathManagerMock.getBackendDirPath = jest.fn().mockReturnValue('backend');
+    stateManagerMock.getMeta = jest.fn();
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it(' when no functions are present', async () => {
+    stateManagerMock.getMeta.mockReturnValue({
+      auth: {
+        authtriggertestb3a9da62b3a9da62: {
+          customAuth: false,
+          providerPlugin: 'awscloudformation',
+          service: 'Cognito',
+        },
+      },
+    });
+    readCFNTemplateMock.mockReturnValue(undefined);
+    await ensureLambdaExecutionRoleOutputs();
+    expect(writeCFNTemplateMock).not.toBeCalled();
+  });
+
+  it(' when functions have no role arns in outputs', async () => {
+    stateManagerMock.getMeta.mockReturnValue({
+      auth: {
+        authtriggertestb3a9da62b3a9da62: {
+          customAuth: false,
+          dependsOn: [
+            {
+              attributes: ['Arn', 'Name'],
+              category: 'function',
+              resourceName: 'authtriggertestb3a9da62b3a9da62PostAuthentication',
+              triggerProvider: 'Cognito',
+            },
+            {
+              attributes: ['Arn', 'Name'],
+              category: 'function',
+              resourceName: 'authtriggertestb3a9da62b3a9da62PostConfirmation',
+              triggerProvider: 'Cognito',
+            },
+            {
+              attributes: ['Arn', 'Name'],
+              category: 'function',
+              resourceName: 'authtriggertestb3a9da62b3a9da62PreAuthentication',
+              triggerProvider: 'Cognito',
+            },
+            {
+              attributes: ['Arn', 'Name'],
+              category: 'function',
+              resourceName: 'authtriggertestb3a9da62b3a9da62PreSignup',
+              triggerProvider: 'Cognito',
+            },
+          ],
+          providerPlugin: 'awscloudformation',
+          service: 'Cognito',
+        },
+      },
+      function: {
+        authtriggertestb3a9da62b3a9da62PostAuthentication: {
+          build: true,
+          providerPlugin: 'awscloudformation',
+          service: 'Lambda',
+        },
+        authtriggertestb3a9da62b3a9da62PostConfirmation: {
+          build: true,
+          providerPlugin: 'awscloudformation',
+          service: 'Lambda',
+        },
+        authtriggertestb3a9da62b3a9da62PreAuthentication: {
+          build: true,
+          providerPlugin: 'awscloudformation',
+          service: 'Lambda',
+        },
+        authtriggertestb3a9da62b3a9da62PreSignup: {
+          build: true,
+          providerPlugin: 'awscloudformation',
+          service: 'Lambda',
+        },
+      },
+    });
+    readCFNTemplateMock.mockReturnValue({
+      templateFormat: CFNTemplateFormat.JSON,
+      cfnTemplate: {
+        Outputs: {
+          Name: {
+            Value: {
+              Ref: 'LambdaFunction',
+            },
+          },
+          Arn: {
+            Value: {
+              'Fn::GetAtt': ['LambdaFunction', 'Arn'],
+            },
+          },
+          LambdaExecutionRole: {
+            Value: {
+              Ref: 'LambdaExecutionRole',
+            },
+          },
+          Region: {
+            Value: {
+              Ref: 'AWS::Region',
+            },
+          },
+        },
+      },
+    });
+    await ensureLambdaExecutionRoleOutputs();
+    expect(writeCFNTemplateMock.mock.calls[0][0]).toMatchInlineSnapshot(`
+      Object {
+        "Outputs": Object {
+          "Arn": Object {
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "LambdaFunction",
+                "Arn",
+              ],
+            },
+          },
+          "LambdaExecutionRole": Object {
+            "Value": Object {
+              "Ref": "LambdaExecutionRole",
+            },
+          },
+          "LambdaExecutionRoleArn": Object {
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "LambdaExecutionRole",
+                "Arn",
+              ],
+            },
+          },
+          "Name": Object {
+            "Value": Object {
+              "Ref": "LambdaFunction",
+            },
+          },
+          "Region": Object {
+            "Value": Object {
+              "Ref": "AWS::Region",
+            },
+          },
+        },
+      }
+    `);
+  });
+
+    it(' when functions have role arns in outputs', async () => {
+        stateManagerMock.getMeta.mockReturnValue({
+            "auth": {
+              "authtriggertestb3a9da62b3a9da62": {
+                "customAuth": false,
+                "dependsOn": [
+                  {
+                    "attributes": [
+                      "Arn",
+                      "Name"
+                    ],
+                    "category": "function",
+                    "resourceName": "authtriggertestb3a9da62b3a9da62PostAuthentication",
+                    "triggerProvider": "Cognito"
+                  },
+                  {
+                    "attributes": [
+                      "Arn",
+                      "Name"
+                    ],
+                    "category": "function",
+                    "resourceName": "authtriggertestb3a9da62b3a9da62PostConfirmation",
+                    "triggerProvider": "Cognito"
+                  },
+                  {
+                    "attributes": [
+                      "Arn",
+                      "Name"
+                    ],
+                    "category": "function",
+                    "resourceName": "authtriggertestb3a9da62b3a9da62PreAuthentication",
+                    "triggerProvider": "Cognito"
+                  },
+                  {
+                    "attributes": [
+                      "Arn",
+                      "Name"
+                    ],
+                    "category": "function",
+                    "resourceName": "authtriggertestb3a9da62b3a9da62PreSignup",
+                    "triggerProvider": "Cognito"
+                  }
+                ],
+                "providerPlugin": "awscloudformation",
+                "service": "Cognito",
+              }
+            },
+            "function": {
+              "authtriggertestb3a9da62b3a9da62PostAuthentication": {
+                "build": true,
+                "providerPlugin": "awscloudformation",
+                "service": "Lambda",
+              },
+              "authtriggertestb3a9da62b3a9da62PostConfirmation": {
+                "build": true,
+                "providerPlugin": "awscloudformation",
+                "service": "Lambda",
+              },
+              "authtriggertestb3a9da62b3a9da62PreAuthentication": {
+                "build": true,
+                "providerPlugin": "awscloudformation",
+                "service": "Lambda",
+              },
+              "authtriggertestb3a9da62b3a9da62PreSignup": {
+                "build": true,
+                "providerPlugin": "awscloudformation",
+                "service": "Lambda",
+              }
+            }
+          })
+          readCFNTemplateMock.mockReturnValue({
+            templateFormat: CFNTemplateFormat.JSON,
+            cfnTemplate: {
+              Outputs: {
+                Name: {
+                  Value: {
+                    Ref: 'LambdaFunction',
+                  },
+                },
+                Arn: {
+                  Value: {
+                    'Fn::GetAtt': ['LambdaFunction', 'Arn'],
+                  },
+                },
+                LambdaExecutionRole: {
+                  Value: {
+                    Ref: 'LambdaExecutionRole',
+                  },
+                },
+                LambdaExecutionRoleArn: {
+                    Value: {
+                      Ref: 'LambdaExecutionRoleArn',
+                    },
+                  },
+                Region: {
+                  Value: {
+                    Ref: 'AWS::Region',
+                  },
+                },
+              },
+            },
+          });
+        await ensureLambdaExecutionRoleOutputs();
+        expect(writeCFNTemplateMock).not.toBeCalled();;
+    })
+});

--- a/packages/amplify-category-function/src/events/preExportHandler.ts
+++ b/packages/amplify-category-function/src/events/preExportHandler.ts
@@ -1,4 +1,4 @@
-import { ensureLambdaExecutionRoleOutputs } from './prePushHandler';
+import { ensureLambdaExecutionRoleOutputs } from '../provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 /**
  * prePush Handler event for function category
  */

--- a/packages/amplify-category-function/src/events/prePushHandler.ts
+++ b/packages/amplify-category-function/src/events/prePushHandler.ts
@@ -1,15 +1,14 @@
 import {
-  $TSContext, stateManager, pathManager, readCFNTemplate, writeCFNTemplate, AmplifySupportedService,
+  $TSContext, stateManager
 } from 'amplify-cli-core';
-import * as path from 'path';
 import { categoryName } from '../constants';
 import {
   FunctionSecretsStateManager,
   getLocalFunctionSecretNames,
-  storeSecretsPendingRemoval,
+  storeSecretsPendingRemoval
 } from '../provider-utils/awscloudformation/secrets/functionSecretsStateManager';
+import { ensureLambdaExecutionRoleOutputs } from '../provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 import { ensureEnvironmentVariableValues } from '../provider-utils/awscloudformation/utils/environmentVariablesHelper';
-
 /**
  * prePush Handler event for function category
  */
@@ -31,30 +30,3 @@ const ensureFunctionSecrets = async (context: $TSContext): Promise<void> => {
   await storeSecretsPendingRemoval(context, functionNames);
 };
 
-/**
- * updates function cfn stack with lambda execution role arn parameter
- */
-export const ensureLambdaExecutionRoleOutputs = async (): Promise<void> => {
-  const amplifyMeta = stateManager.getMeta();
-  const functionNames = Object.keys(amplifyMeta?.[categoryName]);
-  // filter lambda layer from lambdas in function
-  const lambdaFunctionNames = functionNames.filter(functionName => {
-    const functionObj = amplifyMeta?.[categoryName]?.[functionName];
-    return functionObj.service === AmplifySupportedService.LAMBDA;
-  });
-  for (const functionName of lambdaFunctionNames) {
-    const templateSourceFilePath = path.join(pathManager.getBackendDirPath(), categoryName, functionName, `${functionName}-cloudformation-template.json`);
-    const { cfnTemplate } = readCFNTemplate(templateSourceFilePath);
-    if (!cfnTemplate?.Outputs?.LambdaExecutionRoleArn) {
-      cfnTemplate.Outputs.LambdaExecutionRoleArn = {
-        Value: {
-          'Fn::GetAtt': [
-            'LambdaExecutionRole',
-            'Arn',
-          ],
-        },
-      };
-      await writeCFNTemplate(cfnTemplate, templateSourceFilePath);
-    }
-  }
-};

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -11,7 +11,6 @@ import { postEnvRemoveHandler } from './events/postEnvRemoveHandler';
 import { postPushHandler } from './events/postPushHandler';
 import { preExportHandler } from './events/preExportHandler';
 import { prePushHandler } from './events/prePushHandler';
-import { ensureLambdaExecutionRoleOutputs } from './provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 // eslint-disable-next-line import/no-cycle
 import { updateConfigOnEnvInit } from './provider-utils/awscloudformation';
 import { cloneSecretsOnEnvInitHandler } from './provider-utils/awscloudformation/secrets/cloneSecretsOnEnvInitHandler';

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -11,6 +11,7 @@ import { postEnvRemoveHandler } from './events/postEnvRemoveHandler';
 import { postPushHandler } from './events/postPushHandler';
 import { preExportHandler } from './events/preExportHandler';
 import { prePushHandler } from './events/prePushHandler';
+import { ensureLambdaExecutionRoleOutputs } from './provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 // eslint-disable-next-line import/no-cycle
 import { updateConfigOnEnvInit } from './provider-utils/awscloudformation';
 import { cloneSecretsOnEnvInitHandler } from './provider-utils/awscloudformation/secrets/cloneSecretsOnEnvInitHandler';
@@ -36,12 +37,12 @@ export { lambdasWithApiDependency } from './provider-utils/awscloudformation/uti
 export { hashLayerResource } from './provider-utils/awscloudformation/utils/layerHelpers';
 export { migrateLegacyLayer } from './provider-utils/awscloudformation/utils/layerMigrationUtils';
 export { packageResource } from './provider-utils/awscloudformation/utils/package';
+export { ensureLambdaExecutionRoleOutputs } from './provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 export {
   updateDependentFunctionsCfn,
   addAppSyncInvokeMethodPermission,
 } from './provider-utils/awscloudformation/utils/updateDependentFunctionCfn';
 export { loadFunctionParameters } from './provider-utils/awscloudformation/utils/loadFunctionParameters';
-
 /**
  * Entry point for adding function resource
  */

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
@@ -1,0 +1,30 @@
+import { AmplifyCategories, AmplifySupportedService, pathManager, readCFNTemplate, stateManager, writeCFNTemplate } from 'amplify-cli-core';
+import * as path from 'path';
+
+/**
+ * updates function cfn stack with lambda execution role arn parameter
+ */
+ export const ensureLambdaExecutionRoleOutputs = async (): Promise<void> => {
+    const amplifyMeta = stateManager.getMeta();
+    const functionNames = Object.keys(amplifyMeta?.[AmplifyCategories.FUNCTION] ?? []);
+    // filter lambda layer from lambdas in function
+    const lambdaFunctionNames = functionNames.filter(functionName => {
+      const functionObj = amplifyMeta?.[AmplifyCategories.FUNCTION]?.[functionName];
+      return functionObj.service === AmplifySupportedService.LAMBDA;
+    });
+    for (const functionName of lambdaFunctionNames) {
+      const templateSourceFilePath = path.join(pathManager.getBackendDirPath(), AmplifyCategories.FUNCTION, functionName, `${functionName}-cloudformation-template.json`);
+      const { cfnTemplate } = readCFNTemplate(templateSourceFilePath);
+      if (cfnTemplate.Outputs !== undefined && !cfnTemplate?.Outputs?.LambdaExecutionRoleArn) {
+        cfnTemplate.Outputs.LambdaExecutionRoleArn = {
+          Value: {
+            'Fn::GetAtt': [
+              'LambdaExecutionRole',
+              'Arn',
+            ],
+          },
+        };
+        await writeCFNTemplate(cfnTemplate, templateSourceFilePath);
+      }
+    }
+  };

--- a/packages/amplify-e2e-core/src/init/non-interactive-init.ts
+++ b/packages/amplify-e2e-core/src/init/non-interactive-init.ts
@@ -29,6 +29,33 @@ export const nonInteractiveInitAttach = async (
 };
 
 /**
+ * Executes a non-interactive init to migrate a local project to an existing cloud environment with forcePush flag
+ */
+ export const nonInteractiveInitWithForcePushAttach = async (
+  projRoot: string,
+  amplifyInitConfig: AmplifyInitConfig,
+  categoriesConfig?: CategoriesConfig,
+  testingWithLatestCodebase = false,
+  awsProviderConfig = getAwsProviderConfig(),
+): Promise<void> => {
+  const args = [
+    'init',
+    '--yes',
+    '--amplify',
+    JSON.stringify(amplifyInitConfig),
+    '--providers',
+    JSON.stringify({
+      awscloudformation: awsProviderConfig,
+    }),
+    '--forcePush'
+  ];
+  if (categoriesConfig) {
+    args.push('--categories', JSON.stringify(categoriesConfig));
+  }
+  await execa(getCLIPath(testingWithLatestCodebase), args, { cwd: projRoot });
+};
+
+/**
  * Returns an AmplifyConfig object with a default editor
  */
 export const getAmplifyInitConfig = (projectName: string, envName: string): AmplifyInitConfig => ({

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/git-clone-migration-tests.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/git-clone-migration-tests.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for headless init/pull workflows on git-cloned projects
+ * These tests exercise workflows that hosting executes during backend builds
+ */
+
+ import {
+  addAuthUserPoolOnly,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getAmplifyInitConfig, getProjectConfig,
+  getSocialProviders,
+  getTeamProviderInfo, gitCleanFdx,
+  gitCommitAll,
+  gitInit,
+  nonInteractiveInitWithForcePushAttach
+} from '@aws-amplify/amplify-e2e-core';
+import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
+  
+  describe('attach amplify to git-cloned project', () => {
+    const envName = 'test';
+    let projRoot: string;
+    beforeAll(async () => {
+      projRoot = await createNewProjectDir('clone-test');
+      await initJSProjectWithProfileV10(projRoot, { envName, disableAmplifyAppCreation: false });
+      await addAuthUserPoolOnly(projRoot, {});
+      await amplifyPushAuth(projRoot);
+      await gitInit(projRoot);
+      await gitCommitAll(projRoot);
+    });
+  
+    afterAll(async () => {
+      await deleteProject(projRoot);
+      deleteProjectDir(projRoot);
+    });
+  
+    test('headless init and forcePush when triggers are added', async () => {
+      const { projectName } = getProjectConfig(projRoot);
+      const preCleanTpi = getTeamProviderInfo(projRoot);
+      await gitCleanFdx(projRoot);
+
+      const socialProviders = getSocialProviders();
+      const categoriesConfig = {
+        auth: {
+          facebookAppIdUserPool: socialProviders.FACEBOOK_APP_ID,
+          facebookAppSecretUserPool: socialProviders.FACEBOOK_APP_SECRET,
+          googleAppIdUserPool: socialProviders.GOOGLE_APP_ID,
+          googleAppSecretUserPool: socialProviders.GOOGLE_APP_SECRET,
+          // eslint-disable-next-line spellcheck/spell-checker
+          loginwithamazonAppIdUserPool: socialProviders.AMAZON_APP_ID,
+          // eslint-disable-next-line spellcheck/spell-checker
+          loginwithamazonAppSecretUserPool: socialProviders.AMAZON_APP_SECRET,
+        },
+      };
+      // checks amplify hosting forcePush on existing projects with v10.5.1
+      expect( () => nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, envName), categoriesConfig, true)).not.toThrow();
+    });
+  });
+  

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/git-clone-migration-tests.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/git-clone-migration-tests.test.ts
@@ -37,7 +37,6 @@ import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
   
     test('headless init and forcePush when triggers are added', async () => {
       const { projectName } = getProjectConfig(projRoot);
-      const preCleanTpi = getTeamProviderInfo(projRoot);
       await gitCleanFdx(projRoot);
 
       const socialProviders = getSocialProviders();
@@ -54,7 +53,7 @@ import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
         },
       };
       // checks amplify hosting forcePush on existing projects with v10.5.1
-      expect( () => nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, envName), categoriesConfig, true)).not.toThrow();
+      expect( () => nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, envName), categoriesConfig, false)).not.toThrow();
     });
   });
   

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -194,6 +194,8 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
     });
 
     await prePushLambdaLayerPrompt(context, resources);
+    await context.amplify.invokePluginMethod(context, AmplifyCategories.FUNCTION,
+      AmplifySupportedService.LAMBDA, 'ensureLambdaExecutionRoleOutputs', []);
     await prepareBuildableResources(context, resources);
     await buildOverridesEnabledResources(context, resources);
 

--- a/scripts/split-e2e-test-filters.ts
+++ b/scripts/split-e2e-test-filters.ts
@@ -43,4 +43,5 @@ export const migrationFromV6Tests = [
 export const migrationFromV10Tests = [
     "src/__tests__/migration_tests_v10/scaffold.test.ts",
     "src/__tests__/migration_tests_v10/dotnet_runtime_update_migration.test.ts",
+    "src/__tests__/migration_tests_v10/git-clone-migration-tests.test.ts",
 ]

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -69,6 +69,7 @@ const WINDOWS_TEST_SKIP_LIST: string[] = [
   'geo-update-1_pkg',
   'geo-update-2_pkg',
   'git-clone-attach_pkg',
+  'git-clone-migration_pkg',
   'hooks-a_pkg',
   'import_auth_1a_pkg',
   'import_auth_1b_pkg',

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -69,7 +69,7 @@ const WINDOWS_TEST_SKIP_LIST: string[] = [
   'geo-update-1_pkg',
   'geo-update-2_pkg',
   'git-clone-attach_pkg',
-  'git-clone-migration_pkg',
+  'git-clone-migration-tests_v10',
   'hooks-a_pkg',
   'import_auth_1a_pkg',
   'import_auth_1b_pkg',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- added function in push resource to ensure cfn lambda outputs when forcePush flag is used to push in headless init call.
```amplify init --forcePush```
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #11714 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- added unit tests
- manual test with headless calls
- added a git/headless migration e2e test for the scenario
- e2e test suite: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/akz/issue11714

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
