### PR TITLE
fix: export storage types bug

### DIFF
--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -7,7 +7,6 @@ import { v4 as uuid } from 'uuid';
 import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
 import { KEY_DOWN_ARROW } from '../utils';
 import { amplifyRegions } from '../configure';
-import execa from 'execa';
 
 const defaultSettings = {
   name: EOL,

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
 import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';
 import { KEY_DOWN_ARROW } from '../utils';
 import { amplifyRegions } from '../configure';
+import execa from 'execa';
 
 const defaultSettings = {
   name: EOL,
@@ -493,31 +494,7 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
   });
 }
 
-export function initHeadless(cwd: string, appId: string, envName: string, settings: Record<string, unknown>) {
-  const s = { ...defaultSettings, ...settings };
-  let env;
-
-  if (s.disableAmplifyAppCreation === true) {
-    env = {
-      CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
-    };
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    spawn(getCLIPath(), ['init', '--appId', appId, '--envName', envName, '--yes'], {
-      cwd,
-      stripColors: true,
-      env,
-      disableCIDetection: s.disableCIDetection,
-    })
-      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
-      .run((err: Error) => {
-        if (!err) {
-          addCircleCITags(cwd);
-          resolve();
-        } else {
-          reject(err);
-        }
-      });
-  });
-}
+export const initHeadless = async (projRoot: string, appId: string, envName: string): Promise<void> => {
+  const args = ['init', '--yes', '--appId', appId, '--envName', envName];
+  await execa(getCLIPath(), args, { cwd: projRoot });
+};

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -493,11 +493,22 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
   });
 }
 
-export function initHeadless(cwd: string, appId: string, envName: string) {
+export function initHeadless(cwd: string, appId: string, envName: string, settings: Record<string, unknown>) {
+  const s = { ...defaultSettings, ...settings };
+  let env;
+
+  if (s.disableAmplifyAppCreation === true) {
+    env = {
+      CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
+    };
+  }
+
   return new Promise<void>((resolve, reject) => {
     spawn(getCLIPath(), ['init', '--appId', appId, '--envName', envName, '--yes'], {
       cwd,
       stripColors: true,
+      env,
+      disableCIDetection: s.disableCIDetection,
     })
       .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
       .run((err: Error) => {

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -492,3 +492,21 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
       });
   });
 }
+
+export function initHeadless(cwd: string, appId: string, envName: string) {
+  return new Promise<void>((resolve, reject) => {
+    spawn(getCLIPath(), ['init', '--appId', appId, '--envName', envName, '--yes'], {
+      cwd,
+      stripColors: true,
+    })
+      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
+      .run((err: Error) => {
+        if (!err) {
+          addCircleCITags(cwd);
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -494,13 +494,5 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
 }
 
 export function initHeadless(cwd: string, envName: string, appId: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['init', '--yes', '--envName', envName, '--appId', appId], { cwd, stripColors: true }).run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        reject(err);
-      }
-    });
-  });
+  return spawn(getCLIPath(), ['init', '--yes', '--envName', envName, '--appId', appId], { cwd, stripColors: true }).runAsync();
 }

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -494,7 +494,14 @@ export function amplifyStatus(cwd: string, expectedStatus: string, testingWithLa
   });
 }
 
-export const initHeadless = async (projRoot: string, appId: string, envName: string): Promise<void> => {
-  const args = ['init', '--yes', '--appId', appId, '--envName', envName];
-  await execa(getCLIPath(), args, { cwd: projRoot });
-};
+export function initHeadless(cwd: string, envName: string, appId: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['init', '--yes', '--envName', envName, '--appId', appId], { cwd, stripColors: true }).run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}

--- a/packages/amplify-e2e-core/src/utils/git-operations.ts
+++ b/packages/amplify-e2e-core/src/utils/git-operations.ts
@@ -24,6 +24,7 @@ export const gitCleanFdx = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdx'], { cwd });
 };
 
+// It is important to note the difference between -fdx and -fdX
 export const gitCleanFdX = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdX'], { cwd });
 };

--- a/packages/amplify-e2e-core/src/utils/git-operations.ts
+++ b/packages/amplify-e2e-core/src/utils/git-operations.ts
@@ -25,6 +25,8 @@ export const gitCleanFdx = async (cwd: string): Promise<void> => {
 };
 
 // It is important to note the difference between -fdx and -fdX
+// -fdx removes all untracked files
+// -fdX removes all untracked files that are not ignored by git
 export const gitCleanFdX = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdX'], { cwd });
 };

--- a/packages/amplify-e2e-core/src/utils/git-operations.ts
+++ b/packages/amplify-e2e-core/src/utils/git-operations.ts
@@ -24,6 +24,10 @@ export const gitCleanFdx = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdx'], { cwd });
 };
 
+export const gitCleanFdX = async (cwd: string): Promise<void> => {
+  await execa('git', ['clean', '-fdX'], { cwd });
+};
+
 /**
  * Returns a list of files that have unstaged changes in the specified directory
  */

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -24,39 +24,11 @@ export class cdkStack extends cdk.Stack {
 
     /* AWS CDK Code goes here - Learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
 
-    /* Example 1: Set up an SQS queue with an SNS topic */
-
-    // const queue = new sqs.Queue(this, 'sqs-queue', {
-    //   queueName: cdk.Fn.join('-', ['custom-cdk-generated-sqs-queue-test-2', cdk.Fn.ref('env')]),
-    // }); // For name uniqueness
-
-    // // 👇 create sns topic
-    // const topic = new sns.Topic(this, 'sns-topic', {
-    //   topicName: cdk.Fn.join('-', ['custom-cdk-generated-sns-topic-test-2', cdk.Fn.ref('env')]),
-    // }); // For name uniqueness
-
-    // // 👇 subscribe queue to topic
-    // topic.addSubscription(new subs.SqsSubscription(queue));
-
-    // // eslint-disable-next-line no-new
-    // new cdk.CfnOutput(this, 'snsTopicArn', {
-    //   value: topic.topicArn,
-    //   description: 'The arn of the SNS topic',
-    // });
-
-    // /* Example 2: Adding IAM role to the custom stack */
-    // const role = new iam.Role(this, 'CustomRole', {
-    //   roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test-3', cdk.Fn.ref('env')]), // For name uniqueness
-    //   assumedBy: new iam.AccountRootPrincipal(),
-    // });
-
-    // /* Example 3: Adding policy to the IAM role*/
-    // role.addToPolicy(
-    //   new iam.PolicyStatement({
-    //     actions: ['*'],
-    //     resources: [topic.topicArn],
-    //   }),
-    // );
+    /* Example 2: Adding IAM role to the custom stack */
+    const role = new iam.Role(this, 'CustomRole', {
+      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test-5', cdk.Fn.ref('env')]), // For name uniqueness
+      assumedBy: new iam.AccountRootPrincipal(),
+    });
 
     const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
       this,

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -26,7 +26,7 @@ export class cdkStack extends cdk.Stack {
 
     /* Example 2: Adding IAM role to the custom stack */
     const role = new iam.Role(this, 'CustomRole', {
-      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test-5', cdk.Fn.ref('env')]), // For name uniqueness
+      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test', cdk.Fn.ref('env')]), // For name uniqueness
       assumedBy: new iam.AccountRootPrincipal(),
     });
 

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -1,0 +1,136 @@
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
+
+/**
+ * Base amplify stack class
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class cdkStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
+    super(scope, id, props);
+
+    /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
+    // eslint-disable-next-line no-new
+    new cdk.CfnParameter(this, 'env', {
+      type: 'String',
+      description: 'Current Amplify CLI env name',
+    });
+
+    /* AWS CDK Code goes here - Learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
+
+    /* Example 1: Set up an SQS queue with an SNS topic */
+
+    const queue = new sqs.Queue(this, 'sqs-queue', {
+      queueName: cdk.Fn.join('-', ['custom-cdk-generated-sqs-queue-test', cdk.Fn.ref('env')]),
+    }); // For name uniqueness
+
+    // 👇 create sns topic
+    const topic = new sns.Topic(this, 'sns-topic', {
+      topicName: cdk.Fn.join('-', ['custom-cdk-generated-sns-topic-test', cdk.Fn.ref('env')]),
+    }); // For name uniqueness
+
+    // 👇 subscribe queue to topic
+    topic.addSubscription(new subs.SqsSubscription(queue));
+
+    // eslint-disable-next-line no-new
+    new cdk.CfnOutput(this, 'snsTopicArn', {
+      value: topic.topicArn,
+      description: 'The arn of the SNS topic',
+    });
+
+    /* Example 2: Adding IAM role to the custom stack */
+    const role = new iam.Role(this, 'CustomRole', {
+      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test', cdk.Fn.ref('env')]), // For name uniqueness
+      assumedBy: new iam.AccountRootPrincipal(),
+    });
+
+    /* Example 3: Adding policy to the IAM role*/
+    role.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['*'],
+        resources: [topic.topicArn],
+      }),
+    );
+
+    AmplifyHelpers.addResourceDependency(this, amplifyResourceProps.category, amplifyResourceProps.resourceName, [
+      { category: 'storage', resourceName: 'ddb' },
+    ]);
+
+    // const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
+    //         this,
+    //         amplifyResourceProps.category,
+    //         amplifyResourceProps.resourceName,
+    //         [{ category: 'storage', resourceName: 'epigram' }],
+    //       );
+  }
+}
+
+// import * as cdk from 'aws-cdk-lib';
+// import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+// import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
+// import * as iam from 'aws-cdk-lib/aws-iam';
+// import * as sns from 'aws-cdk-lib/aws-sns';
+// import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+// import * as sqs from 'aws-cdk-lib/aws-sqs';
+// import { Construct } from 'constructs';
+
+// export class cdkStack extends cdk.Stack {
+//   constructor(scope: Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
+//     super(scope, id, props);
+//     /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
+//     new cdk.CfnParameter(this, 'env', {
+//       type: 'String',
+//       description: 'Current Amplify CLI env name',
+//     });
+//     /* AWS CDK code goes here - learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
+
+//     // Example 1: Set up an SQS queue with an SNS topic
+
+//     const amplifyProjectInfo = AmplifyHelpers.getProjectInfo();
+//     const sqsQueueResourceNamePrefix = `sqs-queue-${amplifyProjectInfo.projectName}`;
+//     const queue = new sqs.Queue(this, 'sqs-queue', {
+//       queueName: `${sqsQueueResourceNamePrefix}-${cdk.Fn.ref('env')}`,
+//     });
+//     // 👇create sns topic
+
+//     const snsTopicResourceNamePrefix = `sns-topic-${amplifyProjectInfo.projectName}`;
+//     const topic = new sns.Topic(this, 'sns-topic', {
+//       topicName: `${snsTopicResourceNamePrefix}-${cdk.Fn.ref('env')}`,
+//     });
+//     // 👇 subscribe queue to topic
+//     topic.addSubscription(new subs.SqsSubscription(queue));
+//     new cdk.CfnOutput(this, 'snsTopicArn', {
+//       value: topic.topicArn,
+//       description: 'The arn of the SNS topic',
+//     });
+
+//     // Example 2: Adding IAM role to the custom stack
+//     const roleResourceNamePrefix = `CustomRole-${amplifyProjectInfo.projectName}`;
+
+//     const role = new iam.Role(this, 'CustomRole', {
+//       assumedBy: new iam.AccountRootPrincipal(),
+//       roleName: `${roleResourceNamePrefix}-${cdk.Fn.ref('env')}`,
+//     });
+
+//     // Example 3: Adding policy to the IAM role
+
+//     role.addToPolicy(
+//       new iam.PolicyStatement({
+//         actions: ['*'],
+//         resources: [topic.topicArn],
+//       }),
+//     );
+
+//     const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
+//       this,
+//       amplifyResourceProps.category,
+//       amplifyResourceProps.resourceName,
+//       [{ category: 'storage', resourceName: 'epigram' }],
+//     );
+//   }
+// }

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -57,80 +57,11 @@ export class cdkStack extends cdk.Stack {
       }),
     );
 
-    AmplifyHelpers.addResourceDependency(this, amplifyResourceProps.category, amplifyResourceProps.resourceName, [
-      { category: 'storage', resourceName: 'ddb' },
-    ]);
-
-    // const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
-    //         this,
-    //         amplifyResourceProps.category,
-    //         amplifyResourceProps.resourceName,
-    //         [{ category: 'storage', resourceName: 'epigram' }],
-    //       );
+    const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
+      this,
+      amplifyResourceProps.category,
+      amplifyResourceProps.resourceName,
+      [{ category: 'storage', resourceName: 'customStorage' }],
+    );
   }
 }
-
-// import * as cdk from 'aws-cdk-lib';
-// import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
-// import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
-// import * as iam from 'aws-cdk-lib/aws-iam';
-// import * as sns from 'aws-cdk-lib/aws-sns';
-// import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
-// import * as sqs from 'aws-cdk-lib/aws-sqs';
-// import { Construct } from 'constructs';
-
-// export class cdkStack extends cdk.Stack {
-//   constructor(scope: Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
-//     super(scope, id, props);
-//     /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
-//     new cdk.CfnParameter(this, 'env', {
-//       type: 'String',
-//       description: 'Current Amplify CLI env name',
-//     });
-//     /* AWS CDK code goes here - learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
-
-//     // Example 1: Set up an SQS queue with an SNS topic
-
-//     const amplifyProjectInfo = AmplifyHelpers.getProjectInfo();
-//     const sqsQueueResourceNamePrefix = `sqs-queue-${amplifyProjectInfo.projectName}`;
-//     const queue = new sqs.Queue(this, 'sqs-queue', {
-//       queueName: `${sqsQueueResourceNamePrefix}-${cdk.Fn.ref('env')}`,
-//     });
-//     // 👇create sns topic
-
-//     const snsTopicResourceNamePrefix = `sns-topic-${amplifyProjectInfo.projectName}`;
-//     const topic = new sns.Topic(this, 'sns-topic', {
-//       topicName: `${snsTopicResourceNamePrefix}-${cdk.Fn.ref('env')}`,
-//     });
-//     // 👇 subscribe queue to topic
-//     topic.addSubscription(new subs.SqsSubscription(queue));
-//     new cdk.CfnOutput(this, 'snsTopicArn', {
-//       value: topic.topicArn,
-//       description: 'The arn of the SNS topic',
-//     });
-
-//     // Example 2: Adding IAM role to the custom stack
-//     const roleResourceNamePrefix = `CustomRole-${amplifyProjectInfo.projectName}`;
-
-//     const role = new iam.Role(this, 'CustomRole', {
-//       assumedBy: new iam.AccountRootPrincipal(),
-//       roleName: `${roleResourceNamePrefix}-${cdk.Fn.ref('env')}`,
-//     });
-
-//     // Example 3: Adding policy to the IAM role
-
-//     role.addToPolicy(
-//       new iam.PolicyStatement({
-//         actions: ['*'],
-//         resources: [topic.topicArn],
-//       }),
-//     );
-
-//     const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
-//       this,
-//       amplifyResourceProps.category,
-//       amplifyResourceProps.resourceName,
-//       [{ category: 'storage', resourceName: 'epigram' }],
-//     );
-//   }
-// }

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -1,8 +1,6 @@
 import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
-import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
 
 /**
  * Base amplify stack class
@@ -12,26 +10,9 @@ export class cdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
     super(scope, id, props);
 
-    /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
-    // eslint-disable-next-line no-new
     new cdk.CfnParameter(this, 'env', {
       type: 'String',
       description: 'Current Amplify CLI env name',
     });
-
-    /* AWS CDK Code goes here - Learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
-
-    /* Example 2: Adding IAM role to the custom stack */
-    const role = new iam.Role(this, 'CustomRole', {
-      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test', cdk.Fn.ref('env')]), // For name uniqueness
-      assumedBy: new iam.AccountRootPrincipal(),
-    });
-
-    const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
-      this,
-      amplifyResourceProps.category,
-      amplifyResourceProps.resourceName,
-      [{ category: 'storage', resourceName: 'customStorage' }],
-    );
   }
 }

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -1,9 +1,6 @@
 import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
 import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
 import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
 

--- a/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
+++ b/packages/amplify-e2e-tests/custom-resources/custom-cdk-stack-with-storage.ts
@@ -5,6 +5,7 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Construct } from 'constructs';
+import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
 
 /**
  * Base amplify stack class
@@ -25,37 +26,37 @@ export class cdkStack extends cdk.Stack {
 
     /* Example 1: Set up an SQS queue with an SNS topic */
 
-    const queue = new sqs.Queue(this, 'sqs-queue', {
-      queueName: cdk.Fn.join('-', ['custom-cdk-generated-sqs-queue-test', cdk.Fn.ref('env')]),
-    }); // For name uniqueness
+    // const queue = new sqs.Queue(this, 'sqs-queue', {
+    //   queueName: cdk.Fn.join('-', ['custom-cdk-generated-sqs-queue-test-2', cdk.Fn.ref('env')]),
+    // }); // For name uniqueness
 
-    // 👇 create sns topic
-    const topic = new sns.Topic(this, 'sns-topic', {
-      topicName: cdk.Fn.join('-', ['custom-cdk-generated-sns-topic-test', cdk.Fn.ref('env')]),
-    }); // For name uniqueness
+    // // 👇 create sns topic
+    // const topic = new sns.Topic(this, 'sns-topic', {
+    //   topicName: cdk.Fn.join('-', ['custom-cdk-generated-sns-topic-test-2', cdk.Fn.ref('env')]),
+    // }); // For name uniqueness
 
-    // 👇 subscribe queue to topic
-    topic.addSubscription(new subs.SqsSubscription(queue));
+    // // 👇 subscribe queue to topic
+    // topic.addSubscription(new subs.SqsSubscription(queue));
 
-    // eslint-disable-next-line no-new
-    new cdk.CfnOutput(this, 'snsTopicArn', {
-      value: topic.topicArn,
-      description: 'The arn of the SNS topic',
-    });
+    // // eslint-disable-next-line no-new
+    // new cdk.CfnOutput(this, 'snsTopicArn', {
+    //   value: topic.topicArn,
+    //   description: 'The arn of the SNS topic',
+    // });
 
-    /* Example 2: Adding IAM role to the custom stack */
-    const role = new iam.Role(this, 'CustomRole', {
-      roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test', cdk.Fn.ref('env')]), // For name uniqueness
-      assumedBy: new iam.AccountRootPrincipal(),
-    });
+    // /* Example 2: Adding IAM role to the custom stack */
+    // const role = new iam.Role(this, 'CustomRole', {
+    //   roleName: cdk.Fn.join('-', ['custom-cdk-generated-custom-role-test-3', cdk.Fn.ref('env')]), // For name uniqueness
+    //   assumedBy: new iam.AccountRootPrincipal(),
+    // });
 
-    /* Example 3: Adding policy to the IAM role*/
-    role.addToPolicy(
-      new iam.PolicyStatement({
-        actions: ['*'],
-        resources: [topic.topicArn],
-      }),
-    );
+    // /* Example 3: Adding policy to the IAM role*/
+    // role.addToPolicy(
+    //   new iam.PolicyStatement({
+    //     actions: ['*'],
+    //     resources: [topic.topicArn],
+    //   }),
+    // );
 
     const amplifyResources: AmplifyDependentResourcesAttributes = AmplifyHelpers.addResourceDependency(
       this,

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -27,7 +27,7 @@ describe('adding custom resources test', () => {
   const envName = 'dev';
   beforeEach(async () => {
     projRoot = await createNewProjectDir('custom-resources');
-    await initJSProjectWithProfile(projRoot, { envName });
+    await initJSProjectWithProfile(projRoot, { envName, disableAmplifyAppCreation: false });
     await gitInit(projRoot);
   });
 
@@ -39,10 +39,6 @@ describe('adding custom resources test', () => {
   it('export custom storage types', async () => {
     await addAuthWithDefault(projRoot, {});
     await addS3WithGuestAccess(projRoot, {});
-    await amplifyPushAuth(projRoot);
-
-    console.log('LINE 44');
-
     const appId = getAppId(projRoot);
     const cdkResourceName = `custom${uuid().split('-')[0]}`;
     await addCDKCustomResource(projRoot, { name: cdkResourceName });
@@ -51,8 +47,6 @@ describe('adding custom resources test', () => {
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
     await buildCustomResources(projRoot);
     await amplifyPushAuth(projRoot);
-
-    console.log('LINE 52');
 
     await gitCleanFdx(projRoot);
     await initHeadless(projRoot, appId, envName);

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -1,0 +1,64 @@
+import {
+  addCDKCustomResource,
+  addCFNCustomResource,
+  addSimpleDDB,
+  amplifyPushAuth,
+  buildCustomResources,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getProjectMeta,
+  initJSProjectWithProfile,
+  useLatestExtensibilityHelper,
+  gitInit,
+  gitCleanFdx,
+  initHeadless,
+  getAppId,
+  addAuthWithDefault,
+  addS3WithGuestAccess,
+} from '@aws-amplify/amplify-e2e-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { v4 as uuid } from 'uuid';
+import { JSONUtilities } from 'amplify-cli-core';
+
+describe('adding custom resources test', () => {
+  let projRoot: string;
+  const envName = 'dev';
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('custom-resources');
+    await initJSProjectWithProfile(projRoot, { envName });
+    await gitInit(projRoot);
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('export custom storage types', async () => {
+    await addAuthWithDefault(projRoot, {});
+    await addS3WithGuestAccess(projRoot, {});
+    await amplifyPushAuth(projRoot);
+
+    console.log('LINE 44');
+
+    const appId = getAppId(projRoot);
+    const cdkResourceName = `custom${uuid().split('-')[0]}`;
+    await addCDKCustomResource(projRoot, { name: cdkResourceName });
+    const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack-with-storage.ts');
+    const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');
+    fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
+    await buildCustomResources(projRoot);
+    await amplifyPushAuth(projRoot);
+
+    console.log('LINE 52');
+
+    await gitCleanFdx(projRoot);
+    await initHeadless(projRoot, appId, envName);
+    const typesPath = path.join(projRoot, 'amplify', 'backend', 'types', 'amplify-dependent-resources-ref.d.ts');
+    const typesFileJSON = JSONUtilities.readJson(typesPath);
+    const keys = Object.keys(typesFileJSON);
+    expect('auth' in keys && 'custom' in keys && 'storage' in keys).toBeTruthy();
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -55,7 +55,7 @@ describe('adding custom resources test', () => {
     console.log('LINE 52');
 
     await gitCleanFdx(projRoot);
-    await initHeadless(projRoot, appId, envName);
+    await initHeadless(projRoot, appId, envName, {});
     const typesPath = path.join(projRoot, 'amplify', 'backend', 'types', 'amplify-dependent-resources-ref.d.ts');
     const typesFileJSON = JSONUtilities.readJson(typesPath);
     const keys = Object.keys(typesFileJSON);

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -1,15 +1,11 @@
 import {
   addCDKCustomResource,
-  addCFNCustomResource,
-  addSimpleDDB,
   amplifyPushAuth,
   buildCustomResources,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  getProjectMeta,
   initJSProjectWithProfile,
-  useLatestExtensibilityHelper,
   gitInit,
   gitCleanFdx,
   initHeadless,
@@ -37,22 +33,38 @@ describe('adding custom resources test', () => {
   });
 
   it('export custom storage types', async () => {
+    let i = 0;
     await addAuthWithDefault(projRoot, {});
+    console.log(`POINT: ${++i}`);
     await addS3WithGuestAccess(projRoot, {});
+    console.log(`POINT: ${++i}`);
     const appId = getAppId(projRoot);
+    console.log(`POINT: ${++i}`);
     const cdkResourceName = `custom${uuid().split('-')[0]}`;
+    console.log(`POINT: ${++i}`);
     await addCDKCustomResource(projRoot, { name: cdkResourceName });
+    console.log(`POINT: ${++i}`);
     const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack-with-storage.ts');
+    console.log(`POINT: ${++i}`);
     const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');
+    console.log(`POINT: ${++i}`);
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
+    console.log(`POINT: ${++i}`);
     await buildCustomResources(projRoot);
+    console.log(`POINT: ${++i}`);
     await amplifyPushAuth(projRoot);
+    console.log(`POINT: ${++i}`);
 
     await gitCleanFdx(projRoot);
+    console.log(`POINT: ${++i}`);
     await initHeadless(projRoot, appId, envName);
+    console.log(`POINT: ${++i}`);
     const typesPath = path.join(projRoot, 'amplify', 'backend', 'types', 'amplify-dependent-resources-ref.d.ts');
+    console.log(`POINT: ${++i}`);
     const typesFileJSON = JSONUtilities.readJson(typesPath);
+    console.log(`POINT: ${++i}`);
     const keys = Object.keys(typesFileJSON);
+    console.log(`POINT: ${++i}`);
     expect('auth' in keys && 'custom' in keys && 'storage' in keys).toBeTruthy();
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -55,7 +55,7 @@ describe('adding custom resources test', () => {
     console.log('LINE 52');
 
     await gitCleanFdx(projRoot);
-    await initHeadless(projRoot, appId, envName, {});
+    await initHeadless(projRoot, appId, envName);
     const typesPath = path.join(projRoot, 'amplify', 'backend', 'types', 'amplify-dependent-resources-ref.d.ts');
     const typesFileJSON = JSONUtilities.readJson(typesPath);
     const keys = Object.keys(typesFileJSON);

--- a/packages/amplify-provider-awscloudformation/src/initialize-env.ts
+++ b/packages/amplify-provider-awscloudformation/src/initialize-env.ts
@@ -128,6 +128,5 @@ export async function run(context: $TSContext, providerMetadata: $TSMeta) {
   }
   await buildOverridesEnabledResources(context);
   await generateDependentResourcesType();
-  // after this generate type
   return context;
 }

--- a/packages/amplify-provider-awscloudformation/src/initialize-env.ts
+++ b/packages/amplify-provider-awscloudformation/src/initialize-env.ts
@@ -23,6 +23,7 @@ import { buildOverridesEnabledResources } from './build-override-enabled-resourc
 import { S3BackendZipFileName } from './constants';
 import { fileLogger } from './utils/aws-logger';
 import { downloadZip, extractZip } from './zip-util';
+import { generateDependentResourcesType } from '@aws-amplify/amplify-category-custom';
 
 const logger = fileLogger('initialize-env');
 
@@ -126,5 +127,7 @@ export async function run(context: $TSContext, providerMetadata: $TSMeta) {
     }
   }
   await buildOverridesEnabledResources(context);
+  await generateDependentResourcesType();
+  // after this generate type
   return context;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The function for generating types was getting called when the cfn files were not yet generated for all resources. This happened because the order of the array of resources did not have custom as the last resource. The types were being built in the custom category. The fix is to build the types again after all of the cfn files have been created in amplify init. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
[# 11847](https://github.com/aws-amplify/amplify-cli/issues/11847)

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
