### PR TITLE
fix: skip deleting from parameter store if no parameters to delete

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/delete-from-service.ts
@@ -23,6 +23,9 @@ export const deleteEnvironmentParametersFromService = async (context: $TSContext
 const deleteParametersFromParameterStore = async (appId: string, envName: string, ssmClient: SSMType): Promise<void> => {
   try {
     const envKeysInParameterStore: Array<string> = await getAllEnvParametersFromParameterStore(appId, envName, ssmClient);
+    if (!envKeysInParameterStore.length) {
+      return;
+    }
     const chunkedKeys: Array<Array<string>> = chunkForParameterStore(envKeysInParameterStore);
     await Promise.all(
       chunkedKeys.map(keys => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change bypasses the delete call to parameter store if there are no parameters to delete.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
