### PR TITLE
fix: store email channel role arn to amplify meta output

### DIFF
--- a/packages/amplify-category-notifications/src/__tests__/channel-email.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-email.test.ts
@@ -1,0 +1,56 @@
+import { prompter } from 'amplify-prompts';
+import * as channelEmail from '../channel-email';
+import { ChannelAction, ChannelConfigDeploymentType, IChannelAPIResponse } from '../channel-types';
+import { $TSAny, $TSContext, AmplifyCategories, AmplifySupportedService } from 'amplify-cli-core';
+import { ChannelType } from '../notifications-backend-cfg-channel-api';
+
+jest.mock('amplify-prompts');
+const prompterMock = prompter as jest.Mocked<typeof prompter>;
+
+const mockPinpointResponseData = (status: boolean, action: ChannelAction): IChannelAPIResponse => ({
+  action,
+  channel: ChannelType.Email,
+  deploymentType: ChannelConfigDeploymentType.INLINE,
+  output: undefined,
+  response: {
+    capability: AmplifyCategories.NOTIFICATIONS,
+    pluginName: AmplifyCategories.NOTIFICATIONS,
+    resourceProviderServiceName: AmplifySupportedService.PINPOINT,
+    status,
+    subCapability: ChannelType.Email,
+  },
+});
+
+const mockPinpointClient = {
+  updateEmailChannel: jest.fn().mockImplementation(() => ({
+    promise: jest.fn(() => mockPinpointResponseData(true, ChannelAction.ENABLE)),
+  })),
+};
+
+const mockContext = (output: $TSAny, client: $TSAny): $TSContext =>
+  (({
+    exeInfo: {
+      serviceMeta: {
+        output,
+      },
+      pinpointClient: client,
+    },
+    print: {
+      info: jest.fn(),
+      error: jest.fn(),
+    },
+  } as unknown) as $TSContext);
+
+describe('channel-FCM', () => {
+  test('enable should store role arn', async () => {
+    prompterMock.input.mockResolvedValueOnce('fake@email.com');
+    prompterMock.input.mockResolvedValueOnce('fake:arn:identity');
+    prompterMock.input.mockResolvedValueOnce('fake:arn:role');
+
+    const mockContextObj = mockContext({ Enabled: true }, mockPinpointClient);
+    const data = await channelEmail.enable(mockContextObj, 'successMessage');
+    expect(mockPinpointClient.updateEmailChannel).toBeCalled();
+    expect(data).toEqual(mockPinpointResponseData(true, ChannelAction.ENABLE));
+    expect(mockContextObj.exeInfo.serviceMeta.output['Email'].RoleArn).toEqual('fake:arn:role');
+  });
+});

--- a/packages/amplify-category-notifications/src/channel-email.ts
+++ b/packages/amplify-category-notifications/src/channel-email.ts
@@ -1,6 +1,4 @@
-import {
-  $TSAny, $TSContext, AmplifyError, AmplifyFault,
-} from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyError, AmplifyFault } from 'amplify-cli-core';
 import { printer, prompter } from 'amplify-prompts';
 
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
@@ -16,7 +14,7 @@ const deploymentType = ChannelConfigDeploymentType.INLINE;
  * Configure Email channel on analytics resource
  * @param context amplify cli context
  */
-export const configure = async (context: $TSContext):Promise<void> => {
+export const configure = async (context: $TSContext): Promise<void> => {
   const isChannelEnabled = context.exeInfo.serviceMeta.output[channelName]?.Enabled;
 
   if (isChannelEnabled) {
@@ -41,7 +39,7 @@ export const configure = async (context: $TSContext):Promise<void> => {
  * @param context amplify cli context
  * @param successMessage message to be printed on successfully enabling channel
  */
-export const enable = async (context:$TSContext, successMessage: string|undefined):Promise<$TSAny> => {
+export const enable = async (context: $TSContext, successMessage: string | undefined): Promise<$TSAny> => {
   let answers;
   if (context.exeInfo.pinpointInputParams?.[channelName]) {
     answers = validateInputParams(context.exeInfo.pinpointInputParams[channelName]);
@@ -53,7 +51,9 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
     answers = {
       FromAddress: await prompter.input(`The 'From' Email address used to send emails`, { initial: channelOutput.FromAddress }),
       Identity: await prompter.input('The ARN of an identity verified with SES', { initial: channelOutput.Identity }),
-      RoleArn: await prompter.input(`The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service`, { initial: channelOutput.RoleArn }),
+      RoleArn: await prompter.input(`The ARN of an IAM Role used to submit events to Mobile notifications' event ingestion service`, {
+        initial: channelOutput.RoleArn,
+      }),
     };
   }
 
@@ -69,7 +69,10 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
   try {
     const data = await context.exeInfo.pinpointClient.updateEmailChannel(params).promise();
     spinner.succeed(successMessage ?? `The ${channelName} channel has been successfully enabled.`);
-    context.exeInfo.serviceMeta.output[channelName] = data.EmailChannelResponse;
+    context.exeInfo.serviceMeta.output[channelName] = {
+      RoleArn: params.EmailChannelRequest.RoleArn,
+      ...data.EmailChannelResponse,
+    };
     return buildPinpointChannelResponseSuccess(ChannelAction.ENABLE, deploymentType, channelName, data.EmailChannelResponse);
   } catch (err) {
     if (err && err.code === 'NotFoundException') {
@@ -80,17 +83,21 @@ export const enable = async (context:$TSContext, successMessage: string|undefine
     }
 
     spinner.stop();
-    throw new AmplifyFault('NotificationsChannelEmailFault', {
-      message: `Failed to enable the ${channelName} channel.`,
-      details: err.message,
-    }, err);
+    throw new AmplifyFault(
+      'NotificationsChannelEmailFault',
+      {
+        message: `Failed to enable the ${channelName} channel.`,
+        details: err.message,
+      },
+      err,
+    );
   }
 };
 
-const validateInputParams = (channelInput: $TSAny) : $TSAny => {
-  if (!channelInput.FromAddress || !channelInput.Identity || !channelInput.RoleArn) {
+const validateInputParams = (channelInput: $TSAny): $TSAny => {
+  if (!channelInput.FromAddress || !channelInput.Identity) {
     throw new AmplifyError('UserInputError', {
-      message: 'FromAddress, Identity or RoleArn is missing for the Email channel',
+      message: 'FromAddress or Identity is missing for the Email channel',
       resolution: 'Provide the required parameters for the Email channel',
     });
   }
@@ -102,7 +109,7 @@ const validateInputParams = (channelInput: $TSAny) : $TSAny => {
  * @param context - amplify cli context
  * @returns Pinpoint API response
  */
-export const disable = async (context:$TSContext) : Promise<$TSAny> => {
+export const disable = async (context: $TSContext): Promise<$TSAny> => {
   const channelOutput = validateInputParams(context.exeInfo.serviceMeta.output[channelName]);
   const params = {
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
@@ -110,6 +117,7 @@ export const disable = async (context:$TSContext) : Promise<$TSAny> => {
       Enabled: false,
       FromAddress: channelOutput.FromAddress,
       Identity: channelOutput.Identity,
+      RoleArn: channelOutput.RoleArn,
     },
   };
   spinner.start('Disabling Email Channel.');
@@ -127,10 +135,14 @@ export const disable = async (context:$TSContext) : Promise<$TSAny> => {
     }
 
     spinner.fail(`Failed to disable the ${channelName} channel.`);
-    throw new AmplifyFault('NotificationsChannelEmailFault', {
-      message: `Failed to disable the ${channelName} channel.`,
-      details: err.message,
-    }, err);
+    throw new AmplifyFault(
+      'NotificationsChannelEmailFault',
+      {
+        message: `Failed to disable the ${channelName} channel.`,
+        details: err.message,
+      },
+      err,
+    );
   }
 };
 
@@ -140,7 +152,7 @@ export const disable = async (context:$TSContext) : Promise<$TSAny> => {
  * @param pinpointApp Pinpoint resource meta
  * @returns Pinpoint API response
  */
-export const pull = async (context:$TSContext, pinpointApp:$TSAny):Promise<$TSAny> => {
+export const pull = async (context: $TSContext, pinpointApp: $TSAny): Promise<$TSAny> => {
   const params = {
     ApplicationId: pinpointApp.Id,
   };
@@ -155,9 +167,13 @@ export const pull = async (context:$TSContext, pinpointApp:$TSAny):Promise<$TSAn
   } catch (err) {
     spinner.stop();
     if (err.code !== 'NotFoundException') {
-      throw new AmplifyFault('NotificationsChannelEmailFault', {
-        message: `Failed to pull the ${channelName} channel.`,
-      }, err);
+      throw new AmplifyFault(
+        'NotificationsChannelEmailFault',
+        {
+          message: `Failed to pull the ${channelName} channel.`,
+        },
+        err,
+      );
     }
 
     return undefined;


### PR DESCRIPTION
#### Description of changes
- stores role arn for email channel notifications to amplify meta channel output section

#### Issue #11819

#### Description of how you validated changes
- manual and unit tests

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
