### PR TITLE
chore: move context-extensions to amplify-cli-core

### DIFF
--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -27,7 +27,9 @@ export type $TSContext = {
     migrationInfo: $TSAny;
     projectHasMobileHubResources: boolean;
     prompt: $TSAny;
-    patching: $TSAny;
+    patching: {
+        replace(filePath: string, oldContent: string, newContent: string): Promise<string>;
+    };
     exeInfo: $TSAny;
     input: $TSAny;
     parameters: $TSAny;

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -27,6 +27,7 @@ export type $TSContext = {
     migrationInfo: $TSAny;
     projectHasMobileHubResources: boolean;
     prompt: $TSAny;
+    patching: $TSAny;
     exeInfo: $TSAny;
     input: $TSAny;
     parameters: $TSAny;
@@ -242,6 +243,9 @@ export class ApiCategoryFacade {
     // (undocumented)
     static transformGraphQLSchema(context: $TSContext, options: $TSAny): Promise<DeploymentResources | DeploymentResources_2 | undefined>;
 }
+
+// @public (undocumented)
+export function attachExtensions(context: $TSContext): void;
 
 // @public (undocumented)
 export const AWS_AMPLIFY_DEFAULT_BANNER_URL = "https://aws-amplify.github.io/amplify-cli/banner-message.json";
@@ -860,7 +864,7 @@ export type IContextTemplate = {
         target: string;
         props: $TSObject;
         directory: string;
-    }) => string;
+    }) => Promise<string>;
 };
 
 // @public (undocumented)
@@ -1241,6 +1245,22 @@ export enum PluginAPIError {
 }
 
 // @public (undocumented)
+const print_2: {
+    info: typeof info;
+    fancy: typeof fancy;
+    warning: typeof warning;
+    error: typeof error;
+    success: typeof success;
+    table: typeof table;
+    debug: typeof debug;
+    green: typeof green;
+    yellow: typeof yellow;
+    red: typeof red;
+    blue: typeof blue;
+};
+export { print_2 as print }
+
+// @public (undocumented)
 export const projectNotInitializedError: () => AmplifyError;
 
 // @public (undocumented)
@@ -1565,6 +1585,17 @@ export type WriteCFNTemplateOptions = {
 
 // Warnings were encountered during analysis:
 //
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "info" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "fancy" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "warning" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "error" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "success" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "table" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "debug" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "green" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "yellow" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "red" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "blue" needs to be exported by the entry point index.d.ts
 // src/types.ts:17:3 - (ae-forgotten-export) The symbol "AmplifyToolkit" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -27,9 +27,6 @@ export type $TSContext = {
     migrationInfo: $TSAny;
     projectHasMobileHubResources: boolean;
     prompt: $TSAny;
-    patching: {
-        replace(filePath: string, oldContent: string, newContent: string): Promise<string>;
-    };
     exeInfo: $TSAny;
     input: $TSAny;
     parameters: $TSAny;

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -1585,17 +1585,17 @@ export type WriteCFNTemplateOptions = {
 
 // Warnings were encountered during analysis:
 //
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "info" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "fancy" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "warning" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "error" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "success" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "table" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "debug" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "green" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "yellow" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "red" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:182:12 - (ae-forgotten-export) The symbol "blue" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "info" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "fancy" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "warning" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "error" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "success" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "table" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "debug" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "green" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "yellow" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "red" needs to be exported by the entry point index.d.ts
+// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "blue" needs to be exported by the entry point index.d.ts
 // src/types.ts:17:3 - (ae-forgotten-export) The symbol "AmplifyToolkit" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -250,6 +250,9 @@ export class ApiCategoryFacade {
 export function attachExtensions(context: $TSContext): void;
 
 // @public (undocumented)
+export function attachPrint(context: $TSContext): void;
+
+// @public (undocumented)
 export const AWS_AMPLIFY_DEFAULT_BANNER_URL = "https://aws-amplify.github.io/amplify-cli/banner-message.json";
 
 // @public (undocumented)
@@ -267,6 +270,9 @@ export class BannerMessage {
     // (undocumented)
     static initialize: (cliVersion: string) => BannerMessage;
 }
+
+// @public (undocumented)
+export function blue(message: string): void;
 
 // @public (undocumented)
 export type BooleanFeatureFlag = {
@@ -517,6 +523,9 @@ export type DataParameter = {
 };
 
 // @public (undocumented)
+export function debug(message: string, title?: string): void;
+
+// @public (undocumented)
 export class DebugConfigValueNotSetError extends Error {
 }
 
@@ -599,6 +608,9 @@ export class EnvVarFormatError extends Error {
 }
 
 // @public (undocumented)
+export function error(message: string): void;
+
+// @public (undocumented)
 export type ErrorParameter = {
     message: string;
     stack: string;
@@ -624,6 +636,9 @@ export class ExportedStackNotInValidStateError extends Error {
 // @public (undocumented)
 export class ExportPathValidationError extends Error {
 }
+
+// @public (undocumented)
+export function fancy(message?: string): void;
 
 // @public (undocumented)
 export type FeatureFlagConfiguration = {
@@ -717,6 +732,9 @@ export const getPackageManager: (rootPath?: string) => PackageManager | null;
 
 // @public (undocumented)
 export const getPermissionsBoundaryArn: (env?: string) => string | undefined;
+
+// @public (undocumented)
+export function green(message: string): void;
 
 // @public (undocumented)
 export type HookEvent = {
@@ -894,6 +912,9 @@ export interface IDeploymentStateManager {
     // (undocumented)
     updateStatus: (status: DeploymentStatus) => Promise<void>;
 }
+
+// @public (undocumented)
+export function info(message: string): void;
 
 // @public (undocumented)
 export type INotificationsResource = IAnalyticsResource;
@@ -1298,6 +1319,9 @@ export function ReadTags(tagsFilePath: string): Tag[];
 // @public (undocumented)
 export const recursiveOmit: (obj: $TSObject, path: Array<string>) => void;
 
+// @public (undocumented)
+export function red(message: string): void;
+
 // Warning: (ae-forgotten-export) The symbol "deploymentSecretsRemove" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1482,10 +1506,18 @@ export type SubCommandInfo = {
 };
 
 // @public (undocumented)
+export function success(message: string): void;
+
+// @public (undocumented)
 export const supportedEnvEvents: HooksVerb[];
 
 // @public (undocumented)
 export const supportedEvents: Record<HooksVerb, HooksNoun[]>;
+
+// @public (undocumented)
+export function table(data: string[][], options?: {
+    format?: 'markdown' | 'lean';
+}): void;
 
 // @public (undocumented)
 export interface Tag {
@@ -1577,6 +1609,9 @@ export class ViewResourceTableParams {
 }
 
 // @public (undocumented)
+export function warning(message: string): void;
+
+// @public (undocumented)
 export const writeCFNTemplate: (template: object, filePath: string, options?: WriteCFNTemplateOptions) => Promise<void>;
 
 // @public (undocumented)
@@ -1585,19 +1620,11 @@ export type WriteCFNTemplateOptions = {
     minify?: boolean;
 };
 
+// @public (undocumented)
+export function yellow(message: string): void;
+
 // Warnings were encountered during analysis:
 //
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "info" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "fancy" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "warning" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "error" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "success" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "table" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "debug" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "green" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "yellow" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "red" needs to be exported by the entry point index.d.ts
-// src/context/context-extensions.ts:257:19 - (ae-forgotten-export) The symbol "blue" needs to be exported by the entry point index.d.ts
 // src/types.ts:17:3 - (ae-forgotten-export) The symbol "AmplifyToolkit" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -32,8 +32,11 @@
     "amplify-prompts": "2.6.3",
     "chalk": "^4.1.1",
     "ci-info": "^2.0.0",
+    "cli-table3": "^0.6.0",
     "cloudform-types": "^4.2.0",
+    "colors": "1.4.0",
     "dotenv": "^8.2.0",
+    "ejs": "^3.1.7",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.3",
@@ -50,6 +53,7 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
+    "@types/ejs": "^3.1.1",
     "@types/fs-extra": "^8.0.1",
     "@types/hjson": "^2.4.2",
     "@types/json-schema": "^7.0.5",

--- a/packages/amplify-cli-core/src/context/context-extensions.ts
+++ b/packages/amplify-cli-core/src/context/context-extensions.ts
@@ -175,47 +175,47 @@ function attachPatching(context: $TSContext) {
   };
 }
 
-function attachPrint(context: $TSContext) {
+export function attachPrint(context: $TSContext) {
   context.print = print;
 }
 
-function info(message: string): void {
+export function info(message: string): void {
   console.log(colors.info(message));
 }
 
-function warning(message: string): void {
+export function warning(message: string): void {
   console.log(colors.warning(message));
 }
 
-function error(message: string): void {
+export function error(message: string): void {
   console.log(colors.error(message));
 }
 
-function success(message: string): void {
+export function success(message: string): void {
   console.log(colors.success(message));
 }
 
-function green(message: string): void {
+export function green(message: string): void {
   console.log(colors.green(message));
 }
 
-function yellow(message: string): void {
+export function yellow(message: string): void {
   console.log(colors.yellow(message));
 }
 
-function red(message: string): void {
+export function red(message: string): void {
   console.log(colors.red(message));
 }
 
-function blue(message: string): void {
+export function blue(message: string): void {
   console.log(colors.blue(message));
 }
 
-function fancy(message?: string): void {
+export function fancy(message?: string): void {
   console.log(message);
 }
 
-function debug(message: string, title = 'DEBUG'): void {
+export function debug(message: string, title = 'DEBUG'): void {
   const topLine = `vvv -----[ ${title} ]----- vvv`;
   const botLine = `^^^ -----[ ${title} ]----- ^^^`;
 
@@ -224,7 +224,7 @@ function debug(message: string, title = 'DEBUG'): void {
   console.log(colors.rainbow(botLine));
 }
 
-function table(data: string[][], options: { format?: 'markdown' | 'lean' } = {}): void {
+export function table(data: string[][], options: { format?: 'markdown' | 'lean' } = {}): void {
   let t: CLITable.Table;
   switch (options.format) {
     case 'markdown': {

--- a/packages/amplify-cli-core/src/context/context-extensions.ts
+++ b/packages/amplify-cli-core/src/context/context-extensions.ts
@@ -179,22 +179,6 @@ function attachPrint(context: $TSContext) {
   context.print = print;
 }
 
-const print = {
-  info,
-  fancy,
-  warning,
-  error,
-  success,
-  table,
-  debug,
-  green,
-  yellow,
-  red,
-  blue,
-};
-
-export { print };
-
 function info(message: string): void {
   console.log(colors.info(message));
 }
@@ -269,6 +253,20 @@ function table(data: string[][], options: { format?: 'markdown' | 'lean' } = {})
   }
   console.log(t.toString());
 }
+
+export const print = {
+  info,
+  fancy,
+  warning,
+  error,
+  success,
+  table,
+  debug,
+  green,
+  yellow,
+  red,
+  blue,
+};
 
 function columnHeaderDivider(cliTable: CLITable.Table): string[] {
   return findWidths(cliTable).map(w => Array(w).join('-'));

--- a/packages/amplify-cli-core/src/context/context-extensions.ts
+++ b/packages/amplify-cli-core/src/context/context-extensions.ts
@@ -40,7 +40,6 @@ export function attachExtensions(context: $TSContext) {
   attachFilesystem(context);
   attachPrint(context);
   attachParameters(context);
-  attachPatching(context);
   attachRuntime(context);
   attachPrompt(context);
   attachTemplate(context);
@@ -163,17 +162,6 @@ const contextFileSystem = {
     return result;
   },
 };
-
-function attachPatching(context: $TSContext) {
-  context.patching = {
-    replace: async (filePath: string, oldContent: string, newContent: string): Promise<string> => {
-      const fileContent = fs.readFileSync(filePath, 'utf-8');
-      const updatedFileContent = fileContent.replace(oldContent, newContent);
-      fs.writeFileSync(filePath, updatedFileContent, 'utf-8');
-      return Promise.resolve(updatedFileContent);
-    },
-  };
-}
 
 export function attachPrint(context: $TSContext) {
   context.print = print;

--- a/packages/amplify-cli-core/src/context/context-extensions.ts
+++ b/packages/amplify-cli-core/src/context/context-extensions.ts
@@ -1,10 +1,10 @@
 import CLITable from 'cli-table3';
 import importedColors from 'colors/safe';
 import ejs from 'ejs';
+import { $TSContext } from '../types';
 import * as fs from 'fs-extra';
 import inquirer from 'inquirer';
 import * as path from 'path';
-import { Context } from './domain/context';
 
 importedColors.setTheme({
   highlight: 'cyan',
@@ -36,7 +36,7 @@ type CliPrintColors = typeof importedColors & {
 
 const colors = importedColors as CliPrintColors;
 
-export function attachExtentions(context: Context) {
+export function attachExtensions(context: $TSContext) {
   attachFilesystem(context);
   attachPrint(context);
   attachParameters(context);
@@ -46,7 +46,7 @@ export function attachExtentions(context: Context) {
   attachTemplate(context);
 }
 
-function attachPrompt(context: Context) {
+function attachPrompt(context: $TSContext) {
   context.prompt = {
     confirm: async (message: string, defaultValue = false): Promise<boolean> => {
       const { yesno } = await inquirer.prompt({
@@ -84,7 +84,7 @@ function attachPrompt(context: Context) {
   };
 }
 
-function attachParameters(context: Context) {
+function attachParameters(context: $TSContext) {
   const { argv, plugin, command, subCommands, options } = context.input;
 
   context.parameters = {
@@ -111,7 +111,7 @@ function attachParameters(context: Context) {
   /* tslint:enable */
 }
 
-function attachRuntime(context: Context) {
+function attachRuntime(context: $TSContext) {
   context.runtime = {
     plugins: [],
   };
@@ -134,7 +134,7 @@ function attachRuntime(context: Context) {
   });
 }
 
-function attachFilesystem(context: Context) {
+function attachFilesystem(context: $TSContext) {
   context.filesystem = contextFileSystem;
 }
 
@@ -164,7 +164,7 @@ const contextFileSystem = {
   },
 };
 
-function attachPatching(context: Context) {
+function attachPatching(context: $TSContext) {
   context.patching = {
     replace: async (filePath: string, oldContent: string, newContent: string): Promise<string> => {
       const fileContent = fs.readFileSync(filePath, 'utf-8');
@@ -175,7 +175,7 @@ function attachPatching(context: Context) {
   };
 }
 
-function attachPrint(context: Context) {
+function attachPrint(context: $TSContext) {
   context.print = print;
 }
 
@@ -313,7 +313,7 @@ const CLI_TABLE_MARKDOWN = {
   middle: '|',
 };
 
-function attachTemplate(context: Context) {
+function attachTemplate(context: $TSContext) {
   context.template = {
     async generate(opts: { template: string; target: string; props: object; directory: string }): Promise<string> {
       const template = opts.template;

--- a/packages/amplify-cli-core/src/index.ts
+++ b/packages/amplify-cli-core/src/index.ts
@@ -32,4 +32,5 @@ export * from './errors/amplify-error';
 export * from './errors/amplify-fault';
 export * from './errors/amplify-exception';
 export * from './errors/project-not-initialized-error';
+export * from './context/context-extensions';
 export * from './help';

--- a/packages/amplify-cli-core/src/types.ts
+++ b/packages/amplify-cli-core/src/types.ts
@@ -11,8 +11,8 @@ import { Tag } from './tags';
 export type $TSAny = any; // eslint-disable-line  @typescript-eslint/no-explicit-any
 
 /**
-  * Use it for all CLI Context class references, it enables a quick way to see what we have on the context
-  */
+ * Use it for all CLI Context class references, it enables a quick way to see what we have on the context
+ */
 export type $TSContext = {
   amplify: AmplifyToolkit;
   /**
@@ -23,6 +23,7 @@ export type $TSContext = {
   migrationInfo: $TSAny;
   projectHasMobileHubResources: boolean;
   prompt: $TSAny;
+  patching: $TSAny;
   exeInfo: $TSAny;
   input: $TSAny;
   parameters: $TSAny;
@@ -33,22 +34,22 @@ export type $TSContext = {
   filesystem: IContextFilesystem;
   template: IContextTemplate;
   updatingAuth: $TSAny;
- };
+};
 
 /**
-  * type for category name
-  */
+ * type for category name
+ */
 export type CategoryName = string;
 
 /**
-  * type for resource name
-  */
+ * type for resource name
+ */
 export type ResourceName = string;
 
 /**
-  * User amplify-prompts package instead
-  * @deprecated
-  */
+ * User amplify-prompts package instead
+ * @deprecated
+ */
 export type IContextPrint = {
   /**
    * Use printer.info from amplify-prompts instead
@@ -108,9 +109,9 @@ export type IContextPrint = {
 };
 
 /**
-  * Use stateManager from amplify-cli-core instead
-  * @deprecated
-  */
+ * Use stateManager from amplify-cli-core instead
+ * @deprecated
+ */
 export type IContextFilesystem = {
   remove: (targetPath: string) => void;
   read: (targetPath: string, encoding?: string) => $TSAny;
@@ -121,16 +122,16 @@ export type IContextFilesystem = {
 };
 
 /**
-  * ejs template interface
-  * @deprecated
-  */
+ * ejs template interface
+ * @deprecated
+ */
 export type IContextTemplate = {
-  generate: (opts: { template: string; target: string; props: $TSObject; directory: string }) => string;
+  generate: (opts: { template: string; target: string; props: $TSObject; directory: string }) => Promise<string>;
 };
 
 /**
-  * Plugin platform interface
-  */
+ * Plugin platform interface
+ */
 export type IPluginPlatform = {
   pluginDirectories: string[];
   pluginPrefixes: string[];
@@ -142,15 +143,15 @@ export type IPluginPlatform = {
 };
 
 /**
-  * Plugin collection interface
-  */
+ * Plugin collection interface
+ */
 export type IPluginCollection = {
   [pluginType: string]: IPluginInfo[];
 };
 
 /**
-  * Plugin interface
-  */
+ * Plugin interface
+ */
 export type IPluginInfo = {
   packageName: string;
   packageVersion: string;
@@ -159,8 +160,8 @@ export type IPluginInfo = {
 };
 
 /**
-  * Deployment secrets type
-  */
+ * Deployment secrets type
+ */
 export type DeploymentSecrets = {
   appSecrets: Array<{
     rootStackId: string;
@@ -169,68 +170,68 @@ export type DeploymentSecrets = {
 };
 
 /**
-  * Plugins or other packages bundled with the CLI that pass a file to a system command or execute a binary, must export a function named
-  * "getPackageAssetPaths" of this type.
-  *
-  * The function must return the relative paths of all files and folders that the package passes into a system command.
-  * If the package is an Amplify plugin, the path must be relative to the location of the amplify-plugin.json file
-  * If the package is not an Amplify plugin, the path must be relative to the location of require.resolve('your-package')
-  *
-  * This function will be executed by the CLI during installation.
-  *
-  * At runtime, the assets can be retrieved at path.join(pathManager.getAmplifyPackageLibDirPath(packageName), relativePath)
-  * where "pathManager" is the PathManager instance exported by this package,
-  * "packageName" is the name of your package (used as a key to locate the assets),
-  * and "relativePath" is the path to the asset relative to the root of the package.
-  *
-  * For example, suppose you have a package called "my-fancy-package".
-  * This package expects at runtime to have access to all of the binary files in the folder "<package-root>/resources/binaries"
-  * as well as access to a jar file at "<package-root>/resources/jars/myJar.jar"
-  *
-  * In that case, this package will export the following function:
-  *
-  * export const getPackageAssetPaths = () => ['resources/binaries', 'resources/jars/myJar.jar'];
-  *
-  * A binary could then be accessed at:
-  * path.join(pathManager.getAmplifyPackageLibDirPath('my-fancy-package'), 'resources/binaries', 'myBinary')
-  *
-  * Likewise the jar can be retrieved at path.join(pathManager.getAmplifyPackageLibDirPath('my-fancy-package'), 'resources/jars/myJar.jar')
-  */
+ * Plugins or other packages bundled with the CLI that pass a file to a system command or execute a binary, must export a function named
+ * "getPackageAssetPaths" of this type.
+ *
+ * The function must return the relative paths of all files and folders that the package passes into a system command.
+ * If the package is an Amplify plugin, the path must be relative to the location of the amplify-plugin.json file
+ * If the package is not an Amplify plugin, the path must be relative to the location of require.resolve('your-package')
+ *
+ * This function will be executed by the CLI during installation.
+ *
+ * At runtime, the assets can be retrieved at path.join(pathManager.getAmplifyPackageLibDirPath(packageName), relativePath)
+ * where "pathManager" is the PathManager instance exported by this package,
+ * "packageName" is the name of your package (used as a key to locate the assets),
+ * and "relativePath" is the path to the asset relative to the root of the package.
+ *
+ * For example, suppose you have a package called "my-fancy-package".
+ * This package expects at runtime to have access to all of the binary files in the folder "<package-root>/resources/binaries"
+ * as well as access to a jar file at "<package-root>/resources/jars/myJar.jar"
+ *
+ * In that case, this package will export the following function:
+ *
+ * export const getPackageAssetPaths = () => ['resources/binaries', 'resources/jars/myJar.jar'];
+ *
+ * A binary could then be accessed at:
+ * path.join(pathManager.getAmplifyPackageLibDirPath('my-fancy-package'), 'resources/binaries', 'myBinary')
+ *
+ * Likewise the jar can be retrieved at path.join(pathManager.getAmplifyPackageLibDirPath('my-fancy-package'), 'resources/jars/myJar.jar')
+ */
 export type GetPackageAssetPaths = () => Promise<string[]>;
 
 /**
-  * Placeholder type
-  */
+ * Placeholder type
+ */
 export type $IPluginManifest = $TSAny;
 
 /**
-  * Use it for all file content read from amplify-meta.json
-  */
+ * Use it for all file content read from amplify-meta.json
+ */
 export type $TSMeta = $TSAny;
 
 /**
-  * Use it for all file content read from team-provider-info.json
-  */
+ * Use it for all file content read from team-provider-info.json
+ */
 export type $TSTeamProviderInfo = $TSAny;
 
 /**
-  * Use it for all object initializer usages: {}
-  */
+ * Use it for all object initializer usages: {}
+ */
 export type $TSObject = Record<string, $TSAny>;
 
 /**
-  * There are tons of places where we use these two pieces of information to identify a resource
-  * We can use this type to type those instances
-  */
+ * There are tons of places where we use these two pieces of information to identify a resource
+ * We can use this type to type those instances
+ */
 export interface ResourceTuple {
   category: string;
   resourceName: string;
- }
+}
 
 /* eslint-disable @typescript-eslint/naming-convention */
 /**
-  * enum for supported Amplify frontend choices
-  */
+ * enum for supported Amplify frontend choices
+ */
 export enum AmplifyFrontend {
   android = 'android',
   ios = 'ios',
@@ -238,8 +239,8 @@ export enum AmplifyFrontend {
 }
 
 /**
-  * AmplifyProjectConfig interface
-  */
+ * AmplifyProjectConfig interface
+ */
 export interface AmplifyProjectConfig {
   projectName: string;
   version: string;
@@ -248,8 +249,8 @@ export interface AmplifyProjectConfig {
 }
 
 /**
-  * higher level context object that could be used in plugins
-  */
+ * higher level context object that could be used in plugins
+ */
 export interface ProviderContext {
   provider: string;
   service: string;
@@ -257,12 +258,12 @@ export interface ProviderContext {
 }
 
 /**
-  * Placeholder type
-  */
+ * Placeholder type
+ */
 export type $TSCopyJob = $TSAny;
 
- // Temporary interface until Context refactor
- interface AmplifyToolkit {
+// Temporary interface until Context refactor
+interface AmplifyToolkit {
   confirmPrompt: (prompt: string, defaultValue?: boolean) => Promise<boolean>;
   constants: $TSAny;
   constructExeInfo: (context: $TSContext) => $TSAny;
@@ -326,9 +327,9 @@ export type $TSCopyJob = $TSAny;
     category: string,
     resource: string,
     questionOptions?: {
-     headless?: boolean;
-     serviceSuffix?: { [serviceName: string]: string };
-     serviceDeletionInfo?: { [serviceName: string]: string };
+      headless?: boolean;
+      serviceSuffix?: { [serviceName: string]: string };
+      serviceDeletionInfo?: { [serviceName: string]: string };
     },
     resourceNameCallback?: (resourceName: string) => Promise<void>,
   ) => Promise<{ service: string; resourceName: string } | undefined>;
@@ -390,7 +391,9 @@ export type $TSCopyJob = $TSAny;
   leaveBreadcrumbs: (category: string, resourceName: string, breadcrumbs: unknown) => void;
   readBreadcrumbs: (category: string, resourceName: string) => $TSAny;
   loadRuntimePlugin: (context: $TSContext, pluginId: string) => Promise<$TSAny>;
-  getImportedAuthProperties: (context: $TSContext) => {
+  getImportedAuthProperties: (
+    context: $TSContext,
+  ) => {
     imported: boolean;
     userPoolId?: string;
     authRoleArn?: string;
@@ -399,5 +402,5 @@ export type $TSCopyJob = $TSAny;
     unauthRoleName?: string;
   };
   invokePluginMethod: <T>(context: $TSContext, category: string, service: string | undefined, method: string, args: $TSAny[]) => Promise<T>;
-  getTags: (context: $TSContext) => Tag[],
- }
+  getTags: (context: $TSContext) => Tag[];
+}

--- a/packages/amplify-cli-core/src/types.ts
+++ b/packages/amplify-cli-core/src/types.ts
@@ -23,7 +23,9 @@ export type $TSContext = {
   migrationInfo: $TSAny;
   projectHasMobileHubResources: boolean;
   prompt: $TSAny;
-  patching: $TSAny;
+  patching: {
+    replace(filePath: string, oldContent: string, newContent: string): Promise<string>;
+  };
   exeInfo: $TSAny;
   input: $TSAny;
   parameters: $TSAny;

--- a/packages/amplify-cli-core/src/types.ts
+++ b/packages/amplify-cli-core/src/types.ts
@@ -23,9 +23,6 @@ export type $TSContext = {
   migrationInfo: $TSAny;
   projectHasMobileHubResources: boolean;
   prompt: $TSAny;
-  patching: {
-    replace(filePath: string, oldContent: string, newContent: string): Promise<string>;
-  };
   exeInfo: $TSAny;
   input: $TSAny;
   parameters: $TSAny;

--- a/packages/amplify-cli/src/__tests__/init-steps/s0-analyzeProject.test.ts
+++ b/packages/amplify-cli/src/__tests__/init-steps/s0-analyzeProject.test.ts
@@ -4,12 +4,9 @@ import { constructMockPluginPlatform } from '../extensions/amplify-helpers/mock-
 import { Input } from '../../domain/input';
 import { constructContext } from '../../context-manager';
 
-jest.mock('amplify-cli-core');
-
-const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
-stateManagerMock.getLocalAWSInfo.mockReturnValue({ envA: 'test', envB: 'test' });
-stateManagerMock.getLocalEnvInfo.mockReturnValue({ defaultEditor: 'Visual Studio Code' });
-stateManagerMock.getTeamProviderInfo.mockReturnValue({});
+jest.spyOn(stateManager, 'getLocalAWSInfo').mockReturnValue({ envA: 'test', envB: 'test' });
+jest.spyOn(stateManager, 'getLocalEnvInfo').mockReturnValue({ defaultEditor: 'Visual Studio Code' });
+jest.spyOn(stateManager, 'getTeamProviderInfo').mockReturnValue({});
 
 describe('analyzeProject', () => {
   let mockContext;
@@ -22,7 +19,7 @@ describe('analyzeProject', () => {
       '-y',
     ];
     const mockInput = new Input(mockProcessArgv);
-    mockContext = constructContext(mockPluginPlatform, mockInput) as unknown as $TSContext;
+    mockContext = (constructContext(mockPluginPlatform, mockInput) as unknown) as $TSContext;
     const frontendPlugins = [
       {
         name: 'amplify-frontend-javascript',
@@ -47,7 +44,9 @@ describe('analyzeProject', () => {
   });
 
   it('recognizes the default editor', async () => {
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /* noop */ });
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {
+      /* noop */
+    });
     const result = await analyzeProject(mockContext);
     expect(result.exeInfo.localEnvInfo.defaultEditor).toStrictEqual('Visual Studio Code');
     consoleLogSpy.mockClear();
@@ -59,8 +58,8 @@ describe('analyzeProject', () => {
         envName: 'test',
       },
     };
-    stateManagerMock.getLocalAWSInfo.mockReturnValue({});
-    stateManagerMock.getTeamProviderInfo.mockReturnValue({ test: {}, other: {} });
+    jest.spyOn(stateManager, 'getTeamProviderInfo').mockReturnValue({ test: {}, other: {} });
+    jest.spyOn(stateManager, 'getLocalAWSInfo').mockReturnValue({});
     await analyzeProject(mockContext);
     expect(mockContext.exeInfo.isNewEnv).toBe(false);
   });
@@ -71,8 +70,8 @@ describe('analyzeProject', () => {
         envName: 'new',
       },
     };
-    stateManagerMock.getLocalAWSInfo.mockReturnValue({});
-    stateManagerMock.getTeamProviderInfo.mockReturnValue({ test: {}, other: {} });
+    jest.spyOn(stateManager, 'getTeamProviderInfo').mockReturnValue({ test: {}, other: {} });
+    jest.spyOn(stateManager, 'getLocalAWSInfo').mockReturnValue({});
     await analyzeProject(mockContext);
     expect(mockContext.exeInfo.isNewEnv).toBe(true);
   });

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -1,7 +1,6 @@
 import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
 import * as _ from 'lodash';
 import { init } from './app-config';
-// eslint-disable-next-line spellcheck/spell-checker
 import { attachExtensions } from 'amplify-cli-core';
 import { NoUsageData, UsageData } from './domain/amplify-usageData';
 import { ProjectSettings } from './domain/amplify-usageData/UsageDataTypes';

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -1,8 +1,8 @@
-import { $TSAny, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, stateManager } from 'amplify-cli-core';
 import * as _ from 'lodash';
 import { init } from './app-config';
 // eslint-disable-next-line spellcheck/spell-checker
-import { attachExtentions as attachExtensions } from './context-extensions';
+import { attachExtensions } from 'amplify-cli-core';
 import { NoUsageData, UsageData } from './domain/amplify-usageData';
 import { ProjectSettings } from './domain/amplify-usageData/UsageDataTypes';
 import { Context } from './domain/context';
@@ -14,7 +14,7 @@ import { PluginPlatform } from './domain/plugin-platform';
  */
 export const constructContext = (pluginPlatform: PluginPlatform, input: Input): Context => {
   const context = new Context(pluginPlatform, input);
-  attachExtensions(context);
+  attachExtensions((context as unknown) as $TSContext);
   return context;
 };
 

--- a/packages/amplify-cli/src/plugin-manager.ts
+++ b/packages/amplify-cli/src/plugin-manager.ts
@@ -14,7 +14,7 @@ import { AddPluginResult, AddPluginError } from './domain/add-plugin-result';
 import { twoPluginsAreTheSame } from './plugin-helpers/compare-plugins';
 import { AmplifyEvent } from './domain/amplify-event';
 import { constants } from './domain/constants';
-import { print } from './context-extensions';
+import { print } from 'amplify-cli-core';
 import { postInstallInitialization } from './utils/post-install-initialization';
 
 export async function getPluginPlatform(): Promise<PluginPlatform> {

--- a/packages/amplify-opensearch-simulator/API.md
+++ b/packages/amplify-opensearch-simulator/API.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { $TSAny } from 'amplify-cli-core';
 import execa from 'execa';
 import { GetPackageAssetPaths } from 'amplify-cli-core';

--- a/packages/amplify-opensearch-simulator/API.md
+++ b/packages/amplify-opensearch-simulator/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { $TSAny } from 'amplify-cli-core';
 import execa from 'execa';
 import { GetPackageAssetPaths } from 'amplify-cli-core';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8782,6 +8782,11 @@
   resolved "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.1.tgz#a1af9bb9e8e43f5a2190f876cfd4120a5fae41ab"
   integrity sha512-evutJ8HynqPgm07LaG7nj7VqFqfAYpAjpKYYjhj5rlD5ukdF0hFiqHQo94Tu1FBJQkWDQPt3f1DaXLOGEL1nAw==
 
+"@types/ejs@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.1.tgz#29c539826376a65e7f7d672d51301f37ed718f6d"
+  integrity sha512-RQul5wEfY7BjWm0sYY86cmUN/pcXWGyVxWX93DFFJvcrxax5zKlieLwA3T77xJGwNcZW0YW6CYG70p1m8xPFmA==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -24216,9 +24221,9 @@ unc-path-regex@^0.1.2:
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
 
 undici@^4.9.3, undici@^5.8.0:
-  version "5.16.0"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz#6b64f9b890de85489ac6332bd45ca67e4f7d9943"
-  integrity sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==
+  version "5.18.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz#e88a77a74d991a30701e9a6751e4193a26fabda9"
+  integrity sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==
   dependencies:
     busboy "^1.6.0"
 


### PR DESCRIPTION

#### Description of changes

Moves `context-extensions` to `amplify-cli-core`.

Context Extensions attaches most of the properties to the Amplify Context. The file has no amplify dependencies except a reference to the context interface (in its previous state, the `Context` class in `amplify-cli/`, now `$TSContext`).

With this file in `amplify-cli`, mocking context is difficult because depending on `amplify-cli/` in other projects creates a circular dependency. Moving this file to `amplify-cli-core` makes it easier to mock.

#### Issue #, if available


#### Description of how you validated changes

#### Checklist


- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
