### PR TITLE
fix: get credentials from credential_process in aws profile config

### DIFF
--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -95,31 +95,25 @@ export class PathManager {
 
   getAmplifyAdminDirPath = (): string => this.constructPath(this.getHomeDotAmplifyDirPath(), [PathConstants.AmplifyAdminDirName]);
 
-  getAmplifyAdminConfigFilePath = (): string => this.constructPath(
-    this.getAmplifyAdminDirPath(), [PathConstants.AmplifyAdminConfigFileName],
-  );
+  getAmplifyAdminConfigFilePath = (): string =>
+    this.constructPath(this.getAmplifyAdminDirPath(), [PathConstants.AmplifyAdminConfigFileName]);
 
   getAmplifyDirPath = (projectPath?: string): string => this.constructPath(projectPath, [PathConstants.AmplifyDirName]);
 
-  getDotConfigDirPath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName],
-  );
+  getDotConfigDirPath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName]);
 
-  getBackendDirPath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName],
-  );
+  getBackendDirPath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName]);
 
-  getCurrentCloudBackendDirPath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName],
-  );
+  getCurrentCloudBackendDirPath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName]);
 
-  getCurrentResourceParametersJsonPath = (projectPath: string | undefined, categoryName: string, resourceName: string): string => path.join(
-    this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.ParametersJsonFileName,
-  );
+  getCurrentResourceParametersJsonPath = (projectPath: string | undefined, categoryName: string, resourceName: string): string =>
+    path.join(this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.ParametersJsonFileName);
 
-  getCurrentCfnTemplatePath = (projectPath: string | undefined, categoryName: string, resourceName: string): string => path.join(
-    this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.CfnFileName(resourceName),
-  );
+  getCurrentCfnTemplatePath = (projectPath: string | undefined, categoryName: string, resourceName: string): string =>
+    path.join(this.getCurrentCloudBackendDirPath(projectPath), categoryName, resourceName, PathConstants.CfnFileName(resourceName));
 
   getAmplifyRcFilePath = (projectPath?: string): string => this.constructPath(projectPath, [PathConstants.AmplifyRcFileName]);
 
@@ -129,53 +123,43 @@ export class PathManager {
    * Returns the full path to the `team-provider-info.json` file
    * @deprecated Use envParamManager from amplify-environment-parameters
    */
-  getTeamProviderInfoFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.TeamProviderInfoFileName],
-  );
+  getTeamProviderInfoFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.TeamProviderInfoFileName]);
 
-  getProjectConfigFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.ProjectConfigFileName],
-  );
+  getProjectConfigFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.ProjectConfigFileName]);
 
-  getLocalEnvFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.LocalEnvFileName],
-  );
+  getLocalEnvFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.LocalEnvFileName]);
 
-  getLocalAWSInfoFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.LocalAWSInfoFileName],
-  );
+  getLocalAWSInfoFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.DotConfigDirName, PathConstants.LocalAWSInfoFileName]);
 
-  getAmplifyMetaFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.AmplifyMetaFileName],
-  );
+  getAmplifyMetaFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.AmplifyMetaFileName]);
 
-  getBackendConfigFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.BackendConfigFileName],
-  );
+  getBackendConfigFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.BackendConfigFileName]);
 
-  getTagFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.TagsFileName],
-  );
+  getTagFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, PathConstants.TagsFileName]);
 
-  getCurrentTagFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName, PathConstants.TagsFileName],
-  );
+  getCurrentTagFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.CurrentCloudBackendDirName, PathConstants.TagsFileName]);
 
-  getResourceDirectoryPath = (projectPath: string | undefined, category: string, resourceName: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, category, resourceName],
-  );
+  getResourceDirectoryPath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.BackendDirName, category, resourceName]);
 
-  getResourceInputsJsonFilePath = (projectPath: string | undefined, category: string, resourceName: string): string => path.join(
-    this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.CLIInputsJsonFileName,
-  );
+  getResourceInputsJsonFilePath = (projectPath: string | undefined, category: string, resourceName: string): string =>
+    path.join(this.getResourceDirectoryPath(projectPath, category, resourceName), PathConstants.CLIInputsJsonFileName);
 
   getResourceParametersFilePath = (projectPath: string | undefined, category: string, resourceName: string): string => {
     let isBuildParametersJson = false;
     const resourceDirPath = this.getResourceDirectoryPath(projectPath, category, resourceName);
     if (
-      !fs.existsSync(path.join(resourceDirPath, PathConstants.ParametersJsonFileName))
-      && fs.existsSync(path.join(resourceDirPath, PathConstants.CLIInputsJsonFileName))
-      && overriddenCategories.includes(category)
+      !fs.existsSync(path.join(resourceDirPath, PathConstants.ParametersJsonFileName)) &&
+      fs.existsSync(path.join(resourceDirPath, PathConstants.CLIInputsJsonFileName)) &&
+      overriddenCategories.includes(category)
     ) {
       isBuildParametersJson = true;
     }
@@ -194,31 +178,33 @@ export class PathManager {
     return path.join(basePath, PathConstants.CfnFileName(resourceName));
   };
 
-  getReadMeFilePath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.ReadMeFileName],
-  );
+  getReadMeFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.ReadMeFileName]);
 
-  getCurrentAmplifyMetaFilePath = (projectPath?: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.CurrentCloudBackendDirName,
-    PathConstants.AmplifyMetaFileName,
-  ]);
+  getCurrentAmplifyMetaFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.CurrentCloudBackendDirName,
+      PathConstants.AmplifyMetaFileName,
+    ]);
 
-  getCurrentBackendConfigFilePath = (projectPath?: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.CurrentCloudBackendDirName,
-    PathConstants.BackendConfigFileName,
-  ]);
+  getCurrentBackendConfigFilePath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.CurrentCloudBackendDirName,
+      PathConstants.BackendConfigFileName,
+    ]);
 
   getDotAWSDirPath = (): string => path.normalize(path.join(homedir(), PathConstants.DotAWSDirName));
 
-  getCustomPoliciesPath = (category: string, resourceName: string): string => path.join(
-    this.getResourceDirectoryPath(undefined, category, resourceName), PathConstants.CustomPoliciesFilename,
-  );
+  getCustomPoliciesPath = (category: string, resourceName: string): string =>
+    path.join(this.getResourceDirectoryPath(undefined, category, resourceName), PathConstants.CustomPoliciesFilename);
 
-  getAWSCredentialsFilePath = (): string => path.normalize(path.join(this.getDotAWSDirPath(), PathConstants.AWSCredentials));
+  getAWSCredentialsFilePath = (): string =>
+    process.env.AWS_SHARED_CREDENTIALS_FILE || path.normalize(path.join(this.getDotAWSDirPath(), PathConstants.AWSCredentials));
 
-  getAWSConfigFilePath = (): string => path.normalize(path.join(this.getDotAWSDirPath(), PathConstants.AWSConfig));
+  getAWSConfigFilePath = (): string =>
+    process.env.AWS_CONFIG_FILE || path.normalize(path.join(this.getDotAWSDirPath(), PathConstants.AWSConfig));
 
   getCLIJSONFilePath = (projectPath: string, env?: string): string => {
     const fileName = env === undefined ? PathConstants.CLIJSONFileName : PathConstants.CLIJsonWithEnvironmentFileName(env);
@@ -230,42 +216,44 @@ export class PathManager {
 
   getDeploymentSecrets = (): string => path.normalize(path.join(this.getDotAWSAmplifyDirPath(), PathConstants.DeploymentSecretsFileName));
 
-  getHooksDirPath = (projectPath?: string): string => this.constructPath(
-    projectPath, [PathConstants.AmplifyDirName, PathConstants.HooksDirName],
-  );
+  getHooksDirPath = (projectPath?: string): string =>
+    this.constructPath(projectPath, [PathConstants.AmplifyDirName, PathConstants.HooksDirName]);
 
-  getHooksConfigFilePath = (projectPath?: string): string => path.join(
-    this.getHooksDirPath(projectPath), PathConstants.HooksConfigFileName,
-  );
+  getHooksConfigFilePath = (projectPath?: string): string =>
+    path.join(this.getHooksDirPath(projectPath), PathConstants.HooksConfigFileName);
 
-  getOverrideDirPath = (projectPath: string, category: string, resourceName: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.BackendDirName,
-    category,
-    resourceName,
-    PathConstants.OverrideDirName,
-  ]);
+  getOverrideDirPath = (projectPath: string, category: string, resourceName: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.BackendDirName,
+      category,
+      resourceName,
+      PathConstants.OverrideDirName,
+    ]);
 
-  getRootOverrideDirPath = (projectPath: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.BackendDirName,
-    PathConstants.ProviderName,
-    PathConstants.OverrideDirName,
-  ]);
+  getRootOverrideDirPath = (projectPath: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.BackendDirName,
+      PathConstants.ProviderName,
+      PathConstants.OverrideDirName,
+    ]);
 
-  getRootStackBuildDirPath = (projectPath: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.BackendDirName,
-    PathConstants.ProviderName,
-    PathConstants.BuildDirName,
-  ]);
+  getRootStackBuildDirPath = (projectPath: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.BackendDirName,
+      PathConstants.ProviderName,
+      PathConstants.BuildDirName,
+    ]);
 
-  getCurrentCloudRootStackDirPath = (projectPath: string): string => this.constructPath(projectPath, [
-    PathConstants.AmplifyDirName,
-    PathConstants.CurrentCloudBackendDirName,
-    PathConstants.ProviderName,
-    PathConstants.BuildDirName,
-  ]);
+  getCurrentCloudRootStackDirPath = (projectPath: string): string =>
+    this.constructPath(projectPath, [
+      PathConstants.AmplifyDirName,
+      PathConstants.CurrentCloudBackendDirName,
+      PathConstants.ProviderName,
+      PathConstants.BuildDirName,
+    ]);
 
   private constructPath = (projectPath?: string, segments: string[] = []): string => {
     if (!projectPath) {

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -93,6 +93,7 @@ export const initializeEnv = async (
       context.usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_PLATFORM);
       await sequential(initializationTasks);
     } catch (e) {
+      spinner.fail();
       throw new AmplifyFault(
         'ProjectInitFault',
         {

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -632,9 +632,31 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
     projectConfigInfo.configLevel = 'amplifyAdmin';
     appId = appId || authType.appId;
 
-    awsConfig = await getTempCredsWithAdminTokens(context, appId);
+    try {
+      awsConfig = await getTempCredsWithAdminTokens(context, appId);
+    } catch (err) {
+      throw new AmplifyError(
+        'ProfileConfigurationError',
+        {
+          message: 'Failed to get AWS credentials',
+          details: err.message,
+        },
+        err,
+      );
+    }
   } else if (authType.type === 'profile') {
-    awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
+    try {
+      awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
+    } catch (err) {
+      throw new AmplifyError(
+        'ProfileConfigurationError',
+        {
+          message: 'Failed to get profile credentials',
+          details: err.message,
+        },
+        err,
+      );
+    }
   } else if (authType.type === 'accessKeys') {
     awsConfig = loadConfigFromPath(projectConfigInfo.config.awsConfigFilePath);
   }
@@ -763,7 +785,18 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
 
   if (awsConfigInfo.configLevel === 'project') {
     if (awsConfigInfo.config.useProfile) {
-      resultAWSConfigInfo = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
+      try {
+        resultAWSConfigInfo = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
+      } catch (err) {
+        throw new AmplifyError(
+          'ProfileConfigurationError',
+          {
+            message: 'Failed to get profile credentials',
+            details: err.message,
+          },
+          err,
+        );
+      }
     } else {
       resultAWSConfigInfo = {
         accessKeyId: awsConfigInfo.config.accessKeyId,

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -632,21 +632,9 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
     projectConfigInfo.configLevel = 'amplifyAdmin';
     appId = appId || authType.appId;
 
-    try {
-      awsConfig = await getTempCredsWithAdminTokens(context, appId);
-    } catch (e) {
-      context.print.error(`Failed to get credentials: ${e.message || e}`);
-      await context.usageData.emitError(e);
-      exitOnNextTick(1);
-    }
+    awsConfig = await getTempCredsWithAdminTokens(context, appId);
   } else if (authType.type === 'profile') {
-    try {
-      awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
-    } catch (e) {
-      context.print.error(`Failed to get profile: ${e.message || e}`);
-      await context.usageData.emitError(e);
-      exitOnNextTick(1);
-    }
+    awsConfig = await systemConfigManager.getProfiledAwsConfig(context, authType.profileName);
   } else if (authType.type === 'accessKeys') {
     awsConfig = loadConfigFromPath(projectConfigInfo.config.awsConfigFilePath);
   }
@@ -775,13 +763,7 @@ export async function getAwsConfig(context: $TSContext): Promise<AwsSdkConfig> {
 
   if (awsConfigInfo.configLevel === 'project') {
     if (awsConfigInfo.config.useProfile) {
-      try {
-        resultAWSConfigInfo = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
-      } catch (e) {
-        context.print.error(`Failed to get profile: ${e.message || e}`);
-        await context.usageData.emitError(e);
-        exitOnNextTick(1);
-      }
+      resultAWSConfigInfo = await systemConfigManager.getProfiledAwsConfig(context, awsConfigInfo.config.profileName);
     } else {
       resultAWSConfigInfo = {
         accessKeyId: awsConfigInfo.config.accessKeyId,

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -1,8 +1,6 @@
-import {
-  $TSAny, $TSContext, AmplifyError, JSONUtilities, pathManager, SecretFileMode, spinner,
-} from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyError, JSONUtilities, pathManager, SecretFileMode, spinner } from 'amplify-cli-core';
 
-import * as aws from 'aws-sdk';
+import { STS, ProcessCredentials } from 'aws-sdk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as ini from 'ini';
@@ -10,6 +8,7 @@ import * as inquirer from 'inquirer';
 import proxyAgent from 'proxy-agent';
 import * as constants from './constants';
 import { fileLogger } from './utils/aws-logger';
+import { AwsSdkConfig } from './utils/auth-types';
 
 const logger = fileLogger('system-config-manager');
 
@@ -74,13 +73,17 @@ export const setProfile = (awsConfigInfo: $TSAny, profileName: string): void => 
 /**
  * Gets AWS configuration for a profile
  */
-export const getProfiledAwsConfig = async (context: $TSContext, profileName: string, isRoleSourceProfile?: boolean): Promise<$TSAny> => {
-  let awsConfigInfo;
+export const getProfiledAwsConfig = async (
+  context: $TSContext,
+  profileName: string,
+  isRoleSourceProfile?: boolean,
+): Promise<AwsSdkConfig> => {
+  let awsConfigInfo: AwsSdkConfig;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
   const profileConfig = getProfileConfig(profileName);
   if (profileConfig) {
     logger('getProfiledAwsConfig.profileConfig', [profileConfig])();
-    if (!isRoleSourceProfile && (profileConfig.role_arn || profileConfig.credential_process)) {
+    if (!isRoleSourceProfile && profileConfig.role_arn) {
       const roleCredentials = await getRoleCredentials(context, profileName, profileConfig);
       delete profileConfig.role_arn;
       delete profileConfig.source_profile;
@@ -88,14 +91,17 @@ export const getProfiledAwsConfig = async (context: $TSContext, profileName: str
         ...profileConfig,
         ...roleCredentials,
       };
+    } else if (profileConfig.credential_process) {
+      const credentialProcess = new ProcessCredentials({ profile: profileName });
+      await credentialProcess.getPromise();
 
-      if (profileConfig.credential_process) {
-        const chain = new aws.CredentialProviderChain();
-        const processProvider = () => new aws.ProcessCredentials({ profile: profileName });
-        chain.providers.push(processProvider);
-
-        awsConfigInfo.credentialProvider = chain;
-      }
+      awsConfigInfo = {
+        region: profileConfig.region,
+        accessKeyId: credentialProcess.accessKeyId,
+        secretAccessKey: credentialProcess.secretAccessKey,
+        sessionToken: credentialProcess.sessionToken,
+        expiration: credentialProcess.expireTime,
+      };
     } else {
       logger('getProfiledAwsConfig.getProfileCredentials', [profileName]);
       const profileCredentials = getProfileCredentials(profileName);
@@ -143,7 +149,7 @@ const getRoleCredentials = async (context: $TSContext, profileName: string, prof
       mfaTokenCode = await getMfaTokenCode();
     }
     logger('getRoleCredentials.aws.STS', [sourceProfileAwsConfig])();
-    const sts = new aws.STS(sourceProfileAwsConfig);
+    const sts = new STS(sourceProfileAwsConfig);
     const assumeRoleRequest = {
       RoleArn: profileConfig.role_arn,
       RoleSessionName: roleSessionName,
@@ -232,10 +238,11 @@ const validateCachedCredentials = (roleCredentials: $TSAny): boolean => {
   let isValid = false;
 
   if (roleCredentials) {
-    isValid = !isCredentialsExpired(roleCredentials)
-      && roleCredentials.accessKeyId
-      && roleCredentials.secretAccessKey
-      && roleCredentials.sessionToken;
+    isValid =
+      !isCredentialsExpired(roleCredentials) &&
+      roleCredentials.accessKeyId &&
+      roleCredentials.secretAccessKey &&
+      roleCredentials.sessionToken;
   }
 
   return isValid;

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -1,6 +1,6 @@
 import { $TSAny, $TSContext, AmplifyError, JSONUtilities, pathManager, SecretFileMode, spinner } from 'amplify-cli-core';
 
-import aws, { STS, ProcessCredentials } from 'aws-sdk';
+import { STS, ProcessCredentials } from 'aws-sdk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as ini from 'ini';

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -1,6 +1,6 @@
 import { $TSAny, $TSContext, AmplifyError, JSONUtilities, pathManager, SecretFileMode, spinner } from 'amplify-cli-core';
 
-import { STS, ProcessCredentials } from 'aws-sdk';
+import aws, { STS, ProcessCredentials } from 'aws-sdk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as ini from 'ini';
@@ -92,7 +92,7 @@ export const getProfiledAwsConfig = async (
         ...roleCredentials,
       };
     } else if (profileConfig.credential_process) {
-      const credentialProcess = new ProcessCredentials({ profile: profileName });
+      const credentialProcess = new ProcessCredentials({ profile: profileName, filename: configFilePath });
       await credentialProcess.getPromise();
 
       awsConfigInfo = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
We had some logic to handle AWS credential_process profiles, but we were not actually calling the credential process (or at least not in all cases). This change calls the credential process when we are initially resolving credentials.

I updated some error handling to use AmplifyError and remove some calls to process.exit because it caused some hanging spinners if the credential process fails.

There is also a change to respect the `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` environment variables when resolving the path to the aws config and credentials files.

There are also an unfortunate amount of lint fixes :(

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/11319 https://github.com/aws-amplify/amplify-cli/issues/4488

#### Description of how you validated changes
Manually tested, updated existing unit tests and running e2e now: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/foyleef/cred-process

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
