### PR TITLE
fix: filter parameter validation when pushing subset of resources

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -106,10 +106,27 @@ export const pushResources = async (
     resourceParamManager.setParam(parameterName, value);
   };
 
+  const parametersToCheck = resourcesToBuild
+    .filter(({ category: c, resourceName: r }) => {
+      // Filter based on optional parameters
+      if (category) {
+        if (c !== category) {
+          return false;
+        }
+      }
+      if (resourceName) {
+        if (r !== resourceName) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+
   if (context?.exeInfo?.inputParams?.yes || context?.exeInfo?.inputParams?.headless) {
-    await envParamManager.verifyExpectedEnvParameters();
+    await envParamManager.verifyExpectedEnvParameters(parametersToCheck);
   } else {
-    const missingParameters = await envParamManager.getMissingParameters();
+    const missingParameters = await envParamManager.getMissingParameters(parametersToCheck);
     if (missingParameters.length > 0) {
       for (const { categoryName, resourceName, parameterName } of missingParameters) {
         await promptMissingParameter(categoryName, resourceName, parameterName , envParamManager);

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { IAmplifyResource } from 'amplify-cli-core';
+
 // @public (undocumented)
 export const cloneEnvParamManager: (srcEnvParamManager: IEnvironmentParameterManager, destEnvName: string) => Promise<void>;
 
@@ -19,7 +21,7 @@ export const getEnvParamManager: (envName?: string) => IEnvironmentParameterMana
 export type IEnvironmentParameterManager = {
     cloneEnvParamsToNewEnvParamManager: (destManager: IEnvironmentParameterManager) => Promise<void>;
     downloadParameters: (downloadHandler: ServiceDownloadHandler) => Promise<void>;
-    getMissingParameters: () => Promise<{
+    getMissingParameters: (resourceFilterList?: IAmplifyResource[]) => Promise<{
         categoryName: string;
         resourceName: string;
         parameterName: string;
@@ -29,7 +31,7 @@ export type IEnvironmentParameterManager = {
     init: () => Promise<void>;
     removeResourceParamManager: (category: string, resource: string) => void;
     save: (serviceUploadHandler?: ServiceUploadHandler) => Promise<void>;
-    verifyExpectedEnvParameters: () => Promise<void>;
+    verifyExpectedEnvParameters: (resourceFilterList?: IAmplifyResource[]) => Promise<void>;
 };
 
 // @public (undocumented)

--- a/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
@@ -124,6 +124,23 @@ describe('verifyExpectedEnvParameters', () => {
     }
     expect(error).toBeDefined();
   });
+
+  it('does not throw when a parameter is missing on an ignored resource', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
+
+    funcParamManager.setParam('missingParam', 'missingValue');
+    envParamManager.save();
+    funcParamManager.deleteParam('missingParam');
+
+    let error = undefined;
+    try {
+      await envParamManager.verifyExpectedEnvParameters([{ category: 'auth', resourceName: 'mockAuth', service: 'Cognito' }]);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).not.toBeDefined();
+  });
 });
 
 describe('getMissingParameters', () => {
@@ -143,5 +160,19 @@ describe('getMissingParameters', () => {
 
     expect(await envParamManager.getMissingParameters())
       .toEqual([{ categoryName: 'function', resourceName: 'funcName', parameterName: 'missingParam' }]);
+  });
+
+  it('returns an empty array when a parameter is missing on an ignored resource', async () => {
+    const envParamManager = (await ensureEnvParamManager()).instance;
+    const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
+
+    funcParamManager.setParam('missingParam', 'missingValue');
+    envParamManager.save();
+    funcParamManager.deleteParam('missingParam');
+
+    expect(
+      await envParamManager.getMissingParameters([{ category: 'auth', resourceName: 'mockAuth', service: 'Cognito' }])
+    ).toEqual([]);
+
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR reduces the parameters which are validated on push to only the resources being pushed.

Fixes https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/15994/workflows/e7662d31-b6d1-438b-8410-e9662d443274/jobs/780641/tests

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
`notifications-multi-env.test.ts` passed locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
