### PR TITLE
fix: force ProcessCredentials to prefer config file

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -92,8 +92,12 @@ export const getProfiledAwsConfig = async (
         ...roleCredentials,
       };
     } else if (profileConfig.credential_process) {
-      const credentialProcess = new ProcessCredentials({ profile: profileName, filename: configFilePath });
+      // need to force AWS_SDK_LOAD_CONFIG to a truthy value to force ProcessCredentials to prefer the credential process in ~/.aws/config instead of ~/.aws/credentials
+      const sdkLoadConfigOriginal = process.env.AWS_SDK_LOAD_CONFIG;
+      process.env.AWS_SDK_LOAD_CONFIG = '1';
+      const credentialProcess = new ProcessCredentials({ profile: profileName });
       await credentialProcess.getPromise();
+      process.env.AWS_SDK_LOAD_CONFIG = sdkLoadConfigOriginal;
 
       awsConfigInfo = {
         region: profileConfig.region,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The AWS SDK ProcessCredentials class requires the AWS_SDK_LOAD_CONFIG environment variable to be set in order for the credential process in `~/.aws/config` to take precedence over `~/.aws/credentials`. This change forces that environment variable to be set while executing the credential process

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
fixes https://github.com/aws-amplify/amplify-cli/issues/12120
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested and added a unit test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
