### PR TITLE
fix: branch name logic format script

### DIFF
--- a/scripts/extract-formatting-changes.ts
+++ b/scripts/extract-formatting-changes.ts
@@ -97,7 +97,7 @@ const main = async () => {
     if (!base || !head) {
       throw new Error('Missing revisions to compare');
     }
-    // assertCleanWorkingTree();
+    assertCleanWorkingTree();
     const unfilteredFiles = getChangedFiles(base, head);
     const prettierCompatibleFiles = unfilteredFiles.filter(doesFileExist).filter(isCompatibleWithPrettier);
     if (prettierCompatibleFiles.length === 0) {

--- a/scripts/extract-formatting-changes.ts
+++ b/scripts/extract-formatting-changes.ts
@@ -97,7 +97,7 @@ const main = async () => {
     if (!base || !head) {
       throw new Error('Missing revisions to compare');
     }
-    assertCleanWorkingTree();
+    // assertCleanWorkingTree();
     const unfilteredFiles = getChangedFiles(base, head);
     const prettierCompatibleFiles = unfilteredFiles.filter(doesFileExist).filter(isCompatibleWithPrettier);
     if (prettierCompatibleFiles.length === 0) {
@@ -109,9 +109,8 @@ const main = async () => {
       input: process.stdin,
       output: process.stdout,
     });
-    const confirmedBranchName = branch ?? (await confirmBranchName(rl, defaultBranchName));
+    const confirmedBranchName = branch.trim() || (await confirmBranchName(rl, defaultBranchName));
     if (await confirmBranchCreation(rl, confirmedBranchName)) {
-      console.log(args);
       const baseRevision = getHashForRevision(base);
       createBranch(baseRevision, confirmedBranchName);
       checkoutBranch(confirmedBranchName);


### PR DESCRIPTION

#### Description of changes
Fixes botched logic for determining a branch's name


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
