### PR TITLE
fix(amplify-frontend-ios): xcode scirpt binary path resolves correctly

### DIFF
--- a/packages/amplify-frontend-ios/lib/amplify-xcode.js
+++ b/packages/amplify-frontend-ios/lib/amplify-xcode.js
@@ -22,7 +22,7 @@ const path = require('path');
 const { pathManager } = require('amplify-cli-core');
 
 const BINARY_PATH = 'resources/amplify-xcode';
-const PACKAGE_NAME = 'amplify-frontend-ios';
+const PACKAGE_NAME = '@aws-amplify/amplify-frontend-ios';
 const amplifyXcodePath = () => path.join(pathManager.getAmplifyPackageLibDirPath(PACKAGE_NAME), BINARY_PATH);
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The package name is changed with the scope added since last release. Resolve the xcode binary path accordingly so that the script will run successfully.
#### Issue #, if available
Fix https://github.com/aws-amplify/amplify-studio/issues/47
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
`amplify-dev codegen models` in an amplify swift project
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
