### PR TITLE
fix(mock): Swallow stack trace on an un-initialized project upon `amplify mock api`

### DIFF
--- a/packages/amplify-cli-core/src/errors/amplify-error.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-error.ts
@@ -20,5 +20,6 @@ export class AmplifyError extends AmplifyException {
    */
   constructor(name: AmplifyErrorType, options: AmplifyExceptionOptions, downstreamException?: Error) {
     super(name, 'ERROR', options, downstreamException);
+    this.stack = undefined;
   }
 }

--- a/packages/amplify-cli-core/src/errors/amplify-exception.ts
+++ b/packages/amplify-cli-core/src/errors/amplify-exception.ts
@@ -10,6 +10,7 @@ export abstract class AmplifyException extends Error {
   public readonly details?: string;
   public readonly link?: string;
   public readonly code?: string;
+  public readonly cause?: Error;
 
   /**
    * You should use AmplifyError or AmplifyFault to throw an exception.
@@ -44,10 +45,11 @@ export abstract class AmplifyException extends Error {
     this.resolution = options.resolution;
     this.code = options.code;
     this.link = options.link ?? AMPLIFY_SUPPORT_DOCS.CLI_PROJECT_TROUBLESHOOTING.url;
+    this.cause = options.cause;
   }
 
   toObject = (): object => {
-    const { name: errorName, message: errorMessage, details: errorDetails, resolution, link, stack } = this;
+    const { name: errorName, message: errorMessage, details: errorDetails, resolution, link, stack, cause } = this;
 
     return {
       errorName,
@@ -55,6 +57,7 @@ export abstract class AmplifyException extends Error {
       errorDetails,
       resolution,
       link,
+      cause,
       ...(process.argv.includes('--debug') ? { stack } : {}),
     };
   };
@@ -73,6 +76,7 @@ export type AmplifyExceptionOptions = {
   details?: string;
   resolution?: string;
   link?: string;
+  cause?: Error;
 
   // CloudFormation or NodeJS error codes
   code?: string;

--- a/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
+++ b/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
@@ -82,7 +82,6 @@ describe('test exception handler', () => {
 
     expect(printerMock.error).toHaveBeenCalledWith(amplifyError.message);
     expect(printerMock.info).toHaveBeenCalledWith(amplifyError.details);
-    expect(printerMock.debug).toHaveBeenCalledWith(amplifyError.stack);
   });
 
   it('error handler should handle encountered errors gracefully', async () => {
@@ -107,7 +106,6 @@ describe('test exception handler', () => {
 
     expect(printerMock.error).toHaveBeenCalledWith(amplifyError.message);
     expect(printerMock.info).toHaveBeenCalledWith(amplifyError.details);
-    expect(printerMock.debug).toHaveBeenCalledWith(amplifyError.stack);
     expect(printerMock.error).toHaveBeenCalledWith('Failed to report error: MockTestError');
   });
 });

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-env-info.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/get-env-info.test.ts
@@ -19,9 +19,15 @@ test('Return env file info', () => {
   expect(getEnvInfo()).toHaveProperty('test', true);
 });
 
-test('Throw EnvironmentNotInitializedError', () => {
+test('Throw EnvironmentNotInitializedError only one', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation();
   stateManagerMock.localEnvInfoExists.mockReturnValue(false);
-  expect(() => {
+  try {
     getEnvInfo();
-  }).toThrow();
+  } catch(error) {
+    expect(error.message).toBe('Current environment cannot be determined.');
+    expect(error.resolution).toBe("Use 'amplify init' in the root of your app directory to create a new environment.");
+    expect(error.cause).toEqual(new Error('`amplify init` not done'));
+  }
+  expect(spy).toHaveBeenCalledTimes(1);
 });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/get-env-info.ts
@@ -1,14 +1,27 @@
+import { StackEvent } from 'aws-sdk/clients/cloudformation';
+import { Message } from './../../../../amplify-cli-core/lib/banner-message/index.d';
 import { $TSAny, AmplifyError, stateManager } from 'amplify-cli-core';
 
 /**
  * returns the current environment info
  */
+let exceptionPrinted = false;
+
 export const getEnvInfo = (): $TSAny => {
+try {
   if (stateManager.localEnvInfoExists()) {
     return stateManager.getLocalEnvInfo();
   }
   throw new AmplifyError('EnvironmentNotInitializedError', {
     message: 'Current environment cannot be determined.',
     resolution: `Use 'amplify init' in the root of your app directory to create a new environment.`,
-  });
+    cause: new Error('`amplify init` not done'),
+  }); 
+  // handle error message gracefully by swallowing the stack trace
+} catch(error) {
+  if (!exceptionPrinted) {
+    exceptionPrinted = true;
+    console.error(`Error: ${error.message}\nResolution: ${error.resolution}`);
+  } 
+}
 };


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/1324

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
