### PR TITLE
chore: jest config normalization

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -384,7 +384,7 @@ jobs:
           command: |
             source .circleci/local_publish_helpers.sh
             verifyPkgCli
-            
+
   amplify_sudo_install_test:
     <<: *defaults
     steps:
@@ -472,7 +472,7 @@ jobs:
             source .circleci/local_publish_helpers.sh
             changeNpmGlobalPath
             cd packages/amplify-migration-tests
-            retry yarn run migration_v5.2.0 --no-cache --maxWorkers= $TEST_SUITE
+            retry yarn run migration_v5.2.0 --no-cache --maxWorkers=3 $TEST_SUITE
           no_output_timeout: 65m
       - run: *scan_e2e_test_artifacts
       - store_test_results:

--- a/.vscode/amplify-cli.code-workspace
+++ b/.vscode/amplify-cli.code-workspace
@@ -8,9 +8,11 @@
     }
   ],
   "settings": {
-    "eslint.alwaysShowStatus": true
+    "eslint.alwaysShowStatus": true,
+    "coverage-gutters.coverageFileNames": ["lcov.info"],
+    "coverage-gutters.showGutterCoverage": true
   },
   "extensions": {
-    "recommendations": ["Orta.vscode-jest", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    "recommendations": ["Orta.vscode-jest", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "ryanluker.vscode-coverage-gutters"]
   }
 }

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -59,6 +59,10 @@
   },
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -49,6 +49,10 @@
   },
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -38,6 +38,10 @@
   },
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -34,6 +34,10 @@
   },
   "jest": {
     "testURL": "http://localhost",
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -66,6 +66,10 @@
       "node"
     ],
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "coverageReporters": [
       "json",
       "html"

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -67,6 +67,10 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testRegex": "(src/__tests__/.*.test.ts)$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/amplify-cli-extensibility-helper/package.json
+++ b/packages/amplify-cli-extensibility-helper/package.json
@@ -44,6 +44,10 @@
     "transform": {
       "^.+\\.(ts|tsx)?$": "ts-jest"
     },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testRegex": "(src/__tests__/.*.test.ts)$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/amplify-cli-logger/package.json
+++ b/packages/amplify-cli-logger/package.json
@@ -24,6 +24,10 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testRegex": "(/src/__tests__/.*|(\\.|/)test)\\.tsx?$",
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -127,6 +127,10 @@
     "typescript": "^4.5.5"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -42,8 +42,7 @@
     "testEnvironment": "node",
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/**/*.{ts,tsx,js,jsx}",
-      "!src/__tests__/"
+      "index.js"
     ]
   }
 }

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -40,6 +40,10 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ]
   }
 }

--- a/packages/amplify-environment-parameters/package.json
+++ b/packages/amplify-environment-parameters/package.json
@@ -41,6 +41,10 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testURL": "http://localhost",
     "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [

--- a/packages/amplify-frontend-ios/package.json
+++ b/packages/amplify-frontend-ios/package.json
@@ -29,6 +29,10 @@
   },
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "testURL": "http://localhost",
     "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [

--- a/packages/amplify-frontend-ios/package.json
+++ b/packages/amplify-frontend-ios/package.json
@@ -30,8 +30,8 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/**/*.{ts,tsx,js,jsx}",
-      "!src/__tests__/"
+      "lib/**/*.{ts,tsx,js,jsx}",
+      "!lib/__tests__/"
     ],
     "testURL": "http://localhost",
     "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",

--- a/packages/amplify-graphql-migration-tests/package.json
+++ b/packages/amplify-graphql-migration-tests/package.json
@@ -22,6 +22,10 @@
   "license": "Apache-2.0",
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-opensearch-simulator/jest.config.js
+++ b/packages/amplify-opensearch-simulator/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
-  transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-  },
-};

--- a/packages/amplify-opensearch-simulator/package.json
+++ b/packages/amplify-opensearch-simulator/package.json
@@ -46,6 +46,20 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "roots": [
+      "<rootDir>/src"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ]
   }
 }

--- a/packages/amplify-prompts/jest.config.js
+++ b/packages/amplify-prompts/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
-  transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-  },
-};

--- a/packages/amplify-prompts/package.json
+++ b/packages/amplify-prompts/package.json
@@ -36,10 +36,13 @@
   },
   "jest": {
     "collectCoverage": true,
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
     "testURL": "http://localhost",
+    "roots": [
+      "<rootDir>/src"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
     "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -103,6 +103,10 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-util-headless-input/package.json
+++ b/packages/amplify-util-headless-input/package.json
@@ -24,6 +24,10 @@
     "fs-extra": "^8.1.0"
   },
   "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx,js,jsx}",
+      "!src/__tests__/"
+    ],
     "clearMocks": true,
     "coverageDirectory": "coverage",
     "testEnvironment": "node",

--- a/scripts/collect-test-coverage.ts
+++ b/scripts/collect-test-coverage.ts
@@ -40,7 +40,7 @@ const mergeCoverageMap = (files: string[]): istanbul.CoverageMap => {
     map.merge(JSON.parse(json));
   });
   // Remove coverage from lib, e2e, and test files
-  map.filter(file => !file.match(/(lib\/.*?|__e2e__|__tests__)/));
+  map.filter(file => !file.match(/(__e2e__|__tests__)/));
   return map;
 };
 

--- a/scripts/collect-test-coverage.ts
+++ b/scripts/collect-test-coverage.ts
@@ -29,9 +29,7 @@ const copyPackageCoverage = (pkg: string) => {
 };
 
 const getCoveragePath = (pkg: string): string => {
-  const p = path.join('./packages', pkg, 'coverage/coverage-final.json');
-  console.log(p);
-  return p;
+  return path.join('./packages', pkg, 'coverage/coverage-final.json');
 };
 
 const mergeCoverageMap = (files: string[]): istanbul.CoverageMap => {
@@ -41,7 +39,7 @@ const mergeCoverageMap = (files: string[]): istanbul.CoverageMap => {
     const fileCoverageMap = istanbul.createCoverageMap(JSON.parse(json));
     map.merge(fileCoverageMap);
   });
-  // Remove coverage from lib, e2e, and test files
+  // Remove coverage from e2e, and test files
   map.filter(file => !file.match(/(__e2e__|__tests__)/));
   return map;
 };


### PR DESCRIPTION
#### Description of changes

This PR moves all jest configurations to the `"jest"` block of each project's `package.json`. Additionally, a `collectCoverageFrom` option is added to each Jest config.

In some projects, Jest configs were stored in both a `jest.config.js` file and the `package.json` `"jest"` block. This is a no-op. Since the majority of projects were using the Jest config in `package.json`, all packages were standardized on that norm.

Additionally, a `collectCoverageFrom` option was added to each Jest config file. In the absence of the `collectCoverageFrom` option, coverage statistics were only collected on files that are actually loaded during testing. This can lead to underreporting coverage.

See [the jest documentation](https://jestjs.io/docs/cli#--collectcoveragefromglob).
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran tests, verified tests passing. Verified coverage was collected from a sampling of previously missing files.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
