### PR TITLE
fix: export AmplifyProjectInfo

### DIFF
--- a/packages/amplify-cli-extensibility-helper/API.md
+++ b/packages/amplify-cli-extensibility-helper/API.md
@@ -124,6 +124,12 @@ export interface AmplifyDDBResourceTemplate extends AmplifyCDKL1 {
     dynamoDBTable?: ddb.CfnTable;
 }
 
+// @public (undocumented)
+export type AmplifyProjectInfo = {
+    envName: string;
+    projectName: string;
+};
+
 export { AmplifyResourceProps }
 
 // @public (undocumented)
@@ -182,8 +188,6 @@ export type ApigwPathPolicy = {
     };
 };
 
-// Warning: (ae-forgotten-export) The symbol "AmplifyProjectInfo" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export const getProjectInfo: () => AmplifyProjectInfo;
 

--- a/packages/amplify-cli-extensibility-helper/src/index.ts
+++ b/packages/amplify-cli-extensibility-helper/src/index.ts
@@ -1,5 +1,6 @@
 export { addCDKResourceDependency as addResourceDependency, AmplifyResourceProps } from '@aws-amplify/amplify-category-custom';
 export { getProjectInfo } from './helpers/project-info';
+export { AmplifyProjectInfo } from './types';
 export { AmplifyApiGraphQlResourceStackTemplate } from './types/api/amplify-api-resource-stack-types';
 export { AmplifyApiRestResourceStackTemplate, ApigwPathPolicy } from './types/api/types';
 export { AmplifyAuthCognitoStackTemplate, AmplifyUserPoolGroupStackTemplate } from './types/auth/types';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This is a small PR that exports a type used by already public `getProjectInfo`. So that customers can import that type and use it to define symbols that store return of getProjectInfo() calls.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
