### PR TITLE
test: improve resiliency of e2e tests on windows

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1320,6 +1320,7 @@ commands:
                   setNpmRegistryUrlToLocal
                   changeNpmGlobalPath
                   amplify version
+                  cd packages/amplify-e2e-tests
                   retry runE2eTest
                 no_output_timeout: 65m
   scan_e2e_test_artifacts:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -129,7 +129,6 @@ jobs:
           steps:
             - checkout
             - run: yarn config set script-shell $(which bash)
-            - run: yarn run production-build
             - run:
                 name: Build tests
                 command: yarn build-tests

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -129,6 +129,7 @@ jobs:
           steps:
             - checkout
             - run: yarn config set script-shell $(which bash)
+            - run: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
             - run:
                 name: Build tests
                 command: yarn build-tests

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1302,7 +1302,7 @@ commands:
                   source $BASH_ENV
                   amplify version
                   cd packages/amplify-e2e-tests
-                  retry yarn run e2e --no-cache --maxWorkers=3 --forceExit $TEST_SUITE
+                  retry runE2eTest
                 no_output_timeout: 65m
       - when:
           condition:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -129,7 +129,7 @@ jobs:
           steps:
             - checkout
             - run: yarn config set script-shell $(which bash)
-            - run: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+            - run: yarn run production-build
             - run:
                 name: Build tests
                 command: yarn build-tests

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -116,6 +116,19 @@ jobs:
           key: amplify-cli-ssh-deps-{{ .Branch }}
           paths:
             - ~/.ssh
+  build_tests_standalone:
+    parameters:
+      os:
+        type: executor
+        default: l_xlarge
+    executor: l_xlarge
+    steps:
+      - checkout
+      - run: yarn config set script-shell $(which bash)
+      - run: yarn install
+      - run:
+          name: Build tests
+          command: yarn build-tests
   build_windows_workspace_for_e2e:
     parameters:
       os:
@@ -913,6 +926,7 @@ workflows:
             branches:
               ignore:
                 - beta
+      - build_tests_standalone
       - build_windows_workspace_for_e2e:
           filters:
             branches:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -270,13 +270,6 @@ function setAwsAccountCredentials {
 function runE2eTest {
     FAILED_TEST_REGEX_FILE="./amplify-e2e-reports/amplify-e2e-failed-test.txt"
 
-    if [ -z "$FIRST_RUN" ] || [ "$FIRST_RUN" == "true" ]; then
-        startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
-        setNpmRegistryUrlToLocal
-        changeNpmGlobalPath
-        cd $(pwd)/packages/amplify-e2e-tests
-    fi
-
     if [ -f  $FAILED_TEST_REGEX_FILE ]; then
         # read the content of failed tests
         failedTests=$(<$FAILED_TEST_REGEX_FILE)

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -280,9 +280,9 @@ function runE2eTest {
     if [ -f  $FAILED_TEST_REGEX_FILE ]; then
         # read the content of failed tests
         failedTests=$(<$FAILED_TEST_REGEX_FILE)
-        yarn run e2e --no-cache --maxWorkers=3 $TEST_SUITE -t "$failedTests"
+        yarn run e2e --forceExit --no-cache --maxWorkers=3 $TEST_SUITE -t "$failedTests"
     else
-        yarn run e2e --no-cache --maxWorkers=3 $TEST_SUITE
+        yarn run e2e --forceExit --no-cache --maxWorkers=3 $TEST_SUITE
     fi
 }
 

--- a/nx.json
+++ b/nx.json
@@ -31,6 +31,10 @@
       "inputs": ["default", "^production"],
       "dependsOn": ["^build"]
     },
+    "build-tests": {
+      "inputs": ["default", "^production"],
+      "dependsOn": ["build", "^build"]
+    },
     "prepare": {
       "inputs": ["default", "^default"],
       "dependsOn": ["^prepare"]

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import Ajv from 'ajv';
 import { ApiKeyConfig } from '@aws-amplify/graphql-transformer-interfaces';
 import * as cdk from 'aws-cdk-lib';
@@ -1014,8 +1016,8 @@ export type IAuthResource = IAmplifyResource;
 // @public (undocumented)
 export type IContextFilesystem = {
     remove: (targetPath: string) => void;
-    read: (targetPath: string, encoding?: string) => $TSAny;
-    write: (targetPath: string, data: unknown) => void;
+    read: (targetPath: string, encoding?: BufferEncoding) => $TSAny;
+    write: (targetPath: string, data: string | NodeJS.ArrayBufferView) => void;
     exists: (targetPath: string) => boolean;
     isFile: (targetPath: string) => boolean;
     path: (...pathParts: string[]) => string;
@@ -1308,7 +1310,7 @@ export class JSONUtilities {
     static stringify: (data: unknown, options?: {
         minify?: boolean;
         orderedKeys?: boolean;
-    }) => string | undefined;
+    }) => string;
     // (undocumented)
     static writeJson: (fileName: string, data: unknown, options?: {
         mode?: number;

--- a/packages/amplify-cli-core/src/cfnUtilities.ts
+++ b/packages/amplify-cli-core/src/cfnUtilities.ts
@@ -60,7 +60,7 @@ const writeCFNTemplateDefaultOptions: Required<WriteCFNTemplateOptions> = {
  */
 export const writeCFNTemplate = async (template: object, filePath: string, options?: WriteCFNTemplateOptions): Promise<void> => {
   const mergedOptions = { ...writeCFNTemplateDefaultOptions, ...options };
-  let serializedTemplate: string | undefined;
+  let serializedTemplate: string;
   switch (mergedOptions.templateFormat) {
     case CFNTemplateFormat.JSON:
       serializedTemplate = JSONUtilities.stringify(template, { minify: mergedOptions.minify });

--- a/packages/amplify-cli-core/src/context/context-extensions.ts
+++ b/packages/amplify-cli-core/src/context/context-extensions.ts
@@ -140,11 +140,11 @@ const contextFileSystem = {
   remove: (targetPath: string): void => {
     fs.removeSync(targetPath);
   },
-  read: (targetPath: string, encoding = 'utf8'): string => {
-    const result = fs.readFileSync(targetPath, encoding);
+  read: (targetPath: string, encoding: BufferEncoding = 'utf8'): string => {
+    const result = fs.readFileSync(targetPath, { encoding });
     return result;
   },
-  write: (targetPath: string, data: unknown): void => {
+  write: (targetPath: string, data: string | NodeJS.ArrayBufferView): void => {
     fs.ensureFileSync(targetPath);
     fs.writeFileSync(targetPath, data, 'utf-8');
   },

--- a/packages/amplify-cli-core/src/jsonUtilities.ts
+++ b/packages/amplify-cli-core/src/jsonUtilities.ts
@@ -73,7 +73,7 @@ export class JSONUtilities {
     const dirPath = path.dirname(fileName);
     fs.ensureDirSync(dirPath);
 
-    const writeFileOptions: { encoding: string; mode?: number } = { encoding: 'utf8', mode: options?.mode };
+    const writeFileOptions: { encoding: BufferEncoding; mode?: number } = { encoding: 'utf8', mode: options?.mode };
     if (mergedOptions.secureFile) {
       writeFileOptions.mode = 0o600;
     }
@@ -124,7 +124,7 @@ export class JSONUtilities {
       minify?: boolean;
       orderedKeys?: boolean; // if true, will print object keys in alphabetical order
     },
-  ): string | undefined => {
+  ): string => {
     if (!data) {
       throw new Error("'data' argument missing");
     }

--- a/packages/amplify-cli-core/src/types.ts
+++ b/packages/amplify-cli-core/src/types.ts
@@ -292,8 +292,8 @@ export type IContextPrint = {
  */
 export type IContextFilesystem = {
   remove: (targetPath: string) => void;
-  read: (targetPath: string, encoding?: string) => $TSAny;
-  write: (targetPath: string, data: unknown) => void;
+  read: (targetPath: string, encoding?: BufferEncoding) => $TSAny;
+  write: (targetPath: string, data: string | NodeJS.ArrayBufferView) => void;
   exists: (targetPath: string) => boolean;
   isFile: (targetPath: string) => boolean;
   path: (...pathParts: string[]) => string;

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@aws-amplify/amplify-category-auth": "3.0.0-beta.8",
     "@aws-amplify/amplify-e2e-core": "4.7.1",
+    "@aws-amplify/amplify-opensearch-simulator": "1.2.2-beta.3",
     "@aws-amplify/graphql-transformer-core": "^1.1.0",
     "amplify-cli-core": "4.0.0-beta.8",
     "amplify-dynamodb-simulator": "2.5.8",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -30,6 +30,7 @@
     "amplify-cli-core": "4.0.0-beta.8",
     "amplify-dynamodb-simulator": "2.5.8",
     "amplify-headless-interface": "1.17.1",
+    "amplify-storage-simulator": "1.7.3",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-cdk-lib": "~2.53.0",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
- makes sure that retry loop of e2e tests re-runs only failed tests not all tests
- make `yarn clean && yarn build-tests` possible (not leveraged in workspace build eventually due to other dependencies on full build but nice to have).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e%2Fsobkamil%2Fimprove-e2e-tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
