### PR TITLE
fix: node function executable not found error to print pm name

### DIFF
--- a/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
+++ b/packages/amplify-nodejs-function-runtime-provider/src/utils/legacyBuild.ts
@@ -58,7 +58,7 @@ const runPackageManager = (cwd: string, buildType?: BuildType, scriptName?: stri
     });
   } catch (error) {
     if (error.code === 'ENOENT') {
-      throw new Error(`Packaging lambda function failed. Could not find ${packageManager} executable in the PATH.`);
+      throw new Error(`Packaging lambda function failed. Could not find ${packageManager.packageManager} executable in the PATH.`);
     } else if (error.stdout?.includes('YN0050: The --production option is deprecated')) {
       throw new Error('Packaging lambda function failed. Yarn 2 is not supported. Use Yarn 1.x and push again.');
     } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

modifies error to print package manager name, mitigates the following error on push if npm or yarn is not found on the system:

```
:octagonal_sign: Packaging lambda function failed. Could not find [object Object] executable in the PATH
```

#### Issue #, if available

tbd

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

n/a

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
