### PR TITLE
chore: mockAll adds capabilities for function and resource selection

### DIFF
--- a/packages/amplify-prompts/package.json
+++ b/packages/amplify-prompts/package.json
@@ -3,6 +3,7 @@
   "version": "2.6.5",
   "description": "Utility functions for Amplify CLI terminal I/O",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -1,60 +1,65 @@
-import { getInvoker, category, isMockable, getBuilder } from '@aws-amplify/amplify-category-function';
 import * as path from 'path';
-import * as inquirer from 'inquirer';
+import { BuildType } from '@aws-amplify/amplify-function-plugin-interface';
+import { getInvoker, category, isMockable, getBuilder } from '@aws-amplify/amplify-category-function';
+import { prompter, printer } from '@aws-amplify/amplify-prompts';
 import { $TSContext, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
 import _ from 'lodash';
-import { BuildType } from '@aws-amplify/amplify-function-plugin-interface';
 import { loadLambdaConfig } from '../utils/lambda/load-lambda-config';
 
 const DEFAULT_TIMEOUT_SECONDS = 10;
 
-export async function start(context: $TSContext) {
+export async function start(context: $TSContext): Promise<void> {
   const ampMeta = stateManager.getMeta();
-  let resourceName = context?.input?.subCommands?.[0];
-  if (!resourceName) {
+  const resourceNameInput = context?.input?.subCommands?.[0];
+  const resourceNames = [resourceNameInput];
+  if (!resourceNameInput) {
     const choices = _.keys(_.get(ampMeta, ['function'])).filter((resourceName) => isMockable(context, resourceName).isMockable);
     if (choices.length < 1) {
       throw new Error('There are no mockable functions in the project. Use `amplify add function` to create one.');
-    } else if (choices.length == 1) {
-      resourceName = choices[0];
+    } else if (choices.length === 1) {
+      resourceNames.push(choices[0]);
     } else {
-      const resourceNameQuestion = [
-        {
-          type: 'list',
-          name: 'resourceName',
-          message: 'Select the function to mock',
-          choices,
-        },
-      ];
-      ({ resourceName } = await inquirer.prompt<{ resourceName: string }>(resourceNameQuestion));
+      // prompt for functions
+      resourceNames.push(
+        ...(await prompter.pick<'many', string>('Select the Function', choices, {
+          returnSize: 'many',
+        })),
+      );
     }
   } else {
-    const mockable = isMockable(context, resourceName);
+    const mockable = isMockable(context, resourceNameInput);
     if (!mockable.isMockable) {
-      throw new Error(`Unable to mock ${resourceName}. ${mockable.reason}`);
+      throw new Error(`Unable to mock ${resourceNameInput}. ${mockable.reason}`);
     }
   }
 
-  const event = await resolveEvent(context, resourceName);
-  const lambdaConfig = await loadLambdaConfig(context, resourceName);
-  if (!lambdaConfig?.handler) {
-    throw new Error(`Could not parse handler for ${resourceName} from cloudformation file`);
-  }
-  context.print.blue('Ensuring latest function changes are built...');
-  await getBuilder(context, resourceName, BuildType.DEV)();
-  const invoker = await getInvoker(context, { resourceName, handler: lambdaConfig.handler, envVars: lambdaConfig.environment });
-  context.print.blue('Starting execution...');
-  try {
-    const result = await timeConstrainedInvoker(invoker({ event }), context.input.options as InvokerOptions);
-    const stringResult =
-      typeof result === 'object' ? JSON.stringify(result, undefined, 2) : typeof result === 'undefined' ? 'undefined' : result;
-    context.print.success('Result:');
-    context.print.info(typeof result === 'undefined' ? '' : stringResult);
-  } catch (err) {
-    context.print.error(`${resourceName} failed with the following error:`);
-    context.print.info(err);
-  } finally {
-    context.print.blue('Finished execution.');
+  // iterate over each of the selected functions, removing any `undefined` results
+  for (const resourceName of resourceNames.filter(Boolean)) {
+    const event = await resolveEvent(context, resourceName);
+    const lambdaConfig = await loadLambdaConfig(context, resourceName);
+    if (!lambdaConfig?.handler) {
+      throw new Error(`Could not parse handler for ${resourceName} from cloudformation file`);
+    }
+    printer.info('Ensuring latest function changes are built...');
+    await getBuilder(context, resourceName, BuildType.DEV)();
+    const invoker = await getInvoker(context, {
+      resourceName,
+      handler: lambdaConfig.handler,
+      envVars: lambdaConfig.environment,
+    });
+    printer.info('Starting execution...');
+    try {
+      const result = await timeConstrainedInvoker(invoker({ event }), context.input.options as InvokerOptions);
+      const stringResult =
+        typeof result === 'object' ? JSON.stringify(result, undefined, 2) : typeof result === 'undefined' ? 'undefined' : result;
+      printer.success('Result:');
+      printer.info(typeof result === 'undefined' ? '' : stringResult);
+    } catch (err) {
+      printer.error(`${name} failed with the following error:`);
+      printer.info(err);
+    } finally {
+      printer.info('Finished execution.');
+    }
   }
 }
 
@@ -98,26 +103,24 @@ const resolveEvent = async (context: $TSContext, resourceName: string): Promise<
   let promptForEvent = true;
   if (eventName) {
     const validatorOutput = eventNameValidator(eventName);
+    console.log(validatorOutput);
     const isValid = typeof validatorOutput !== 'string';
     if (!isValid) {
-      context.print.warning(validatorOutput as string);
+      printer.warn(validatorOutput as string);
     } else {
       promptForEvent = false;
     }
   }
 
   if (promptForEvent) {
-    const eventNameQuestion = [
-      {
-        type: 'input',
-        name: 'eventName',
-        message: `Provide the path to the event JSON object relative to ${resourcePath}`,
-        validate: eventNameValidator,
-        default: 'src/event.json',
+    const question = `Provide the path to the event JSON object relative to ${resourcePath}`;
+    eventName = await prompter.input(question, {
+      validate: (value) => {
+        const validatorOutput = eventNameValidator(value);
+        return typeof validatorOutput === 'string' ? validatorOutput : true;
       },
-    ];
-    const resourceAnswers = await inquirer.prompt(eventNameQuestion);
-    eventName = resourceAnswers.eventName as string;
+      initial: 'src/event.json',
+    });
   }
 
   return JSONUtilities.readJson(path.resolve(path.join(resourcePath, eventName)));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`amplify mock` will allow the following

1.  mock with functions
2. prompts users to select the resources they would like to mock
3. allows multi select on functions to mock

Example:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/87995712/226360433-cf8b88b3-e5a7-4d5e-8d74-e03470ce3907.png">

<img width="439" alt="image" src="https://user-images.githubusercontent.com/87995712/226360680-1348f100-04ee-4aec-a5f4-2940c4c77353.png"> 

modified function mock flow and mock all flow to provide the functionality. `amplify mock function ` will now allow users to select functions to run.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

manual testing. Working on adding test but could not find the necessary exports to use.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
