### PR TITLE
fix(amplify-util-uibuilder): update codegen-ui to 2.8.0

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.7.2",
-    "@aws-amplify/codegen-ui-react": "2.7.2",
+    "@aws-amplify/codegen-ui": "2.8.0",
+    "@aws-amplify/codegen-ui-react": "2.8.0",
     "amplify-cli-core": "3.5.1",
     "amplify-prompts": "2.6.2",
     "aws-sdk": "^2.1233.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,21 +216,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.7.2":
-  version "2.7.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.7.2.tgz#3789a9f0e989aff6009f27d15106f979fa752898"
-  integrity sha512-glUu6mNY/z8NwBe9D+MauyKENguujlPgnHZYbVouqAa+y4KTwLnXF6valkg6pOFI2bed7eBRzTtIdmo29BVJvA==
+"@aws-amplify/codegen-ui-react@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.8.0.tgz#49b70919f74016914968cf7f58e657462d199a7d"
+  integrity sha512-EF/l35yk0ilXnp4VtqUekHbAbNXT5tOvfqUznOy1h2uniAf99Z+tRZYG4HGLzFfpraUB8psumXs3C/p3FVDMaA==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.7.2"
+    "@aws-amplify/codegen-ui" "2.8.0"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.7.2":
-  version "2.7.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.7.2.tgz#aa4ca4f21162e7b6badf49e71987eb3507177906"
-  integrity sha512-nAVfanYejH0HB9wIbfObFZLo73Uec5MeUlH5CfUMWyZP2MF59BgAp+zy3IStiJxq+kpH4xVitAdKLNAz6ubqhQ==
+"@aws-amplify/codegen-ui@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.8.0.tgz#7cfde751d67b029371b5f708802160b2bf3257a1"
+  integrity sha512-3I+k2hWJeVwHVGiexvZqwScpt9o8sMD7WZ/svpCo2/byvs83bYj4VJRly7Hj0n+QqkJWHDxECs4b27lIb1E8YA==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Update codegen packages to 2.8.0:
- data model relationships support
- support bidirectional hasMany
- fixes for forms validations
- fix for nonModel fields in forms

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
unit & e2e tests in codegen-ui

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
1 failure when running locally:
```
packages/amplify-cli/src/__tests__/test-aborting.test.ts
test SIGINT with execute
thrown: "Exceeded timeout of 5000 ms for a test.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
