### PR TITLE
fix: e2e test retry

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -276,7 +276,7 @@ function runE2eTest {
 
     if [ -f  $FAILED_TEST_REGEX_FILE ]; then
         # read the content of failed tests
-        failedTests=$(<$FAILED_TEST_REGEX_FILE)=
+        failedTests=$(<$FAILED_TEST_REGEX_FILE)
         yarn run e2e --no-cache --maxWorkers=3 $TEST_SUITE -t "$failedTests"
     else
         yarn run e2e --no-cache --maxWorkers=3 $TEST_SUITE


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Trailing `=` sign is causing retries to skip failed tests and it is masking failures.

See https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/15796/workflows/8ed3fe53-e2f6-4793-bb3e-193ec29583db/jobs/772859 .

![image](https://user-images.githubusercontent.com/5849952/217980122-f542306b-f939-474b-9b08-de32d9efbca8.png)
![image](https://user-images.githubusercontent.com/5849952/217980151-c0e1ce12-926c-4bed-ad8f-ac132e78215e.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
