### PR TITLE
fix: remove default value from interactions intent and slot

### DIFF
--- a/packages/amplify-category-interactions/src/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
+++ b/packages/amplify-category-interactions/src/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
@@ -249,7 +249,7 @@ async function configure(context, defaultValuesFilename, serviceMetadata, resour
 }
 
 async function addIntent(context, resourceName, intents, parameters) {
-  let intentName = await askIntent(resourceName);
+  let intentName = await askIntent();
 
   // Checks for duplicate intent names
   while (
@@ -259,7 +259,7 @@ async function addIntent(context, resourceName, intents, parameters) {
     printer.blankLine();
     printer.info('Intent names must be unique');
     printer.blankLine();
-    intentName = await askIntent(resourceName);
+    intentName = await askIntent();
   }
 
   const utterances = await addUtterance(resourceName);
@@ -315,9 +315,8 @@ async function addIntent(context, resourceName, intents, parameters) {
   };
 }
 
-async function askIntent(resourceName) {
+async function askIntent() {
   return prompter.input('Give a unique name for the new intent:', {
-    initial: resourceName,
     validate: matchRegex(
       /^([A-Za-z]_?){1,100}$/,
       'Intent name can only contain letters and underscores, cannot be empty, and must be no longer than 100 characters',
@@ -402,9 +401,8 @@ async function addSlot(context, intentName, resourceName, parameters) {
   return [slots];
 }
 
-async function askSlotName(resourceName) {
+async function askSlotName() {
   return prompter.input('Enter a name for your slot (e.g. Location)', {
-    initial: resourceName,
     validate: matchRegex(
       /^([A-Za-z]_?){1,100}$/,
       'Slot name can only contain letters, must be no longer than 100 characters, and cannot be empty',

--- a/packages/amplify-category-interactions/src/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
+++ b/packages/amplify-category-interactions/src/provider-utils/awscloudformation/service-walkthroughs/lex-walkthrough.js
@@ -351,7 +351,7 @@ async function addSlot(context, intentName, resourceName, parameters) {
       required: true,
       customType: false,
     };
-    slot.name = await askSlotName(resourceName);
+    slot.name = await askSlotName();
 
     // Checks for duplicate slot names
     while (
@@ -365,7 +365,7 @@ async function addSlot(context, intentName, resourceName, parameters) {
       printer.blankLine();
       printer.info('Slot names must be unique');
       printer.blankLine();
-      slot.name = await askSlotName(resourceName);
+      slot.name = await askSlotName();
     }
 
     slot.type = await getSlotType(context, newSlotTypes, parameters);


### PR DESCRIPTION
#### Description of changes
— removes default value from interactions intent and slot name, it was added by mistake during inquirer to prompt migration


#### Issue #[12098](https://github.com/aws-amplify/amplify-cli/issues/12098)

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
— manual test

#### Checklist

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
