### PR TITLE
fix: prevent analytics/notifications migration if there is not a pinpoint app added

### DIFF
--- a/packages/amplify-category-analytics/src/__tests__/migrations/in-app-messaging-migration.test.ts
+++ b/packages/amplify-category-analytics/src/__tests__/migrations/in-app-messaging-migration.test.ts
@@ -1,0 +1,34 @@
+import { $TSContext, JSONUtilities } from 'amplify-cli-core';
+import { inAppMessagingMigrationCheck } from '../../migrations/in-app-messaging-migration';
+
+jest.mock('../../utils/pinpoint-helper', () => ({
+  hasResource: jest.fn().mockReturnValue(false),
+  getNotificationsCategoryHasPinpointIfExists: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../utils/analytics-helper', () => ({
+  getAnalyticsResources: jest.fn().mockReturnValue(['mockResource']),
+}));
+
+jest.mock('amplify-cli-core', () => ({
+  ...(jest.requireActual('amplify-cli-core') as {}),
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('mockDirPath'),
+  },
+}));
+
+describe('InAppMessagingMigration', () => {
+  beforeEach(() => {
+    JSONUtilities.readJson = jest.fn().mockReturnValue({});
+  });
+
+  it('should not attempt migration if there is NOT a pinpoint app', async () => {
+    const mockContext = {
+      amplify: {
+        getProjectMeta: jest.fn(() => ({})),
+      },
+    };
+    await inAppMessagingMigrationCheck(mockContext as unknown as $TSContext);
+    expect(JSONUtilities.readJson).not.toBeCalled();
+  });
+});

--- a/packages/amplify-category-analytics/src/migrations/in-app-messaging-migration.ts
+++ b/packages/amplify-category-analytics/src/migrations/in-app-messaging-migration.ts
@@ -15,7 +15,7 @@ import { analyticsPush } from '../commands/analytics';
 import { invokeAuthPush } from '../plugin-client-api-auth';
 import { getAllDefaults } from '../provider-utils/awscloudformation/default-values/pinpoint-defaults';
 import { getAnalyticsResources } from '../utils/analytics-helper';
-import * as pinpointHelper from '../utils/pinpoint-helper';
+
 import {
   getNotificationsCategoryHasPinpointIfExists,
   getPinpointRegionMappings,
@@ -29,18 +29,19 @@ import {
 export const inAppMessagingMigrationCheck = async (context: $TSContext): Promise<void> => {
   const projectBackendDirPath = pathManager.getBackendDirPath();
   const resources = getAnalyticsResources(context);
-  const hasPinpointResource = pinpointHelper.hasResource(context);
 
-  if (resources.length > 0 && hasPinpointResource && !pinpointHasInAppMessagingPolicy(context)) {
+  if (resources.length > 0 && !pinpointHasInAppMessagingPolicy(context)) {
     const amplifyMeta = stateManager.getMeta();
     const analytics = amplifyMeta[AmplifyCategories.ANALYTICS] || {};
     Object.keys(analytics).forEach((resourceName) => {
       const analyticsResourcePath = path.join(projectBackendDirPath, AmplifyCategories.ANALYTICS, resourceName);
       const templateFilePath = path.join(analyticsResourcePath, 'pinpoint-cloudformation-template.json');
-      const cfn = JSONUtilities.readJson(templateFilePath);
-      const updatedCfn = migratePinpointCFN(cfn);
-      fs.ensureDirSync(analyticsResourcePath);
-      JSONUtilities.writeJson(templateFilePath, updatedCfn);
+      if (fs.existsSync(templateFilePath)) {
+        const cfn = JSONUtilities.readJson(templateFilePath);
+        const updatedCfn = migratePinpointCFN(cfn);
+        fs.ensureDirSync(analyticsResourcePath);
+        JSONUtilities.writeJson(templateFilePath, updatedCfn);
+      }
     });
   }
 

--- a/packages/amplify-category-analytics/src/migrations/in-app-messaging-migration.ts
+++ b/packages/amplify-category-analytics/src/migrations/in-app-messaging-migration.ts
@@ -37,7 +37,7 @@ export const inAppMessagingMigrationCheck = async (context: $TSContext): Promise
     Object.keys(analytics).forEach((resourceName) => {
       const analyticsResourcePath = path.join(projectBackendDirPath, AmplifyCategories.ANALYTICS, resourceName);
       const templateFilePath = path.join(analyticsResourcePath, 'pinpoint-cloudformation-template.json');
-      const cfn = JSONUtilities.readJson(templateFilePath, { throwIfNotExist: false });
+      const cfn = JSONUtilities.readJson(templateFilePath);
       const updatedCfn = migratePinpointCFN(cfn);
       fs.ensureDirSync(analyticsResourcePath);
       JSONUtilities.writeJson(templateFilePath, updatedCfn);


### PR DESCRIPTION
#### Description of changes
- the migration added for analytics/notifications should not happen if there isn't a pinpoint app added to the project


#### Issue #[11633](https://github.com/aws-amplify/amplify-cli/issues/11633)

#### Description of how you validated changes
- unit test added
- manual test

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
