### PR TITLE
fix: modal windows test for opensearch simulator

### DIFF
--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -974,7 +974,7 @@ export const isPackaged: boolean;
 export const isResourceNameUnique: (category: string, resourceName: string, throwOnMatch?: boolean) => boolean;
 
 // @public (undocumented)
-export const isWindowsPlatform: boolean;
+export const isWindowsPlatform(): boolean;
 
 // @public (undocumented)
 export class JSONUtilities {

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -974,7 +974,7 @@ export const isPackaged: boolean;
 export const isResourceNameUnique: (category: string, resourceName: string, throwOnMatch?: boolean) => boolean;
 
 // @public (undocumented)
-export const isWindowsPlatform(): boolean;
+export const isWindowsPlatform: () => boolean;
 
 // @public (undocumented)
 export class JSONUtilities {

--- a/packages/amplify-cli-core/src/utils/windows-utils.ts
+++ b/packages/amplify-cli-core/src/utils/windows-utils.ts
@@ -2,4 +2,4 @@
  * Check if running on Windows OS
  * @returns true if the CLI is used from Windows machine, false otherwise
  */
-export const isWindowsPlatform = process?.platform?.startsWith('win');
+export const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');

--- a/packages/amplify-cli/src/amplify-exception-handler.ts
+++ b/packages/amplify-cli/src/amplify-exception-handler.ts
@@ -178,7 +178,7 @@ const nodeErrorToAmplifyException = (err: NodeJS.ErrnoException): AmplifyExcepti
 
 const nodeErrorTypeToAmplifyExceptionType = (__err: NodeJS.ErrnoException): AmplifyFaultType => 'UnknownNodeJSFault';
 const mapNodeErrorToResolution = (err: NodeJS.ErrnoException): string => {
-  if (!isWindowsPlatform && err.code === 'EACCES' && err.message.includes('/.amplify/')) {
+  if (!isWindowsPlatform() && err.code === 'EACCES' && err.message.includes('/.amplify/')) {
     return `Try running 'sudo chown -R $(whoami):$(id -gn) ~/.amplify' to fix this`;
   }
   return `Please report this issue at https://github.com/aws-amplify/amplify-cli/issues and include the project identifier from: 'amplify diagnose --send-report'`;

--- a/packages/amplify-opensearch-simulator/src/index.ts
+++ b/packages/amplify-opensearch-simulator/src/index.ts
@@ -124,7 +124,7 @@ export const launch = async (
   retry = 0,
   startTime: number = Date.now(),
 ): Promise<OpenSearchEmulator> => {
-  if (isWindowsPlatform) {
+  if (isWindowsPlatform()) {
     throw new AmplifyError('SearchableMockUnsupportedPlatformError', {
       message: 'Cannot launch OpenSearch simulator on windows OS',
       link: AMPLIFY_SUPPORT_DOCS.CLI_GRAPHQL_TROUBLESHOOTING.url,

--- a/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
+++ b/packages/amplify-util-mock/src/CFNParser/resource-processors/appsync.ts
@@ -86,7 +86,7 @@ export function appSyncDataSourceHandler(
   }
 
   if (typeName === 'AMAZON_ELASTICSEARCH') {
-    if (isWindowsPlatform) {
+    if (isWindowsPlatform()) {
       printer.info(`@searchable mocking is not supported on Windows. Search queries against the mock API will not work.`);
     }
 

--- a/packages/amplify-util-mock/src/__e2e__/utils/index.ts
+++ b/packages/amplify-util-mock/src/__e2e__/utils/index.ts
@@ -21,8 +21,8 @@ jest.mock('amplify-cli-core', () => ({
   ...(jest.requireActual('amplify-cli-core') as {}),
   pathManager: {
     getAmplifyPackageLibDirPath: jest.fn().mockReturnValue('../amplify-dynamodb-simulator'),
-    getAmplifyLibRoot: jest.fn().mockReturnValue('')
-  }
+    getAmplifyLibRoot: jest.fn().mockReturnValue(''),
+  },
 }));
 
 export async function launchDDBLocal() {
@@ -42,7 +42,11 @@ export async function launchDDBLocal() {
   return { emulator, dbPath, client };
 }
 
-export async function deploy(transformerOutput: any, client?: DynamoDB, opensearchURL?: URL): Promise<{ config: any; simulator: AmplifyAppSyncSimulator }> {
+export async function deploy(
+  transformerOutput: any,
+  client?: DynamoDB,
+  opensearchURL?: URL,
+): Promise<{ config: any; simulator: AmplifyAppSyncSimulator }> {
   let config: any = processTransformerStacks(transformerOutput);
   config.appSync.apiKey = 'da-fake-api-key';
 
@@ -97,7 +101,7 @@ async function configureLambdaDataSource(config) {
 }
 
 async function configureOpensearchDataSource(config, opensearchURL) {
-  if (isWindowsPlatform) {
+  if (isWindowsPlatform()) {
     return config;
   }
   const opensearchDataSourceType = 'AMAZON_ELASTICSEARCH';
@@ -119,7 +123,7 @@ async function configureOpensearchDataSource(config, opensearchURL) {
           },
         };
       }),
-    )
+    ),
   };
 }
 
@@ -151,23 +155,27 @@ export function logDebug(...msgs) {
   }
 }
 
-export async function setupSearchableMockResources(pathToSearchableMockResources: string): Promise<{ emulator: openSearchEmulator.OpenSearchEmulator}> {
+export async function setupSearchableMockResources(
+  pathToSearchableMockResources: string,
+): Promise<{ emulator: openSearchEmulator.OpenSearchEmulator }> {
   const pathToSearchableTrigger = path.join(pathToSearchableMockResources, 'searchable-lambda-trigger');
   fs.ensureDirSync(pathToSearchableTrigger);
 
   const searchableLambdaResourceDir = path.resolve(__dirname, '..', '..', '..', 'resources', 'mock-searchable-lambda-trigger');
   fs.copySync(searchableLambdaResourceDir, pathToSearchableTrigger, { overwrite: true });
 
-  const pathToOpensearchLocal = path.join(pathToSearchableMockResources, openSearchEmulator.packageName, openSearchEmulator.relativePathToOpensearchLocal);
+  const pathToOpensearchLocal = path.join(
+    pathToSearchableMockResources,
+    openSearchEmulator.packageName,
+    openSearchEmulator.relativePathToOpensearchLocal,
+  );
   fs.ensureDirSync(pathToOpensearchLocal);
   const pathToOpensearchData = path.join(pathToSearchableMockResources, 'searchable-data');
   fs.ensureDirSync(pathToOpensearchData);
 
-  const emulator = await openSearchEmulator.launch(
-    pathToOpensearchData, {
-      port: null,
-    }
-  );
+  const emulator = await openSearchEmulator.launch(pathToOpensearchData, {
+    port: null,
+  });
 
   return { emulator };
 }

--- a/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e_v2__/searchable-transformer.e2e.test.ts
@@ -65,7 +65,7 @@ describe('@searchable transformer', () => {
       let ddbClient;
       ({ dbPath, emulator: ddbEmulator, client: ddbClient } = await launchDDBLocal());
 
-      if (!isWindowsPlatform) {
+      if (!isWindowsPlatform()) {
         do {
           pathToSearchableMockResources = path.join('/tmp', `amplify-cli-emulator-opensearch-${v4()}`);
         } while (fs.existsSync(pathToSearchableMockResources));
@@ -88,7 +88,7 @@ describe('@searchable transformer', () => {
       });
 
       // create test records and wait for 5 secs for local indices to update
-      if (!isWindowsPlatform) {
+      if (!isWindowsPlatform()) {
         await createTestRecords();
         await new Promise(r => setTimeout(r, 5000));
       }
@@ -125,7 +125,7 @@ describe('@searchable transformer', () => {
    * Test queries below
    */
 
-  if (isWindowsPlatform) {
+  if (isWindowsPlatform()) {
     test('@searchable allows the mock server to run on windows', async () => {
       const response = await GRAPHQL_CLIENT.query(
         `query {

--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -78,7 +78,7 @@ export class APITest {
       const appSyncConfig: AmplifyAppSyncSimulatorConfig = await this.runTransformer(context, this.apiParameters);
 
       // If any of the model types are searchable, start opensearch local instance
-      if (appSyncConfig?.tables?.some((table: $TSAny) => table?.isSearchable) && !isWindowsPlatform) {
+      if (appSyncConfig?.tables?.some((table: $TSAny) => table?.isSearchable) && !isWindowsPlatform()) {
         this.opensearchURL = await this.startOpensearchLocalServer(context, isLocalDBEmpty);
       }
       this.appSyncSimulator.init(appSyncConfig);
@@ -320,7 +320,7 @@ export class APITest {
   }
 
   private async configureOpensearchDataSource(config: $TSAny): Promise<$TSAny> {
-    if (isWindowsPlatform) {
+    if (isWindowsPlatform()) {
       return config;
     }
     const opensearchDataSourceType = 'AMAZON_ELASTICSEARCH';

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -96,6 +96,7 @@ const WINDOWS_SMOKE_TESTS = [
 const TEST_EXCLUSIONS: { l: string[]; w: string[] } = {
   l: [],
   w: [
+    'src/__tests__/opensearch-simulator/opensearch-simulator.test.ts',
     'src/__tests__/amplify-app.test.ts',
     'src/__tests__/analytics-2.test.ts',
     'src/__tests__/api_2a.test.ts',


### PR DESCRIPTION
#### Description of changes
Fixes modal test in `opensearch-simulator.test`.

The principal change is refactoring `isWindowsPlatform` to be a method that returns a boolean, instead of a direct proxy to `process.platform`. This makes it simpler and safer to mock the value of `isWindowsPlatform`.

All files that depend on `isWindowsPlatform` are not refactored to use `isWindowsPlatform()`. The `opensearch-simulator` test is refactored to remove the platform modality and to mock that value instead. 

The opensearch test cannot be run on windows. It has been added to the windows exclusion list for e2e tests.
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
