### PR TITLE
fix: remove unnecessary update of pluginDirectories with 'packaged-node-modules'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "link-dev": "cd packages/amplify-cli && ln -s \"$(pwd)/bin/amplify\" \"$(yarn global bin)/amplify-dev\" && cd -",
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
-    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=1082",
+    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=1069",
     "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "lint-fix-package-json": "yarn lint-check-package-json --fix",
     "lint-check-package-json": "yarn eslint --no-eslintrc --config .eslint.package.json.js '**/package.json'",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "link-aa-win": "node ./scripts/link-bin.js packages/amplify-app/bin/amplify-app amplify-app-dev",
     "link-dev": "cd packages/amplify-cli && ln -s \"$(pwd)/bin/amplify\" \"$(yarn global bin)/amplify-dev\" && cd -",
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
-    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=1085",
+    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=1082",
     "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "lint-fix-package-json": "yarn lint-check-package-json --fix",
     "lint-check-package-json": "yarn eslint --no-eslintrc --config .eslint.package.json.js '**/package.json'",

--- a/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
+++ b/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
@@ -38,12 +38,16 @@ export async function scanPluginPlatform(pluginPlatform?: PluginPlatform): Promi
     await sequential(scanUserLocationTasks);
   }
 
-  if (isPackaged && !pluginPlatform!.pluginDirectories.includes(constants.PACKAGED_NODE_MODULES)) {
-    pluginPlatform!.pluginDirectories.push(constants.PACKAGED_NODE_MODULES);
+  if (!pluginPlatform.pluginDirectories) {
+    pluginPlatform.pluginDirectories = new PluginPlatform().pluginDirectories;
   }
 
-  if (pluginPlatform!.pluginDirectories.length > 0 && pluginPlatform!.pluginPrefixes.length > 0) {
-    const scanDirTasks = pluginPlatform!.pluginDirectories.map((directory) => async () => {
+  if (isPackaged && !pluginPlatform.pluginDirectories.includes(constants.PACKAGED_NODE_MODULES)) {
+    pluginPlatform.pluginDirectories.push(constants.PACKAGED_NODE_MODULES);
+  }
+
+  if (pluginPlatform.pluginDirectories.length > 0 && pluginPlatform!.pluginPrefixes.length > 0) {
+    const scanDirTasks = pluginPlatform.pluginDirectories.map((directory) => async () => {
       directory = normalizePluginDirectory(directory);
       const exists = await fs.pathExists(directory);
       if (exists) {

--- a/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
+++ b/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
@@ -38,7 +38,7 @@ export async function scanPluginPlatform(pluginPlatform?: PluginPlatform): Promi
     await sequential(scanUserLocationTasks);
   }
 
-  if (isPackaged) {
+  if (isPackaged && !pluginPlatform!.pluginDirectories.includes(constants.PACKAGED_NODE_MODULES)) {
     pluginPlatform!.pluginDirectories.push(constants.PACKAGED_NODE_MODULES);
   }
 

--- a/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
+++ b/packages/amplify-cli/src/plugin-helpers/scan-plugin-platform.ts
@@ -19,58 +19,54 @@ import {
 import sequential from 'promise-sequential';
 
 export async function scanPluginPlatform(pluginPlatform?: PluginPlatform): Promise<PluginPlatform> {
-  pluginPlatform = pluginPlatform || readPluginsJsonFile() || new PluginPlatform();
+  const pluginPlatformLocal = pluginPlatform || readPluginsJsonFile() || new PluginPlatform();
 
-  pluginPlatform!.plugins = new PluginCollection();
+  pluginPlatformLocal.plugins = new PluginCollection();
 
-  await addCore(pluginPlatform!);
+  await addCore(pluginPlatformLocal);
 
-  if (pluginPlatform!.userAddedLocations && pluginPlatform!.userAddedLocations.length > 0) {
+  if (pluginPlatformLocal.userAddedLocations && pluginPlatformLocal.userAddedLocations.length > 0) {
     // clean up the userAddedLocation first
-    pluginPlatform!.userAddedLocations = pluginPlatform!.userAddedLocations.filter((pluginDirPath) => {
+    pluginPlatformLocal.userAddedLocations = pluginPlatformLocal.userAddedLocations.filter((pluginDirPath) => {
       const result = fs.existsSync(pluginDirPath);
       return result;
     });
 
-    const scanUserLocationTasks = pluginPlatform!.userAddedLocations.map(
-      (pluginDirPath) => async () => await verifyAndAdd(pluginPlatform!, pluginDirPath),
+    const scanUserLocationTasks = pluginPlatformLocal.userAddedLocations.map(
+      (pluginDirPath) => async () => await verifyAndAdd(pluginPlatformLocal, pluginDirPath),
     );
     await sequential(scanUserLocationTasks);
   }
 
-  if (!pluginPlatform.pluginDirectories) {
-    pluginPlatform.pluginDirectories = new PluginPlatform().pluginDirectories;
+  if (isPackaged && !pluginPlatformLocal.pluginDirectories.includes(constants.PACKAGED_NODE_MODULES)) {
+    pluginPlatformLocal.pluginDirectories.push(constants.PACKAGED_NODE_MODULES);
   }
 
-  if (isPackaged && !pluginPlatform.pluginDirectories.includes(constants.PACKAGED_NODE_MODULES)) {
-    pluginPlatform.pluginDirectories.push(constants.PACKAGED_NODE_MODULES);
-  }
-
-  if (pluginPlatform.pluginDirectories.length > 0 && pluginPlatform!.pluginPrefixes.length > 0) {
-    const scanDirTasks = pluginPlatform.pluginDirectories.map((directory) => async () => {
+  if (pluginPlatformLocal.pluginDirectories.length > 0 && pluginPlatformLocal.pluginPrefixes.length > 0) {
+    const scanDirTasks = pluginPlatformLocal.pluginDirectories.map((directory) => async () => {
       directory = normalizePluginDirectory(directory);
       const exists = await fs.pathExists(directory);
       if (exists) {
         //adding subDir based on amplify-
         const subDirNames = await fs.readdir(directory);
-        await addPluginPrefixWithMatchingPattern(subDirNames, directory, pluginPlatform!);
+        await addPluginPrefixWithMatchingPattern(subDirNames, directory, pluginPlatformLocal);
         //adding plugin based on @aws-amplify/amplify-
         if (subDirNames.includes('@aws-amplify')) {
           const nameSpacedDir = path.join(directory, '@aws-amplify');
           const nameSpacedPackages = await fs.readdir(nameSpacedDir);
-          await addPluginPrefixWithMatchingPattern(nameSpacedPackages, nameSpacedDir, pluginPlatform!);
+          await addPluginPrefixWithMatchingPattern(nameSpacedPackages, nameSpacedDir, pluginPlatformLocal);
         }
       }
     });
     await sequential(scanDirTasks);
   }
 
-  pluginPlatform!.lastScanTime = new Date();
-  writePluginsJsonFile(pluginPlatform!);
+  pluginPlatformLocal.lastScanTime = new Date();
+  writePluginsJsonFile(pluginPlatformLocal);
 
-  await checkPlatformHealth(pluginPlatform);
+  await checkPlatformHealth(pluginPlatformLocal);
 
-  return pluginPlatform;
+  return pluginPlatformLocal;
 }
 
 export function getCorePluginDirPath(): string {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
`amplify plugin scan` every time adds `"packaged-node-modules"` to `pluginDirectories` list in `~/.amplify/plugins.json`. So after several plugin scanning it looks like this:
```json
"pluginDirectories": [
  "cli-local-node-modules",
  "cli-parent-directory",
  "global-node-modules",
  "packaged-node-modules",
  "packaged-node-modules",
  "packaged-node-modules",
  "packaged-node-modules",
  "packaged-node-modules",
  "packaged-node-modules",
  "packaged-node-modules"
]
```
 I've added check if `"packaged-node-modules"` already exists in this list

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
I've build cli binary and tested it locally. I also ran `yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
