### PR TITLE
fix: optional-chain exeInfo in pushResources to support mock command w/ resource changes

### DIFF
--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -137,7 +137,7 @@ export const pushResources = async (
   let continueToPush = !!context?.exeInfo?.inputParams?.yes || rebuild;
 
   if (!continueToPush) {
-    if (context.exeInfo.iterativeRollback) {
+    if (context.exeInfo?.iterativeRollback) {
       printer.info('The CLI will rollback the last known iterative deployment.');
     }
     await showBuildDirChangesMessage();

--- a/packages/amplify-util-mock/src/mockAll.ts
+++ b/packages/amplify-util-mock/src/mockAll.ts
@@ -18,6 +18,7 @@ export async function mockAllCategories(context: any) {
         context.print.info(
           'Some resources have changed locally and these resources are not mockable. The resources listed below need to be pushed to the cloud before starting the mock server.',
         );
+        context.amplify.constructExeInfo(context);
         const didPush = await context.amplify.pushResources(context, undefined, undefined, resourceToBePushed);
         if (!didPush) {
           context.print.info('\n\nMocking may not work as expected since some of the changed resources were not pushed.');


### PR DESCRIPTION
#### Description of changes
Currently, if you attempt to run `amplify mock` with an added Auth category (for example) you will see a failure on reading `iterativeRollback` from null. Optional chaining the exeInfo which doesn't exist in the mock case.

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran on `amplify` and `amplify-dev` w/ change to verify correct behavior.

**Existing Amplify Behavior**
<img width="527" alt="Screenshot 2023-03-07 at 8 36 55 AM" src="https://user-images.githubusercontent.com/91494052/223489292-2e916792-dba0-4080-97b5-69d02155770e.png">


**Updated Behavior (Ignore dev-build cloudform warnings)**
<img width="536" alt="Screenshot 2023-03-07 at 8 37 10 AM" src="https://user-images.githubusercontent.com/91494052/223489321-b1907b00-b7ba-433e-baa4-8e17387fe608.png">

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
