### PR TITLE
chore: exclude custom resource test on windows temporarily

### DIFF
--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -108,6 +108,9 @@ const TEST_EXCLUSIONS: { l: string[]; w: string[] } = {
     'src/__tests__/api_3.test.ts',
     'src/__tests__/api_5.test.ts',
     'src/__tests__/custom_policies_container.test.ts',
+    // TODO: this is required to jump over breaking change between 2.53 and 2.68 of CDK.
+    // Remove exclusion for both custom resource tests after we ship new extensibility helper.
+    'src/__tests__/custom_resources.test.ts',
     'src/__tests__/custom-resource-with-storage.test.ts',
     'src/__tests__/datastore-modelgen.test.ts',
     'src/__tests__/delete.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Follow up on https://github.com/aws-amplify/amplify-cli/pull/12240 .
Missed one test that require windows exclusion until next release.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
