### PR TITLE
fix: add filter for parameters starting with AMPLIFY_

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
@@ -7,8 +7,11 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
 jest.mock('../../aws-utils/aws-ssm');
 
 const fakeAppId = 'fakeAppId';
-const keys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two', 'toBeIgnored'];
-const expectedKeys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two'];
+const keyPrefix = '/amplify/id/dev/'
+let keys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two', 'toBeIgnored'];
+let expectedKeys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two'];
+keys = keys.map(key => keyPrefix + key);
+expectedKeys = expectedKeys.map(key => keyPrefix + key);
 const envName: string = 'dev';
 const contextStub = {
   exeInfo: {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
@@ -7,7 +7,8 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
 jest.mock('../../aws-utils/aws-ssm');
 
 const fakeAppId = 'fakeAppId';
-const keys: Array<string> = ['one', 'two'];
+const keys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two', 'toBeIgnored'];
+const expectedKeys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two'];
 const envName: string = 'dev';
 const contextStub = {
   exeInfo: {
@@ -43,7 +44,7 @@ describe('parameters-delete-handler', () => {
     await deleteEnvironmentParametersFromService((contextStub as unknown) as $TSContext, envName);
     expect(deleteParametersPromiseMock).toBeCalledTimes(1);
     expect(deleteParametersMock).toBeCalledTimes(1);
-    const expectedDeleteParamater = getSsmSdkParametersDeleteParameters(keys);
+    const expectedDeleteParamater = getSsmSdkParametersDeleteParameters(expectedKeys);
     expect(deleteParametersMock).toBeCalledWith(expectedDeleteParamater);
 
     expect(getParametersByPathPromiseMock).toBeCalledTimes(1);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/delete-from-service.test.ts
@@ -7,7 +7,7 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
 jest.mock('../../aws-utils/aws-ssm');
 
 const fakeAppId = 'fakeAppId';
-const keyPrefix = '/amplify/id/dev/'
+const keyPrefix = '/amplify/id/dev/';
 let keys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two', 'toBeIgnored'];
 let expectedKeys: Array<string> = ['AMPLIFY_one', 'AMPLIFY_two'];
 keys = keys.map(key => keyPrefix + key);

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -34,6 +34,13 @@ const deleteParametersFromParameterStore = async (appId: string, envName: string
   }
 };
 
+function isAmplifyParameter(parameter: string) {
+  const keyPrefix = 'AMPLIFY_';
+  const splitParam = parameter.split('/');
+  const lastPartOfPath = splitParam.slice(-1).pop();
+  return lastPartOfPath!.startsWith(keyPrefix);
+}
+
 const getAllEnvParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<Array<string>> => {
   const keyPrefix = 'AMPLIFY_';
   const parametersUnderPath: Array<string> = [];
@@ -41,9 +48,7 @@ const getAllEnvParametersFromParameterStore = async (appId: string, envName: str
   do {
     const ssmArgument = getSsmSdkParametersGetParametersByPath(appId, envName, recievedNextToken);
     const data = await ssmClient.getParametersByPath(ssmArgument).promise();
-    parametersUnderPath.push(
-      ...data.Parameters.map(returnedParameter => returnedParameter.Name).filter(name => name.startsWith(keyPrefix)),
-    );
+    parametersUnderPath.push(...data.Parameters.map(returnedParameter => returnedParameter.Name).filter(name => isAmplifyParameter(name)));
     recievedNextToken = data.NextToken;
   } while (recievedNextToken);
   return parametersUnderPath;

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -42,7 +42,6 @@ function isAmplifyParameter(parameter: string) {
 }
 
 const getAllEnvParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<Array<string>> => {
-  const keyPrefix = 'AMPLIFY_';
   const parametersUnderPath: Array<string> = [];
   let recievedNextToken = '';
   do {

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -35,12 +35,15 @@ const deleteParametersFromParameterStore = async (appId: string, envName: string
 };
 
 const getAllEnvParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<Array<string>> => {
+  const keyPrefix = 'AMPLIFY_';
   const parametersUnderPath: Array<string> = [];
   let recievedNextToken = '';
   do {
     const ssmArgument = getSsmSdkParametersGetParametersByPath(appId, envName, recievedNextToken);
     const data = await ssmClient.getParametersByPath(ssmArgument).promise();
-    parametersUnderPath.push(...data.Parameters.map(returnedParameter => returnedParameter.Name));
+    parametersUnderPath.push(
+      ...data.Parameters.map(returnedParameter => returnedParameter.Name).filter(name => name.startsWith(keyPrefix)),
+    );
     recievedNextToken = data.NextToken;
   } while (recievedNextToken);
   return parametersUnderPath;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds a filter to retrieved parameters that ensures that only parameters that begin with "AMPLIFY_" are deleted from PS.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
