### PR TITLE
chore(amplify-util-uibuilder): formFeatureFlags metadata

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,8 +14,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/codegen-ui": "2.8.0",
-    "@aws-amplify/codegen-ui-react": "2.8.0",
+    "@aws-amplify/codegen-ui": "2.9.0",
+    "@aws-amplify/codegen-ui-react": "2.9.0",
     "amplify-cli-core": "4.0.0-beta.8",
     "amplify-prompts": "2.6.4",
     "aws-sdk": "^2.1233.0",

--- a/packages/amplify-util-uibuilder/src/clients/amplify-studio-client.ts
+++ b/packages/amplify-util-uibuilder/src/clients/amplify-studio-client.ts
@@ -12,6 +12,10 @@ import { getTransformerVersion } from '../commands/utils/featureFlags';
 export type StudioMetadata = {
   autoGenerateForms: boolean;
   autoGenerateViews: boolean;
+  formFeatureFlags: {
+    isRelationshipSupported: boolean;
+    isNonModelSupported: boolean;
+  };
 };
 
 /**
@@ -107,6 +111,10 @@ export default class AmplifyStudioClient {
     this.metadata = {
       autoGenerateForms: false,
       autoGenerateViews: false,
+      formFeatureFlags: {
+        isRelationshipSupported: false,
+        isNonModelSupported: false,
+      },
     };
   }
 
@@ -126,6 +134,10 @@ export default class AmplifyStudioClient {
       this.metadata = {
         autoGenerateForms: response.features?.autoGenerateForms === 'true',
         autoGenerateViews: response.features?.autoGenerateViews === 'true',
+        formFeatureFlags: {
+          isRelationshipSupported: response.features?.isRelationshipSupported === 'true',
+          isNonModelSupported: response.features?.isNonModelSupported === 'true',
+        },
       };
     } catch (err) {
       throw new Error(`Failed to load metadata: ${err.message}`);

--- a/packages/amplify-util-uibuilder/src/commands/generateComponents.ts
+++ b/packages/amplify-util-uibuilder/src/commands/generateComponents.ts
@@ -51,6 +51,7 @@ export const run = async (context: $TSContext, eventType: 'PostPush' | 'PostPull
         formSchemas.entities,
         dataSchema,
         studioClient.metadata.autoGenerateForms && studioClient.isGraphQLSupported,
+        studioClient.metadata.formFeatureFlags,
       ),
     };
 
@@ -108,6 +109,13 @@ export const run = async (context: $TSContext, eventType: 'PostPush' | 'PostPull
         `The components ${invalidComponentNames.join(
           ', ',
         )} were synced with an older version of Amplify Studio. Please re-sync your components with Figma to get latest features and changes.`, // eslint-disable-line spellcheck/spell-checker
+      );
+    }
+
+    // TODO: remove this warning message after release + 6 weeks
+    if (hasSuccessfulForm && (dataSchema?.models || dataSchema?.nonModels)) {
+      printer.warn(
+        'For data models with relationships, Amplify forms will now automatically contain relationship fields. This may change forms in your application. Please verify that all forms in your application are working as expected.',
       );
     }
 

--- a/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
@@ -12,6 +12,7 @@ import {
   getGenericFromDataStore,
   StudioForm,
   StudioSchema,
+  FormFeatureFlags,
 } from '@aws-amplify/codegen-ui';
 import {
   AmplifyRenderer,
@@ -95,11 +96,16 @@ export const createUiBuilderTheme = (
 /**
  * Writes form file to the work space
  */
-export const createUiBuilderForm = (context: $TSContext, schema: StudioForm, dataSchema?: GenericDataSchema): StudioForm => {
+export const createUiBuilderForm = (
+  context: $TSContext,
+  schema: StudioForm,
+  dataSchema?: GenericDataSchema,
+  formFeatureFlags?: FormFeatureFlags,
+): StudioForm => {
   const uiBuilderComponentsPath = getUiBuilderComponentsPath(context);
   const rendererFactory = new StudioTemplateRendererFactory(
     (form: StudioForm) =>
-      new AmplifyFormRenderer(form, dataSchema, config) as unknown as StudioTemplateRenderer<
+      new AmplifyFormRenderer(form, dataSchema, config, formFeatureFlags) as unknown as StudioTemplateRenderer<
         unknown,
         StudioForm,
         FrameworkOutputManager<unknown>,

--- a/packages/amplify-util-uibuilder/src/commands/utils/syncAmplifyUiBuilderComponents.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/syncAmplifyUiBuilderComponents.ts
@@ -1,6 +1,14 @@
 import { printer } from 'amplify-prompts';
 import { $TSContext } from 'amplify-cli-core';
-import { StudioComponent, StudioTheme, GenericDataSchema, StudioForm, StudioSchema, checkIsSupportedAsForm } from '@aws-amplify/codegen-ui';
+import {
+  StudioComponent,
+  StudioTheme,
+  GenericDataSchema,
+  StudioForm,
+  StudioSchema,
+  checkIsSupportedAsForm,
+  FormFeatureFlags,
+} from '@aws-amplify/codegen-ui';
 import { createUiBuilderComponent, createUiBuilderForm, createUiBuilderTheme, generateBaseForms } from './codegenResources';
 import { getUiBuilderComponentsPath } from './getUiBuilderComponentsPath';
 
@@ -95,6 +103,7 @@ export const generateUiBuilderForms = (
   formSchemas: any[],
   dataSchema?: GenericDataSchema,
   autoGenerateForms?: boolean,
+  formFeatureFlags?: FormFeatureFlags,
 ): CodegenResponse<StudioForm>[] => {
   const modelMap: { [model: string]: Set<'create' | 'update'> } = {};
   if (dataSchema?.dataSourceType === 'DataStore' && autoGenerateForms) {
@@ -106,7 +115,7 @@ export const generateUiBuilderForms = (
   }
   const codegenForm = (schema: StudioForm): CodegenResponse<StudioForm> => {
     try {
-      const form = createUiBuilderForm(context, schema, dataSchema);
+      const form = createUiBuilderForm(context, schema, dataSchema, formFeatureFlags);
       return { resultType: 'SUCCESS', schema: form };
     } catch (e) {
       printer.debug(`Failure caught processing ${schema.name}`);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Conditionally renders relationship and non-model fields based on `formFeatureFlags` metadata
- Adds temporary warning message for all customers with relationships or non-model types in their data schema
- Upgrades `codegen-ui` and `codegen-ui-react` to `2.9.0`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Followed [this guide](https://github.com/aws-amplify/amplify-codegen-ui/blob/main/CONTRIBUTING.md#testing-updates-to-cli) to validate changes. Relationship and nonmodel fields are only rendered when the `formFeatureFlags` metadata are `true`. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
