### PR TITLE
fix: windows test failing on long paths

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -462,6 +462,9 @@ jobs:
           steps:
             - attach_workspace:
                 at: ~/.
+            - run:
+                name: Git enable long paths
+                command: git config --global core.longpaths true
       - when:
           condition:
             or:

--- a/packages/amplify-e2e-core/src/utils/git-operations.ts
+++ b/packages/amplify-e2e-core/src/utils/git-operations.ts
@@ -31,6 +31,10 @@ export const gitCleanFdX = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdX'], { cwd });
 };
 
+export const gitSetLongPaths = async (cwd: string): Promise<void> => {
+  await execa('git', ['config', '--global', 'core.longpaths', 'true'], { cwd });
+};
+
 /**
  * Returns a list of files that have unstaged changes in the specified directory
  */

--- a/packages/amplify-e2e-core/src/utils/git-operations.ts
+++ b/packages/amplify-e2e-core/src/utils/git-operations.ts
@@ -31,10 +31,6 @@ export const gitCleanFdX = async (cwd: string): Promise<void> => {
   await execa('git', ['clean', '-fdX'], { cwd });
 };
 
-export const gitSetLongPaths = async (cwd: string): Promise<void> => {
-  await execa('git', ['config', '--global', 'core.longpaths', 'true'], { cwd });
-};
-
 /**
  * Returns a list of files that have unstaged changes in the specified directory
  */

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -8,7 +8,6 @@ import {
   initJSProjectWithProfile,
   gitInit,
   gitCleanFdX,
-  gitSetLongPaths,
   initHeadless,
   getAppId,
   addAuthWithDefault,
@@ -25,7 +24,6 @@ describe('adding custom resources test', () => {
   beforeEach(async () => {
     projRoot = await createNewProjectDir(projectName);
     await initJSProjectWithProfile(projRoot, { envName, disableAmplifyAppCreation: false });
-    await gitSetLongPaths(projRoot);
     await gitInit(projRoot);
   });
 

--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -8,6 +8,7 @@ import {
   initJSProjectWithProfile,
   gitInit,
   gitCleanFdX,
+  gitSetLongPaths,
   initHeadless,
   getAppId,
   addAuthWithDefault,
@@ -24,6 +25,7 @@ describe('adding custom resources test', () => {
   beforeEach(async () => {
     projRoot = await createNewProjectDir(projectName);
     await initJSProjectWithProfile(projRoot, { envName, disableAmplifyAppCreation: false });
+    await gitSetLongPaths(projRoot);
     await gitInit(projRoot);
   });
 
@@ -36,7 +38,7 @@ describe('adding custom resources test', () => {
     await addAuthWithDefault(projRoot);
     await addS3WithGuestAccess(projRoot);
     const appId = getAppId(projRoot);
-    const cdkResourceName = `custom${uuid().split('-')[0]}`;
+    const cdkResourceName = `c${uuid().split('-')[0]}`;
     await addCDKCustomResource(projRoot, { name: cdkResourceName });
     const srcCustomResourceFilePath = path.join(__dirname, '..', '..', projectName, 'custom-cdk-stack-with-storage.ts');
     const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This test is failing on windows because some paths it is trying to use are too long for git on windows. This should allow these long paths. It also slightly shortens the name of the custom resource. I couldn't shorten the name of the project without the test failing locally. 

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/117126550/225111853-ad91b47e-923c-49ea-9ae7-27c56c8b402c.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
