### PR TITLE
chore: add prettier commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,7 @@ If the change is a breaking change ([as defined by semantic versioning](https://
    - Use slashes to separate parts of branch names
 1. Once your work is committed and you're ready to share, run `yarn test`. Manually test your changes in a sample app with different edge cases and also test across different platforms if possible.
 1. Run `yarn lint-fix` to find and fix any linting errors
+1. Run `yarn prettify:changes` to fix styling issues
 1. Then, push your branch: `git push origin HEAD` (pushes the current branch to origin remote)
 1. Open GitHub to create a PR from your newly published branch. Fill out the PR template and submit a PR.
 1. Finally, the Amplify CLI team will review your PR. Add reviewers based on the core member who is tracking the issue with you or code owners. _In the meantime, address any automated check that fail (such as linting, unit tests, etc. in CI)_

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
     "pkg-all": "source .circleci/local_publish_helpers.sh && generatePkgCli",
     "pkg-all-local": "yarn verdaccio-start && yarn verdaccio-connect && yarn publish-to-verdaccio && yarn pkg-all && yarn verdaccio-disconnect",
+    "prettify": "yarn prettier --write .",
+    "prettify:changes": "git diff --name-only --diff-filter MRA | xargs yarn prettier --write",
     "yarn-use-bash": "yarn config set script-shell /bin/bash",
     "verdaccio-start": "source .circleci/local_publish_helpers.sh && startLocalRegistry \"$(pwd)/.circleci/verdaccio.yaml\"",
     "verdaccio-clean": "rimraf ../verdaccio-cache",


### PR DESCRIPTION

#### Description of changes

Adds a couple of useful prettier related commands to `package.json`.

The CI pipeline now fails if any file in the repository is not formatted correctly.
These commands will make it easier to format the codebase to match the CI specification.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
