### PR TITLE
chore: correctly filter failed cfn events for displaying error messages

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cfn.js
@@ -188,7 +188,7 @@ class CloudFormation {
         stack =>
           (this.eventMap['eventToCategories'] && this.eventMap['eventToCategories'].has(stack.LogicalResourceId)) ||
           (this.eventMap['rootResources'] &&
-            this.eventMap['rootResources'].map(resource => resource.key).includes(stack.LogicalResourceId)),
+            this.eventMap['rootResources'].some(resource => resource.key === stack.LogicalResourceId)),
       )
       .filter(stack => !RESOURCE_CASCADE_FAIL_REASONS.includes(stack.ResourceStatusReason));
   }


### PR DESCRIPTION
#### Description of changes

Change: do not filter AWS::CloudFormation::Stack type failure events if they have valid error message

While displaying error messages from a failed CFN deployment, library filters out any stack events that are for `AWS::CloudFormation::Stack` type resource. As a result situations where the cfn template had errors are not displayed to the customer. As an example see the before and after CX

**Before**

```console
Deploying resources into prod environment. This will take a few minutes. ⠸
Deploying root stack app11533 [ ---------------------------------------- ] 0/2
Deployment failed.
Deploying root stack app11533 [ ====================-------------------- ] 1/2
        amplify-app11533-prod-144550   AWS::CloudFormation::Stack     UPDATE_ROLLBACK_COMPLETE      
        functionapp11533bc562f1e       AWS::CloudFormation::Stack     UPDATE_FAILED                 
Deployed function app11533bc562f1e [ ======================================== ] 3/3

🛑 The following resources failed to deploy:
🛑 Resource is not in the state stackUpdateComplete

Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/
```

**After**

```console
Deployment failed.
Deploying root stack app11533 [ ---------------------------------------- ] 0/2
        amplify-app11533-prod-144550   AWS::CloudFormation::Stack     UPDATE_ROLLBACK_IN_PROGRESS    Fri Jan 20 2023 15:16:09…     
        functionapp11533bc562f1e       AWS::CloudFormation::Stack     UPDATE_FAILED                  Fri Jan 20 2023 15:16:09…     
Deployed function app11533bc562f1e [ ======================================== ] 3/3

🛑 The following resources failed to deploy:
Resource Name: functionapp11533bc562f1e (AWS::CloudFormation::Stack)
Event Type: update
Reason: Parameters: [var1] do not exist in the template
URL: <URL>


🛑 Resource is not in the state stackUpdateComplete
Name: functionapp11533bc562f1e (AWS::CloudFormation::Stack), Event Type: update, Reason: Parameters: [var1] do not exist in the template

Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/
```


#### Issue #, if available

There are many issues filed where customers struggled to find the real root cause of the cfn deployment failure. Some examples are

https://github.com/aws-amplify/amplify-cli/issues/11533
https://github.com/aws-amplify/amplify-cli/issues/11723

#### Description of how you validated changes

Manually and unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
