### PR TITLE
fix: notifications and deploy spinners clashing

### DIFF
--- a/packages/amplify-category-notifications/src/display-utils.ts
+++ b/packages/amplify-category-notifications/src/display-utils.ts
@@ -1,4 +1,3 @@
-import { spinner } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 
 /**
@@ -18,14 +17,14 @@ export const viewShowDeferredModeInstructions = (): void => {
  * Display status that Auth and Pinpoint resources are being deployed to the cloud
  */
 export const viewShowInlineModeInstructionsStart = async (channelName: string): Promise<void> => {
-  spinner.start(`Channel ${channelName} requires a Pinpoint resource in the cloud. Proceeding to deploy Auth and Pinpoint resources...`);
+  printer.info(`Channel ${channelName} requires a Pinpoint resource in the cloud. Proceeding to deploy Auth and Pinpoint resources...`);
 };
 
 /**
  * Display status that Auth and Pinpoint resources have been successfully deployed to the cloud
  */
 export const viewShowInlineModeInstructionsStop = async (channelName: string): Promise<void> => {
-  spinner.succeed(`Channel ${channelName}: Auth and Pinpoint resources deployed successfully...`);
+  printer.success(`Channel ${channelName}: Auth and Pinpoint resources deployed successfully.`);
 };
 
 /**
@@ -34,5 +33,5 @@ export const viewShowInlineModeInstructionsStop = async (channelName: string): P
  * @param err Error thrown by the pinpoint helper
  */
 export const viewShowInlineModeInstructionsFail = async (channelName: string, err: Error|string): Promise<void> => {
-  spinner.fail(`Channel ${channelName}: Auth and Pinpoint resources deployment failed with Error ${err}`);
+  printer.error(`Channel ${channelName}: Auth and Pinpoint resources deployment failed with Error ${err}`);
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
During an `amplify env add` and `amplify env checkout` with notifications, I ran into this spinner line being repeated thousands of times:

<img width="975" alt="Screen Shot 2023-02-14 at 6 11 14 PM" src="https://user-images.githubusercontent.com/1815789/218909739-6af6fc05-61c7-4e04-877f-1606d9e02ed7.png">


The spinner at the bottom of the output keeps flickering.

After changing the notifications spinner to a single printed line, the output looks like a typical deployment.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested `amplify env add`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
