### PR TITLE
fix: json stringify values before upload to ps

### DIFF
--- a/packages/amplify-provider-awscloudformation/API.md
+++ b/packages/amplify-provider-awscloudformation/API.md
@@ -28,7 +28,7 @@ export function getConfiguredLocationServiceClient(context: $TSContext, options?
 export function getConfiguredSSMClient(context: any): Promise<SSM>;
 
 // @public (undocumented)
-export const getEnvParametersUploadHandler: (context: $TSContext) => Promise<(key: string, value: unknown) => Promise<void>>;
+export const getEnvParametersUploadHandler: (context: $TSContext) => Promise<(key: string, value: string | boolean | number) => Promise<void>>;
 
 // @public (undocumented)
 export const getLocationRegionMapping: () => $TSObject;

--- a/packages/amplify-provider-awscloudformation/API.md
+++ b/packages/amplify-provider-awscloudformation/API.md
@@ -28,7 +28,7 @@ export function getConfiguredLocationServiceClient(context: $TSContext, options?
 export function getConfiguredSSMClient(context: any): Promise<SSM>;
 
 // @public (undocumented)
-export const getEnvParametersUploadHandler: (context: $TSContext) => Promise<(key: string, value: string) => Promise<void>>;
+export const getEnvParametersUploadHandler: (context: $TSContext) => Promise<(key: string, value: unknown) => Promise<void>>;
 
 // @public (undocumented)
 export const getLocationRegionMapping: () => $TSObject;

--- a/packages/amplify-provider-awscloudformation/src/utils/upload-env-parameters.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/upload-env-parameters.ts
@@ -9,7 +9,7 @@ import { resolveAppId } from './resolve-appId';
  */
 export const getEnvParametersUploadHandler = async (
   context: $TSContext,
-): Promise<((key: string, value: unknown) => Promise<void>) | undefined> => {
+): Promise<((key: string, value: string | boolean | number) => Promise<void>) | undefined> => {
   let appId: string;
   try {
     appId = resolveAppId(context);
@@ -26,8 +26,8 @@ const uploadParameterToParameterStore = (
   appId: string,
   envName: string,
   ssmClient: SSMType,
-): ((key: string, value: unknown) => Promise<void>) => {
-  return async (key: string, value: unknown): Promise<void> => {
+): ((key: string, value: string | boolean | number) => Promise<void>) => {
+  return async (key: string, value: string | boolean | number): Promise<void> => {
     try {
       const stringValue: string = JSON.stringify(value);
       const sdkParameters = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change JSON stringifies values before they are uploaded to parameter store. This ensures that only strings are uploaded and ensures that values can be converted back to their original types when they are downloaded from parameter store.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
