### PR TITLE
chore: fix e2e tests

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
@@ -1,4 +1,4 @@
-import { JSONUtilities } from 'amplify-cli-core';
+import { isWindowsPlatform, JSONUtilities } from 'amplify-cli-core';
 import {
   addCDKCustomResource,
   addCFNCustomResource,
@@ -67,8 +67,11 @@ describe('adding custom resources test', () => {
     await buildCustomResources(projRoot);
 
     // check if latest @aws-amplify/cli-extensibility-helper works
-    useLatestExtensibilityHelper(projRoot, cdkResourceName);
-    await buildCustomResources(projRoot);
+    // skip on Windows, we don't start local registry there
+    if (!isWindowsPlatform()) {
+      useLatestExtensibilityHelper(projRoot, cdkResourceName);
+      await buildCustomResources(projRoot);
+    }
 
     await amplifyPushAuth(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
@@ -130,7 +130,7 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
         query: gql(listNotesQuery),
         fetchPolicy: 'no-cache',
       }),
-    ).rejects.toThrow(`GraphQL error: Not Authorized to access note on type String`);
+    ).rejects.toThrow(`GraphQL error: Not Authorized to access note on type`);
 
     const appSyncInvalidClient = new AWSAppSyncClient({
       url,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixes 2 e2e tests:
- Skips custom resource build with local registry on windows
- Loosens assertion in schema auth test - we only care about "Not Authorized" part there.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
