### PR TITLE
chore: exit publish script on lerna failure

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,5 +1,17 @@
 #!/bin/bash -e
 
+# lerna has a bug (https://github.com/lerna/lerna/issues/1066) where failed publishes do not set the exit code properly
+# this causes the script to keep running even after failed publishes
+# this function forces failed publishes to exit on failure
+function lernaPublishExitOnFailure {
+  # exit on failure
+  set -e
+  # run lerna publish with the args that were passed to this function
+  # duplicate stdout to a temp file
+  # grep the temp file for the lerna err token and return exit 1 if found (-v option inverts grep exit code)
+  npx lerna publish $@ | tee /tmp/publish-results && grep -qvz "lerna ERR!" < /tmp/publish-results
+}
+
 if [ -z "$GITHUB_EMAIL" ]; then
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     git config --global user.email not@used.com
@@ -37,10 +49,10 @@ if [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
 
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     echo "Publishing to local registry under latest tag"
-    npx lerna publish --exact --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-push --yes --include-merged-tags
+    lernaPublishExitOnFailure --exact --preid=$NPM_TAG --conventional-commits --conventional-prerelease --no-push --yes --include-merged-tags
   else
     echo "Publishing to NPM under $NPM_TAG tag"
-    npx lerna publish --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --yes --include-merged-tags
+    lernaPublishExitOnFailure --exact --dist-tag=$NPM_TAG --preid=$NPM_TAG --conventional-commits --conventional-prerelease --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --yes --include-merged-tags
   fi
 
 # @latest release
@@ -49,7 +61,7 @@ elif [[ "$CIRCLE_BRANCH" == "release" ]]; then
   npx lerna version --exact --conventional-commits --conventional-graduate --yes --no-push --include-merged-tags --message "chore(release): Publish latest [ci skip]"
 
   # publish versions that were just computed
-  npx lerna publish from-git --yes --no-push
+  lernaPublishExitOnFailure from-git --yes --no-push
 
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     echo "Published packages to verdaccio"
@@ -88,14 +100,14 @@ elif [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^r
   # if publishing locally to verdaccio
   if [[ "$LOCAL_PUBLISH_TO_LATEST" == "true" ]]; then
     # publish to verdaccio with no dist tag (default to latest)
-    npx lerna publish from-git --yes --no-push
+    lernaPublishExitOnFailure from-git --yes --no-push
     echo "Published packages to verdaccio"
     echo "Exiting without pushing release commit or release tags"
     exit 0
   fi
 
   # publish versions that were just computed
-  npx lerna publish from-git --yes --no-push --dist-tag rc
+  lernaPublishExitOnFailure from-git --yes --no-push --dist-tag rc
 
   # push release commit
   git push origin "$CIRCLE_BRANCH"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a backlog item to work around [this bug in lerna](https://github.com/lerna/lerna/issues/1066) where failed publish commands still exit with success. In the past, this has caused our publish job to continue even when the npm publish failed.

This change wraps the `lerna publish` command in a function that scans for `lerna: ERR!` in the output and fails if found

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually verified as close to the real thing as I could locally. Running e2e now which will verify that the publish to verdaccio is working correctly. This will give confidence that the other publish command will also work correctly.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
