### PR TITLE
fix(amplify-util-mock): cannot read property 'stop' of undefined, optionally stop

### DIFF
--- a/packages/amplify-util-mock/src/api/api.ts
+++ b/packages/amplify-util-mock/src/api/api.ts
@@ -54,7 +54,7 @@ export class APITest {
   private userOverriddenSlots: string[] = [];
   private searchableTables: string[] = [];
 
-  async start(context, port: number = MOCK_API_PORT, wsPort: number = MOCK_API_PORT) {
+  public async start(context, port: number = MOCK_API_PORT, wsPort: number = MOCK_API_PORT) {
     try {
       context.amplify.addCleanUpTask(async (context) => {
         await this.stop(context);
@@ -73,7 +73,7 @@ export class APITest {
         wsPort,
       });
       await this.appSyncSimulator.start();
-      await this.resolverOverrideManager.start();
+      this.resolverOverrideManager.start();
       await this.watch(context);
       const appSyncConfig: AmplifyAppSyncSimulatorConfig = await this.runTransformer(context, this.apiParameters);
 
@@ -99,7 +99,7 @@ export class APITest {
     }
   }
 
-  async stop(context) {
+  public async stop(context) {
     this.ddbClient = null;
     if (this.watcher) {
       await this.watcher.close();
@@ -129,8 +129,8 @@ export class APITest {
       );
     }
 
-    await this.appSyncSimulator.stop();
-    this.resolverOverrideManager.stop();
+    await this.appSyncSimulator?.stop();
+    this.resolverOverrideManager?.stop();
   }
 
   private async runTransformer(context, parameters = {}) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

adds an optional call to `.stop()` for instances that have not yet been created in the `APITest` class for `amplify mock api`

Currently if you do not have a GraphQL API in your project you will see the following error:

```
Failed to start API Mocking. Running cleanup tasks.
TypeError: Cannot read property 'stop' of undefined
```

This is because [`this.getAppSyncAPI`](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-util-mock/src/api/api.ts#L65) rightfully throws, and so the [simulator isn't started](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-util-mock/src/api/api.ts#L75-L76) by the time our [catch block](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-util-mock/src/api/api.ts#L94) attempts to call `APITest.stop` (and `APITest.stop` calls the `stop` method of instances that were not created)

It appears if any of [these lines](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-util-mock/src/api/api.ts#L62-L74) throw, the error will be swallowed and customers are presented with the error shown above.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-category-api/issues/884
https://github.com/aws-amplify/amplify-category-api/issues/903
https://github.com/aws-amplify/amplify-category-api/issues/1323

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

built with `yarn setup-dev` and ran with `amplify-dev` in a project without a GraphQL API

```console
➜  /Users/josef/.yarn/bin/amplify-dev mock api
Debugger attached.
Failed to start API Mocking. Running cleanup tasks.
MockProcessFault: Failed to start API Mocking.. Reason: No AppSync API is added to the project
    at APITest.start (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-util-mock/lib/api/api.js:103:19)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async start (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-util-mock/lib/api/index.js:11:9)
    at async Object.run (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-util-mock/lib/commands/mock/api.js:14:9)
    at async Object.executeAmplifyCommand (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-util-mock/lib/amplify-plugin-index.js:33:5)
    at async executePluginModuleCommand (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-cli/lib/execution-manager.js:135:5)
    at async executeCommand (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-cli/lib/execution-manager.js:33:9)
    at async Object.run (/Users/josef/Documents/projects/aws-amplify/amplify-cli/packages/amplify-cli/lib/index.js:117:5) {
  classification: 'FAULT',
  options: {
    message: 'Failed to start API Mocking.. Reason: No AppSync API is added to the project',
    link: 'https://docs.amplify.aws/cli/graphql/troubleshooting/'
  },
  downstreamException: undefined,
  toObject: [Function (anonymous)],
  details: undefined,
  resolution: undefined,
  code: undefined,
  link: 'https://docs.amplify.aws/cli/graphql/troubleshooting/'
}
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
