### PR TITLE
feat: bump API plugin depedencies to consume legacy rds fix

### DIFF
--- a/packages/amplify-cli-npm/index.ts
+++ b/packages/amplify-cli-npm/index.ts
@@ -16,5 +16,5 @@ export const install = async (): Promise<void> => {
   return binary.install();
 };
 
-// force minor version bump to 10.6
+// force minor version bump to 10.7.2
 //

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -34,7 +34,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^4.1.5",
+    "@aws-amplify/amplify-category-api": "4.1.6-legacyrdsfix.0",
     "@aws-amplify/amplify-category-auth": "2.15.1",
     "@aws-amplify/amplify-category-custom": "2.6.3",
     "@aws-amplify/amplify-category-storage": "3.7.1",

--- a/packages/amplify-container-hosting/package.json
+++ b/packages/amplify-container-hosting/package.json
@@ -23,7 +23,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^4.1.5",
+    "@aws-amplify/amplify-category-api": "4.1.6-legacyrdsfix.0",
     "amplify-cli-core": "3.6.1",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-"@aws-amplify/amplify-category-api@^4.1.5":
-  version "4.1.5"
-  resolved "https://registry.npmjs.org/@aws-amplify/amplify-category-api/-/amplify-category-api-4.1.5.tgz#1949adb842a095a993564212d69f06966500236b"
-  integrity sha512-6GfRtmX5UBEuSLJ54dDtxx6HbvdAcW2T10A0x7TtIjOnhQJb6GQkamkRA4joVC53wfOxxy82cL4GuuDtwiVIjw==
+"@aws-amplify/amplify-category-api@4.1.6-legacyrdsfix.0":
+  version "4.1.6-legacyrdsfix.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-category-api/-/amplify-category-api-4.1.6-legacyrdsfix.0.tgz#b497aa10f180a085dfa81be4dd71b7fcfea85458"
+  integrity sha512-UWH8R8jy054YuoudbtsByKgiJvqGwB+P1sgesEftI7r4jM9MFQWxM8MuqiVJeWeqRUfXb6JeNm8IXljy5vk78Q==
   dependencies:
     "@aws-amplify/graphql-auth-transformer" "1.2.4"
     "@aws-amplify/graphql-default-value-transformer" "0.7.6"
@@ -123,7 +123,7 @@
     graphql-http-transformer "5.2.46"
     graphql-key-transformer "3.2.46"
     graphql-predictions-transformer "3.2.46"
-    graphql-relational-schema-transformer "2.21.13"
+    graphql-relational-schema-transformer "2.21.14-legacyrdsfix.0"
     graphql-transformer-common "4.24.3"
     graphql-transformer-core "7.6.9"
     graphql-versioned-transformer "5.2.46"
@@ -15597,10 +15597,10 @@ graphql-predictions-transformer@3.2.46, graphql-predictions-transformer@^3.2.46:
     graphql-transformer-common "4.24.3"
     graphql-transformer-core "7.6.9"
 
-graphql-relational-schema-transformer@2.21.13:
-  version "2.21.13"
-  resolved "https://registry.npmjs.org/graphql-relational-schema-transformer/-/graphql-relational-schema-transformer-2.21.13.tgz#266aeeea307efd478b8127537bb13854e26db5a8"
-  integrity sha512-40IUDKwJhyq3/dZKw4ytQlBZQPJEDzenJTkp4lAzjCESOgXbaF7m0NsdibBGbarSfWhfdPlSFWVB0ywiM+kFmg==
+graphql-relational-schema-transformer@2.21.14-legacyrdsfix.0:
+  version "2.21.14-legacyrdsfix.0"
+  resolved "https://registry.npmjs.org/graphql-relational-schema-transformer/-/graphql-relational-schema-transformer-2.21.14-legacyrdsfix.0.tgz#aefa29e6b0b9822239f008f5c573ddaa99ecd511"
+  integrity sha512-tmSb9Ken4mb4hxp2R0R7y4xWzRKqZoLDma790fQGFO2CtFmmiZHtmrWXjq/tJhdO3L0SI+ge4FzoGjsdlSMsiA==
   dependencies:
     cloudform "^4.2.0"
     cloudform-types "^4.2.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Bump the API plugin dependency to consume the tagged release version `4.1.6-legacyrdsfix.0` which includes the fix to legacy RDS transformers added via `amplify api add-graphql-datasource` command .

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
