### PR TITLE
fix: correct deleting wrong keys

### DIFF
--- a/packages/amplify-opensearch-simulator/API.md
+++ b/packages/amplify-opensearch-simulator/API.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { $TSAny } from 'amplify-cli-core';
 import execa from 'execa';
 import { GetPackageAssetPaths } from 'amplify-cli-core';

--- a/packages/amplify-opensearch-simulator/API.md
+++ b/packages/amplify-opensearch-simulator/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { $TSAny } from 'amplify-cli-core';
 import execa from 'execa';
 import { GetPackageAssetPaths } from 'amplify-cli-core';

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
@@ -43,7 +43,7 @@ describe('parameters-delete-handler', () => {
     await deleteEnvironmentParametersFromService((contextStub as unknown) as $TSContext, envName);
     expect(deleteParametersPromiseMock).toBeCalledTimes(1);
     expect(deleteParametersMock).toBeCalledTimes(1);
-    const expectedDeleteParamater = getSsmSdkParametersDeleteParameters(fakeAppId, envName, keys);
+    const expectedDeleteParamater = getSsmSdkParametersDeleteParameters(keys);
     expect(deleteParametersMock).toBeCalledWith(expectedDeleteParamater);
 
     expect(getParametersByPathPromiseMock).toBeCalledTimes(1);

--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -204,4 +204,5 @@ module.exports = {
   prePushCfnTemplateModifier,
   getApiKeyConfig,
   getEnvParametersUploadHandler,
+  deleteEnvironmentParametersFromService,
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -14,24 +14,24 @@ export const deleteEnvironmentParametersFromService = async (context: $TSContext
 };
 
 const deleteParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<void> => {
-    try {
-      const envKeysInParameterStore: Array<string> = await getAllEnvParametersFromParameterStore(appId, envName, ssmClient);
-      const chunkedKeys: Array<Array<string>> = chunkForParameterStore(envKeysInParameterStore);
-      await Promise.all(
-        chunkedKeys.map(chunk => {
-          const ssmArgument = getSsmSdkParametersDeleteParameters(appId, envName, chunk);
-          return ssmClient.deleteParameters(ssmArgument).promise();
-        }),
-      );
-    } catch (e) {
-      throw new AmplifyFault(
-        'ParametersDeleteFault',
-        {
-          message: `Failed to delete parameters from the service`,
-        },
-        e,
-      );
-    }
+  try {
+    const envKeysInParameterStore: Array<string> = await getAllEnvParametersFromParameterStore(appId, envName, ssmClient);
+    const chunkedKeys: Array<Array<string>> = chunkForParameterStore(envKeysInParameterStore);
+    await Promise.all(
+      chunkedKeys.map(keys => {
+        const ssmArgument = getSsmSdkParametersDeleteParameters(keys);
+        return ssmClient.deleteParameters(ssmArgument).promise();
+      }),
+    );
+  } catch (e) {
+    throw new AmplifyFault(
+      'ParametersDeleteFault',
+      {
+        message: `Failed to delete parameters from the service`,
+      },
+      e,
+    );
+  }
 };
 
 const getAllEnvParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<Array<string>> => {

--- a/packages/amplify-provider-awscloudformation/src/utils/get-ssm-sdk-parameters.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/get-ssm-sdk-parameters.ts
@@ -1,6 +1,6 @@
-export const getSsmSdkParametersDeleteParameters = (appId: string, envName: string, keys: Array<string>): SsmDeleteParameters => {
+export const getSsmSdkParametersDeleteParameters = (keys: Array<string>): SsmDeleteParameters => {
   const sdkParameters = {
-    Names: keys.map(key => `/amplify/${appId}/${envName}/${key}`),
+    Names: keys,
   };
   return sdkParameters;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR fixes a bug where the wrong key was being passed to the delete handler.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
