### PR TITLE
fix: skip backend sync on force push

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/push.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/push.test.ts
@@ -1,5 +1,7 @@
 import { $TSContext } from 'amplify-cli-core';
-import * as pushCommandModule from '../../commands/push';
+import { run as pushCommand } from '../../commands/push';
+import * as updateTrackedFilesModule from '../../extensions/amplify-helpers/update-tracked-files';
+import * as currentCloudBackendUtilsModule from '../../extensions/amplify-helpers/current-cloud-backend-utils';
 
 describe('amplify push:', () => {
   const mockContext = {
@@ -29,29 +31,29 @@ describe('amplify push:', () => {
   });
 
   it('push run method should exist', () => {
-    expect(pushCommandModule.run).toBeDefined();
+    expect(pushCommand).toBeDefined();
   });
 
   it('push run should sync current backend', async () => {
-    const syncCurrentCloudBackendSpy = jest.spyOn(pushCommandModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
+    const syncCurrentCloudBackendSpy = jest.spyOn(currentCloudBackendUtilsModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
     syncCurrentCloudBackendSpy.mockImplementation(() => Promise.resolve());
 
-    const updateTrackedFilesSpy = jest.spyOn(pushCommandModule, 'updateTrackedFiles') as jest.SpyInstance;
-    updateTrackedFilesSpy.mockImplementation(() => Promise.resolve());
+    const updateCognitoTrackedFilesSpy = jest.spyOn(updateTrackedFilesModule, 'updateCognitoTrackedFiles') as jest.SpyInstance;
+    updateCognitoTrackedFilesSpy.mockImplementation(() => Promise.resolve());
 
-    await pushCommandModule.run(mockContext as unknown as $TSContext);
+    await pushCommand(mockContext as unknown as $TSContext);
     expect(syncCurrentCloudBackendSpy).toHaveBeenCalled();
   });
 
   it('push --force run should NOT sync current backend', async () => {
-    const syncCurrentCloudBackendSpy = jest.spyOn(pushCommandModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
+    const syncCurrentCloudBackendSpy = jest.spyOn(currentCloudBackendUtilsModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
     syncCurrentCloudBackendSpy.mockImplementation(() => Promise.resolve());
 
-    const updateTrackedFilesSpy = jest.spyOn(pushCommandModule, 'updateTrackedFiles') as jest.SpyInstance;
-    updateTrackedFilesSpy.mockImplementation(() => Promise.resolve());
+    const updateCognitoTrackedFilesSpy = jest.spyOn(updateTrackedFilesModule, 'updateCognitoTrackedFiles') as jest.SpyInstance;
+    updateCognitoTrackedFilesSpy.mockImplementation(() => Promise.resolve());
 
     mockContext.parameters.options.force = true;
-    await pushCommandModule.run(mockContext as unknown as $TSContext);
+    await pushCommand(mockContext as unknown as $TSContext);
     expect(syncCurrentCloudBackendSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/amplify-cli/src/__tests__/commands/push.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/push.test.ts
@@ -24,6 +24,10 @@ describe('amplify push:', () => {
     },
   };
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('push run method should exist', () => {
     expect(pushCommandModule.run).toBeDefined();
   });

--- a/packages/amplify-cli/src/__tests__/commands/push.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/push.test.ts
@@ -1,0 +1,53 @@
+import { $TSContext } from 'amplify-cli-core';
+import * as pushCommandModule from '../../commands/push';
+
+describe('amplify push:', () => {
+  const mockContext = {
+    amplify: {
+      pushResources: jest.fn(),
+      constructExeInfo: jest.fn().mockReturnValue({
+        inputParams: {
+          yes: true,
+        },
+      }),
+    },
+    exeInfo: {
+      localEnvInfo: {
+        noUpdateBackend: false,
+      },
+    },
+    parameters: {
+      options: {
+        force: false,
+      },
+      command: 'push',
+    },
+  };
+
+  it('push run method should exist', () => {
+    expect(pushCommandModule.run).toBeDefined();
+  });
+
+  it('push run should sync current backend', async () => {
+    const syncCurrentCloudBackendSpy = jest.spyOn(pushCommandModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
+    syncCurrentCloudBackendSpy.mockImplementation(() => Promise.resolve());
+
+    const updateTrackedFilesSpy = jest.spyOn(pushCommandModule, 'updateTrackedFiles') as jest.SpyInstance;
+    updateTrackedFilesSpy.mockImplementation(() => Promise.resolve());
+
+    await pushCommandModule.run(mockContext as unknown as $TSContext);
+    expect(syncCurrentCloudBackendSpy).toHaveBeenCalled();
+  });
+
+  it('push --force run should NOT sync current backend', async () => {
+    const syncCurrentCloudBackendSpy = jest.spyOn(pushCommandModule, 'syncCurrentCloudBackend') as jest.SpyInstance;
+    syncCurrentCloudBackendSpy.mockImplementation(() => Promise.resolve());
+
+    const updateTrackedFilesSpy = jest.spyOn(pushCommandModule, 'updateTrackedFiles') as jest.SpyInstance;
+    updateTrackedFilesSpy.mockImplementation(() => Promise.resolve());
+
+    mockContext.parameters.options.force = true;
+    await pushCommandModule.run(mockContext as unknown as $TSContext);
+    expect(syncCurrentCloudBackendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-cli/src/commands/push.ts
+++ b/packages/amplify-cli/src/commands/push.ts
@@ -11,7 +11,7 @@ import { updateCognitoTrackedFiles } from '../extensions/amplify-helpers/update-
 /**
  * Download and unzip deployment bucket contents to #current-cloud-backend so amplify status shows correct state
  */
-const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
+export const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
   context.exeInfo.restoreBackend = false;
   const currentEnv = context.exeInfo.localEnvInfo.envName;
 
@@ -46,7 +46,7 @@ const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
 /**
  * Updates tracked files for auto updates in the build directory that will not be detected for 'amplify push'
  */
-const updateTrackedFiles = async (): Promise<void> => {
+export const updateTrackedFiles = async (): Promise<void> => {
   await updateCognitoTrackedFiles();
 };
 
@@ -61,7 +61,12 @@ export const run = async (context: $TSContext): Promise<$TSAny> => {
   if (context.parameters.options?.force) {
     context.exeInfo.forcePush = true;
   }
-  await syncCurrentCloudBackend(context);
+
+  // force flag ignores project status check
+  if (!context.exeInfo.forcePush) {
+    await syncCurrentCloudBackend(context);
+  }
+
   await updateTrackedFiles();
   return context.amplify.pushResources(context);
 };

--- a/packages/amplify-cli/src/domain/amplify-toolkit.ts
+++ b/packages/amplify-cli/src/domain/amplify-toolkit.ts
@@ -94,7 +94,7 @@ export class AmplifyToolkit {
     return require('../extensions/amplify-helpers/push-resources').pushResources;
   }
   get storeCurrentCloudBackend() {
-    return require('../extensions/amplify-helpers/push-resources').storeCurrentCloudBackend;
+    return require('../extensions/amplify-helpers/current-cloud-backend-utils').storeCurrentCloudBackend;
   }
   get readJsonFile() {
     return require('../extensions/amplify-helpers/read-json-file').readJsonFile;

--- a/packages/amplify-cli/src/extensions/amplify-helpers/current-cloud-backend-utils.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/current-cloud-backend-utils.ts
@@ -1,0 +1,52 @@
+import { $TSAny, $TSContext, AmplifyFault, spinner, stateManager } from 'amplify-cli-core';
+import sequential from 'promise-sequential';
+import { notifyFieldAuthSecurityChange, notifyListQuerySecurityChange, notifySecurityEnhancement } from './auth-notifications';
+import { getProviderPlugins } from './get-provider-plugins';
+import { getProjectConfig } from './get-project-config';
+
+/**
+ * Download and unzip deployment bucket contents to #current-cloud-backend so amplify status shows correct state
+ */
+export const syncCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
+  context.exeInfo.restoreBackend = false;
+  const currentEnv = context.exeInfo.localEnvInfo.envName;
+
+  try {
+    const amplifyMeta = stateManager.getMeta();
+    const providerPlugins = getProviderPlugins(context);
+    const pullCurrentCloudTasks: (() => Promise<$TSAny>)[] = [];
+
+    for (const provider of context.exeInfo.projectConfig.providers) {
+      const providerModule = await import(providerPlugins[provider]);
+      pullCurrentCloudTasks.push(() => providerModule.initEnv(context, amplifyMeta.providers[provider]));
+    }
+
+    await notifySecurityEnhancement(context);
+
+    if (!(await notifyFieldAuthSecurityChange(context))) {
+      await notifyListQuerySecurityChange(context);
+    }
+
+    spinner.start(`Fetching updates to backend environment: ${currentEnv} from the cloud.`);
+    await sequential(pullCurrentCloudTasks);
+    spinner.succeed(`Successfully pulled backend environment ${currentEnv} from the cloud.`);
+  } catch (e) {
+    spinner.fail(`There was an error pulling the backend environment ${currentEnv}.`);
+    throw new AmplifyFault('BackendPullFault', { message: e.message }, e);
+  }
+};
+
+/**
+ * Delegates storeCurrentCloudBackend to all providers (just aws cfn provider)
+ */
+export const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
+  const { providers } = getProjectConfig();
+  const providerPlugins = getProviderPlugins(context);
+
+  await Promise.all(
+    providers.map(async (provider: string) => {
+      const providerModule = await import(providerPlugins[provider]);
+      return providerModule.storeCurrentCloudBackend(context);
+    }),
+  );
+};

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -201,18 +201,3 @@ const providersPush = async (
     }),
   );
 };
-
-/**
- * Delegates storeCurrentCloudBackend to all providers (just aws cfn provider)
- */
-export const storeCurrentCloudBackend = async (context: $TSContext): Promise<void> => {
-  const { providers } = getProjectConfig();
-  const providerPlugins = getProviderPlugins(context);
-
-  await Promise.all(
-    providers.map(async (provider: string) => {
-      const providerModule = await import(providerPlugins[provider]);
-      return providerModule.storeCurrentCloudBackend(context);
-    }),
-  );
-};

--- a/packages/amplify-e2e-tests/src/__tests__/push.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/push.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable spellcheck/spell-checker */
+import {
+  addAuthWithDefault,
+  amplifyPushForce,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getProjectMeta,
+  initJSProjectWithProfile,
+  amplifyPushAuth,
+} from '@aws-amplify/amplify-e2e-core';
+import * as AWS from 'aws-sdk';
+
+describe('amplify push ', () => {
+  let pushProjRoot: string;
+  beforeEach(async () => {
+    pushProjRoot = await createNewProjectDir('push-test');
+  });
+
+  afterEach(async () => {
+    await deleteProject(pushProjRoot);
+    deleteProjectDir(pushProjRoot);
+  });
+
+  it('test push --force override current-cloud-backed zip', async () => {
+    await initJSProjectWithProfile(pushProjRoot, {
+      disableAmplifyAppCreation: false,
+      name: 'testPush',
+    });
+
+    await addAuthWithDefault(pushProjRoot);
+    const amplifyMeta = getProjectMeta(pushProjRoot);
+    const meta = amplifyMeta.providers.awscloudformation;
+    const bucketName = meta.DeploymentBucketName;
+
+    const s3 = new AWS.S3();
+    await s3
+      .deleteObject({
+        Bucket: bucketName,
+        Key: '#current-cloud-backend.zip',
+      })
+      .promise();
+
+    await expect(amplifyPushAuth(pushProjRoot)).rejects.toThrow();
+    await amplifyPushForce(pushProjRoot);
+  });
+});


### PR DESCRIPTION
#### Description of changes
— skips backend sync on force push, as force push is ignoring resource status and always executes the push
— this also helps to override deployed backed in case if the deployed backed zip is corrupted

#### Description of how you validated changes
— manual changes
— unit tests added
— `yarn test` and `yarn e2e` pass

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
