### PR TITLE
fix: use regionalized sts calls for admin login

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -93,7 +93,9 @@ async function getAdminCognitoCredentials(idToken: CognitoIdToken, identityId: s
 }
 
 async function getAdminStsCredentials(idToken: CognitoIdToken, region: string): Promise<AwsSdkConfig> {
-  const sts = new aws.STS();
+  const sts = new aws.STS({
+    stsRegionalEndpoints: 'regional',
+  });
   const { Credentials } = await sts
     .assumeRole({
       RoleArn: idToken.payload['cognito:preferred_role'],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
configures a regional STS client when making calls for studio login. This is to support opt-in regions where non-regionalized STS tokens are not valid

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
