### PR TITLE
chore: update e2e docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,7 +549,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:18
     steps:
       - setup_remote_docker
       - aws-ecr/build-and-push-image:
@@ -560,8 +560,8 @@ jobs:
           checkout: true
           create-repo: false
           dockerfile: Dockerfile
-          repo: amplify-cli-e2e-base-image-repo-public
-          tag: "latest,${CIRCLE_SHA1}"
+          repo: amplify-cli-e2e-base-image-node18-repo-public
+          tag: "latest,${CIRCLE_SHA1},node18"
 
 workflows:
   build_and_push_image:
@@ -572,3 +572,4 @@ workflows:
             branches:
               only:
                 - e2e-image-build
+                - e2e-image-build-vnext

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,7 +549,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/node:18
+      - image: cimg/node:18.14
     steps:
       - setup_remote_docker
       - aws-ecr/build-and-push-image:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN sudo apt-get install -y \
   groff \
   python2 \
   python-pip \
-  libpython-dev \
+  libpython2-dev \
   less \
   tree
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:18
+FROM cimg/node:18.14
 RUN sudo npm install -g npm@7
 RUN npm -v
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM cimg/node:18.14
-RUN sudo npm install -g npm@7
+RUN sudo npm install -g npm@9
 RUN npm -v
 WORKDIR /tmp
 RUN sudo apt-get update
@@ -16,7 +16,7 @@ RUN sudo apt-get install -y \
   lsof \
   jq \
   groff \
-  python \
+  python2 \
   python-pip \
   libpython-dev \
   less \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN sudo apt-get update
 RUN sudo apt-get install apt-transport-https
 RUN sudo apt-get update
 RUN sudo apt-get install dotnet-sdk-6.0
-RUN dotnet --version
 RUN dotnet --list-sdks
 RUN dotnet tool install -g amazon.lambda.tools
 RUN dotnet tool install -g amazon.lambda.testtool-6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,11 +70,9 @@ RUN sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 RUN sudo apt-get update
 RUN sudo apt-get install apt-transport-https
 RUN sudo apt-get update
-RUN sudo apt-get install dotnet-sdk-3.1
 RUN sudo apt-get install dotnet-sdk-6.0
 RUN dotnet --version
 RUN dotnet --list-sdks
 RUN dotnet tool install -g amazon.lambda.tools
-RUN dotnet tool install -g amazon.lambda.testtool-3.1
 RUN dotnet tool install -g amazon.lambda.testtool-6.0
 ENV PATH=${PATH}:/home/circleci/.dotnet/tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN python3 --version
 
 #Install .Net
 WORKDIR /tmp
-RUN sudo apt-get install apt-transport-https ca-certificates
+RUN sudo apt-get install -y apt-transport-https ca-certificates
 RUN wget -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 RUN sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
 RUN wget https://packages.microsoft.com/config/debian/9/prod.list
@@ -68,9 +68,9 @@ RUN sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 RUN sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 
 RUN sudo apt-get update
-RUN sudo apt-get install apt-transport-https
+RUN sudo apt-get install -y apt-transport-https
 RUN sudo apt-get update
-RUN sudo apt-get install dotnet-sdk-6.0
+RUN sudo apt-get install -y dotnet-sdk-6.0
 RUN dotnet --list-sdks
 RUN dotnet tool install -g amazon.lambda.tools
 RUN dotnet tool install -g amazon.lambda.testtool-6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:14
+FROM cimg/node:18
 RUN sudo npm install -g npm@7
 RUN npm -v
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN sudo apt-get install -y \
   lsof \
   jq \
   groff \
+  python2 \
+  libpython2-dev \
   python3 \
   python3-pip \
   libpython3-dev \
@@ -44,34 +46,9 @@ RUN curl -O https://dl.google.com/go/go1.14.1.linux-amd64.tar.gz
 RUN sudo tar -C /usr/local -xzf go1.14.1.linux-amd64.tar.gz
 ENV PATH=${PATH}:/usr/local/go/bin
 
-# Install Python
-WORKDIR /tmp
-RUN sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl
-RUN curl -O https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz
-RUN sudo tar -C /usr/local -xf Python-3.8.2.tar.xz
-WORKDIR /usr/local/Python-3.8.2
-RUN sudo ./configure
-RUN sudo make -j 4
-RUN sudo make install
-RUN sudo apt install python3-pip
-RUN pip3 install --user pipenv
-RUN python3 --version
-
 #Install .Net
-WORKDIR /tmp
-RUN sudo apt-get install -y apt-transport-https ca-certificates
-RUN wget -O- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
-RUN sudo mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
-RUN wget https://packages.microsoft.com/config/debian/9/prod.list
-RUN sudo mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
-RUN sudo chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
-RUN sudo chown root:root /etc/apt/sources.list.d/microsoft-prod.list
-
-RUN sudo apt-get update
-RUN sudo apt-get install -y apt-transport-https
-RUN sudo apt-get update
 RUN sudo apt-get install -y dotnet-sdk-6.0
-RUN dotnet --list-sdks
+RUN sudo dotnet --list-sdks
 RUN dotnet tool install -g amazon.lambda.tools
 RUN dotnet tool install -g amazon.lambda.testtool-6.0
 ENV PATH=${PATH}:/home/circleci/.dotnet/tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN sudo apt-get install -y \
   lsof \
   jq \
   groff \
-  python2 \
-  python-pip \
-  libpython2-dev \
+  python3 \
+  python3-pip \
+  libpython3-dev \
   less \
   tree
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Use Node 18
- Drop .NET core 3.1 (not supported on ubuntu 22)
- Cleanup python instalation

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
