### PR TITLE
fix: windows test failing change path and project name

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import { v4 as uuid } from 'uuid';
 
 describe('adding custom resources test', () => {
-  const projectName = 'custom-resources';
+  const projectName = 'cusres';
   let projRoot: string;
   const envName = 'dev';
   beforeEach(async () => {
@@ -38,7 +38,7 @@ describe('adding custom resources test', () => {
     const appId = getAppId(projRoot);
     const cdkResourceName = `custom${uuid().split('-')[0]}`;
     await addCDKCustomResource(projRoot, { name: cdkResourceName });
-    const srcCustomResourceFilePath = path.join(__dirname, '..', '..', projectName, 'custom-cdk-stack-with-storage.ts');
+    const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack-with-storage.ts');
     const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
     await buildCustomResources(projRoot);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This E2E test on windows is failing with this message. This may be due to the project name. I also realized that the path on line 41 should not depend on the project name.
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/117126550/225405563-981626c4-d75b-474d-bad8-e0b2e06db506.png">


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
