### PR TITLE
fix: use configured region when manually configuring credentials

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
@@ -2,6 +2,7 @@ import { $TSContext, pathManager, JSONUtilities } from 'amplify-cli-core';
 import _ from 'lodash';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as configManager from '../configuration-manager';
 import { loadConfigurationForEnv } from '../configuration-manager';
 import { mocked } from 'ts-jest/utils';
 
@@ -40,5 +41,29 @@ describe('load configuration for env', () => {
     const context_clone = _.cloneDeep(context_stub);
     await loadConfigurationForEnv(context_clone, 'oldenv');
     expect(context_clone).toStrictEqual(context_stub);
+  });
+
+  it('uses region in awsConfigInfo.config if present', async () => {
+    const contextStub = {
+      exeInfo: {
+        awsConfigInfo: {
+          config: {
+            accessKeyId: 'testAccessKey',
+            secretAccessKey: 'testSecretKey',
+            region: 'us-test-1',
+          },
+        },
+      },
+    } as $TSContext;
+    const resolveRegionSpy = jest.spyOn(configManager, 'resolveRegion');
+    const result = await loadConfigurationForEnv(contextStub, 'test');
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "accessKeyId": "testAccessKey",
+        "region": "us-test-1",
+        "secretAccessKey": "testSecretKey",
+      }
+    `);
+    expect(resolveRegionSpy).not.toBeCalled();
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/configuration-manager.test.ts
@@ -25,6 +25,8 @@ JSONUtilities_mock.readJson.mockReturnValue({
   },
 });
 
+const resolveRegionSpy = jest.spyOn(configManager, 'resolveRegion');
+
 describe('load configuration for env', () => {
   it('does not overwrite awsConfigInfo in context object', async () => {
     const context_stub = {
@@ -55,7 +57,6 @@ describe('load configuration for env', () => {
         },
       },
     } as $TSContext;
-    const resolveRegionSpy = jest.spyOn(configManager, 'resolveRegion');
     const result = await loadConfigurationForEnv(contextStub, 'test');
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -65,5 +66,29 @@ describe('load configuration for env', () => {
       }
     `);
     expect(resolveRegionSpy).not.toBeCalled();
+  });
+
+  it('copies resolved region to config.region', async () => {
+    const contextStub = {
+      exeInfo: {
+        awsConfigInfo: {
+          config: {
+            accessKeyId: 'testAccessKey',
+            secretAccessKey: 'testSecretKey',
+          },
+        },
+      },
+    } as $TSContext;
+    const origRegion = process.env.AWS_REGION;
+    process.env.AWS_REGION = 'us-test-2';
+    const result = await loadConfigurationForEnv(contextStub, 'test');
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "accessKeyId": "testAccessKey",
+        "region": "us-test-2",
+        "secretAccessKey": "testSecretKey",
+      }
+    `);
+    process.env.AWS_REGION = origRegion;
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -617,8 +617,11 @@ export async function loadConfigurationForEnv(context: $TSContext, env: string, 
 
   if (awsConfigInfo?.config?.accessKeyId && awsConfigInfo?.config?.secretAccessKey) {
     // Already loaded config
-    if (!awsConfigInfo.region) {
+    if (!awsConfigInfo.region && !awsConfigInfo?.config?.region) {
       awsConfigInfo.region = resolveRegion();
+      if (typeof awsConfigInfo.config === 'object') {
+        awsConfigInfo.config.region = awsConfigInfo.region;
+      }
     }
 
     return awsConfigInfo.config;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When configuring a project to use access keys instead of a profile there was a bug where the configured region was not being used and instead trying to resolve a region using environment variables. This change fixes the behavior to use the region specified in the CLI walkthrough for setting up a new user.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually validated and added unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
