### PR TITLE
feat: inject project info into overrides

### DIFF
--- a/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
@@ -1,5 +1,5 @@
 import { AmplifyAuthCognitoStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyAuthCognitoStackTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(resources: AmplifyAuthCognitoStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
 
 }

--- a/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/auth/override.ts.sample
@@ -1,5 +1,5 @@
-import { AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyAuthCognitoStackTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyAuthCognitoStackTemplate) {
-    
+export function override(resources: AmplifyAuthCognitoStackTemplate, projectInfo: AmplifyProjectInfo) {
+
 }

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
@@ -1,5 +1,5 @@
-import { AmplifyUserPoolGroupStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyProjectInfo, AmplifyUserPoolGroupStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyUserPoolGroupStackTemplate) {
-    
+export function override(resources: AmplifyUserPoolGroupStackTemplate, projectInfo: AmplifyProjectInfo) {
+
 }

--- a/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
+++ b/packages/amplify-category-auth/resources/overrides-resource/userPoolGroups/override.ts.sample
@@ -1,5 +1,5 @@
 import { AmplifyProjectInfo, AmplifyUserPoolGroupStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyUserPoolGroupStackTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(resources: AmplifyUserPoolGroupStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
 
 }

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -29,6 +29,7 @@ import { generateNestedAuthTriggerTemplate } from '../utils/generate-auth-trigge
 import { createUserPoolGroups, updateUserPoolGroups } from '../utils/synthesize-resources';
 import { AmplifyAuthCognitoStack } from './auth-cognito-stack-builder';
 import { AuthStackSynthesizer } from './stack-synthesizer';
+import { getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 /**
  *  Class to handle Auth cdk generation / override functionality
@@ -123,10 +124,11 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
           external: true,
         },
       });
+      const projectInfo = getProjectInfo();
       try {
         await sandboxNode
           .run(overrideCode, path.join(overrideDir, 'build', 'override.js'))
-          .override(this._authTemplateObj as AmplifyAuthCognitoStack & AmplifyStackTemplate);
+          .override(this._authTemplateObj as AmplifyAuthCognitoStack & AmplifyStackTemplate, projectInfo);
       } catch (err) {
         throw new AmplifyError(
           'InvalidOverrideError',

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -197,7 +197,8 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
       });
       const projectInfo = getProjectInfo();
       try {
-        await sandboxNode.run(overrideCode)
+        await sandboxNode
+          .run(overrideCode)
           .override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate, projectInfo);
       } catch (err: $TSAny) {
         throw new AmplifyError(

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/user-pool-group-stack-transform.ts
@@ -22,6 +22,7 @@ import { AuthInputState } from '../auth-inputs-manager/auth-input-state';
 import { CognitoCLIInputs } from '../service-walkthrough-types/awsCognito-user-input-types';
 import { AmplifyUserPoolGroupStack, AmplifyUserPoolGroupStackOutputs } from './index';
 import { AuthStackSynthesizer } from './stack-synthesizer';
+import { getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 /**
  * UserPool groups metadata
@@ -194,8 +195,10 @@ export class AmplifyUserPoolGroupTransform extends AmplifyCategoryTransform {
         timeout: 5000,
         sandbox: {},
       });
+      const projectInfo = getProjectInfo();
       try {
-        await sandboxNode.run(overrideCode).override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate);
+        await sandboxNode.run(overrideCode)
+          .override(this._userPoolGroupTemplateObj as AmplifyUserPoolGroupStack & AmplifyStackTemplate, projectInfo);
       } catch (err: $TSAny) {
         throw new AmplifyError(
           'InvalidOverrideError',

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
@@ -1,5 +1,5 @@
 import { AmplifyDDBResourceTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyDDBResourceTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(resources: AmplifyDDBResourceTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
 
 }

--- a/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/DynamoDB/override.ts.sample
@@ -1,5 +1,5 @@
-import { AmplifyDDBResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyDDBResourceTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyDDBResourceTemplate) {
-    
+export function override(resources: AmplifyDDBResourceTemplate, projectInfo: AmplifyProjectInfo) {
+
 }

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
@@ -1,5 +1,5 @@
-import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyProjectInfo, AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyS3ResourceTemplate) {
-    
+export function override(resources: AmplifyS3ResourceTemplate, projectInfo: AmplifyProjectInfo) {
+
 }

--- a/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
+++ b/packages/amplify-category-storage/resources/overrides-resource/S3/override.ts.sample
@@ -1,5 +1,5 @@
 import { AmplifyProjectInfo, AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyS3ResourceTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(resources: AmplifyS3ResourceTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
 
 }

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
@@ -1,4 +1,4 @@
-import { AmplifyDDBResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyDDBResourceTemplate, getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import { $TSAny, $TSContext, AmplifyError, buildOverrideDir, JSONUtilities, pathManager } from 'amplify-cli-core';
 import { formatter } from 'amplify-prompts';
 import * as cdk from 'aws-cdk-lib';
@@ -214,8 +214,10 @@ export class DDBStackTransform {
             external: true,
           },
         });
+        const projectInfo = getProjectInfo();
         try {
-          await sandboxNode.run(overrideCode, overrideJSFilePath).override(this._resourceTemplateObj as AmplifyDDBResourceTemplate);
+          await sandboxNode.run(overrideCode, overrideJSFilePath)
+            .override(this._resourceTemplateObj as AmplifyDDBResourceTemplate, projectInfo);
         } catch (err) {
           throw new AmplifyError(
             'InvalidOverrideError',

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/ddb-stack-transform.ts
@@ -216,7 +216,8 @@ export class DDBStackTransform {
         });
         const projectInfo = getProjectInfo();
         try {
-          await sandboxNode.run(overrideCode, overrideJSFilePath)
+          await sandboxNode
+            .run(overrideCode, overrideJSFilePath)
             .override(this._resourceTemplateObj as AmplifyDDBResourceTemplate, projectInfo);
         } catch (err) {
           throw new AmplifyError(

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyS3ResourceTemplate, getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import {
   $TSAny,
   $TSContext,
@@ -223,7 +223,9 @@ export class AmplifyS3ResourceStackTransform {
           },
         });
         try {
-          await sandboxNode.run(overrideCode, overrideJSFilePath).override(this.resourceTemplateObj as AmplifyS3ResourceTemplate);
+          const projectInfo = getProjectInfo();
+          await sandboxNode.run(overrideCode, overrideJSFilePath)
+            .override(this.resourceTemplateObj as AmplifyS3ResourceTemplate, projectInfo);
         } catch (err: $TSAny) {
           throw new AmplifyError(
             'InvalidOverrideError',

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -224,7 +224,8 @@ export class AmplifyS3ResourceStackTransform {
         });
         try {
           const projectInfo = getProjectInfo();
-          await sandboxNode.run(overrideCode, overrideJSFilePath)
+          await sandboxNode
+            .run(overrideCode, overrideJSFilePath)
             .override(this.resourceTemplateObj as AmplifyS3ResourceTemplate, projectInfo);
         } catch (err: $TSAny) {
           throw new AmplifyError(

--- a/packages/amplify-cli-extensibility-helper/API.md
+++ b/packages/amplify-cli-extensibility-helper/API.md
@@ -125,10 +125,10 @@ export interface AmplifyDDBResourceTemplate extends AmplifyCDKL1 {
 }
 
 // @public (undocumented)
-export type AmplifyProjectInfo = {
+export type AmplifyProjectInfo = Readonly<{
     envName: string;
     projectName: string;
-};
+}>;
 
 export { AmplifyResourceProps }
 

--- a/packages/amplify-cli-extensibility-helper/src/types.ts
+++ b/packages/amplify-cli-extensibility-helper/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * PUBLIC API: Amplify project type
  */
-export type AmplifyProjectInfo = {
+export type AmplifyProjectInfo = Readonly<{
   envName: string;
   projectName: string;
-};
+}>;

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -13,6 +13,7 @@ export * from './appsync';
 export * from './envVars';
 export * from './getAppId';
 export * from './headless';
+export * from './overrides';
 export * from './nexpect';
 export * from './pinpoint';
 export * from './projectMeta';

--- a/packages/amplify-e2e-core/src/utils/overrides.ts
+++ b/packages/amplify-e2e-core/src/utils/overrides.ts
@@ -1,0 +1,7 @@
+import * as fs from 'fs-extra';
+
+export const replaceOverrideFileWitProjectInfo = (srcPath: string, destPath: string, envName: string, projectName: string) => {
+  const content = fs.readFileSync(srcPath).toString();
+  const contentWithProjectInfo = content.replace('##EXPECTED_ENV_NAME', envName).replace('##EXPECTED_PROJECT_NAME', projectName);
+  fs.writeFileSync(destPath, contentWithProjectInfo);
+};

--- a/packages/amplify-e2e-core/src/utils/overrides.ts
+++ b/packages/amplify-e2e-core/src/utils/overrides.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 
-export const replaceOverrideFileWitProjectInfo = (srcPath: string, destPath: string, envName: string, projectName: string) => {
+export const replaceOverrideFileWithProjectInfo = (srcPath: string, destPath: string, envName: string, projectName: string) => {
   const content = fs.readFileSync(srcPath).toString();
   const contentWithProjectInfo = content.replace('##EXPECTED_ENV_NAME', envName).replace('##EXPECTED_PROJECT_NAME', projectName);
   fs.writeFileSync(destPath, contentWithProjectInfo);

--- a/packages/amplify-e2e-tests/overrides/override-auth.ts
+++ b/packages/amplify-e2e-tests/overrides/override-auth.ts
@@ -1,6 +1,6 @@
 import { AmplifyProjectInfo, AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(props: AmplifyAuthCognitoStackTemplate, projectInfo: AmplifyProjectInfo): void {
+export function override(props: AmplifyAuthCognitoStackTemplate, amplifyProjectInfo: AmplifyProjectInfo): void {
   props.userPool.deviceConfiguration = {
     challengeRequiredOnNewDevice: true,
   };
@@ -8,7 +8,7 @@ export function override(props: AmplifyAuthCognitoStackTemplate, projectInfo: Am
     attributesRequireVerificationBeforeUpdate: ['email'],
   };
 
-  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+  if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error('Project info is missing in override');
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-auth.ts
+++ b/packages/amplify-e2e-tests/overrides/override-auth.ts
@@ -9,6 +9,6 @@ export function override(props: AmplifyAuthCognitoStackTemplate, amplifyProjectI
   };
 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
-    throw new Error('Project info is missing in override');
+    throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-auth.ts
+++ b/packages/amplify-e2e-tests/overrides/override-auth.ts
@@ -1,9 +1,14 @@
-export function override(props: any): any {
+import { AmplifyProjectInfo, AmplifyAuthCognitoStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(props: AmplifyAuthCognitoStackTemplate, projectInfo: AmplifyProjectInfo): void {
   props.userPool.deviceConfiguration = {
     challengeRequiredOnNewDevice: true,
   };
   props.userPool.userAttributeUpdateSettings = {
     attributesRequireVerificationBeforeUpdate: ['email'],
   };
-  return props;
+
+  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+    throw new Error('Project info is missing in override');
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-auth.ts
+++ b/packages/amplify-e2e-tests/overrides/override-auth.ts
@@ -11,4 +11,12 @@ export function override(props: AmplifyAuthCognitoStackTemplate, amplifyProjectI
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
+
+  if (amplifyProjectInfo.envName != '##EXPECTED_ENV_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
+
+  if (amplifyProjectInfo.projectName != '##EXPECTED_PROJECT_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -9,4 +9,12 @@ export function override(props: AmplifyRootStackTemplate, amplifyProjectInfo: Am
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
+
+  if (amplifyProjectInfo.envName != '##EXPECTED_ENV_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
+
+  if (amplifyProjectInfo.projectName != '##EXPECTED_PROJECT_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -3,10 +3,10 @@ import { AmplifyProjectInfo, AmplifyRootStackTemplate } from '@aws-amplify/cli-e
 function getRandomInt(max) {
   return Math.floor(Math.random() * max);
 }
-export function override(props: AmplifyRootStackTemplate, projectInfo: AmplifyProjectInfo): void {
+export function override(props: AmplifyRootStackTemplate, amplifyProjectInfo: AmplifyProjectInfo): void {
   props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
 
-  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+  if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error('Project info is missing in override');
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -1,7 +1,12 @@
+import { AmplifyProjectInfo, AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+
 function getRandomInt(max) {
   return Math.floor(Math.random() * max);
 }
-export function override(props: any): void {
+export function override(props: AmplifyRootStackTemplate, projectInfo: AmplifyProjectInfo): void {
   props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
-  return props;
+
+  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+    throw new Error('Project info is missing in override');
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -7,6 +7,6 @@ export function override(props: AmplifyRootStackTemplate, amplifyProjectInfo: Am
   props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
-    throw new Error('Project info is missing in override');
+    throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
@@ -1,5 +1,11 @@
-export function override(props: any) {
+import { AmplifyDDBResourceTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(props: AmplifyDDBResourceTemplate, projectInfo: AmplifyProjectInfo): void {
   props.dynamoDBTable.streamSpecification = {
     streamViewType: 'NEW_AND_OLD_IMAGES',
   };
+
+  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+    throw new Error('Project info is missing in override');
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
@@ -6,6 +6,6 @@ export function override(props: AmplifyDDBResourceTemplate, amplifyProjectInfo: 
   };
 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
-    throw new Error('Project info is missing in override');
+    throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
@@ -8,4 +8,12 @@ export function override(props: AmplifyDDBResourceTemplate, amplifyProjectInfo: 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
+
+  if (amplifyProjectInfo.envName != '##EXPECTED_ENV_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
+
+  if (amplifyProjectInfo.projectName != '##EXPECTED_PROJECT_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-ddb.ts
@@ -1,11 +1,11 @@
 import { AmplifyDDBResourceTemplate, AmplifyProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(props: AmplifyDDBResourceTemplate, projectInfo: AmplifyProjectInfo): void {
+export function override(props: AmplifyDDBResourceTemplate, amplifyProjectInfo: AmplifyProjectInfo): void {
   props.dynamoDBTable.streamSpecification = {
     streamViewType: 'NEW_AND_OLD_IMAGES',
   };
 
-  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+  if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error('Project info is missing in override');
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
@@ -1,12 +1,12 @@
 import { AmplifyProjectInfo, AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(props: AmplifyS3ResourceTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(props: AmplifyS3ResourceTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
   //Enable versioning on the bucket
   props.s3Bucket.versioningConfiguration = {
     status: 'Enabled',
   };
 
-  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+  if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error('Project info is missing in override');
   }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
@@ -9,4 +9,12 @@ export function override(props: AmplifyS3ResourceTemplate, amplifyProjectInfo: A
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
+
+  if (amplifyProjectInfo.envName != '##EXPECTED_ENV_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
+
+  if (amplifyProjectInfo.projectName != '##EXPECTED_PROJECT_NAME') {
+    throw new Error(`Unexpected envName: ${amplifyProjectInfo.envName}`);
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
@@ -1,6 +1,12 @@
-export function override(props: any) {
+import { AmplifyProjectInfo, AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+
+export function override(props: AmplifyS3ResourceTemplate, projectInfo: AmplifyProjectInfo) {
   //Enable versioning on the bucket
   props.s3Bucket.versioningConfiguration = {
     status: 'Enabled',
   };
+
+  if (!projectInfo || !projectInfo.envName || !projectInfo.projectName) {
+    throw new Error('Project info is missing in override');
+  }
 }

--- a/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
+++ b/packages/amplify-e2e-tests/overrides/override-storage-s3.ts
@@ -7,6 +7,6 @@ export function override(props: AmplifyS3ResourceTemplate, amplifyProjectInfo: A
   };
 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
-    throw new Error('Project info is missing in override');
+    throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);
   }
 }

--- a/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
@@ -11,7 +11,7 @@ import {
   getProjectMeta,
   getUserPool,
   initJSProjectWithProfile,
-  replaceOverrideFileWitProjectInfo,
+  replaceOverrideFileWithProjectInfo,
   runAmplifyAuthConsole,
 } from '@aws-amplify/amplify-e2e-core';
 import * as path from 'path';
@@ -102,7 +102,7 @@ describe('zero config auth', () => {
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-auth.ts');
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', PROJECT_NAME);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', PROJECT_NAME);
     await amplifyPushOverride(projRoot);
 
     // check overwritten config

--- a/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
@@ -11,6 +11,7 @@ import {
   getProjectMeta,
   getUserPool,
   initJSProjectWithProfile,
+  replaceOverrideFileWitProjectInfo,
   runAmplifyAuthConsole,
 } from '@aws-amplify/amplify-e2e-core';
 import * as path from 'path';
@@ -101,7 +102,7 @@ describe('zero config auth', () => {
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-auth.ts');
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', PROJECT_NAME);
     await amplifyPushOverride(projRoot);
 
     // check overwritten config

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -62,6 +62,7 @@ describe('amplify init e', () => {
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');
 
     // create a new env, and the override should remain in place
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'envb', projectName);
     await addEnvironment(projRoot, { envName: 'envb' });
     const newestEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newestEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -11,7 +11,7 @@ import {
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
-  replaceOverrideFileWitProjectInfo,
+  replaceOverrideFileWithProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 
 import { addEnvironment } from '../environment/env';
@@ -56,13 +56,13 @@ describe('amplify init e', () => {
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-root.ts');
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');
 
     // create a new env, and the override should remain in place
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'envb', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'envb', projectName);
     await addEnvironment(projRoot, { envName: 'envb' });
     const newestEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newestEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -11,6 +11,7 @@ import {
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
+  replaceOverrideFileWitProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 
 import { addEnvironment } from '../environment/env';
@@ -27,7 +28,8 @@ describe('amplify init e', () => {
   });
 
   it('should init the project and override root and push', async () => {
-    await initJSProjectWithProfile(projRoot, {});
+    const projectName = 'initTest';
+    await initJSProjectWithProfile(projRoot, { name: projectName });
     const meta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(meta.Region).toBeDefined();
     const { AuthRoleName, UnauthRoleName, UnauthRoleArn, AuthRoleArn, DeploymentBucketName } = meta;
@@ -54,7 +56,7 @@ describe('amplify init e', () => {
 
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-root.ts');
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
@@ -16,7 +16,7 @@ import {
   initJSProjectWithProfile,
   overrideDDB,
   overrideS3,
-  replaceOverrideFileWitProjectInfo,
+  replaceOverrideFileWithProjectInfo,
   updateDDBWithTrigger,
   updateSimpleDDBwithGSI,
 } from '@aws-amplify/amplify-e2e-core';
@@ -70,7 +70,7 @@ describe('s3 override tests', () => {
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-storage-s3.ts');
     const cfnFilePath = path.join(projRoot, 'amplify', 'backend', 'storage', resourceName, 'build', 'cloudformation-template.json');
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await buildOverrideStorage(projRoot);
     let s3CFNFileJSON = JSONUtilities.readJson<$TSObject>(cfnFilePath);
     // check if overrides are applied to the cfn file
@@ -207,7 +207,7 @@ describe('ddb override tests', () => {
       `${resourceName}-cloudformation-template.json`,
     );
 
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await buildOverrideStorage(projRoot);
     let ddbCFNFileJSON = JSONUtilities.readJson<$TSObject>(cfnFilePath);
     // check if overrides are applied to the cfn file

--- a/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
@@ -16,6 +16,7 @@ import {
   initJSProjectWithProfile,
   overrideDDB,
   overrideS3,
+  replaceOverrideFileWitProjectInfo,
   updateDDBWithTrigger,
   updateSimpleDDBwithGSI,
 } from '@aws-amplify/amplify-e2e-core';
@@ -44,7 +45,8 @@ describe('s3 override tests', () => {
   });
 
   it('override S3 Removal property', async () => {
-    await initJSProjectWithProfile(projRoot, {});
+    const projectName = 's3OverrideTest';
+    await initJSProjectWithProfile(projRoot, { name: projectName });
     await addAuthWithDefault(projRoot, {});
     await addS3WithGuestAccess(projRoot, {});
     await overrideS3(projRoot);
@@ -68,7 +70,7 @@ describe('s3 override tests', () => {
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-storage-s3.ts');
     const cfnFilePath = path.join(projRoot, 'amplify', 'backend', 'storage', resourceName, 'build', 'cloudformation-template.json');
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await buildOverrideStorage(projRoot);
     let s3CFNFileJSON = JSONUtilities.readJson<$TSObject>(cfnFilePath);
     // check if overrides are applied to the cfn file
@@ -173,7 +175,8 @@ describe('ddb override tests', () => {
 
   it('override DDB StreamSpecification property', async () => {
     const resourceName = `dynamo${uuid.v4().split('-')[0]}`;
-    await initJSProjectWithProfile(projRoot, {});
+    const projectName = 'ddbOverrideTest';
+    await initJSProjectWithProfile(projRoot, { name: projectName });
     await addSimpleDDB(projRoot, { name: resourceName });
     await overrideDDB(projRoot);
 
@@ -204,7 +207,7 @@ describe('ddb override tests', () => {
       `${resourceName}-cloudformation-template.json`,
     );
 
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await buildOverrideStorage(projRoot);
     let ddbCFNFileJSON = JSONUtilities.readJson<$TSObject>(cfnFilePath);
     // check if overrides are applied to the cfn file

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
@@ -7,6 +7,7 @@ import {
   deleteProjectDir,
   getProjectMeta,
   amplifyPushOverride,
+  replaceOverrideFileWitProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 import { JSONUtilities } from 'amplify-cli-core';
 import { versionCheck, allowedVersionsToMigrateFrom, initJSProjectWithProfileV4_52_0 } from '../../../migration-helpers';
@@ -30,7 +31,8 @@ describe('amplify init', () => {
   });
 
   it('should init the project and override root and push', async () => {
-    await initJSProjectWithProfileV4_52_0(projRoot, {});
+    const projectName = 'initMigrationTest';
+    await initJSProjectWithProfileV4_52_0(projRoot, { name: projectName });
     const meta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(meta.Region).toBeDefined();
     // turn ON feature flag
@@ -42,7 +44,7 @@ describe('amplify init', () => {
     await amplifyOverrideRoot(projRoot, { testingWithLatestCodebase: true });
     const srcOverrideFilePath = path.join(__dirname, '..', '..', '..', '..', '..', 'amplify-e2e-tests', 'overrides', 'override-root.ts');
     const destOverrideFilePath = path.join(projRoot, 'amplify', 'backend', 'awscloudformation', 'override.ts');
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot, true);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
 import {
   deleteProject,

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests/overrides/init-migration.test.ts
@@ -6,7 +6,7 @@ import {
   deleteProjectDir,
   getProjectMeta,
   amplifyPushOverride,
-  replaceOverrideFileWitProjectInfo,
+  replaceOverrideFileWithProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 import { JSONUtilities } from 'amplify-cli-core';
 import { versionCheck, allowedVersionsToMigrateFrom, initJSProjectWithProfileV4_52_0 } from '../../../migration-helpers';
@@ -43,7 +43,7 @@ describe('amplify init', () => {
     await amplifyOverrideRoot(projRoot, { testingWithLatestCodebase: true });
     const srcOverrideFilePath = path.join(__dirname, '..', '..', '..', '..', '..', 'amplify-e2e-tests', 'overrides', 'override-root.ts');
     const destOverrideFilePath = path.join(projRoot, 'amplify', 'backend', 'awscloudformation', 'override.ts');
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot, true);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/auth-override.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/auth-override.migration.test.ts
@@ -10,7 +10,7 @@ import {
   getAppId,
   getProjectMeta,
   getUserPool,
-  replaceOverrideFileWitProjectInfo,
+  replaceOverrideFileWithProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 import { versionCheck, allowedVersionsToMigrateFrom } from '../../migration-helpers';
 import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
@@ -56,7 +56,7 @@ describe('amplify migration test auth', () => {
     // this is where we will write our override logic to
     const destOverrideFilePath = path.join(projRoot1, 'amplify', 'backend', 'auth', `${authResourceName}`, 'override.ts');
     const srcOverrideFilePath = path.join(__dirname, '..', '..', '..', 'overrides', 'override-auth.ts');
-    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot1);
 
     const appId = getAppId(projRoot1);

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/auth-override.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/auth-override.migration.test.ts
@@ -10,12 +10,12 @@ import {
   getAppId,
   getProjectMeta,
   getUserPool,
+  replaceOverrideFileWitProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
 import { versionCheck, allowedVersionsToMigrateFrom } from '../../migration-helpers';
 import { initJSProjectWithProfileV10 } from '../../migration-helpers-v10/init';
 import { assertNoParameterChangesBetweenProjects, collectCloudformationDiffBetweenProjects } from '../../migration-helpers/utils';
 import * as path from 'path';
-import * as fs from 'fs-extra';
 
 describe('amplify migration test auth', () => {
   let projRoot1: string;
@@ -41,7 +41,8 @@ describe('amplify migration test auth', () => {
   });
 
   it('...should add auth with overrides and work fine on latest version', async () => {
-    await initJSProjectWithProfileV10(projRoot1, { name: 'authTest', disableAmplifyAppCreation: false });
+    const projectName = 'authTest';
+    await initJSProjectWithProfileV10(projRoot1, { name: projectName, disableAmplifyAppCreation: false });
 
     await addAuthWithDefault(projRoot1, {});
     await amplifyPushWithoutCodegen(projRoot1);
@@ -55,7 +56,7 @@ describe('amplify migration test auth', () => {
     // this is where we will write our override logic to
     const destOverrideFilePath = path.join(projRoot1, 'amplify', 'backend', 'auth', `${authResourceName}`, 'override.ts');
     const srcOverrideFilePath = path.join(__dirname, '..', '..', '..', 'overrides', 'override-auth.ts');
-    fs.copyFileSync(srcOverrideFilePath, destOverrideFilePath);
+    replaceOverrideFileWitProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
     await amplifyPushOverride(projRoot1);
 
     const appId = getAppId(projRoot1);

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
@@ -1,5 +1,5 @@
-import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyProjectInfo, AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyRootStackTemplate) {
-    
+export function override(resources: AmplifyRootStackTemplate, projectInfo: AmplifyProjectInfo) {
+
 }

--- a/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
+++ b/packages/amplify-provider-awscloudformation/resources/overrides-resource/override.ts.sample
@@ -1,5 +1,5 @@
 import { AmplifyProjectInfo, AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
 
-export function override(resources: AmplifyRootStackTemplate, projectInfo: AmplifyProjectInfo) {
+export function override(resources: AmplifyRootStackTemplate, amplifyProjectInfo: AmplifyProjectInfo) {
 
 }

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -24,6 +24,7 @@ import { configurePermissionsBoundaryForInit } from './permissions-boundary/perm
 import { prePushCfnTemplateModifier } from './pre-push-cfn-processor/pre-push-cfn-modifier';
 import { fileLogger } from './utils/aws-logger';
 import { storeCurrentCloudBackend } from './utils/upload-current-cloud-backend';
+import { getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 
 const logger = fileLogger('initializer');
 
@@ -102,7 +103,8 @@ export const run = async (context: $TSContext): Promise<void> => {
               external: true,
             },
           });
-          await sandboxNode.run(overrideCode).override(configuration);
+          const projectInfo = getProjectInfo();
+          await sandboxNode.run(overrideCode).override(configuration, projectInfo);
         }
       } catch (err) {
         // absolutely want to throw if there is a compile or runtime error

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -1,4 +1,4 @@
-import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyRootStackTemplate, getProjectInfo } from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from 'aws-cdk-lib';
 import {
   $TSContext,
@@ -78,8 +78,9 @@ export class AmplifyRootStackTransform {
           external: true,
         },
       });
+      const projectInfo = getProjectInfo();
       try {
-        await sandboxNode.run(overrideCode).override(this._rootTemplateObj as AmplifyRootStackTemplate);
+        await sandboxNode.run(overrideCode).override(this._rootTemplateObj as AmplifyRootStackTemplate, projectInfo);
       } catch (err) {
         throw new AmplifyError(
           'InvalidOverrideError',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR injects `AmplifyProjectInfo` into override functions as second parameter.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
