### PR TITLE
chore: use nodejs 14.x compatible with CDK

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -468,6 +468,7 @@ jobs:
           condition:
             equal: [*windows-e2e-executor-medium, << parameters.os >>]
           steps:
+            - install_node14_windows
             - attach_workspace:
                 at: ~/.
             - run:
@@ -1365,3 +1366,13 @@ commands:
               exit 1
             fi
           when: always
+  install_node14_windows:
+    description: Install Node 14 on Windows
+    steps:
+      - run:
+          name: Install Node 14
+          command: |
+            nvm version
+            nvm install 14.18.0
+            nvm use 14.18.0
+            nvm ls

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -148,6 +148,7 @@ jobs:
           condition:
             equal: [*windows-e2e-executor-xlarge, << parameters.os >>]
           steps:
+            - install_node14_windows
             - checkout
             - run: yarn config set script-shell $(which bash)
             - run: yarn run production-build
@@ -1376,3 +1377,10 @@ commands:
             nvm install 14.18
             nvm use 14.18
             nvm ls
+      - run:
+          name: Check Node, install yarn
+          command: |
+            node --version
+            npm --version
+            npm install -g yarn
+            yarn --version

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1373,6 +1373,6 @@ commands:
           name: Install Node 14
           command: |
             nvm version
-            nvm install 14.18.0
-            nvm use 14.18.0
+            nvm install 14.18
+            nvm use 14.18
             nvm ls


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This installs 14.18 required by latest `constructs` version.

Related change https://github.com/aws/constructs/commit/ed62f4122aa352f3e97e93af070ef76c3ab0c5e9#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

I.e. fixes:

```
[14.088,"o","� \u001b[0;31mPackaging overrides failed.\u001b[0m\u001b[0K\u001b[?25l\r\nCommand failed with exit code 1: yarn.cmd install\u001b[0K\r\nwarning package.json: No license field\u001b[0K\r\nwarning overrides-dependencies@1.0.0: No license field\u001b[0K\r\n
error constructs@10.1.285: The engine \"node\" is incompatible with this module. Expected version \">= 14.18.0\". Got \"14.1\u001b[0K7\r\n.5\"\u001b[0K\r\nerror Found incompatible module.\u001b[0K\r\ninfo No lockfile found.\u001b[0K\r\n[1/4] Resolving packages...\u001b[0K\r\n[2/4] Fetching packages...\u001b[0K\r\ninfo Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.\u001b[0K\r\n\u001b[0K\r\nResolution: There may be errors in your overrides file. If so, fix the errors and try again.\u001b[0K\r\nLearn more at: https://docs.amplify.aws/cli/project/troubleshooting/\u001b[0K\r\n\u001b[0K\r\nInvalidOverrideError: Packaging overrides failed.\u001b[0K\r\n    at buildOverrideDir (C:\\Users\\circleci\\repo\\packages\\amplify-cli-core\\lib\\overrides-manager\\override-skeleton-gener\u001b[0Ka\r\ntor.js:108:19)\u001b[0K\r\n    at generateOverrideSkeleton (C:\\Users\\circleci\\repo\\packages\\amplify-cli-core\\lib\\overrides-manager\\override-skelet\u001b[0Ko\r\nn-generator.js:46:40)\u001b[0K\r\n    at Object.run (C:\\Users\\circleci\\repo\\packages\\amplify-provider-awscloudformation\\lib\\commands\\awscloudformation\\ov\u001b[0Ke\r\nrride.js:40:59)\u001b[0K\r\n    at Object.executeAmplifyCommand (C:\\Users\\circleci\\repo\\packages\\amplify-provider-awscloudformation\\lib\\amplify-plu\u001b[0Kg\r\nin-index.js:12:25)\u001b[0K\r\n    at C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:152:47\u001b[0K\r\n    at executePluginModuleCommand (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:135:11)\u001b[0K\r\n    at async executeCommand (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:33:9)\u001b[0K\r\n    at async Object.run (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\index.js:117:5)\u001b[0K\r\n\u001b[0K\r\nCommand failed with exit code 1: yarn.cmd install\u001b[0K\r\nwarning package.json: No license field\u001b[0K\r\nwarning overrides-dependencies@1.0.0: No license field\u001b[0K\r\nerror constructs@10.1.285: The engine \"node\" is incompatible with this module. Expected version \">= 14.18.0\". Got \"14.1\u001b[0K7\r\n.5\"\u001b[0K\r\nerror Found incompatible module.\u001b[0K\r\ninfo No lockfile found.\u001b[0K\r\n[1/4] Resolving packages...\u001b[0K\r\n[2/4] Fetching packages...\u001b[0K\r\ninfo Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.\u001b[0K\r\nError: Command failed with exit code 1: yarn.cmd install\u001b[0K\r\nwarning package.json: No license field\u001b[0K\r\nwarning overrides-dependencies@1.0.0: No license field\u001b[0K\r\nerror constructs@10.1.285: The engine \"node\" is incompatible with this module. Expected version \">= 14.18.0\". Got \"14.1\u001b[0K7\r\n.5\"\u001b[0K\r\nerror Found incompatible module.\u001b[0K\r\ninfo No lockfile found.\u001b[0K\r\n[1/4] Resolving packages...\u001b[0K\r\n[2/4] Fetching packages...\u001b[0K\r\ninfo Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.\u001b[0K\r\n    at makeError (C:\\Users\\circleci\\repo\\node_modules\\execa\\lib\\error.js:60:11)\u001b[0K\r\n    at Function.module.exports.sync (C:\\Users\\circleci\\repo\\node_modules\\execa\\index.js:194:17)\u001b[0K\r\n    at buildOverrideDir (C:\\Users\\circleci\\repo\\packages\\amplify-cli-core\\lib\\overrides-manager\\override-skeleton-gener\u001b[0Ka\r\ntor.js:77:25)\u001b[0K\r\n    at generateOverrideSkeleton (C:\\Users\\circleci\\repo\\packages\\amplify-cli-core\\lib\\overrides-manager\\override-skelet\u001b[0Ko\r\nn-generator.js:46:40)\u001b[0K\r\n    at Object.run (C:\\Users\\circleci\\repo\\packages\\amplify-provider-awscloudformation\\lib\\commands\\awscloudformation\\ov\u001b[0Ke\r\nrride.js:40:59)\u001b[0K\r\n    at Object.executeAmplifyCommand (C:\\Users\\circleci\\repo\\packages\\amplify-provider-awscloudformation\\lib\\amplify-plu\u001b[0Kg\r\nin-index.js:12:25)\u001b[0K\r\n    at C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:152:47\u001b[0K\r\n    at executePluginModuleCommand (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:135:11)\u001b[0K\r\n    at async executeCommand (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\execution-manager.js:33:9)\u001b[0K\r\n    at async Object.run (C:\\Users\\circleci\\repo\\packages\\amplify-cli\\lib\\index.js:117:5)\u001b[0K\r\n\u001b[0K\u001b[?25h"]
[14.212,"o","\u001b[?25l\r\nSession Identifier: 7fe8d7ea-b4f2-4bdc-bb6e-aa6308934981\u001b[0K\r\n\u001b[0K\u001b[?25h"]
```


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
