### PR TITLE
fix: stops cdk v1 warning for non cdk custom resource

### DIFF
--- a/packages/amplify-migration-tests/custom-resources/custom-cfn-stack.json
+++ b/packages/amplify-migration-tests/custom-resources/custom-cfn-stack.json
@@ -1,14 +1,14 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Parameters": {
-        "env": {
-            "Type": "String"
-        }
-    },
-    "Resources": {
-        "HelloBucket": {
-            "Type": "AWS::S3::Bucket"
-        }
-    },
-    "Outputs": {}
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Parameters": {
+    "env": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "HelloBucket": {
+      "Type": "AWS::S3::Bucket"
+    }
+  },
+  "Outputs": {}
 }

--- a/packages/amplify-migration-tests/custom-resources/custom-cfn-stack.json
+++ b/packages/amplify-migration-tests/custom-resources/custom-cfn-stack.json
@@ -1,0 +1,14 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+        "env": {
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "HelloBucket": {
+            "Type": "AWS::S3::Bucket"
+        }
+    },
+    "Outputs": {}
+}

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/custom-stack.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/custom-stack.migration.test.ts
@@ -32,12 +32,18 @@ describe('adding custom resources migration test', () => {
   it('add/update CDK and CFN custom resources', async () => {
     const cdkResourceName = `custom${uuid().split('-')[0]}`;
     const cfnResourceName = `custom${uuid().split('-')[0]}`;
+    const cfnResourceNameWithV10 = `custom${uuid().split('-')[0]}`;
 
     await initJSProjectWithProfileV10(projRoot, { name: 'customMigration', disableAmplifyAppCreation: false });
     const appId = getAppId(projRoot);
     expect(appId).toBeDefined();
 
     await addCDKCustomResource(projRoot, { name: cdkResourceName });
+    await addCFNCustomResource(projRoot, { name: cfnResourceNameWithV10, promptForCategorySelection: false });
+    const srcCFNCustomResourceFilePath = path.join(__dirname, '..', '..', '..', 'custom-resources', 'custom-cfn-stack.json');
+    // adding a resource to custom cfn stack
+    const destCFNCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cfnResourceNameWithV10,`${cfnResourceNameWithV10}-cloudformation-template.json`);
+    fs.copyFileSync(srcCFNCustomResourceFilePath, destCFNCustomResourceFilePath);
 
     // this is where we will write our custom cdk stack logic to
     const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/custom-stack.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/custom-stack.migration.test.ts
@@ -42,7 +42,14 @@ describe('adding custom resources migration test', () => {
     await addCFNCustomResource(projRoot, { name: cfnResourceNameWithV10, promptForCategorySelection: false });
     const srcCFNCustomResourceFilePath = path.join(__dirname, '..', '..', '..', 'custom-resources', 'custom-cfn-stack.json');
     // adding a resource to custom cfn stack
-    const destCFNCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cfnResourceNameWithV10,`${cfnResourceNameWithV10}-cloudformation-template.json`);
+    const destCFNCustomResourceFilePath = path.join(
+      projRoot,
+      'amplify',
+      'backend',
+      'custom',
+      cfnResourceNameWithV10,
+      `${cfnResourceNameWithV10}-cloudformation-template.json`,
+    );
     fs.copyFileSync(srcCFNCustomResourceFilePath, destCFNCustomResourceFilePath);
 
     // this is where we will write our custom cdk stack logic to

--- a/packages/amplify-provider-awscloudformation/src/__tests__/print-cdk-migration-warning.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/print-cdk-migration-warning.test.ts
@@ -105,7 +105,7 @@ describe('print migration warning tests', () => {
       {
         category: 'custom',
         resourceName: 'someResource2',
-        service: 'mockService2',
+        service: 'customCDK',
       },
     ];
 
@@ -126,6 +126,31 @@ describe('print migration warning tests', () => {
       Follow this guide: https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html
       "
     `);
+  });
+
+  it('no migration message when there are only custom CFN resources', async () => {
+    const resourcesToBeCreated = [
+      {
+        category: 'auth',
+        resourceName: 'someResource',
+        service: 'Cognito',
+      },
+    ];
+    const resourcesToBeUpdated = [
+      {
+        category: 'custom',
+        resourceName: 'someResource3',
+        service: 'customCloudformation',
+      },
+    ];
+
+    const allResources = [...resourcesToBeCreated, ...resourcesToBeUpdated];
+    mockContext.amplify.getResourceStatus.mockResolvedValue({ allResources });
+    detectAffectedDirectDependenciesMock.mockReturnValue(inputPayload);
+    fsMock.existsSync.mockReturnValue(false);
+    printerMock.warn.mockReturnValue(undefined);
+    await printCdkMigrationWarning(mockContext as unknown as $TSContext);
+    expect(printerMock.warn).not.toBeCalled();
   });
 
   it('migration message when there are only overrides', async () => {

--- a/packages/amplify-provider-awscloudformation/src/print-cdk-migration-warning.ts
+++ b/packages/amplify-provider-awscloudformation/src/print-cdk-migration-warning.ts
@@ -65,7 +65,7 @@ const getOverridesWarning = (resourcesToBuild: IAmplifyResource[], dependencyToS
 const getCustomResourcesWarning = (resourcesToBuild: IAmplifyResource[], dependencyToSearch: string): AmplifyWarning | undefined => {
   let customResourcesWarningObject;
   const customResourceImpactedFiles = [];
-  const customCategoryResources = resourcesToBuild.filter((resource) => resource.category === AmplifyCategories.CUSTOM);
+  const customCategoryResources = resourcesToBuild.filter((resource) => resource.category === AmplifyCategories.CUSTOM && resource.service !== 'customCloudformation');
   customCategoryResources.forEach((resource) => {
     const targetDir = path.join(pathManager.getBackendDirPath(), resource.category, resource.resourceName);
     const amplifyDetectorProps: AmplifyNodePkgDetectorProps = {

--- a/packages/amplify-provider-awscloudformation/src/print-cdk-migration-warning.ts
+++ b/packages/amplify-provider-awscloudformation/src/print-cdk-migration-warning.ts
@@ -65,7 +65,9 @@ const getOverridesWarning = (resourcesToBuild: IAmplifyResource[], dependencyToS
 const getCustomResourcesWarning = (resourcesToBuild: IAmplifyResource[], dependencyToSearch: string): AmplifyWarning | undefined => {
   let customResourcesWarningObject;
   const customResourceImpactedFiles = [];
-  const customCategoryResources = resourcesToBuild.filter((resource) => resource.category === AmplifyCategories.CUSTOM && resource.service !== 'customCloudformation');
+  const customCategoryResources = resourcesToBuild.filter(
+    (resource) => resource.category === AmplifyCategories.CUSTOM && resource.service !== 'customCloudformation',
+  );
   customCategoryResources.forEach((resource) => {
     const targetDir = path.join(pathManager.getBackendDirPath(), resource.category, resource.resourceName);
     const amplifyDetectorProps: AmplifyNodePkgDetectorProps = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- added a check to stop cdk v1 warning for non cdk custom resource

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manually tested
- updated e2e to check for specific issue

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
