### PR TITLE
chore: refactor amplify toolkit's singleton and import patterns

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -162,7 +162,7 @@ jobs:
           key: amplify-cli-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           key: amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - run: yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 1250
+      - run: yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 1085
       - run: yarn eslint --no-eslintrc --config .eslint.package.json.js "**/package.json"
       - run: yarn prettier --check .
 

--- a/packages/amplify-cli/API.md
+++ b/packages/amplify-cli/API.md
@@ -6,7 +6,6 @@
 
 /// <reference types="node" />
 
-import { $TSAny } from 'amplify-cli-core';
 import { CommandLineInput } from 'amplify-cli-core/src/types';
 import { CommandLineInput as CommandLineInput_2 } from 'amplify-cli-core';
 import { IAmplifyLogger } from '@aws-amplify/amplify-cli-logger';

--- a/packages/amplify-cli/src/domain/amplify-toolkit.ts
+++ b/packages/amplify-cli/src/domain/amplify-toolkit.ts
@@ -1,16 +1,7 @@
-import * as path from 'path';
-import { $TSContext } from 'amplify-cli-core';
 import { Context } from './context';
 
 export class AmplifyToolkit {
   private _cleanUpTasks: Array<(...args: any[]) => any>;
-  private _invokePluginMethod?: <T>(
-    context: $TSContext,
-    category: string,
-    service: string | null,
-    method: string,
-    args: any[],
-  ) => Promise<T>;
 
   get confirmPrompt() {
     return require('../extensions/amplify-helpers/confirm-prompt').confirmPrompt;
@@ -54,7 +45,7 @@ export class AmplifyToolkit {
   get getEnvDetails() {
     return require('../extensions/amplify-helpers/get-env-details').getEnvDetails;
   }
-  get getEnvInfo(): () => any {
+  get getEnvInfo() {
     return require('../extensions/amplify-helpers/get-env-info').getEnvInfo;
   }
   get getPluginInstance() {
@@ -63,10 +54,10 @@ export class AmplifyToolkit {
   get getProjectConfig() {
     return require('../extensions/amplify-helpers/get-project-config').getProjectConfig;
   }
-  get getProjectDetails(): () => any {
+  get getProjectDetails() {
     return require('../extensions/amplify-helpers/get-project-details').getProjectDetails;
   }
-  get getProjectMeta(): () => any {
+  get getProjectMeta() {
     return require('../extensions/amplify-helpers/get-project-meta').getProjectMeta;
   }
   get getResourceStatus() {

--- a/packages/amplify-cli/src/domain/amplify-toolkit.ts
+++ b/packages/amplify-cli/src/domain/amplify-toolkit.ts
@@ -1,84 +1,9 @@
 import * as path from 'path';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { $TSContext } from 'amplify-cli-core';
 import { Context } from './context';
 
 export class AmplifyToolkit {
-  private _confirmPrompt: any;
-  private _constants: any;
-  private _constructExeInfo: any;
-  private _copyBatch: any;
-  private _crudFlow: any;
-  private _deleteProject: any;
-  private _executeProviderUtils: any;
-  private _getAllEnvs: any;
-  private _getPlugin: any;
-  private _getCategoryPluginInfo: any;
-  private _getAllCategoryPluginInfo: any;
-  private _getFrontendPlugins: any;
-  private _getEnvDetails: any;
-  private _getEnvInfo?: () => $TSAny;
-  private _getProviderPlugins: any;
-  private _getPluginInstance: any;
-  private _getProjectConfig: any;
-  private _getProjectDetails?: () => $TSAny;
-  private _getProjectMeta?: () => $TSAny;
-  private _getResourceStatus: any;
-  private _getResourceOutputs: any;
-  private _getWhen: any;
-  private _inputValidation: any;
-  private _listCategories: any;
-  private _makeId: any;
-  private _openEditor: any;
-  private _onCategoryOutputsChange: any;
-  private _pathManager: any;
-  private _pressEnterToContinue: any;
-  private _pushResources: any;
-  private _storeCurrentCloudBackend: any;
-  private _readJsonFile: any;
-  private _removeResource: any;
-  private _sharedQuestions: any;
-  private _showAllHelp: any;
-  private _showHelp: any;
-  private _showHelpfulProviderLinks: any;
-  private _showResourceTable: any;
-  private _showStatusTable: any;
-  private _serviceSelectionPrompt: any;
-  private _updateProjectConfig: any;
-  private _updateamplifyMetaAfterResourceUpdate: any;
-  private _updateamplifyMetaAfterResourceAdd: any;
-  private _updateamplifyMetaAfterResourceDelete: any;
-  private _updateProviderAmplifyMeta: any;
-  private _updateamplifyMetaAfterPush: any;
-  private _updateamplifyMetaAfterBuild: any;
-  private _updateAmplifyMetaAfterPackage: any;
-  private _updateBackendConfigAfterResourceAdd: any;
-  private _updateBackendConfigAfterResourceUpdate: any;
-  private _updateBackendConfigAfterResourceRemove: any;
-  private _loadEnvResourceParameters: any;
-  private _saveEnvResourceParameters: any;
-  private _removeResourceParameters: any;
-  private _removeDeploymentSecrets: any;
-  private _triggerFlow: any;
-  private _addTrigger: any;
-  private _updateTrigger: any;
-  private _deleteTrigger: any;
-  private _deleteAllTriggers: any;
-  private _deleteDeselectedTriggers: any;
-  private _dependsOnBlock: any;
-  private _getTags: any;
-  private _getTriggerMetadata: any;
-  private _getTriggerPermissions: any;
-  private _getTriggerEnvVariables: any;
-  private _getTriggerEnvInputs: any;
-  private _getUserPoolGroupList: any;
-  private _forceRemoveResource: any;
-  private _writeObjectAsJson: any;
-  private _hashDir: any;
-  private _leaveBreadcrumbs: any;
-  private _readBreadcrumbs: any;
-  private _loadRuntimePlugin: any;
-  private _getImportedAuthProperties: any;
-  private _cleanUpTasks: Array<(...args) => any>;
+  private _cleanUpTasks: Array<(...args: any[]) => any>;
   private _invokePluginMethod?: <T>(
     context: $TSContext,
     category: string,
@@ -87,378 +12,243 @@ export class AmplifyToolkit {
     args: any[],
   ) => Promise<T>;
 
-  private _amplifyHelpersDirPath: string = path.normalize(path.join(__dirname, '../extensions/amplify-helpers'));
-
-  get confirmPrompt(): any {
-    this._confirmPrompt = this._confirmPrompt || require(path.join(this._amplifyHelpersDirPath, 'confirm-prompt')).confirmPrompt;
-    return this._confirmPrompt;
+  get confirmPrompt() {
+    return require('../extensions/amplify-helpers/confirm-prompt').confirmPrompt;
   }
-  get constants(): any {
-    this._constants = this._constants || require(path.join(this._amplifyHelpersDirPath, 'constants')).amplifyCLIConstants;
-    return this._constants;
+  get constants() {
+    return require('../extensions/amplify-helpers/constants').amplifyCLIConstants;
   }
-  get constructExeInfo(): any {
-    this._constructExeInfo =
-      this._constructExeInfo || require(path.join(this._amplifyHelpersDirPath, 'construct-exeInfo')).constructExeInfo;
-    return this._constructExeInfo;
+  get constructExeInfo() {
+    return require('../extensions/amplify-helpers/construct-exeInfo').constructExeInfo;
   }
-  get copyBatch(): any {
-    this._copyBatch = this._copyBatch || require(path.join(this._amplifyHelpersDirPath, 'copy-batch')).copyBatch;
-    return this._copyBatch;
+  get copyBatch() {
+    return require('../extensions/amplify-helpers/copy-batch').copyBatch;
   }
-  get crudFlow(): any {
-    this._crudFlow = this._crudFlow || require(path.join(this._amplifyHelpersDirPath, 'permission-flow')).crudFlow;
-    return this._crudFlow;
+  get crudFlow() {
+    return require('../extensions/amplify-helpers/permission-flow').crudFlow;
   }
-  get deleteProject(): any {
-    this._deleteProject = this._deleteProject || require(path.join(this._amplifyHelpersDirPath, 'delete-project')).deleteProject;
-    return this._deleteProject;
+  get deleteProject() {
+    return require('../extensions/amplify-helpers/delete-project').deleteProject;
   }
-  get executeProviderUtils(): any {
-    this._executeProviderUtils =
-      this._executeProviderUtils || require(path.join(this._amplifyHelpersDirPath, 'execute-provider-utils')).executeProviderUtils;
-    return this._executeProviderUtils;
+  get executeProviderUtils() {
+    return require('../extensions/amplify-helpers/execute-provider-utils').executeProviderUtils;
   }
-  get getAllEnvs(): any {
-    this._getAllEnvs = this._getAllEnvs || require(path.join(this._amplifyHelpersDirPath, 'get-all-envs')).getAllEnvs;
-    return this._getAllEnvs;
+  get getAllEnvs() {
+    return require('../extensions/amplify-helpers/get-all-envs').getAllEnvs;
   }
-  get getPlugin(): any {
-    this._getPlugin = this._getPlugin || require(path.join(this._amplifyHelpersDirPath, 'get-plugin')).getPlugin;
-    return this._getPlugin;
+  get getPlugin() {
+    return require('../extensions/amplify-helpers/get-plugin').getPlugin;
   }
-  get getCategoryPluginInfo(): any {
-    this._getCategoryPluginInfo =
-      this._getCategoryPluginInfo || require(path.join(this._amplifyHelpersDirPath, 'get-category-pluginInfo')).getCategoryPluginInfo;
-    return this._getCategoryPluginInfo;
+  get getCategoryPluginInfo() {
+    return require('../extensions/amplify-helpers/get-category-pluginInfo').getCategoryPluginInfo;
   }
-  get getAllCategoryPluginInfo(): any {
-    this._getAllCategoryPluginInfo =
-      this._getAllCategoryPluginInfo ||
-      require(path.join(this._amplifyHelpersDirPath, 'get-all-category-pluginInfos')).getAllCategoryPluginInfo;
-    return this._getAllCategoryPluginInfo;
+  get getAllCategoryPluginInfo() {
+    return require('../extensions/amplify-helpers/get-all-category-pluginInfos').getAllCategoryPluginInfo;
   }
-  get getFrontendPlugins(): any {
-    this._getFrontendPlugins =
-      this._getFrontendPlugins || require(path.join(this._amplifyHelpersDirPath, 'get-frontend-plugins')).getFrontendPlugins;
-    return this._getFrontendPlugins;
+  get getFrontendPlugins() {
+    return require('../extensions/amplify-helpers/get-frontend-plugins').getFrontendPlugins;
   }
-  get getProviderPlugins(): any {
-    this._getProviderPlugins =
-      this._getProviderPlugins || require(path.join(this._amplifyHelpersDirPath, 'get-provider-plugins')).getProviderPlugins;
-    return this._getProviderPlugins;
+  get getProviderPlugins() {
+    return require('../extensions/amplify-helpers/get-provider-plugins').getProviderPlugins;
   }
-  get getEnvDetails(): any {
-    this._getEnvDetails = this._getEnvDetails || require(path.join(this._amplifyHelpersDirPath, 'get-env-details')).getEnvDetails;
-    return this._getEnvDetails;
+  get getEnvDetails() {
+    return require('../extensions/amplify-helpers/get-env-details').getEnvDetails;
   }
-  get getEnvInfo(): () => $TSAny {
-    this._getEnvInfo = this._getEnvInfo || require(path.join(this._amplifyHelpersDirPath, 'get-env-info')).getEnvInfo;
-    return this._getEnvInfo!;
+  get getEnvInfo(): () => any {
+    return require('../extensions/amplify-helpers/get-env-info').getEnvInfo;
   }
-  get getPluginInstance(): any {
-    this._getPluginInstance =
-      this._getPluginInstance || require(path.join(this._amplifyHelpersDirPath, 'get-plugin-instance')).getPluginInstance;
-    return this._getPluginInstance;
+  get getPluginInstance() {
+    return require('../extensions/amplify-helpers/get-plugin-instance').getPluginInstance;
   }
-  get getProjectConfig(): any {
-    this._getProjectConfig =
-      this._getProjectConfig || require(path.join(this._amplifyHelpersDirPath, 'get-project-config')).getProjectConfig;
-    return this._getProjectConfig;
+  get getProjectConfig() {
+    return require('../extensions/amplify-helpers/get-project-config').getProjectConfig;
   }
-  get getProjectDetails(): () => $TSAny {
-    this._getProjectDetails =
-      this._getProjectDetails || require(path.join(this._amplifyHelpersDirPath, 'get-project-details')).getProjectDetails;
-    return this._getProjectDetails!;
+  get getProjectDetails(): () => any {
+    return require('../extensions/amplify-helpers/get-project-details').getProjectDetails;
   }
-  get getProjectMeta(): () => $TSAny {
-    this._getProjectMeta = this._getProjectMeta || require(path.join(this._amplifyHelpersDirPath, 'get-project-meta')).getProjectMeta;
-    return this._getProjectMeta!;
+  get getProjectMeta(): () => any {
+    return require('../extensions/amplify-helpers/get-project-meta').getProjectMeta;
   }
-  get getResourceStatus(): any {
-    this._getResourceStatus =
-      this._getResourceStatus || require(path.join(this._amplifyHelpersDirPath, 'resource-status')).getResourceStatus;
-    return this._getResourceStatus;
+  get getResourceStatus() {
+    return require('../extensions/amplify-helpers/resource-status').getResourceStatus;
   }
-  get getResourceOutputs(): any {
-    this._getResourceOutputs =
-      this._getResourceOutputs || require(path.join(this._amplifyHelpersDirPath, 'get-resource-outputs')).getResourceOutputs;
-    return this._getResourceOutputs;
+  get getResourceOutputs() {
+    return require('../extensions/amplify-helpers/get-resource-outputs').getResourceOutputs;
   }
-  get getWhen(): any {
-    this._getWhen = this._getWhen || require(path.join(this._amplifyHelpersDirPath, 'get-when-function')).getWhen;
-    return this._getWhen;
+  get getWhen() {
+    return require('../extensions/amplify-helpers/get-when-function').getWhen;
   }
-  get inputValidation(): any {
-    this._inputValidation = this._inputValidation || require(path.join(this._amplifyHelpersDirPath, 'input-validation')).inputValidation;
-    return this._inputValidation;
+  get inputValidation() {
+    return require('../extensions/amplify-helpers/input-validation').inputValidation;
   }
-  get listCategories(): any {
-    this._listCategories = this._listCategories || require(path.join(this._amplifyHelpersDirPath, 'list-categories')).listCategories;
-    return this._listCategories;
+  get listCategories() {
+    return require('../extensions/amplify-helpers/list-categories').listCategories;
   }
-  get makeId(): any {
-    this._makeId = this._makeId || require(path.join(this._amplifyHelpersDirPath, 'make-id')).makeId;
-    return this._makeId;
+  get makeId() {
+    return require('../extensions/amplify-helpers/make-id').makeId;
   }
-  get openEditor(): any {
-    this._openEditor = this._openEditor || require(path.join(this._amplifyHelpersDirPath, 'open-editor')).openEditor;
-    return this._openEditor;
+  get openEditor() {
+    return require('../extensions/amplify-helpers/open-editor').openEditor;
   }
-  get onCategoryOutputsChange(): any {
-    this._onCategoryOutputsChange =
-      this._onCategoryOutputsChange ||
-      require(path.join(this._amplifyHelpersDirPath, 'on-category-outputs-change')).onCategoryOutputsChange;
-    return this._onCategoryOutputsChange;
+  get onCategoryOutputsChange() {
+    return require('../extensions/amplify-helpers/on-category-outputs-change').onCategoryOutputsChange;
   }
-  get pathManager(): any {
-    this._pathManager = this._pathManager || require(path.join(this._amplifyHelpersDirPath, 'path-manager'));
-    return this._pathManager;
+  get pathManager() {
+    return require('../extensions/amplify-helpers/path-manager');
   }
-  get pressEnterToContinue(): any {
-    this._pressEnterToContinue = this._pressEnterToContinue || require(path.join(this._amplifyHelpersDirPath, 'press-enter-to-continue'));
-    return this._pressEnterToContinue;
+  get pressEnterToContinue() {
+    return require('../extensions/amplify-helpers/press-enter-to-continue');
   }
-  get pushResources(): any {
-    this._pushResources = this._pushResources || require(path.join(this._amplifyHelpersDirPath, 'push-resources')).pushResources;
-    return this._pushResources;
+  get pushResources() {
+    return require('../extensions/amplify-helpers/push-resources').pushResources;
   }
-  get storeCurrentCloudBackend(): any {
-    this._storeCurrentCloudBackend =
-      this._storeCurrentCloudBackend || require(path.join(this._amplifyHelpersDirPath, 'push-resources')).storeCurrentCloudBackend;
-    return this._storeCurrentCloudBackend;
+  get storeCurrentCloudBackend() {
+    return require('../extensions/amplify-helpers/push-resources').storeCurrentCloudBackend;
   }
-  get readJsonFile(): any {
-    this._readJsonFile = this._readJsonFile || require(path.join(this._amplifyHelpersDirPath, 'read-json-file')).readJsonFile;
-    return this._readJsonFile;
+  get readJsonFile() {
+    return require('../extensions/amplify-helpers/read-json-file').readJsonFile;
   }
-  get removeResource(): any {
-    this._removeResource = this._removeResource || require(path.join(this._amplifyHelpersDirPath, 'remove-resource')).removeResource;
-    return this._removeResource;
+  get removeResource() {
+    return require('../extensions/amplify-helpers/remove-resource').removeResource;
   }
-  get sharedQuestions(): any {
-    this._sharedQuestions = this._sharedQuestions || require(path.join(this._amplifyHelpersDirPath, 'shared-questions')).sharedQuestions;
-    return this._sharedQuestions;
+  get sharedQuestions() {
+    return require('../extensions/amplify-helpers/shared-questions').sharedQuestions;
   }
-  get showHelp(): any {
-    this._showHelp = this._showHelp || require(path.join(this._amplifyHelpersDirPath, 'show-help')).showHelp;
-    return this._showHelp;
+  get showHelp() {
+    return require('../extensions/amplify-helpers/show-help').showHelp;
   }
-  get showAllHelp(): any {
-    this._showAllHelp = this._showAllHelp || require(path.join(this._amplifyHelpersDirPath, 'show-all-help')).showAllHelp;
-    return this._showAllHelp;
+  get showAllHelp() {
+    return require('../extensions/amplify-helpers/show-all-help').showAllHelp;
   }
-  get showHelpfulProviderLinks(): any {
-    this._showHelpfulProviderLinks =
-      this._showHelpfulProviderLinks ||
-      require(path.join(this._amplifyHelpersDirPath, 'show-helpful-provider-links')).showHelpfulProviderLinks;
-    return this._showHelpfulProviderLinks;
+  get showHelpfulProviderLinks() {
+    return require('../extensions/amplify-helpers/show-helpful-provider-links').showHelpfulProviderLinks;
   }
-  get showResourceTable(): any {
-    this._showResourceTable =
-      this._showResourceTable || require(path.join(this._amplifyHelpersDirPath, 'resource-status')).showResourceTable;
-    return this._showResourceTable;
+  get showResourceTable() {
+    return require('../extensions/amplify-helpers/resource-status').showResourceTable;
+  }
+  get showStatusTable() {
+    return require('../extensions/amplify-helpers/resource-status').showStatusTable;
+  }
+  get serviceSelectionPrompt() {
+    return require('../extensions/amplify-helpers/service-select-prompt').serviceSelectionPrompt;
+  }
+  get updateProjectConfig() {
+    return require('../extensions/amplify-helpers/update-project-config').updateProjectConfig;
+  }
+  get updateamplifyMetaAfterResourceUpdate() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateamplifyMetaAfterResourceUpdate;
+  }
+  get updateamplifyMetaAfterResourceAdd() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateamplifyMetaAfterResourceAdd;
+  }
+  get updateamplifyMetaAfterResourceDelete() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateamplifyMetaAfterResourceDelete;
+  }
+  get updateProviderAmplifyMeta() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateProviderAmplifyMeta;
+  }
+  get updateamplifyMetaAfterPush() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateamplifyMetaAfterPush;
+  }
+  get updateamplifyMetaAfterBuild() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateamplifyMetaAfterBuild;
+  }
+  get updateAmplifyMetaAfterPackage() {
+    return require('../extensions/amplify-helpers/update-amplify-meta').updateAmplifyMetaAfterPackage;
+  }
+  get updateBackendConfigAfterResourceAdd() {
+    return require('../extensions/amplify-helpers/update-backend-config').updateBackendConfigAfterResourceAdd;
+  }
+  get updateBackendConfigAfterResourceUpdate() {
+    return require('../extensions/amplify-helpers/update-backend-config').updateBackendConfigAfterResourceUpdate;
+  }
+  get updateBackendConfigAfterResourceRemove() {
+    return require('../extensions/amplify-helpers/update-backend-config').updateBackendConfigAfterResourceRemove;
+  }
+  get loadEnvResourceParameters() {
+    return require('../extensions/amplify-helpers/envResourceParams').loadEnvResourceParameters;
+  }
+  get saveEnvResourceParameters() {
+    return require('../extensions/amplify-helpers/envResourceParams').saveEnvResourceParameters;
+  }
+  get removeResourceParameters() {
+    return require('../extensions/amplify-helpers/envResourceParams').removeResourceParameters;
   }
 
-  get showStatusTable(): any {
-    this._showStatusTable = this._showStatusTable || require(path.join(this._amplifyHelpersDirPath, 'resource-status')).showStatusTable;
-    return this._showStatusTable;
+  get removeDeploymentSecrets() {
+    return require('../extensions/amplify-helpers/envResourceParams').removeDeploymentSecrets;
   }
 
-  get serviceSelectionPrompt(): any {
-    this._serviceSelectionPrompt =
-      this._serviceSelectionPrompt || require(path.join(this._amplifyHelpersDirPath, 'service-select-prompt')).serviceSelectionPrompt;
-    return this._serviceSelectionPrompt;
+  get triggerFlow() {
+    return require('../extensions/amplify-helpers/trigger-flow').triggerFlow;
   }
-  get updateProjectConfig(): any {
-    this._updateProjectConfig =
-      this._updateProjectConfig || require(path.join(this._amplifyHelpersDirPath, 'update-project-config')).updateProjectConfig;
-    return this._updateProjectConfig;
+  get addTrigger() {
+    return require('../extensions/amplify-helpers/trigger-flow').addTrigger;
   }
-  get updateamplifyMetaAfterResourceUpdate(): any {
-    this._updateamplifyMetaAfterResourceUpdate =
-      this._updateamplifyMetaAfterResourceUpdate ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateamplifyMetaAfterResourceUpdate;
-    return this._updateamplifyMetaAfterResourceUpdate;
+  get updateTrigger() {
+    return require('../extensions/amplify-helpers/trigger-flow').updateTrigger;
   }
-  get updateamplifyMetaAfterResourceAdd(): any {
-    this._updateamplifyMetaAfterResourceAdd =
-      this._updateamplifyMetaAfterResourceAdd ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateamplifyMetaAfterResourceAdd;
-    return this._updateamplifyMetaAfterResourceAdd;
+  get deleteTrigger() {
+    return require('../extensions/amplify-helpers/trigger-flow').deleteTrigger;
   }
-  get updateamplifyMetaAfterResourceDelete(): any {
-    this._updateamplifyMetaAfterResourceDelete =
-      this._updateamplifyMetaAfterResourceDelete ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateamplifyMetaAfterResourceDelete;
-    return this._updateamplifyMetaAfterResourceDelete;
+  get deleteAllTriggers() {
+    return require('../extensions/amplify-helpers/trigger-flow').deleteAllTriggers;
   }
-  get updateProviderAmplifyMeta(): any {
-    this._updateProviderAmplifyMeta =
-      this._updateProviderAmplifyMeta || require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateProviderAmplifyMeta;
-    return this._updateProviderAmplifyMeta;
+  get deleteDeselectedTriggers() {
+    return require('../extensions/amplify-helpers/trigger-flow').deleteDeselectedTriggers;
   }
-  get updateamplifyMetaAfterPush(): any {
-    this._updateamplifyMetaAfterPush =
-      this._updateamplifyMetaAfterPush || require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateamplifyMetaAfterPush;
-    return this._updateamplifyMetaAfterPush;
+  get dependsOnBlock() {
+    return require('../extensions/amplify-helpers/trigger-flow').dependsOnBlock;
   }
-  get updateamplifyMetaAfterBuild(): any {
-    this._updateamplifyMetaAfterBuild =
-      this._updateamplifyMetaAfterBuild ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateamplifyMetaAfterBuild;
-    return this._updateamplifyMetaAfterBuild;
+  get getTags() {
+    return require('../extensions/amplify-helpers/get-tags').getTags;
   }
-  get updateAmplifyMetaAfterPackage(): any {
-    this._updateAmplifyMetaAfterPackage =
-      this._updateAmplifyMetaAfterPackage ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-amplify-meta')).updateAmplifyMetaAfterPackage;
-    return this._updateAmplifyMetaAfterPackage;
+  get getTriggerMetadata() {
+    return require('../extensions/amplify-helpers/trigger-flow').getTriggerMetadata;
   }
-  get updateBackendConfigAfterResourceAdd(): any {
-    this._updateBackendConfigAfterResourceAdd =
-      this._updateBackendConfigAfterResourceAdd ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-backend-config')).updateBackendConfigAfterResourceAdd;
-    return this._updateBackendConfigAfterResourceAdd;
+  get getTriggerPermissions() {
+    return require('../extensions/amplify-helpers/trigger-flow').getTriggerPermissions;
   }
-  get updateBackendConfigAfterResourceUpdate(): any {
-    this._updateBackendConfigAfterResourceUpdate =
-      this._updateBackendConfigAfterResourceUpdate ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-backend-config')).updateBackendConfigAfterResourceUpdate;
-    return this._updateBackendConfigAfterResourceUpdate;
+  get getTriggerEnvVariables() {
+    return require('../extensions/amplify-helpers/trigger-flow').getTriggerEnvVariables;
   }
-  get updateBackendConfigAfterResourceRemove(): any {
-    this._updateBackendConfigAfterResourceRemove =
-      this._updateBackendConfigAfterResourceRemove ||
-      require(path.join(this._amplifyHelpersDirPath, 'update-backend-config')).updateBackendConfigAfterResourceRemove;
-    return this._updateBackendConfigAfterResourceRemove;
+  get getTriggerEnvInputs() {
+    return require('../extensions/amplify-helpers/trigger-flow').getTriggerEnvInputs;
   }
-  get loadEnvResourceParameters(): any {
-    this._loadEnvResourceParameters =
-      this._loadEnvResourceParameters || require(path.join(this._amplifyHelpersDirPath, 'envResourceParams')).loadEnvResourceParameters;
-    return this._loadEnvResourceParameters;
-  }
-  get saveEnvResourceParameters(): any {
-    this._saveEnvResourceParameters =
-      this._saveEnvResourceParameters || require(path.join(this._amplifyHelpersDirPath, 'envResourceParams')).saveEnvResourceParameters;
-    return this._saveEnvResourceParameters;
-  }
-  get removeResourceParameters(): any {
-    this._removeResourceParameters =
-      this._removeResourceParameters || require(path.join(this._amplifyHelpersDirPath, 'envResourceParams')).removeResourceParameters;
-    return this._removeResourceParameters;
+  get getUserPoolGroupList() {
+    return require('../extensions/amplify-helpers/get-userpoolgroup-list').getUserPoolGroupList;
   }
 
-  get removeDeploymentSecrets(): any {
-    this._removeDeploymentSecrets =
-      this._removeDeploymentSecrets || require(path.join(this._amplifyHelpersDirPath, 'envResourceParams')).removeDeploymentSecrets;
-    return this._removeDeploymentSecrets;
+  get forceRemoveResource() {
+    return require('../extensions/amplify-helpers/remove-resource').forceRemoveResource;
   }
 
-  get triggerFlow(): any {
-    this._triggerFlow = this._triggerFlow || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).triggerFlow;
-    return this._triggerFlow;
-  }
-  get addTrigger(): any {
-    this._addTrigger = this._addTrigger || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).addTrigger;
-    return this._addTrigger;
-  }
-  get updateTrigger(): any {
-    this._updateTrigger = this._updateTrigger || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).updateTrigger;
-    return this._updateTrigger;
-  }
-  get deleteTrigger(): any {
-    this._deleteTrigger = this._deleteTrigger || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).deleteTrigger;
-    return this._deleteTrigger;
-  }
-  get deleteAllTriggers(): any {
-    this._deleteAllTriggers = this._deleteAllTriggers || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).deleteAllTriggers;
-    return this._deleteAllTriggers;
-  }
-  get deleteDeselectedTriggers(): any {
-    this._deleteDeselectedTriggers =
-      this._deleteDeselectedTriggers || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).deleteDeselectedTriggers;
-    return this._deleteDeselectedTriggers;
-  }
-  get dependsOnBlock(): any {
-    this._dependsOnBlock = this._dependsOnBlock || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).dependsOnBlock;
-    return this._dependsOnBlock;
-  }
-  get getTags(): any {
-    this._getTags = this._getTags || require(path.join(this._amplifyHelpersDirPath, 'get-tags')).getTags;
-    return this._getTags;
-  }
-  get getTriggerMetadata(): any {
-    this._getTriggerMetadata =
-      this._getTriggerMetadata || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).getTriggerMetadata;
-    return this._getTriggerMetadata;
-  }
-  get getTriggerPermissions(): any {
-    this._getTriggerPermissions =
-      this._getTriggerPermissions || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).getTriggerPermissions;
-    return this._getTriggerPermissions;
-  }
-  get getTriggerEnvVariables(): any {
-    this._getTriggerEnvVariables =
-      this._getTriggerEnvVariables || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).getTriggerEnvVariables;
-    return this._getTriggerEnvVariables;
-  }
-  get getTriggerEnvInputs(): any {
-    this._getTriggerEnvInputs =
-      this._getTriggerEnvInputs || require(path.join(this._amplifyHelpersDirPath, 'trigger-flow')).getTriggerEnvInputs;
-    return this._getTriggerEnvInputs;
-  }
-  get getUserPoolGroupList(): any {
-    this._getUserPoolGroupList =
-      this._getUserPoolGroupList || require(path.join(this._amplifyHelpersDirPath, 'get-userpoolgroup-list')).getUserPoolGroupList;
-    return this._getUserPoolGroupList;
+  get writeObjectAsJson() {
+    return require('../extensions/amplify-helpers/write-object-as-json').writeObjectAsJson;
   }
 
-  get forceRemoveResource(): any {
-    this._forceRemoveResource =
-      this._forceRemoveResource || require(path.join(this._amplifyHelpersDirPath, 'remove-resource')).forceRemoveResource;
-    return this._forceRemoveResource;
+  get hashDir() {
+    return require('../extensions/amplify-helpers/hash-dir').hashDir;
   }
 
-  get writeObjectAsJson(): any {
-    this._writeObjectAsJson =
-      this._writeObjectAsJson || require(path.join(this._amplifyHelpersDirPath, 'write-object-as-json')).writeObjectAsJson;
-    return this._writeObjectAsJson;
+  get leaveBreadcrumbs() {
+    return require('../extensions/amplify-helpers/leave-breadcrumbs').leaveBreadcrumbs;
   }
 
-  get hashDir(): any {
-    this._hashDir = this._hashDir || require(path.join(this._amplifyHelpersDirPath, 'hash-dir')).hashDir;
-    return this._hashDir;
+  get readBreadcrumbs() {
+    return require('../extensions/amplify-helpers/read-breadcrumbs').readBreadcrumbs;
   }
 
-  get leaveBreadcrumbs(): any {
-    this._leaveBreadcrumbs =
-      this._leaveBreadcrumbs || require(path.join(this._amplifyHelpersDirPath, 'leave-breadcrumbs')).leaveBreadcrumbs;
-    return this._leaveBreadcrumbs;
+  get loadRuntimePlugin() {
+    return require('../extensions/amplify-helpers/load-runtime-plugin').loadRuntimePlugin;
   }
 
-  get readBreadcrumbs(): any {
-    this._readBreadcrumbs = this._readBreadcrumbs || require(path.join(this._amplifyHelpersDirPath, 'read-breadcrumbs')).readBreadcrumbs;
-    return this._readBreadcrumbs;
+  get getImportedAuthProperties() {
+    return require('../extensions/amplify-helpers/get-imported-auth-properties').getImportedAuthProperties;
   }
 
-  get loadRuntimePlugin(): any {
-    this._loadRuntimePlugin =
-      this._loadRuntimePlugin || require(path.join(this._amplifyHelpersDirPath, 'load-runtime-plugin')).loadRuntimePlugin;
-    return this._loadRuntimePlugin;
-  }
-
-  get getImportedAuthProperties(): any {
-    this._getImportedAuthProperties =
-      this._getImportedAuthProperties ||
-      require(path.join(this._amplifyHelpersDirPath, 'get-imported-auth-properties')).getImportedAuthProperties;
-    return this._getImportedAuthProperties;
-  }
-
-  get invokePluginMethod(): any {
-    this._invokePluginMethod =
-      this._invokePluginMethod || require(path.join(this._amplifyHelpersDirPath, 'invoke-plugin-method')).invokePluginMethod;
-    return this._invokePluginMethod;
+  get invokePluginMethod() {
+    return require('../extensions/amplify-helpers/invoke-plugin-method').invokePluginMethod;
   }
 
   constructor() {


### PR DESCRIPTION
#### Description of changes

This PR is part of a larger effort to make the Amplify Toolkit easier to use.

Currently, the toolkit is using a pattern similar to a singleton to store references to imported modules in the class. Because `require` already caches imported modules, this redirection is not necessary. Additionally, the Toolkit is using redirection around the import path that does not provide additional value, and makes the file more difficult to understand.

This change removes both the singleton pattern and the multiple `path.join`s around the requires.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
