### PR TITLE
feat: prompt for missing backend parameters

### DIFF
--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -353,8 +353,8 @@ export const raiseEvent = async (context: Context, args: AmplifyEventArgs): Prom
         };
         return eventHandler;
       });
-    for (const eventHanler of eventHandlers) {
-      await eventHanler();
+    for (const eventHandler of eventHandlers) {
+      await eventHandler();
     }
   }
 };

--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import sequential from 'promise-sequential';
 import {
   stateManager, executeHooks, HooksMeta,
 } from 'amplify-cli-core';
@@ -354,7 +353,9 @@ export const raiseEvent = async (context: Context, args: AmplifyEventArgs): Prom
         };
         return eventHandler;
       });
-    await sequential(eventHandlers);
+    for (const eventHanler of eventHandlers) {
+      await eventHanler();
+    }
   }
 };
 

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -88,12 +88,14 @@ export const pushResources = async (
   // Verify any environment parameters before push operation
   const envParamManager = (await ensureEnvParamManager()).instance;
 
-  const promptMissingParameter = async (parameter: string, envParamManager: IEnvironmentParameterManager): Promise<void> => {
-    printer.warn(`Could not find value for parameter ${parameter}`);
-    const [, categoryName, resourceName, parameterName] = parameter.split('_');
-
+  const promptMissingParameter = async (
+    categoryName: string,
+    resourceName: string,
+    parameterName: string,
+    envParamManager: IEnvironmentParameterManager,
+  ): Promise<void> => {
+    printer.warn(`Could not find value for parameter ${parameterName}`);
     const value = await prompter.input(`Enter a value for ${parameterName} for the ${categoryName} resource: ${resourceName}`);
-
     const resourceParamManager = envParamManager.getResourceParamManager(categoryName, resourceName);
     resourceParamManager.setParam(parameterName, value);
   };
@@ -103,8 +105,8 @@ export const pushResources = async (
   } else {
     const missingParameters = await envParamManager.getMissingParameters();
     if (missingParameters.length > 0) {
-      for (const parameter of missingParameters) {
-        await promptMissingParameter(parameter, envParamManager);
+      for (const { categoryName, resourceName, parameterName } of missingParameters) {
+        await promptMissingParameter(categoryName, resourceName, parameterName , envParamManager);
       }
       await envParamManager.save(); // Values must be in TPI for CFN deployment to work
     }

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -2,8 +2,8 @@ import {
   $TSContext, AmplifyError, AmplifyFault, AMPLIFY_SUPPORT_DOCS, exitOnNextTick, IAmplifyResource, stateManager,
 } from 'amplify-cli-core';
 import { generateDependentResourcesType } from '@aws-amplify/amplify-category-custom';
-import { ensureEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
-import { printer } from 'amplify-prompts';
+import { ensureEnvParamManager, IEnvironmentParameterManager } from '@aws-amplify/amplify-environment-parameters';
+import { printer, prompter } from 'amplify-prompts';
 import { getResources } from '../../commands/build';
 import { initializeEnv } from '../../initialize-env';
 import { getEnvInfo } from './get-env-info';
@@ -87,7 +87,28 @@ export const pushResources = async (
 
   // Verify any environment parameters before push operation
   const envParamManager = (await ensureEnvParamManager()).instance;
-  envParamManager.verifyExpectedEnvParameters();
+
+  const promptMissingParameter = async (parameter: string, envParamManager: IEnvironmentParameterManager): Promise<void> => {
+    printer.warn(`Could not find value for parameter ${parameter}`);
+    const [, categoryName, resourceName, parameterName] = parameter.split('_');
+
+    const value = await prompter.input(`Enter a value for ${parameterName} for the ${categoryName} resource: ${resourceName}`);
+
+    const resourceParamManager = envParamManager.getResourceParamManager(categoryName, resourceName);
+    resourceParamManager.setParam(parameterName, value);
+  };
+
+  if (context?.exeInfo?.inputParams?.yes || context?.exeInfo?.inputParams?.headless) {
+    await envParamManager.verifyExpectedEnvParameters();
+  } else {
+    const missingParameters = await envParamManager.getMissingParameters();
+    if (missingParameters.length > 0) {
+      for (const parameter of missingParameters) {
+        await promptMissingParameter(parameter, envParamManager);
+      }
+      await envParamManager.save(); // Values must be in TPI for CFN deployment to work
+    }
+  }
 
   // rebuild has an upstream confirmation prompt so no need to prompt again here
   let continueToPush = !!context?.exeInfo?.inputParams?.yes || rebuild;

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -19,6 +19,7 @@ export type IEnvironmentParameterManager = {
     hasResourceParamManager: (category: string, resource: string) => boolean;
     getResourceParamManager: (category: string, resource: string) => ResourceParameterManager;
     save: (serviceUploadHandler?: ServiceUploadHandler) => Promise<void>;
+    getMissingParameters: () => Promise<string[]>;
     verifyExpectedEnvParameters: () => Promise<void>;
 };
 

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -19,7 +19,11 @@ export type IEnvironmentParameterManager = {
     hasResourceParamManager: (category: string, resource: string) => boolean;
     getResourceParamManager: (category: string, resource: string) => ResourceParameterManager;
     save: (serviceUploadHandler?: ServiceUploadHandler) => Promise<void>;
-    getMissingParameters: () => Promise<string[]>;
+    getMissingParameters: () => Promise<{
+        categoryName: string;
+        resourceName: string;
+        parameterName: string;
+    }[]>;
     verifyExpectedEnvParameters: () => Promise<void>;
 };
 

--- a/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
@@ -100,3 +100,48 @@ describe('save', () => {
     `);
   });
 });
+
+describe('verifyExpectedEnvParameters', () => {
+  it('does not throw when nothing is missing', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    envParamManager.save();
+    await envParamManager.verifyExpectedEnvParameters();
+  });
+
+  it('throws when a parameter is missing', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
+
+    funcParamManager.setParam('missingParam', 'missingValue');
+    envParamManager.save();
+    funcParamManager.deleteParam('missingParam');
+
+    let error = undefined;
+    try {
+      await envParamManager.verifyExpectedEnvParameters();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+  });
+});
+
+describe('getMissingParameters', () => {
+  it('returns an empty array when nothing is missing', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    envParamManager.save();
+    expect(await envParamManager.getMissingParameters()).toEqual([]);
+  });
+
+  it('returns array of missing parameters', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
+
+    funcParamManager.setParam('missingParam', 'missingValue');
+    envParamManager.save();
+    funcParamManager.deleteParam('missingParam');
+
+    expect(await envParamManager.getMissingParameters())
+      .toEqual(['AMPLIFY_function_funcName_missingParam']);
+  });
+});

--- a/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
@@ -142,6 +142,6 @@ describe('getMissingParameters', () => {
     funcParamManager.deleteParam('missingParam');
 
     expect(await envParamManager.getMissingParameters())
-      .toEqual(['AMPLIFY_function_funcName_missingParam']);
+      .toEqual([{ categoryName: 'function', resourceName: 'funcName', parameterName: 'missingParam' }]);
   });
 });

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -137,8 +137,8 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
     }
 
     Object.keys(expectedParameters).forEach(expectedParameter => {
-      const [categgoryName, resourceName, parameterName] = getNamesFromParameterStoreKey(expectedParameter);
-      if (!allEnvParams.has(`${categgoryName}_${resourceName}_${parameterName}`)) {
+      const [categoryName, resourceName, parameterName] = getNamesFromParameterStoreKey(expectedParameter);
+      if (!allEnvParams.has(`${categoryName}_${resourceName}_${parameterName}`)) {
         missingResourceParameters.push(expectedParameter);
       }
     });

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -108,8 +108,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
     }
 
     // update param mapping
-    this.parameterMapController
-      .removeAllParameters();
+    this.parameterMapController.removeAllParameters();
     for (const [resourceKey, paramManager] of Object.entries(this.resourceParamManagers)) {
       const [category, resourceName] = splitResourceKey(resourceKey);
       const resourceParams = paramManager.getAllParams();
@@ -122,30 +121,37 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
       }
     }
 
-    this.parameterMapController.save();
+    await this.parameterMapController.save();
+  }
+
+  async getMissingParameters(): Promise<string[]> {
+    const expectedParameters = this.parameterMapController.getParameters();
+    const allEnvParams = new Set();
+    const missingResourceParameters: string[] = [];
+
+    for (const [resourceKey, paramManager] of Object.entries(this.resourceParamManagers)) {
+      const resourceParams = paramManager.getAllParams();
+      for (const paramName of Object.keys(resourceParams)) {
+        allEnvParams.add(`${resourceKey}_${paramName}`);
+      }
+    }
+
+    Object.keys(expectedParameters).forEach(expectedParameter => {
+      const [categgoryName, resourceName, parameterName] = getNamesFromParameterStoreKey(expectedParameter);
+      if (!allEnvParams.has(`${categgoryName}_${resourceName}_${parameterName}`)) {
+        missingResourceParameters.push(expectedParameter);
+      }
+    });
+
+
+    return missingResourceParameters;
   }
 
   /**
    * Throw an error if expected parameters are missing
    */
   async verifyExpectedEnvParameters(): Promise<void> {
-    const expectedParameters = this.parameterMapController.getParameters();
-    const allEnvParams = new Set();
-    const missingParameterNames: string[] = [];
-
-    for (const paramManager of Object.values(this.resourceParamManagers)) {
-      const resourceParams = paramManager.getAllParams();
-      for (const paramName of Object.keys(resourceParams)) {
-        allEnvParams.add(paramName);
-      }
-    }
-
-    Object.keys(expectedParameters).forEach(expectedParameter => {
-      const paramName = getParamaterNameFromParameterStoreKey(expectedParameter);
-      if (!allEnvParams.has(paramName)) {
-        missingParameterNames.push(paramName);
-      }
-    });
+    const missingParameterNames = await this.getMissingParameters();
 
     if (missingParameterNames.length > 0) {
       throw new AmplifyError('MissingExpectedParameterError', {
@@ -179,6 +185,7 @@ export type IEnvironmentParameterManager = {
   hasResourceParamManager: (category: string, resource: string) => boolean;
   getResourceParamManager: (category: string, resource: string) => ResourceParameterManager;
   save: (serviceUploadHandler?: ServiceUploadHandler) => Promise<void>;
+  getMissingParameters: () => Promise<string[]>;
   verifyExpectedEnvParameters: () => Promise<void>;
 }
 
@@ -190,4 +197,8 @@ const getParameterStoreKey = (
   paramName: string,
 ): string => `AMPLIFY_${categoryName}_${resourceName}_${paramName}`;
 
-const getParamaterNameFromParameterStoreKey = (fullParameter: string) => fullParameter.split('_').slice(3).join('_');
+const getNamesFromParameterStoreKey = (fullParameter: string) => {
+  const [, categoryName, resourceName] = fullParameter.split('_');
+  const parameterName = fullParameter.split('_').slice(3).join('_'); // In case parameterName contains underscores
+  return [categoryName, resourceName, parameterName];
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add a generic fallback prompt for missing CloudFormation parameter values. Any prompts that handle specific parameters, such as environment variables in the function category, will be executed first.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
