### PR TITLE
fix: remove duplicate api push in commands-info.ts

### DIFF
--- a/packages/amplify-cli-core/src/help/commands-info.ts
+++ b/packages/amplify-cli-core/src/help/commands-info.ts
@@ -744,12 +744,6 @@ export const commandsInfo: Array<CommandInfo> = [
         subCommandUsage: 'amplify api override',
         subCommandFlags: [],
       },
-      {
-        subCommand: 'push',
-        subCommandDescription: 'Provisions cloud resources with the latest local changes',
-        subCommandUsage: 'amplify api push',
-        subCommandFlags: [],
-      },
     ],
   },
   {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Removes a duplicate push subcommand under "api" in commands-info.ts.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
