### PR TITLE
fix: set NoEcho flag on OAuth creds CFN param

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -788,6 +788,7 @@ Object {
       "Type": "String",
     },
     "hostedUIProviderCreds": Object {
+      "NoEcho": true,
       "Type": "String",
     },
     "hostedUIProviderMeta": Object {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -485,6 +485,16 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
     }
 
     for (const [key, value] of Object.entries(props)) {
+      if (key === 'hostedUIProviderCreds') {
+        this._authTemplateObj.addCfnParameter(
+          {
+            type: 'String',
+            noEcho: true,
+          },
+          key,
+        );
+        continue;
+      }
       if (typeof value === 'string' || (typeof value === 'object' && !Array.isArray(value))) {
         this._authTemplateObj.addCfnParameter(
           {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Sets the [NoEcho](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties) flag on the OAuth parameter passed to the auth stack. This prevents this parameter from being printed in the CloudFormation console and CloudFormation events

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually validated and updated existing snapshot tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
