### PR TITLE
chore: remove jsdoc eslint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^27.0.0",
-    "eslint-plugin-jsdoc": "^37.9.6",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-package-json-dependencies": "^1.0.17",
     "eslint-plugin-prefer-arrow": "^1.2.3",

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable jsdoc/require-jsdoc */
 import inquirer from 'inquirer';
 import _ from 'lodash';
 import { stateManager, open, $TSContext, $TSObject, AmplifyError } from 'amplify-cli-core';

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable jsdoc/require-jsdoc */
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import _, { uniq, pullAll } from 'lodash';

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/auth-request-adaptors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import {
   AddAuthRequest,
   CognitoUserAliasAttributes,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -401,7 +401,6 @@ export const migrate = (__: $TSContext, projectPath: string, resourceName: strin
   JSONUtilities.writeJson(cfnFilePath, newCfn);
 };
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export const updateCFNFileForResourcePermissions = (
   resourceDirPath: string,
   functionParameters: Partial<FunctionParameters>,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
@@ -6,7 +6,6 @@ import { isMultiEnvLayer } from './layerHelpers';
 import { LegacyPermissionEnum } from './layerMigrationUtils';
 import { LayerVersionMetadata, PermissionEnum } from './layerParams';
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 export class LayerCloudState {
   private static instances: Record<string, LayerCloudState> = {};
   private layerVersionsMetadata: LayerVersionMetadata[];
@@ -15,7 +14,6 @@ export class LayerCloudState {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {}
 
-  // eslint-disable-next-line jsdoc/require-jsdoc
   static getInstance(layerName: string): LayerCloudState {
     if (!LayerCloudState.instances[layerName]) {
       LayerCloudState.instances[layerName] = new LayerCloudState();
@@ -119,7 +117,6 @@ export class LayerCloudState {
     return this.layerVersionsMetadata;
   }
 
-  // eslint-disable-next-line jsdoc/require-jsdoc
   public async getLayerVersionsFromCloud(context: $TSContext, layerName: string): Promise<LayerVersionMetadata[]> {
     return this.layerVersionsMetadata || this.loadLayerDataFromCloud(context, layerName);
   }

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -116,7 +116,7 @@ describe('Test S3 transform generates correct CFN template', () => {
   });
 });
 
-// eslint-disable-next-line jest/no-export, jsdoc/require-jsdoc
+// eslint-disable-next-line jest/no-export 
 export class S3MockDataBuilder {
   static mockBucketName = 'mock-stack-builder-bucket-name-99'; // s3 bucket naming rules allows alphanumeric and hyphens
   static mockResourceName = 'mockResourceName';
@@ -170,7 +170,7 @@ export class S3MockDataBuilder {
     /* noop */
   }
 
-  // eslint-disable-next-line jsdoc/require-jsdoc, @typescript-eslint/explicit-function-return-type
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   static getMockGetAllResourcesNoExistingLambdas() {
     return [{ service: 'Cognito', serviceType: 'managed' }];
   }

--- a/packages/amplify-category-storage/src/commands/storage.ts
+++ b/packages/amplify-category-storage/src/commands/storage.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc, jsdoc/require-description */
 import { $TSContext } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import * as path from 'path';

--- a/packages/amplify-category-storage/src/index.ts
+++ b/packages/amplify-category-storage/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc, jsdoc/require-description */
 import { $TSAny, $TSContext, AmplifyCategories, AmplifySupportedService, IAmplifyResource, stateManager } from 'amplify-cli-core';
 import { printer } from 'amplify-prompts';
 import {

--- a/packages/amplify-cli-core/src/serviceSelection.ts
+++ b/packages/amplify-cli-core/src/serviceSelection.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 export type ServiceSelection = {
   provider: string;
   service: string;

--- a/packages/amplify-cli/src/plugin-helpers/platform-health-check.ts
+++ b/packages/amplify-cli/src/plugin-helpers/platform-health-check.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description */
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */

--- a/packages/amplify-console-integration-tests/src/pullAndInit/amplifyArtifactsManager.ts
+++ b/packages/amplify-console-integration-tests/src/pullAndInit/amplifyArtifactsManager.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { $TSAny } from 'amplify-cli-core';

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -3,7 +3,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
-/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { $TSAny } from 'amplify-cli-core';
 import * as fs from 'fs-extra';

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable import/no-cycle */
 import * as os from 'os';
 import * as path from 'path';

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-cycle */
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
-/* eslint-disable jsdoc/require-jsdoc */
 import { EOL } from 'os';
 import { v4 as uuid } from 'uuid';
 import { nspawn as spawn, getCLIPath, singleSelect, addCircleCITags } from '..';

--- a/packages/amplify-e2e-core/src/init/overrideStack.ts
+++ b/packages/amplify-e2e-core/src/init/overrideStack.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 // eslint-disable-next-line import/no-cycle
 import { nspawn as spawn, getCLIPath } from '..';
 

--- a/packages/amplify-e2e-core/src/utils/projectMeta.ts
+++ b/packages/amplify-e2e-core/src/utils/projectMeta.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs-extra';

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable no-return-await */
 import {
   config,

--- a/packages/amplify-e2e-tests/src/import-helpers/expects.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/expects.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import { getProjectMeta, getBackendAmplifyMeta, getTeamProviderInfo, getBackendConfig } from '@aws-amplify/amplify-e2e-core';
 import { AuthParameters } from '@aws-amplify/amplify-category-auth';
 // eslint-disable-next-line import/no-cycle

--- a/packages/amplify-e2e-tests/src/import-helpers/utilities.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/utilities.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import { $TSAny, $TSObject, JSONUtilities } from 'amplify-cli-core';
 import {
   addAuthIdentityPoolAndUserPoolWithOAuth,

--- a/packages/amplify-environment-parameters/src/resource-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/resource-parameter-manager.ts
@@ -6,7 +6,6 @@
 export class ResourceParameterManager {
   private params: Record<string, string> = {};
 
-  // eslint-disable-next-line jsdoc/require-jsdoc
   getParam(name: string): string | undefined {
     return this.params[name];
   }
@@ -33,7 +32,6 @@ export class ResourceParameterManager {
     });
   }
 
-  // eslint-disable-next-line jsdoc/require-jsdoc
   deleteParam(name: string): void {
     delete this.params[name];
   }

--- a/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-javascript/lib/frontend-config-creator.js
@@ -2,7 +2,6 @@
 /* eslint-disable func-style */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable jsdoc/require-jsdoc */
 const path = require('path');
 const Module = require('module');
 const fs = require('fs-extra');

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -6,7 +6,6 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-return-await */
 /* eslint-disable consistent-return */
-/* eslint-disable jsdoc/require-description */
 /* eslint-disable no-continue */
 /* eslint-disable max-len */
 /* eslint-disable spellcheck/spell-checker */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5370,15 +5370,6 @@
     ts-node "^9"
     tslib "^2"
 
-"@es-joy/jsdoccomment@~0.20.1":
-  version "0.20.1"
-  resolved "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz#fe89f435f045ae5aaf89c7a4df3616c03e9d106e"
-  integrity sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==
-  dependencies:
-    comment-parser "1.3.0"
-    esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~2.2.3"
-
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -11267,11 +11258,6 @@ comment-json@~4.2.0:
     has-own-prop "^2.0.0"
     repeat-string "^1.6.1"
 
-comment-parser@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz#68beb7dbe0849295309b376406730cd16c719c44"
-  integrity sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==
-
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
@@ -13067,20 +13053,6 @@ eslint-plugin-jest@^27.0.0:
   integrity sha512-0QVzf+og4YI1Qr3UoprkqqhezAZjFffdi62b0IurkCXMqPtRW84/UT4CKsYT80h/D82LA9avjO/80Ou1LdgbaQ==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
-
-eslint-plugin-jsdoc@^37.9.6:
-  version "37.9.6"
-  resolved "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.6.tgz#4ac0b6f171d818856a6e52987413f54d66a50800"
-  integrity sha512-GDCB0nEwKVaeIzam+t/yB8XG/6tgvc9XgrSwuxqCXVlKRWUqTuTqntZoqAKZAIbWIgYsrnrvrWAyIX/QvhwBcw==
-  dependencies:
-    "@es-joy/jsdoccomment" "~0.20.1"
-    comment-parser "1.3.0"
-    debug "^4.3.3"
-    escape-string-regexp "^4.0.0"
-    esquery "^1.4.0"
-    regextras "^0.8.0"
-    semver "^7.3.5"
-    spdx-expression-parse "^3.0.1"
 
 eslint-plugin-jsx-a11y@^6.5.1:
   version "6.5.1"
@@ -17131,11 +17103,6 @@ jsbn@~0.1.0:
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdoc-type-pratt-parser@~2.2.3:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.3.tgz#3910cd0120054a512a73942d644ef1eb5a9df6e9"
-  integrity sha512-QPyxq62Q8veBSDtDrWmqaEPjSCeknUV9dH/OAGt3q9an8qC8UQDqitQiw1NvoMskIESpoRZ6qzt4H3rlK0xo8A==
-
 jsdom@^16.4.0, jsdom@^16.6.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
@@ -21033,11 +21000,6 @@ regexpu-core@^5.0.1:
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.0.0"
 
-regextras@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
-  integrity sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==
-
 registry-auth-token@^4.0.0:
   version "4.2.1"
   resolved "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz#6d7b4006441918972ccd5fedcd41dc322c79b250"
@@ -22163,7 +22125,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
-spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
+spdx-expression-parse@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==


### PR DESCRIPTION

#### Description of changes

The current version of the `jsdoc` eslint plugin prevents building the CLI on Node >= 18. Upgrading the plugin from v37 to v40 resolves this issue. However, we are no longer using the jsdoc plugin. This removes the `jsdoc` eslint plugin and all references to the lint rule from the source code.



#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
