### PR TITLE
fix: node function executable not found error to print pm name

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -1,27 +1,49 @@
-import { $TSObject, getPackageManager, JSONUtilities } from 'amplify-cli-core';
-import { BuildRequest, BuildResult, BuildType } from 'amplify-function-plugin-interface';
-import execa from 'execa';
-import * as fs from 'fs-extra';
-import glob from 'glob';
-import * as path from 'path';
+import { $TSObject, getPackageManager, JSONUtilities } from "amplify-cli-core";
+import {
+  BuildRequest,
+  BuildResult,
+  BuildType,
+} from "amplify-function-plugin-interface";
+import execa from "execa";
+import * as fs from "fs-extra";
+import glob from "glob";
+import * as path from "path";
 
 /**
  * copied from the former build-resources.js file in amplify-cli with changes for new interface
  */
-export const buildResource = async (request: BuildRequest): Promise<BuildResult> => {
-  const resourceDir = request.service ? request.srcRoot : path.join(request.srcRoot, 'src');
+export const buildResource = async (
+  request: BuildRequest
+): Promise<BuildResult> => {
+  const resourceDir = request.service
+    ? request.srcRoot
+    : path.join(request.srcRoot, "src");
 
-  if (!request.lastBuildTimeStamp || isBuildStale(request.srcRoot, request.lastBuildTimeStamp, request.buildType, request.lastBuildType)) {
+  if (
+    !request.lastBuildTimeStamp ||
+    isBuildStale(
+      request.srcRoot,
+      request.lastBuildTimeStamp,
+      request.buildType,
+      request.lastBuildType
+    )
+  ) {
     installDependencies(resourceDir, request.buildType);
     if (request.legacyBuildHookParams) {
-      runBuildScriptHook(request.legacyBuildHookParams.resourceName, request.legacyBuildHookParams.projectRoot);
+      runBuildScriptHook(
+        request.legacyBuildHookParams.resourceName,
+        request.legacyBuildHookParams.projectRoot
+      );
     }
     return Promise.resolve({ rebuilt: true });
   }
   return Promise.resolve({ rebuilt: false });
 };
 
-const runBuildScriptHook = (resourceName: string, projectRoot: string): void => {
+const runBuildScriptHook = (
+  resourceName: string,
+  projectRoot: string
+): void => {
   const scriptName = `amplify:${resourceName}`;
   if (scriptExists(projectRoot, scriptName)) {
     runPackageManager(projectRoot, undefined, scriptName);
@@ -29,17 +51,29 @@ const runBuildScriptHook = (resourceName: string, projectRoot: string): void => 
 };
 
 const scriptExists = (projectRoot: string, scriptName: string): boolean => {
-  const packageJsonPath = path.normalize(path.join(projectRoot, 'package.json'));
-  const rootPackageJsonContents = JSONUtilities.readJson<$TSObject>(packageJsonPath, { throwIfNotExist: false });
+  const packageJsonPath = path.normalize(
+    path.join(projectRoot, "package.json")
+  );
+  const rootPackageJsonContents = JSONUtilities.readJson<$TSObject>(
+    packageJsonPath,
+    { throwIfNotExist: false }
+  );
 
   return !!rootPackageJsonContents?.scripts?.[scriptName];
 };
 
-const installDependencies = (resourceDir: string, buildType: BuildType): void => {
+const installDependencies = (
+  resourceDir: string,
+  buildType: BuildType
+): void => {
   runPackageManager(resourceDir, buildType);
 };
 
-const runPackageManager = (cwd: string, buildType?: BuildType, scriptName?: string): void => {
+const runPackageManager = (
+  cwd: string,
+  buildType?: BuildType,
+  scriptName?: string
+): void => {
   const packageManager = getPackageManager(cwd);
 
   if (packageManager === null) {
@@ -48,40 +82,57 @@ const runPackageManager = (cwd: string, buildType?: BuildType, scriptName?: stri
     return;
   }
 
-  const useYarn = packageManager.packageManager === 'yarn';
+  const useYarn = packageManager.packageManager === "yarn";
   const args = toPackageManagerArgs(useYarn, buildType, scriptName);
   try {
     execa.sync(packageManager.executable, args, {
       cwd,
-      stdio: 'pipe',
-      encoding: 'utf-8',
+      stdio: "pipe",
+      encoding: "utf-8",
     });
   } catch (error) {
-    if (error.code === 'ENOENT') {
-      throw new Error(`Packaging lambda function failed. Could not find ${packageManager} executable in the PATH.`);
-    } else if (error.stdout?.includes('YN0050: The --production option is deprecated')) {
-      throw new Error('Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again.');
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `Packaging lambda function failed. Could not find ${packageManager.packageManager} executable in the PATH.`
+      );
+    } else if (
+      error.stdout?.includes("YN0050: The --production option is deprecated")
+    ) {
+      throw new Error(
+        "Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again."
+      );
     } else {
-      throw new Error(`Packaging lambda function failed with the error \n${error.message}`);
+      throw new Error(
+        `Packaging lambda function failed with the error \n${error.message}`
+      );
     }
   }
 };
 
-const toPackageManagerArgs = (useYarn: boolean, buildType?: BuildType, scriptName?: string): string[] => {
+const toPackageManagerArgs = (
+  useYarn: boolean,
+  buildType?: BuildType,
+  scriptName?: string
+): string[] => {
   if (scriptName) {
-    return useYarn ? [scriptName] : ['run-script', scriptName];
+    return useYarn ? [scriptName] : ["run-script", scriptName];
   }
 
-  const args = useYarn ? ['--no-bin-links'] : ['install', '--no-bin-links'];
+  const args = useYarn ? ["--no-bin-links"] : ["install", "--no-bin-links"];
 
   if (buildType === BuildType.PROD) {
-    args.push('--production');
+    args.push("--production");
   }
 
   return args;
 };
 
-const isBuildStale = (resourceDir: string, lastBuildTimeStamp: Date, buildType: BuildType, lastBuildType?: BuildType): boolean => {
+const isBuildStale = (
+  resourceDir: string,
+  lastBuildTimeStamp: Date,
+  buildType: BuildType,
+  lastBuildType?: BuildType
+): boolean => {
   const dirTime = new Date(fs.statSync(resourceDir).mtime);
   // If the last build type not matching we have to flag a stale build to force
   // a npm/yarn install. This way devDependencies will not be packaged when we
@@ -91,8 +142,8 @@ const isBuildStale = (resourceDir: string, lastBuildTimeStamp: Date, buildType: 
   }
   const fileUpdatedAfterLastBuild = glob
     .sync(`${resourceDir}/**`)
-    .filter(p => !p.includes('dist'))
-    .filter(p => !p.includes('node_modules'))
-    .find(file => new Date(fs.statSync(file).mtime) > lastBuildTimeStamp);
+    .filter((p) => !p.includes("dist"))
+    .filter((p) => !p.includes("node_modules"))
+    .find((file) => new Date(fs.statSync(file).mtime) > lastBuildTimeStamp);
   return !!fileUpdatedAfterLastBuild;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

modifies error to print package manager name, mitigates the following error on push if npm or yarn is not found on the system:

```
:octagonal_sign: Packaging lambda function failed. Could not find [object Object] executable in the PATH
```

#### Issue #, if available

tbd

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

n/a

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
