### PR TITLE
chore: dont lint in e2e runs

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -916,6 +916,7 @@ workflows:
                 - release
                 - /release_rc\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
+                - /run-e2e\/.*/
       - verify-api-extract:
           requires:
             - build

--- a/.circleci/lint_pr.sh
+++ b/.circleci/lint_pr.sh
@@ -1,4 +1,4 @@
-set -xeo pipefail
+set -xe
 # extract the PR number from the PR link
 PR_NUM=${CIRCLE_PULL_REQUEST##*/}
 

--- a/.circleci/lint_pr.sh
+++ b/.circleci/lint_pr.sh
@@ -8,5 +8,5 @@ if [ -z "$PR_NUM" ]; then
 fi
 
 # get PR file list, filter out removed files, filter only JS/TS files, then pass to the linter
-curl -fsSL https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PR_REPONAME/pulls/$PR_NUM/files | jq -r '.[] | select(.status!="removed") | .filename' | grep -E '\.(js|jsx|ts|tsx)$' | xargs yarn eslint
+curl -fsSL https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PR_REPONAME/pulls/$PR_NUM/files | jq -r '.[] | select(.status!="removed") | .filename' | grep -E '\.(js|jsx|ts|tsx)$' | xargs --no-run-if-empty yarn eslint
 set +x


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When both PR validation job and e2e tests are run for the same PR then e2e linting result wins and is show in GH checks.
However in e2e run lint is no-op... https://github.com/aws-amplify/amplify-cli/blob/4316a610477594f11b7e9b35d97554e5a839e1e9/.circleci/lint_pr.sh#L5-L8

Therefore, we should exclude linting from e2e run.

Unfortunately circle ci doesn't have a good mechanism to only run lint on PR jobs (see https://ruarfff.com/circleci-pr-only/ ). But hence we do run pr validation and e2e tests on PRs usually. Just excluding lint from e2e seems like a cheap and effective solution.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
