### PR TITLE
fix: do not route to plugin when command is invalid

### DIFF
--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -101,6 +101,7 @@ export const run = async (startTime: number): Promise<void> => {
   if (!verificationResult.verified) {
     if (verificationResult.helpCommandAvailable) {
       input.command = constants.HELP;
+      input.plugin = constants.CORE;
     } else {
       throw new AmplifyError('InputValidationError', {
         message: verificationResult.message ?? 'Invalid input',
@@ -206,6 +207,7 @@ export const execute = async (input: CLIInput): Promise<void> => {
     if (verificationResult.helpCommandAvailable) {
       // eslint-disable-next-line no-param-reassign
       input.command = constants.HELP;
+      input.plugin = constants.CORE;
     } else {
       throw new Error(verificationResult.message);
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
When commands are deemed invalid by the input-manager, the command is set to "help" but the plugin is not changed. This leads to invalid commands still being routed to non-core plugins, which sometimes results in users being prompted, even after a message showing that the command is invalid is printed. This change stops commands from being routed to plugins by setting the plugin to core. The plugin that executes the help command does not matter, as all plugins yield the same top-level help. See the first photo below for an example of a prompt appearing after an invalid command message and the second photo for the new behavior.

<img width="702" alt="image" src="https://user-images.githubusercontent.com/117126550/221944788-d51dc3d5-ec07-47ad-beec-04953d8b6c97.png">

<img width="721" alt="image" src="https://user-images.githubusercontent.com/117126550/221945482-f3b2453c-0f01-4e28-980a-881530f15d55.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#12118 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
