### PR TITLE
fix: correctly handle spawned process errors

### DIFF
--- a/packages/amplify-cli-core/src/utils/open.ts
+++ b/packages/amplify-cli-core/src/utils/open.ts
@@ -8,14 +8,24 @@ import { isCI } from '..';
  * @param target The thing you want to open. Can be a URL, file, or executable.
  * @param options opn.Options
  */
-export const open = (target: string, options: opn.Options): Promise<ChildProcess | void> => {
+export const open = async (target: string, options: opn.Options): Promise<ChildProcess | void> => {
   if (isCI()) {
     return Promise.resolve();
   }
+  let childProcess: ChildProcess;
   try {
-    return opn(target, options);
+    childProcess = await opn(target, options);
+    childProcess.on('error', (e) => handleOpenError(e, target));
   } catch (e) {
-    console.warn(`Unable to open ${target}: ${(e as Error).message}`);
+    handleOpenError(e, target);
     return Promise.resolve();
+  }
+  return Promise.resolve(childProcess);
+};
+
+const handleOpenError = (err: Error, target: string) => {
+  console.error(`Unable to open ${target}: ${err.message}`);
+  if ('code' in err && err['code'] == 'ENOENT') {
+    console.warn('Have you installed `xdg-utils` on your machine?');
   }
 };

--- a/packages/amplify-cli-core/src/utils/open.ts
+++ b/packages/amplify-cli-core/src/utils/open.ts
@@ -25,7 +25,7 @@ export const open = async (target: string, options: opn.Options): Promise<ChildP
 
 const handleOpenError = (err: Error, target: string) => {
   console.error(`Unable to open ${target}: ${err.message}`);
-  if ('code' in err && err['code'] == 'ENOENT') {
+  if ('code' in err && err['code'] === 'ENOENT') {
     console.warn('Have you installed `xdg-utils` on your machine?');
   }
 };

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -95,7 +95,6 @@
     "inquirer": "^7.3.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
-    "open": "^8.4.0",
     "ora": "^4.0.3",
     "progress": "^2.0.3",
     "promise-sequential": "^1.1.1",

--- a/packages/amplify-cli/src/extensions/amplify-helpers/open-editor.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/open-editor.ts
@@ -1,12 +1,11 @@
 import * as fs from 'fs-extra';
 import * as which from 'which';
-import open from 'open';
 import execa, { sync as execaSync } from 'execa';
 import * as inquirer from 'inquirer';
 import * as envEditor from 'env-editor';
 import { editorSelection } from './editor-selection';
 import { getEnvInfo } from './get-env-info';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext, open } from 'amplify-cli-core';
 
 export async function openEditor(context: $TSContext, filePath: string, waitToContinue = true): Promise<void> {
   const continueQuestion: inquirer.InputQuestion = {


### PR DESCRIPTION
#### Description of changes

This PR handles any errors that are caused by trying to open a URL or an app. Without the `error` listener, when the spawned child process errors out, it bubbles up and get caught here and ends up terminating the application.

https://github.com/aws-amplify/amplify-cli/blob/73eb14a42a1dda2608ba65f84ea629fa417ec8e6/packages/amplify-cli/src/index.ts#L47

By preventing it from bubbling up, we ensure the cli-flow can continue, since failure to open the app/url automatically is not a critical functionality.

Also update the error message (we only ever see this error in linux distributions where xdg-utils is not installed)

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/12004

#### Description of how you validated changes

Slightly trickier. Somehow the dev build is behaving differently than the production binary. On the same machine and the same app, the binary fails but the dev build succeeds. 

On looking closely, the dev build is using `xdg-utils` from the amplify-cli's `node_modules` but that's not available in the packaged binary.

To reproduce that, I nuked the `xdg-utils` in my dev build's `node_modules` and was successfully able to reproduce and validate the changes.

####Before
```console
➜  xdg-open amplify configure
Follow these steps to set up access to your AWS account:

Sign in to your AWS administrator account:
https://console.aws.amazon.com/
Press Enter to continue
🛑 spawn xdg-open ENOENT

Resolution: Please report this issue at https://github.com/aws-amplify/amplify-cli/issues and include the project identifier from: 'amplify diagnose --send-report'
Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/

Session Identifier: 9d4549ea-49e0-4272-8b6c-922159b52699

✅ Report saved: /tmp/xdgopen/report-1677084531788.zip

✔ Done

Project Identifier: 7e4ff55d8edeead2b4edb6d60e719e9d
```

#### After
```console
➜  xdg-open ad configure         
Follow these steps to set up access to your AWS account:

Sign in to your AWS administrator account:
https://console.aws.amazon.com/
Press Enter to continue
Unable to open https://console.aws.amazon.com/: spawn xdg-open ENOENT
Have you installed `xdg-utils` on your machine?

Specify the AWS Region
? region:  us-east-1
Follow the instructions at
https://docs.amplify.aws/cli/start/install/#configure-the-amplify-cli
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
