### PR TITLE
fix: skip deleting from parameter store if no app id

### DIFF
--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -443,7 +443,7 @@ export const expectParametersOptionalValue = async (
   envName: string,
   category: string,
   resourceName: string,
-) => {
+): Promise<void> => {
   const parametersToRequest = expectToExist.map(exist => exist.name).concat(expectNotExist);
   const result = await getSSMParametersCategoryPrefix(region, appId, envName, category, resourceName, parametersToRequest);
   const mapName = (name: string) => `/amplify/${appId}/${envName}/AMPLIFY_${category}_${resourceName}_${name}`;

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -8,14 +8,14 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
  * Delete CloudFormation parameters from the service
  */
 export const deleteEnvironmentParametersFromService = async (context: $TSContext, envName: string): Promise<void> => {
-  let appId;
   try {
-    appId = resolveAppId(context);
+    const appId = resolveAppId(context);
+    const { client } = await SSM.getInstance(context);
+    await deleteParametersFromParameterStore(appId, envName, client);
   } catch {
     return;
   }
-  const { client } = await SSM.getInstance(context);
-  await deleteParametersFromParameterStore(appId, envName, client);
+  
 };
 
 const deleteParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<void> => {

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -11,7 +11,7 @@ export const deleteEnvironmentParametersFromService = async (context: $TSContext
   let appId;
   try {
     appId = resolveAppId(context);
-  } catch (error) {
+  } catch {
     return;
   }
   const { client } = await SSM.getInstance(context);

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -8,7 +8,12 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
  * Delete CloudFormation parameters from the service
  */
 export const deleteEnvironmentParametersFromService = async (context: $TSContext, envName: string): Promise<void> => {
-  const appId = resolveAppId(context);
+  let appId;
+  try {
+    appId = resolveAppId(context);
+  } catch (error) {
+    return;
+  }
   const { client } = await SSM.getInstance(context);
   await deleteParametersFromParameterStore(appId, envName, client);
 };

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -15,7 +15,6 @@ export const deleteEnvironmentParametersFromService = async (context: $TSContext
   } catch {
     return;
   }
-  
 };
 
 const deleteParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<void> => {

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -3,6 +3,7 @@ import type { SSM as SSMType } from 'aws-sdk';
 import { SSM } from '../aws-utils/aws-ssm';
 import { resolveAppId } from './resolve-appId';
 import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersByPath } from './get-ssm-sdk-parameters';
+import { printer } from 'amplify-prompts';
 
 /**
  * Delete CloudFormation parameters from the service
@@ -12,6 +13,7 @@ export const deleteEnvironmentParametersFromService = async (context: $TSContext
   try {
     appId = resolveAppId(context);
   } catch {
+    printer.debug(`No AppId found when deleting parameters for environment ${envName}`);
     return;
   }
   const { client } = await SSM.getInstance(context);

--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -8,13 +8,14 @@ import { getSsmSdkParametersDeleteParameters, getSsmSdkParametersGetParametersBy
  * Delete CloudFormation parameters from the service
  */
 export const deleteEnvironmentParametersFromService = async (context: $TSContext, envName: string): Promise<void> => {
+  let appId;
   try {
-    const appId = resolveAppId(context);
-    const { client } = await SSM.getInstance(context);
-    await deleteParametersFromParameterStore(appId, envName, client);
+    appId = resolveAppId(context);
   } catch {
     return;
   }
+  const { client } = await SSM.getInstance(context);
+  await deleteParametersFromParameterStore(appId, envName, client);
 };
 
 const deleteParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<void> => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change skips deleting parameters from parameter store upon deleting an environment or an Amplify project if no app ID can be resolved.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
