### PR TITLE
feat: added code workspace to simplify running individual e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ packages/amplify-dynamodb-simulator/__test__/dynamodb-data
 packages/amplify-opensearch-simulator/emulator
 .vscode/*
 .history/*
+!.vscode/amplify-cli.code-workspace
 !.vscode/settings.json
 !.vscode/extensions.json
 .idea

--- a/.vscode/amplify-cli.code-workspace
+++ b/.vscode/amplify-cli.code-workspace
@@ -1,0 +1,16 @@
+{
+  "folders": [
+    {
+      "path": ".."
+    },
+    {
+      "path": "../packages/amplify-e2e-tests"
+    }
+  ],
+  "settings": {
+    "eslint.alwaysShowStatus": true
+  },
+  "extensions": {
+    "recommendations": ["Orta.vscode-jest", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,5 @@
   "jest.runAllTestsFirst": false,
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  }
 }

--- a/packages/amplify-e2e-tests/.vscode/settings.json
+++ b/packages/amplify-e2e-tests/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "jest.jestCommandLine": "yarn e2e",
+    "jest.monitorLongRun": 1800000
+}


### PR DESCRIPTION


#### Description of changes
The `.vscode/amplify-cli.code-workspace` defines two folders in a code workspace. This allows more a more convenient way to run individual e2e tests from the jest test explorer for users of vscode. E2E tests can now be run with the correct configuration inline in the code, or using the test explorer from the main activity bar. 

#### Issue #, if available


#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
