### PR TITLE
chore: add build-and-verify script that runs ci checks locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "amplify-cli",
   "scripts": {
     "addwords": "node ./scripts/add-to-dict.js",
+    "build-and-verify": "yarn clean && yarn dev-build && yarn prettier-check && yarn lint-check && yarn verify-api-extract",
     "build-tests-changed": "nx affected --target=build-tests",
     "build-tests": "nx run-many --target=build-tests --all",
     "build": "nx run-many --target=build --all",


### PR DESCRIPTION


#### Description of changes

Adds an npm script that runs the same checks that are used in the CI. This is helpful for local development to ensure a push will not fail due to a build/lint/style issue.

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
