### PR TITLE
chore: remove circular reference from tsconfig

### DIFF
--- a/packages/amplify-category-custom/tsconfig.json
+++ b/packages/amplify-category-custom/tsconfig.json
@@ -1,19 +1,17 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-      "outDir": "lib",
-      "rootDir": "src",
-      "allowJs": true
-    },
-    "exclude": [
-      "coverage",
-      "lib",
-      "resources",
-    ],
-    "references": [
-      {"path": "../amplify-cli-core"},
-      {"path": "../amplify-prompts"},
-      {"path": "../amplify-cli-extensibility-helper"}
-    ]
-  }
-  
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "allowJs": false
+  },
+  "exclude": [
+    "coverage",
+    "lib",
+    "resources",
+  ],
+  "references": [
+    { "path": "../amplify-cli-core" },
+    { "path": "../amplify-prompts" }
+  ]
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
`@aws-amplify/amplify-cli-extensibility-helper` depends on `@aws-amplify/amplify-category-custom` and contains a reference in it's [tsconfig](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-cli-extensibility-helper/tsconfig.json#L9).

`@aws-amplify/amplify-category-custom` does not depend on the extensibility-helper package so I removed the entry.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
