### PR TITLE
fix: change extract-api to clean and rebuild before running on push

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "finish-release": "./scripts/finish-release.sh",
     "update-data-packages": "./scripts/update-data-dependencies.sh && yarn",
     "extract-api": "nx run-many --target=extract-api --all",
-    "verify-api-extract": "yarn extract-api && ./scripts/verify_extract_api.sh"
+    "verify-api-extract": "yarn extract-api && ./scripts/verify_extract_api.sh",
+    "verify-api-extract:clean": "yarn clean && yarn dev-build && yarn verify-api-extract"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-cli/issues"
@@ -63,7 +64,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "yarn verify-api-extract && yarn build-tests-changed && yarn split-e2e-tests",
+      "pre-push": "yarn verify-api-extract:clean && yarn build-tests-changed && yarn split-e2e-tests",
       "pre-commit": "yarn verify-commit"
     }
   },


### PR DESCRIPTION
#### Description of changes

This changes the pre-push husky script to run a clean and build before doing the api verification.

Currently, extract-api can generate different outputs when the application hasn't been built clean compared to a clean build. This causes unnecessary runs on the CI when the cleanly built repository fails the api check. Including a clean and rebuild of the packages in the precommit hook will reduce the unnecessary CI runs.

#### Issue #, if available


#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
