### PR TITLE
fix: iterative rollback e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -114,7 +114,7 @@ export function cancelIterativeAmplifyPush(
     .wait(`Deploying iterative update ${idx.current} of ${idx.max} into`)
     .wait(/.*AWS::AppSync::GraphQLSchema\s*UPDATE_IN_PROGRESS.*/)
     .sendCtrlC()
-    .runAsync((err: Error) => err.message === 'Process exited with non-zero code 130');
+    .runAsync((err: Error) => err.message === 'Process exited with non zero exit code 130');
 }
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This fixes schema iterative rollback e2e tests. The problem is in the e2e testing code.

The original regression was introduced in https://github.com/aws-amplify/amplify-cli/pull/11651/files#diff-7e3c46591dfadf6a28b860b355600ed92ba329b54f0119a0ec959db990361e27
![image](https://user-images.githubusercontent.com/5849952/218546098-39f385c3-d3c7-4607-adde-fad6e63fe89a.png)


This PR fixes expected error message.



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

By running affected tests.

![image](https://user-images.githubusercontent.com/5849952/218546172-109cb3c7-4c98-4552-8e36-bca21c747123.png)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
