### PR TITLE
fix: throttling logic for ParameterStore SDK calls

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
@@ -40,7 +40,7 @@ const uploadParameterToParameterStore = (
         Type: 'String',
         Value: stringValue,
       };
-      await ssmClient.putParameter(sdkParameters).promise();
+      await executeSdkPromisesWithExponentialBackoff([() => ssmClient.putParameter(sdkParameters).promise()]);
     } catch (e) {
       throw new AmplifyFault(
         'ParameterUploadFault',

--- a/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/exp-backoff-executor.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/exp-backoff-executor.ts
@@ -16,7 +16,7 @@ export const executeSdkPromisesWithExponentialBackoff = async <T>(
       backoffSleepTimeInMs = 200;
       consecutiveRetries = 0;
     } catch (e) {
-      if (e?.code === 'Throttling') {
+      if (e?.code === 'ThrottlingException' || e?.code === 'Throttling') {
         if (consecutiveRetries < MAX_RETRIES) {
           ++consecutiveRetries;
           await new Promise(resolve => setTimeout(resolve, backoffSleepTimeInMs));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Fix throttling logic to catch error code `ThrottlingException` in addition to `Throttling`
- Call `SSM.putParameter` in `executeSdkPromisesWithExponentialBackoff`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
