### PR TITLE
fix: display mfa prompt during backend pull

### DIFF
--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -1,12 +1,9 @@
-import ora from 'ora';
 import sequential from 'promise-sequential';
-import { stateManager, $TSAny, $TSMeta, $TSContext, AmplifyFault } from 'amplify-cli-core';
+import { stateManager, $TSAny, $TSMeta, $TSContext, AmplifyFault, spinner } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import { ensureEnvParamManager, IEnvironmentParameterManager } from '@aws-amplify/amplify-environment-parameters';
 import { getProviderPlugins } from './extensions/amplify-helpers/get-provider-plugins';
 import { ManuallyTimedCodePath } from './domain/amplify-usageData/UsageDataTypes';
-
-const spinner = ora('');
 
 /**
  * Entry point for initializing an environment. Delegates out to plugins initEnv function


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The ora spinner overlaps MFA prompt during the execution of `amplify pull` and other commands that fetch current cloud backend

Before:
![before](https://user-images.githubusercontent.com/61150013/216785040-705067a9-9550-4671-888b-bc7cd04ccce5.gif)

After:
![after](https://user-images.githubusercontent.com/61150013/216785056-bc1eb3aa-a208-446b-b0e6-6a2b44bbe45f.gif)

Related PR (the same issue but with `amplify push`): #9954

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manually run `amplify pull` (see attached gifs)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
