### PR TITLE
chore: bump codegen version to 3.3.5

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -54,7 +54,7 @@
     "amplify-cli-core": "3.5.0",
     "amplify-cli-logger": "1.2.2",
     "amplify-cli-shared-interfaces": "1.1.1",
-    "amplify-codegen": "^3.3.4",
+    "amplify-codegen": "^3.3.5",
     "amplify-console-hosting": "2.3.6",
     "amplify-container-hosting": "2.5.7",
     "amplify-dotnet-function-runtime-provider": "1.7.0",

--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
@@ -49,7 +49,7 @@ exports[`upload Studio CMS assets on push of Studio enabled project uploads expe
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"3.3.4\\",
+    \\"codegenVersion\\": \\"3.3.5\\",
     \\"version\\": \\"6f85ca0ee370ac8e0674a44cc5a4f6a6\\"
 };"
 `;

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -56,7 +56,7 @@
     "@aws-cdk/region-info": "~1.172.0",
     "amplify-cli-core": "3.5.0",
     "amplify-cli-logger": "1.2.2",
-    "amplify-codegen": "^3.3.4",
+    "amplify-codegen": "^3.3.5",
     "amplify-prompts": "2.6.2",
     "amplify-util-import": "2.3.1",
     "archiver": "^5.3.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -34,7 +34,7 @@
     "@hapi/topo": "^5.0.0",
     "amplify-category-function": "4.2.2",
     "amplify-cli-core": "3.5.0",
-    "amplify-codegen": "^3.3.4",
+    "amplify-codegen": "^3.3.5",
     "amplify-dynamodb-simulator": "2.5.2",
     "amplify-prompts": "2.6.2",
     "amplify-provider-awscloudformation": "6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,10 +181,10 @@
     "@aws-amplify/api-graphql" "2.2.18"
     "@aws-amplify/api-rest" "2.0.29"
 
-"@aws-amplify/appsync-modelgen-plugin@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.3.1.tgz#b785afdc66572c1a5312a4c836eb1729527ab36e"
-  integrity sha512-bAj2d7Pa0isFAH3qqxDfIeMTu+8yYbmbOkKhh0TGBWkT6Ce8RZWdV7zeBP7txrJpWjauAcu/jjDZ8p18oa+fiQ==
+"@aws-amplify/appsync-modelgen-plugin@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.3.2.tgz#e4c444f66d209f68810ff5b81236a2363d0f1016"
+  integrity sha512-0P3H7a/kQHOaF1fZfkTKaugVbDTdSX4A2qZxMoujRIeFpquLdJREVKVKj2TGx4S1uHeulhJ19Hap4hUvY2A9og==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^1.18.8"
     "@graphql-codegen/visitor-plugin-common" "^1.22.0"
@@ -9689,12 +9689,12 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-codegen@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.3.4.tgz#2fc8fe25f3302ee6c890874819ad8ff09d7230ea"
-  integrity sha512-fv6/UAIt0TZ+IP+qCTY5d4vA93vJtMRmRaeBj92qt8IerxYrXSD2kexXA96s68FU6aiKntbRy/BrKpgOPQCNZw==
+amplify-codegen@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.3.5.tgz#18c4ddf365a088fe01f5f823570d3f94e33f364f"
+  integrity sha512-AuzNJD6F1s1H/jMIg8QtylnXjzsshul7eWeluOdfCR9XTgLUM8ZHbwXIn21YXHs2QsIR1N97ze0bk4xqz6JhFA==
   dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "2.3.1"
+    "@aws-amplify/appsync-modelgen-plugin" "2.3.2"
     "@aws-amplify/graphql-docs-generator" "3.0.2"
     "@aws-amplify/graphql-types-generator" "3.0.0"
     "@graphql-codegen/core" "1.8.3"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This fixes an Amplify Studio reported issue with schemas having bi-directional hasOne directives.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
E2e test link https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/14376/workflows/38159936-5bba-491f-bbe5-8577daf21ad3

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
