### PR TITLE
fix: limit the prompter list display options to 10 entries

### DIFF
--- a/packages/amplify-prompts/src/prompter.ts
+++ b/packages/amplify-prompts/src/prompter.ts
@@ -243,6 +243,10 @@ class AmplifyPrompter implements Prompter {
       // eslint-disable-next-line spellcheck/spell-checker
       process.once('SIGTSTP', sigTstpListener);
       ({ result } = await this.prompter<{ result: RS extends 'many' ? string[] : string }>({
+        // limit is not part of the TS interface but it's part of the JS API
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        limit: 10,
         // actions is not part of the TS interface but it's part of the JS API
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore


### PR DESCRIPTION
#### Description of changes
- limits the amplify prompter.pick display list to 10 items

#### Issue #[12092](https://github.com/aws-amplify/amplify-cli/issues/12092)

#### Description of how you validated changes
- manual test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
