### PR TITLE
chore: use xlarge for cleanup build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,11 +193,7 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
     steps:
-      - attach_workspace:
-          at: ./
-      - restore_cache:
-          key: >-
-            amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - checkout
       - when:
           condition:
             equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
@@ -258,10 +254,7 @@ workflows:
         - equal: [true, << pipeline.parameters.e2e_resource_cleanup >>]
         - equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
     jobs:
-      - build
       - cleanup_resources:
           context:
             - cleanup-resources
             - e2e-test-context
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,14 @@ executors:
     environment:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
+  l_xlarge: &linux-e2e-executor-large
+    docker:
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+    working_directory: ~/repo
+    resource_class: xlarge
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
 
 # our defined job, and its steps
 jobs:
@@ -52,7 +60,7 @@ jobs:
     parameters:
       os:
         type: executor
-        default: l_large
+        default: l_xlarge
     executor: << parameters.os >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,11 @@ jobs:
       AMPLIFY_DIR: /home/circleci/repo/out
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
     steps:
-      - checkout
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: >-
+            amplify-cli-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - when:
           condition:
             equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
@@ -254,7 +258,10 @@ workflows:
         - equal: [true, << pipeline.parameters.e2e_resource_cleanup >>]
         - equal: [true, << pipeline.parameters.e2e_workflow_cleanup >>]
     jobs:
+      - build
       - cleanup_resources:
           context:
             - cleanup-resources
             - e2e-test-context
+          requires:
+            - build


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The `build` in `e2e_resource_cleanup` keeps crashing randomly. Bumping executor to same size as we use in `build_test_deploy_v3` workflow.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
