### PR TITLE
Modelgen windows fix

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
@@ -30,6 +30,9 @@ fsMock.createWriteStream.mockReturnValue({
   write: {
     bind: jest.fn(),
   },
+  close: (cb: Function) => {
+    cb();
+  },
 } as unknown as fs.WriteStream);
 fsMock.createReadStream.mockImplementation((filePath) => `mock body of ${filePath}` as unknown as fs.ReadStream);
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,5 +1,4 @@
 import { $TSAny, $TSContext, pathManager, stateManager } from 'amplify-cli-core';
-import { printer } from '@aws-amplify/amplify-prompts';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -44,30 +43,26 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     },
   };
   const originalStdoutWrite = process.stdout.write;
+  let tempStdoutWrite: fs.WriteStream = null;
   try {
     // overwrite project config with config that forces codegen to output js to a temp location
     stateManager.setProjectConfig(undefined, forceJSCodegenProjectConfig);
 
     // generateModels and generateModelIntrospection print confusing and duplicate output when executing these codegen paths
     // so pipe stdout to a file and then reset it at the end to suppress this output
-    printer.warn('WARN1');
     await fs.ensureDir(absoluteTempOutputDir);
-    printer.warn('WARN2 ' + absoluteTempOutputDir);
-    const tempStdoutWrite = fs.createWriteStream(path.join(absoluteTempOutputDir, 'temp-console-log.txt'));
-    printer.warn('WARN3');
+    tempStdoutWrite = fs.createWriteStream(path.join(absoluteTempOutputDir, 'temp-console-log.txt'));
     process.stdout.write = tempStdoutWrite.write.bind(tempStdoutWrite);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/models.js#L60
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModels', [context]);
 
-    printer.warn('WARN4');
     // generateModelIntrospection expects --output-dir option to be set
     _.setWith(context, ['parameters', 'options', 'output-dir'], relativeTempOutputDir);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/model-intropection.js#L8
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModelIntrospection', [context]);
 
-    printer.warn('WARN5');
     const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
     const localSchemaJsPath = path.join(absoluteTempOutputDir, 'models', 'schema.js');
     const localModelIntrospectionPath = path.join(absoluteTempOutputDir, 'model-introspection.json');
@@ -82,16 +77,22 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     };
     // ==================== DO NOT MODIFY THIS MAP UNLESS YOU ARE 100% SURE OF THE IMPLICATIONS ====================
 
-    printer.warn('WARN6');
     await uploadCMSArtifacts(await S3.getInstance(context), cmsArtifactLocalToS3KeyMap);
-    printer.warn('WARN7');
   } finally {
-    printer.warn('WARN8');
     stateManager.setProjectConfig(undefined, originalProjectConfig);
-    printer.warn('WARN9');
     process.stdout.write = originalStdoutWrite;
+    if (tempStdoutWrite) {
+      await new Promise((resolve, reject) => {
+        tempStdoutWrite.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(null);
+          }
+        });
+      });
+    }
     await fs.remove(absoluteTempOutputDir);
-    printer.warn('WARN10');
   }
 };
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,4 +1,5 @@
 import { $TSAny, $TSContext, pathManager, stateManager } from 'amplify-cli-core';
+import { printer } from '@aws-amplify/amplify-prompts';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -49,19 +50,24 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
 
     // generateModels and generateModelIntrospection print confusing and duplicate output when executing these codegen paths
     // so pipe stdout to a file and then reset it at the end to suppress this output
+    printer.warn('WARN1');
     await fs.ensureDir(absoluteTempOutputDir);
+    printer.warn('WARN2 ' + absoluteTempOutputDir);
     const tempStdoutWrite = fs.createWriteStream(path.join(absoluteTempOutputDir, 'temp-console-log.txt'));
+    printer.warn('WARN3');
     process.stdout.write = tempStdoutWrite.write.bind(tempStdoutWrite);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/models.js#L60
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModels', [context]);
 
+    printer.warn('WARN4');
     // generateModelIntrospection expects --output-dir option to be set
     _.setWith(context, ['parameters', 'options', 'output-dir'], relativeTempOutputDir);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/model-intropection.js#L8
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModelIntrospection', [context]);
 
+    printer.warn('WARN5');
     const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
     const localSchemaJsPath = path.join(absoluteTempOutputDir, 'models', 'schema.js');
     const localModelIntrospectionPath = path.join(absoluteTempOutputDir, 'model-introspection.json');
@@ -76,11 +82,16 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     };
     // ==================== DO NOT MODIFY THIS MAP UNLESS YOU ARE 100% SURE OF THE IMPLICATIONS ====================
 
+    printer.warn('WARN6');
     await uploadCMSArtifacts(await S3.getInstance(context), cmsArtifactLocalToS3KeyMap);
+    printer.warn('WARN7');
   } finally {
+    printer.warn('WARN8');
     stateManager.setProjectConfig(undefined, originalProjectConfig);
+    printer.warn('WARN9');
     process.stdout.write = originalStdoutWrite;
     await fs.remove(absoluteTempOutputDir);
+    printer.warn('WARN10');
   }
 };
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -51,7 +51,9 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     // generateModels and generateModelIntrospection print confusing and duplicate output when executing these codegen paths
     // so pipe stdout to a file and then reset it at the end to suppress this output
     await fs.ensureDir(absoluteTempOutputDir);
-    tempStdoutWrite = fs.createWriteStream(path.join(absoluteTempOutputDir, 'temp-console-log.txt'));
+    const tempLogFilePath = path.join(absoluteTempOutputDir, 'temp-console-log.txt');
+    await fs.ensureFile(tempLogFilePath);
+    tempStdoutWrite = fs.createWriteStream(tempLogFilePath);
     process.stdout.write = tempStdoutWrite.write.bind(tempStdoutWrite);
 
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/models.js#L60

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -7,7 +7,6 @@ const RUN_SOLO = [
   'src/__tests__/containers-api-1.test.ts',
   'src/__tests__/containers-api-2.test.ts',
   'src/__tests__/env-3.test.ts',
-  'src/__tests__/feature-flags.test.ts',
   'src/__tests__/geo-add-e.test.ts',
   'src/__tests__/geo-add-f.test.ts',
   'src/__tests__/geo-remove-1.test.ts',

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -7,6 +7,7 @@ const RUN_SOLO = [
   'src/__tests__/containers-api-1.test.ts',
   'src/__tests__/containers-api-2.test.ts',
   'src/__tests__/env-3.test.ts',
+  'src/__tests__/feature-flags.test.ts',
   'src/__tests__/geo-add-e.test.ts',
   'src/__tests__/geo-add-f.test.ts',
   'src/__tests__/geo-remove-1.test.ts',

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -72,6 +72,8 @@ const WINDOWS_SMOKE_TESTS = [
   'src/__tests__/env-1.test.ts',
   // export and pull
   'src/__tests__/export-pull-a.test.ts',
+  // feature flags
+  'src/__tests__/feature-flags.test.ts',
   // functions
   'src/__tests__/function_10.test.ts',
   // notifications with function permissions


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixes codegen failure on Windows.

```
[471.869,"o","� \u001b[0;31mEPERM: operation not permitted, lstat 'C:\\Users\\circleci\\AppData\\Local\\Temp\\amplify-e2e-tests\\rest-api_469634\\amplif\u001b[0Ky\u001b[?25l\r\n-codegen-temp\\temp-console-log.txt'\u001b[0m\u001b[0K\r\n\u001b[0K\r\nLearn more at: https://docs.amplify.aws/cli/project/troubleshooting/\u001b[0K\r\n\u001b[0K\r\nDeploymentFault: EPERM: operation not permitted, lstat 'C:\\Users\\circleci\\AppData\\Local\\Temp\\amplify-e2e-tests\\rest-api\u001b[0K_\r\n469634\\amplify-codegen-temp\\temp-console-log.txt'\u001b[0K\r\n    at Object.run (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\amplify-provider-awscloudformation\\lib\\push-resourc\u001b[0Ke\r\ns.js:458:11)\u001b[0K\r\n    at async Promise.all (index 0)\u001b[0K\r\n    at async providersPush (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\extensions\\amplify-helper\u001b[0Ks\r\n\\push-resources.js:160:5)\u001b[0K\r\n    at async AmplifyToolkit.pushResources (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\extensions\u001b[0K\\\r\namplify-helpers\\push-resources.js:134:13)\u001b[0K\r\n    at async Object.executeAmplifyCommand (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\index.js:1\u001b[0K8\r\n9:9)\u001b[0K\r\n    at async executePluginModuleCommand (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\execution-ma\u001b[0Kn\r\nager.js:135:5)\u001b[0K\r\n    at async executeCommand (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\execution-manager.js:33:\u001b[0K9\r\n)\u001b[0K\r\n    at async Object.run (C:\\snapshot\\repo\\build\\node_modules\\@aws-amplify\\cli-internal\\lib\\index.js:117:5)\u001b[0K\r\n\u001b[0K\r\nEPERM: operation not permitted, lstat 'C:\\Users\\circleci\\AppData\\Local\\Temp\\amplify-e2e-tests\\rest-api_469634\\amplify-c\u001b[0Ko\r\ndegen-temp\\temp-console-log.txt'\u001b[0K\r\nError: EPERM: operation not permitted, lstat 'C:\\Users\\circleci\\AppData\\Local\\Temp\\amplify-e2e-tests\\rest-api_469634\\am\u001b[0Kp\r\nlify-codegen-temp\\temp-console-log.txt'\u001b[0K\r\n\u001b[0K\u001b[?25h"]
```

![image](https://user-images.githubusercontent.com/5849952/226086525-0da13a00-3f6f-4b9f-96e6-1735d6e0bb08.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
