### PR TITLE
fix: null entries in TPI file when project has number value resource name

### DIFF
--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -18,7 +18,7 @@ export type IEnvironmentParameterManager = {
     removeResourceParamManager: (category: string, resource: string) => void;
     hasResourceParamManager: (category: string, resource: string) => boolean;
     getResourceParamManager: (category: string, resource: string) => ResourceParameterManager;
-    save: () => void;
+    save: () => Promise<void>;
 };
 
 // @public (undocumented)

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -123,7 +123,7 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
 
   private serializeTPICategories(): Record<string, unknown> {
     return Object.entries(this.resourceParamManagers).reduce((acc, [resourceKey, resourceParams]) => {
-      _.set(acc, splitResourceKey(resourceKey), resourceParams.getAllParams());
+      _.setWith(acc, splitResourceKey(resourceKey), resourceParams.getAllParams(), Object);
       return acc;
     }, {} as Record<string, unknown>);
   }
@@ -145,7 +145,7 @@ export type IEnvironmentParameterManager = {
   removeResourceParamManager: (category: string, resource: string) => void;
   hasResourceParamManager: (category: string, resource: string) => boolean;
   getResourceParamManager: (category: string, resource: string) => ResourceParameterManager;
-  save: () => void;
+  save: () => Promise<void>;
 };
 
 const getParameterStoreKey = (categoryName: string, resourceName: string, paramName: string): string =>


### PR DESCRIPTION
#### Description of changes
- replaces _.set with _.setWith when generating TPI resource entries as _.set will generate N-length array if N key from path array is a number, see https://github.com/lodash/lodash/issues/1316#issuecomment-120753100

#### Issue #11644

#### Description of how you validated changes
- manual testing

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
