### PR TITLE
chore(amplify-util-uibuilder): use introspection schema to generate c…

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -15,15 +15,17 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-prompts": "2.6.5",
-    "@aws-amplify/codegen-ui": "2.8.0",
-    "@aws-amplify/codegen-ui-react": "2.8.0",
+    "@aws-amplify/codegen-ui": "2.9.0",
+    "@aws-amplify/codegen-ui-react": "2.9.0",
     "amplify-cli-core": "4.0.0",
+    "amplify-codegen": "^3.4.0",
     "aws-sdk": "^2.1233.0",
     "fs-extra": "^8.1.0",
     "ora": "^4.0.3",
     "tiny-async-pool": "^2.1.0"
   },
   "devDependencies": {
+    "@aws-amplify/appsync-modelgen-plugin": "^2.4.0",
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "^26.0.20",
     "@types/semver": "^7.1.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/getAmplifyDataSchema.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/getAmplifyDataSchema.test.ts
@@ -1,135 +1,83 @@
-import aws from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
-import { AmplifyCategories, AmplifySupportedService, FeatureFlags } from 'amplify-cli-core'; // eslint-disable-line import/no-extraneous-dependencies
 import { printer } from '@aws-amplify/amplify-prompts'; // eslint-disable-line import/no-extraneous-dependencies
 import { mocked } from 'ts-jest/utils';
-import { AmplifyStudioClient } from '../clients';
 import { getAmplifyDataSchema } from '../commands/utils';
 
-const awsMock = aws as any;
-const printerMock = printer as any;
+jest.mock('@aws-amplify/amplify-prompts');
 
-jest.mock('amplify-cli-core', () => ({
-  ...jest.requireActual('amplify-cli-core'),
-  stateManager: {
-    getMeta: jest.fn(() => ({
-      [AmplifyCategories.API]: {
-        MyResourceName: {
-          service: AmplifySupportedService.APPSYNC,
+const printerMock = mocked(printer);
+
+const sampleIntrospectionSchema = {
+  version: 1,
+  models: {
+    Blog: {
+      name: 'Blog',
+      fields: {
+        id: {
+          name: 'id',
+          isArray: false,
+          type: 'ID',
+          isRequired: true,
+          attributes: [],
         },
       },
-    })),
-    getCLIJSON: jest.fn().mockReturnValue({ features: { graphqltransformer: { transformerversion: 1 } } }),
-    setCLIJSON: jest.fn(),
+      syncable: true,
+      pluralName: 'Users',
+      attributes: [
+        {
+          type: 'model',
+          properties: {},
+        },
+      ],
+      primaryKeyInfo: {
+        isCustomPrimaryKey: false,
+        primaryKeyFieldName: 'id',
+        sortKeyFieldNames: [],
+      },
+    },
   },
-  FeatureFlags: {
-    getBoolean: () => true,
-    getNumber: jest.fn(),
-    reloadValues: jest.fn(),
-  },
-}));
-jest.mock('amplify-prompts');
+  enums: {},
+  nonModels: {},
+};
 
-const mockedFeatureFlags = mocked(FeatureFlags);
-
-const getMockedSchema = jest.fn(
-  // eslint-disable-next-line no-useless-escape, spellcheck/spell-checker
-  () =>
-    `export const schema = {\n    \"models\": {\n        \"Blog\": {\n            \"name\": \"Blog\",\n            \"fields\": {\n                \"id\": {\n                    \"name\": \"id\",\n                    \"isArray\": false,\n                    \"type\": \"ID\",\n                    \"isRequired\": true,\n                    \"attributes\": []\n                },\n                \"title\": {\n                    \"name\": \"title\",\n                    \"isArray\": false,\n                    \"type\": \"String\",\n                    \"isRequired\": false,\n                    \"attributes\": []\n                },\n                \"content\": {\n                    \"name\": \"content\",\n                    \"isArray\": false,\n                    \"type\": \"String\",\n                    \"isRequired\": false,\n                    \"attributes\": []\n                },\n                \"status\": {\n                    \"name\": \"status\",\n                    \"isArray\": false,\n                    \"type\": {\n                        \"enum\": \"Status\"\n                    },\n                    \"isRequired\": false,\n                    \"attributes\": []\n                },\n                \"createdAt\": {\n                    \"name\": \"createdAt\",\n                    \"isArray\": false,\n                    \"type\": \"AWSDateTime\",\n                    \"isRequired\": false,\n                    \"attributes\": [],\n                    \"isReadOnly\": true\n                },\n                \"updatedAt\": {\n                    \"name\": \"updatedAt\",\n                    \"isArray\": false,\n                    \"type\": \"AWSDateTime\",\n                    \"isRequired\": false,\n                    \"attributes\": [],\n                    \"isReadOnly\": true\n                }\n            },\n            \"syncable\": true,\n            \"pluralName\": \"Blogs\",\n            \"attributes\": [\n                {\n                    \"type\": \"model\",\n                    \"properties\": {}\n                },\n                {\n                    \"type\": \"auth\",\n                    \"properties\": {\n                        \"rules\": [\n                            {\n                                \"allow\": \"public\",\n                                \"operations\": [\n                                    \"create\",\n                                    \"update\",\n                                    \"delete\",\n                                    \"read\"\n                                ]\n                            }\n                        ]\n                    }\n                }\n            ]\n        }\n    },\n    \"enums\": {\n        \"Status\": {\n            \"name\": \"Status\",\n            \"values\": [\n                \"ENABLED\",\n                \"DISABLED\"\n            ]\n        }\n    },\n    \"nonModels\": {},\n    \"version\": \"demo\"\n};`,
-);
+const mockedGetModelIntrospection = jest.fn();
 
 describe('should sync amplify backend models', () => {
   let context: any;
 
-  beforeAll(() => {
-    // set metadata response
-    awsMock.AmplifyUIBuilder = jest.fn(() => ({
-      getMetadata: jest.fn(() => ({
-        promise: jest.fn(() => ({
-          features: {
-            autoGenerateForms: 'true',
-            autoGenerateViews: 'true',
-          },
-        })),
-      })),
-    }));
-  });
-
   beforeEach(() => {
     context = {
-      exeInfo: {
-        projectConfig: {
-          javascript: {
-            config: {
-              SourceDir: 'src',
-            },
-          },
-        },
-      },
       amplify: {
-        invokePluginMethod: () => ({}),
+        invokePluginMethod: mockedGetModelIntrospection,
       },
-      parameters: {
-        argv: [],
-      },
-      input: {
-        options: {
-          appId: 'testAppId',
-          envName: 'testEnvName',
-        },
-      },
-      print: { warning: jest.fn() },
     };
 
-    mockedFeatureFlags.getNumber.mockReturnValue(2);
-    getMockedSchema.mockClear();
-    awsMock.AmplifyBackend = jest.fn().mockReturnValue({
-      getBackendAPIModels: jest.fn().mockReturnValue({
-        promise: () => ({
-          Models: getMockedSchema(),
-        }),
-      }),
-    });
+    mockedGetModelIntrospection.mockReset();
   });
 
-  it('should getAmplifyBackendModels', async () => {
-    const client = await AmplifyStudioClient.setClientInfo(context);
-    const dataSchema = await getAmplifyDataSchema(client);
-    expect(getMockedSchema).toBeCalled();
+  it('should get generic schema from introspection schema', async () => {
+    mockedGetModelIntrospection.mockReturnValue(sampleIntrospectionSchema);
+
+    const dataSchema = await getAmplifyDataSchema(context);
     expect(dataSchema).toBeDefined();
     expect(Object.keys(dataSchema!.models)).toContain('Blog');
   });
 
-  it('should not getAmplifyBackendModels and return undefined if graphQLTransformer version not supported', async () => {
-    mockedFeatureFlags.getNumber.mockReturnValue(1);
-    const client = await AmplifyStudioClient.setClientInfo(context);
-    const dataSchema = await getAmplifyDataSchema(client);
-    expect(getMockedSchema).not.toBeCalled();
+  it('should handle schema not found', async () => {
+    mockedGetModelIntrospection.mockReturnValue(undefined);
+
+    const dataSchema = await getAmplifyDataSchema(context);
     expect(dataSchema).toBeUndefined();
+    expect(printerMock.debug).toHaveBeenCalledWith('Local schema not found');
   });
 
-  it('should handle Models not found', async () => {
-    awsMock.AmplifyBackend = jest.fn().mockReturnValue({
-      getBackendAPIModels: jest.fn().mockReturnValue({
-        promise: () => ({
-          Models: undefined,
-        }),
-      }),
+  it('should handle error', async () => {
+    const error = new Error('Something went wrong');
+    mockedGetModelIntrospection.mockImplementation(() => {
+      throw error;
     });
-    const client = await AmplifyStudioClient.setClientInfo(context);
-    const dataSchema = await getAmplifyDataSchema(client);
-    expect(dataSchema).toBeUndefined();
-    expect(printerMock.debug).toHaveBeenCalledWith('Provided ResourceName: MyResourceName did not yield Models.');
-  });
 
-  it('should handle network error', async () => {
-    awsMock.AmplifyBackend = jest.fn().mockReturnValue({
-      getBackendAPIModels: jest.fn().mockReturnValue({
-        promise: jest.fn().mockRejectedValue(new Error('Network Error')),
-      }),
-    });
-    const client = await AmplifyStudioClient.setClientInfo(context);
-    const dataSchema = await getAmplifyDataSchema(client);
+    const dataSchema = await getAmplifyDataSchema(context);
     expect(dataSchema).toBeUndefined();
-    expect(printerMock.debug).toHaveBeenCalledWith('Error: Models not found in AmplifyBackend:GetBackendAPIModels response: Network Error');
+    expect(printerMock.debug).toHaveBeenCalledWith(error.toString());
   });
 });

--- a/packages/amplify-util-uibuilder/src/commands/generateComponents.ts
+++ b/packages/amplify-util-uibuilder/src/commands/generateComponents.ts
@@ -32,7 +32,7 @@ export const run = async (context: $TSContext, eventType: 'PostPush' | 'PostPull
       studioClient.listComponents(),
       studioClient.listThemes(),
       studioClient.listForms(),
-      getAmplifyDataSchema(studioClient),
+      studioClient.isGraphQLSupported ? getAmplifyDataSchema(context) : Promise.resolve(undefined),
     ]);
 
     const nothingWouldAutogenerate = !dataSchema || !studioClient.metadata.autoGenerateForms || !studioClient.isGraphQLSupported;

--- a/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
@@ -26,9 +26,9 @@ import {
   ReactThemeStudioTemplateRendererOptions,
 } from '@aws-amplify/codegen-ui-react';
 import { printer } from '@aws-amplify/amplify-prompts';
-import { $TSContext, AmplifyCategories, AmplifySupportedService, stateManager } from 'amplify-cli-core';
+import { $TSContext } from 'amplify-cli-core';
 import { getUiBuilderComponentsPath } from './getUiBuilderComponentsPath';
-import { AmplifyStudioClient } from '../../clients';
+import { ModelIntrospectionSchema } from '@aws-amplify/appsync-modelgen-plugin';
 
 const config = {
   module: ModuleKind.ES2020,
@@ -203,26 +203,17 @@ export const generateAmplifyUiBuilderUtilFile = (context: $TSContext, { hasForms
  * If models are available, they will be populated in the models field of the returned object.
  * If they're not available, it will return undefined
  */
-export const getAmplifyDataSchema = async (studioClient: AmplifyStudioClient): Promise<GenericDataSchema | undefined> => {
-  if (!studioClient.isGraphQLSupported) {
-    return undefined;
-  }
+export const getAmplifyDataSchema = async (context: $TSContext): Promise<GenericDataSchema | undefined> => {
   try {
-    const meta = stateManager.getMeta();
-    const resourceName = Object.entries(meta[AmplifyCategories.API]).find(
-      ([, value]) => (value as { service: string }).service === AmplifySupportedService.APPSYNC,
-    )?.[0];
-    if (resourceName) {
-      const model = await studioClient.getModels(resourceName);
-      if (model) {
-        const source = model.replace(model.substring(0, model.indexOf(`{`) - 1), ``).replace(/;/g, ``);
-        return getGenericFromDataStore(JSON.parse(source));
-      }
+    const localSchema = await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'getModelIntrospection', [context]);
+
+    if (!localSchema) {
+      printer.debug('Local schema not found');
+      return undefined;
     }
-    printer.debug(`Provided ResourceName: ${resourceName} did not yield Models.`);
-    return undefined;
-  } catch (error) {
-    printer.debug(error.toString());
+    return getGenericFromDataStore(localSchema as ModelIntrospectionSchema);
+  } catch (e) {
+    printer.debug(e.toString());
     return undefined;
   }
 };

--- a/packages/amplify-util-uibuilder/src/utils/prePushHandler.ts
+++ b/packages/amplify-util-uibuilder/src/utils/prePushHandler.ts
@@ -3,11 +3,7 @@ import { printer } from '@aws-amplify/amplify-prompts';
 import AmplifyUIBuilder from 'aws-sdk/clients/amplifyuibuilder';
 import { AmplifyStudioClient } from '../clients';
 import { isFormDetachedFromModel, isFormSchemaCustomized, shouldRenderComponents } from '../commands/utils';
-
-// TODO: replace this type when amplify-codegen package export official types
-type Schema = {
-  models: Record<string, unknown>;
-};
+import { ModelIntrospectionSchema } from '@aws-amplify/appsync-modelgen-plugin';
 
 /**
  * Handles showing a warning for detached forms pre-push.
@@ -22,7 +18,7 @@ export const prePushHandler = async (context: $TSContext): Promise<void> => {
       Promise<{
         entities: AmplifyUIBuilder.Form[];
       }>,
-      Promise<Schema>,
+      Promise<ModelIntrospectionSchema>,
     ]
   >([studioClient.listForms(), context.amplify.invokePluginMethod(context, 'codegen', undefined, 'getModelIntrospection', [context])]);
 
@@ -33,7 +29,7 @@ export const prePushHandler = async (context: $TSContext): Promise<void> => {
   printDetachedFormsWarning(formSchemas, localSchema);
 };
 
-const printDetachedFormsWarning = (formSchemas: { entities: AmplifyUIBuilder.Form[] }, localSchema: Schema): void => {
+const printDetachedFormsWarning = (formSchemas: { entities: AmplifyUIBuilder.Form[] }, localSchema: ModelIntrospectionSchema): void => {
   const modelNames = new Set(Object.keys(localSchema.models));
   const detachedCustomForms: string[] = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,7 +141,7 @@
     "@aws-amplify/api-graphql" "2.2.18"
     "@aws-amplify/api-rest" "2.0.29"
 
-"@aws-amplify/appsync-modelgen-plugin@2.4.0":
+"@aws-amplify/appsync-modelgen-plugin@2.4.0", "@aws-amplify/appsync-modelgen-plugin@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.4.0.tgz#0448d2d5938f7fa411ff34bb5b525e17f050bf30"
   integrity sha512-cOXsQ9qcvc7q31riKJL7kYYQFpriFws6rAO2GG7xRwT+0Dqn5LACSAgPHXBMx8vXI4nQcEYZ/EtxTchD845U6Q==
@@ -176,21 +176,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.8.0.tgz#49b70919f74016914968cf7f58e657462d199a7d"
-  integrity sha512-EF/l35yk0ilXnp4VtqUekHbAbNXT5tOvfqUznOy1h2uniAf99Z+tRZYG4HGLzFfpraUB8psumXs3C/p3FVDMaA==
+"@aws-amplify/codegen-ui-react@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.9.0.tgz#195127505651675ee836297bdeb73f5efdf994b6"
+  integrity sha512-p/1/S72zKbwLKu7oX5FpAgQS4dEze9188PgXxB/ulyppyCAtWSdO+slZk8l8MIyuBI5pt5cUFuW6qd1de71oVw==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.8.0"
+    "@aws-amplify/codegen-ui" "2.9.0"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.8.0.tgz#7cfde751d67b029371b5f708802160b2bf3257a1"
-  integrity sha512-3I+k2hWJeVwHVGiexvZqwScpt9o8sMD7WZ/svpCo2/byvs83bYj4VJRly7Hj0n+QqkJWHDxECs4b27lIb1E8YA==
+"@aws-amplify/codegen-ui@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/codegen-ui/-/codegen-ui-2.9.0.tgz#2e3eb27f8095fa9c4965185d1012c3ce17b2a132"
+  integrity sha512-vxaG9H5mCuI1U7b8ibFbPfYnmoheowuFMQQXU3ZydGl60gh2cWtSdFNtrNOImu9f8J1GS1p47u9B8d+DUzpaXQ==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
…omponents

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
https://github.com/aws-amplify/amplify-cli/pull/12086 - Original PR closed to resolve merge conflicts

1. Update codegen-ui version to 2.9.0: This version expands the function that processes schemas to accept the `ModelIntrospectionSchema` in addition to the MIPR.
2. Change the logic in amplify-util-uibuilder to use the introspection schema instead of the MIPR to generate components.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Used `amplify-dev` against a local CRA app to generate components.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
