### PR TITLE
E2e coverage

### DIFF
--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -739,7 +739,6 @@ export function nspawn(command: string | string[], params: string[] = [], option
     }
     return acc;
   }, {});
-  console.log('########### CHILD ENV ###########', JSON.stringify(childEnv, null, 2));
 
   let pushEnv;
 

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -732,7 +732,15 @@ export function nspawn(command: string | string[], params: string[] = [], option
     command = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
   }
 
-  let childEnv;
+  let childEnv: Record<string, string> = Object.entries(process.env).reduce((acc, [key, value]) => {
+    if (key.startsWith('AMPLIFY_E2E_')) {
+      const trimmedKey = key.replace('AMPLIFY_E2E_', '');
+      return { ...acc, [trimmedKey]: value };
+    }
+    return acc;
+  }, {});
+  console.log('########### CHILD ENV ###########', JSON.stringify(childEnv, null, 2));
+
   let pushEnv;
 
   // For push operations in E2E we have to explicitly disable the Amplify Console App creation
@@ -749,6 +757,7 @@ export function nspawn(command: string | string[], params: string[] = [], option
   // to be able to disable CI detection we do need to pass in a childEnv
   if (options.env || pushEnv || options.disableCIDetection === true) {
     childEnv = {
+      ...childEnv,
       ...process.env,
       ...pushEnv,
       ...options.env,


### PR DESCRIPTION

#### Description of changes

Allows passing in environment variables to the child process in end to end tests.

For example:
```bash
AMPLIFY_E2E_NODE_V8_COVERAGE="$(pwd)/coverage" npm run e2e src/__tests__/init_b.test.ts
```

Allows the `NODE_V8_COVERAGE` env var to be passed to the child process.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
