### PR TITLE
fix: downloading only first 10 parameters

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/ssm-utils/env-parameter-ssm-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/ssm-utils/env-parameter-ssm-helpers.test.ts
@@ -11,19 +11,21 @@ const mockSSM = SSM as jest.Mocked<typeof SSM>;
 
 stateManagerMock.metaFileExists = jest.fn().mockReturnValue(true);
 stateManagerMock.getMeta = jest.fn();
-stateManagerMock.getCurrentEnvName = jest.fn().mockReturnValue('mocked');
+stateManagerMock.getCurrentEnvName = jest.fn().mockReturnValue('mockEnv');
 
 const putParameterPromiseMock = jest.fn().mockImplementation(() => Promise.resolve());
 const getParametersPromiseMock = jest.fn().mockImplementation(() => Promise.resolve());
+
+const getParametersMock = jest.fn().mockImplementation(() => ({
+  promise: getParametersPromiseMock,
+}));
 
 mockSSM.getInstance = jest.fn().mockResolvedValue({
   client: {
     putParameter: jest.fn().mockImplementation(() => ({
       promise: putParameterPromiseMock,
     })),
-    getParameters: jest.fn().mockImplementation(() => ({
-      promise: getParametersPromiseMock,
-    })),
+    getParameters: getParametersMock,
   },
 });
 
@@ -62,7 +64,7 @@ describe('downloading environment parameters', () => {
     expect(returnedFn).toBeDefined();
     const mockParams = await returnedFn(['mockMissingParam']);
     expect(mockParams).toStrictEqual({});
-    expect(getParametersPromiseMock).not.toBeCalled();
+    expect(getParametersMock).not.toBeCalled();
   });
 
   it('returns {} when no keys are supplied', async () => {
@@ -71,7 +73,7 @@ describe('downloading environment parameters', () => {
     expect(returnedFn).toBeDefined();
     const mockParams = await returnedFn([]);
     expect(mockParams).toStrictEqual({});
-    expect(getParametersPromiseMock).not.toBeCalled();
+    expect(getParametersMock).not.toBeCalled();
   });
 
   it('returns an async function which can invoke the SSM client', async () => {
@@ -83,6 +85,7 @@ describe('downloading environment parameters', () => {
     expect(returnedFn).toBeDefined();
     const mockParams = await returnedFn(['key']);
     expect(mockParams).toStrictEqual({ 'key': 'value' });
+    expect(getParametersMock).toBeCalledTimes(1);
     expect(getParametersPromiseMock).toBeCalledTimes(1);
   });
 
@@ -95,15 +98,24 @@ describe('downloading environment parameters', () => {
       const key = `key${i}`;
       keys.push(key);
       expectedParams[key] = 'value';
-      mockCloudParams.push({ Name: `/amplify/mockAppId/mockEnv/${key}`, Value: '"value"' });
+      mockCloudParams.push({ Name: `/amplify/mockedAppId/mockEnv/${key}`, Value: '"value"' });
     }
-
+    const expectedKeyPaths = keys.map(key => `/amplify/mockedAppId/mockEnv/${key}`);
     getParametersPromiseMock.mockResolvedValueOnce({ Parameters: mockCloudParams.slice(0, 10) });
     getParametersPromiseMock.mockResolvedValueOnce({ Parameters: mockCloudParams.slice(10) });
 
     const returnedFn = await getEnvParametersDownloadHandler(contextMock);
     expect(returnedFn).toBeDefined();
     const mockParams = await returnedFn(keys);
+    expect(getParametersMock).toBeCalledTimes(2);
+    expect(getParametersMock).toBeCalledWith({
+      Names: expectedKeyPaths.slice(0, 10),
+      WithDecryption: false,
+    });
+    expect(getParametersMock).toBeCalledWith({
+      Names: expectedKeyPaths.slice(10),
+      WithDecryption: false,
+    });
     expect(mockParams).toStrictEqual(expectedParams);
     expect(getParametersPromiseMock).toBeCalledTimes(2);
   });

--- a/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
@@ -106,11 +106,10 @@ const downloadParametersFromParameterStore = (
 };
 
 const convertKeyPathsToSdkPromises = (ssmClient: SSMType, keyPaths: string[]): (() => Promise<SSMType.GetParametersByPathResult>)[] => {
-  let parameterSliceIndex = 0;
   const sdkParameterChunks = [];
   for (let i = 0; i < keyPaths.length; i += 10) {
     sdkParameterChunks.push({
-      Names: keyPaths.slice(parameterSliceIndex, Math.min(parameterSliceIndex + 10, keyPaths.length)),
+      Names: keyPaths.slice(i, Math.min(i + 10, keyPaths.length)),
       WithDecryption: false,
     });
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixing I bug I introduced on the `parameter-store-integration` branch during a refactor

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
