### PR TITLE
fix: change FCM ApiKey to Server Key label as displayed in firebase console

### DIFF
--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -47,7 +47,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
     answers = {
-      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
+      ApiKey: await prompter.input('Server Key', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
     };
   }
 
@@ -80,8 +80,8 @@ export const enable = async (context: $TSContext, successMessage: string | undef
 const validateInputParams = (channelInput: $TSAny): $TSAny => {
   if (!channelInput.ApiKey) {
     throw new AmplifyError('UserInputError', {
-      message: 'ApiKey is missing for the FCM channel',
-      resolution: 'Provide the ApiKey for the FCM channel',
+      message: 'Server Key is missing for the FCM channel',
+      resolution: 'Server Key for the FCM channel',
     });
   }
   return channelInput;
@@ -102,10 +102,9 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
       channelOutput = context.exeInfo.serviceMeta.output[channelName];
     }
     answers = {
-      ApiKey: await prompter.input('ApiKey', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
+      ApiKey: await prompter.input('Server Key', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
     };
   }
-
   const params = {
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
     GCMChannelRequest: {


### PR DESCRIPTION
#### Description of changes
- change FCM label for ApiKey to Server Key in order to match firebase console label and to avoid confusion


#### Issue #[9955](https://github.com/aws-amplify/amplify-cli/issues/9955)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
