### PR TITLE
chore: image build with binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,8 @@ orbs:
                             <<parameters.path>> \
                             --build-arg PKG_AWS_ACCESS_KEY=$PKG_AWS_ACCESS_KEY \
                             --build-arg PKG_AWS_SECRET_ACCESS_KEY=$PKG_AWS_SECRET_ACCESS_KEY \
-                            --build-arg PKG_AWS_SESSION_TOKEN=$PKG_AWS_SESSION_TOKEN
+                            --build-arg PKG_AWS_SESSION_TOKEN=$PKG_AWS_SESSION_TOKEN \
+                            --build-arg AWS_REGION=$AWS_REGION
                         fi
                     name: Build docker image
                     no_output_timeout: <<parameters.no-output-timeout>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,7 +565,7 @@ jobs:
           create-repo: false
           dockerfile: Dockerfile
           repo: amplify-cli-e2e-base-image-repo-public
-          tag: "pkg-fetch,${CIRCLE_SHA1}"
+          tag: "latest,${CIRCLE_SHA1}"
 
 workflows:
   build_and_push_image:
@@ -578,4 +578,3 @@ workflows:
             branches:
               only:
                 - e2e-image-build
-                - e2e-image-build-pkg-fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,10 @@ orbs:
                             <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
                             -f <<parameters.path>>/<<parameters.dockerfile>> \
                             $docker_tag_args \
-                            <<parameters.path>>
+                            <<parameters.path>> \
+                            --build-arg PKG_AWS_ACCESS_KEY=$PKG_AWS_ACCESS_KEY \
+                            --build-arg PKG_AWS_SECRET_ACCESS_KEY=$PKG_AWS_SECRET_ACCESS_KEY \
+                            --build-arg PKG_AWS_SESSION_TOKEN=$PKG_AWS_SESSION_TOKEN
                         fi
                     name: Build docker image
                     no_output_timeout: <<parameters.no-output-timeout>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,14 +561,17 @@ jobs:
           create-repo: false
           dockerfile: Dockerfile
           repo: amplify-cli-e2e-base-image-repo-public
-          tag: "latest,${CIRCLE_SHA1}"
+          tag: "pkg-fetch,${CIRCLE_SHA1}"
 
 workflows:
   build_and_push_image:
     jobs:
       - build:
-          context: amplify-cli-ecr
+          context:
+            - amplify-cli-ecr
+            - amplify-pkg-fetch-node-binaries
           filters:
             branches:
               only:
                 - e2e-image-build
+                - e2e-image-build-pkg-fetch

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ ARG PKG_AWS_ACCESS_KEY
 ARG PKG_AWS_SECRET_ACCESS_KEY
 ARG PKG_AWS_SESSION_TOKEN
 ARG AWS_REGION
-RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY \
-  aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY \
+RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY && \
+  aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY  && \
   aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
 ENV binaries_bucket_name="amplify-cli-pkg-fetch-nodejs-binaries"
 ENV binaries_tag="v3.4"
@@ -56,17 +56,17 @@ ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
 ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
 ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
 ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
-RUN mkdir -p ~/.pkg-cache/$binaries_tag \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched \
+RUN mkdir -p ~/.pkg-cache/$binaries_tag && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched && \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched && \
   ls ~/.pkg-cache/$binaries_tag
 
 # Install Java

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ ARG PKG_AWS_ACCESS_KEY
 ARG PKG_AWS_SECRET_ACCESS_KEY
 ARG PKG_AWS_SESSION_TOKEN
 ARG AWS_REGION
-RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY
-RUN aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY
-RUN aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
+RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY \
+  aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY \
+  aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
 ENV binaries_bucket_name="amplify-cli-pkg-fetch-nodejs-binaries"
 ENV binaries_tag="v3.4"
 ENV fourteen_version="14.21.3"
@@ -56,18 +56,18 @@ ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
 ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
 ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
 ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
-RUN mkdir -p ~/.pkg-cache/$binaries_tag
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched
-RUN ls ~/.pkg-cache/$binaries_tag
+RUN mkdir -p ~/.pkg-cache/$binaries_tag \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched \
+  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched \
+  ls ~/.pkg-cache/$binaries_tag
 
 # Install Java
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,52 @@ RUN sudo apt-get install -y \
 
 RUN sudo pip install awscli
 
+# Put Node.js PKG binaries in cache location
+ARG PKG_AWS_ACCESS_KEY
+ARG PKG_AWS_SECRET_ACCESS_KEY
+ARG PKG_AWS_SESSION_TOKEN
+ARG AWS_REGION
+RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY
+RUN aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY
+RUN aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
+# amplify-cli-pkg-fetch-nodejs-binaries
+ENV binaries_bucket_name="testbinaries"
+ENV binaries_tag="v3.4"
+ENV fourteen_version="14.21.3"
+ENV eighteen_version="18.15.0"
+ENV linux_arm_14_binary_filename="node-v$fourteen_version-linux-arm64"
+ENV linux_x64_14_binary_filename="node-v$fourteen_version-linux-x64"
+ENV win_arm_14_binary_filename="node-v$fourteen_version-win-arm64"
+ENV win_x64_14_binary_filename="node-v$fourteen_version-win-x64"
+ENV mac_x64_14_binary_filename="node-v$fourteen_version-macos-x64"
+ENV linux_arm_18_binary_filename="node-v$eighteen_version-linux-arm64"
+ENV linux_x64_18_binary_filename="node-v$eighteen_version-linux-x64"
+ENV win_arm_18_binary_filename="node-v$eighteen_version-win-arm64"
+ENV win_x64_18_binary_filename="node-v$eighteen_version-win-x64"
+ENV mac_x64_18_binary_filename="node-v$eighteen_version-macos-x64"
+ENV linux_arm_14_binary_filename_fetched="fetched-v$fourteen_version-linux-arm64"
+ENV linux_x64_14_binary_filename_fetched="fetched-v$fourteen_version-linux-x64"
+ENV win_arm_14_binary_filename_fetched="fetched-v$fourteen_version-win-arm64"
+ENV win_x64_14_binary_filename_fetched="fetched-v$fourteen_version-win-x64"
+ENV mac_x64_14_binary_filename_fetched="fetched-v$fourteen_version-macos-x64"
+ENV linux_arm_18_binary_filename_fetched="fetched-v$eighteen_version-linux-arm64"
+ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
+ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
+ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
+ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
+RUN mkdir -p ~/.pkg-cache/$binaries_tag
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched
+RUN ls ~/.pkg-cache/$binaries_tag
+
 # Install Java
 WORKDIR /tmp
 RUN curl -O https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
@@ -79,47 +125,3 @@ RUN dotnet tool install -g amazon.lambda.testtool-3.1
 RUN dotnet tool install -g amazon.lambda.testtool-6.0
 ENV PATH=${PATH}:/home/circleci/.dotnet/tools
 
-# Put Node.js PKG binaries in cache location
-ARG PKG_AWS_ACCESS_KEY
-ARG PKG_AWS_SECRET_ACCESS_KEY
-ARG PKG_AWS_SESSION_TOKEN
-RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY
-RUN aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY
-RUN aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
-# amplify-cli-pkg-fetch-nodejs-binaries
-ENV binaries_bucket_name="testbinaries"
-ENV binaries_tag="v3.4"
-ENV fourteen_version="14.21.3"
-ENV eighteen_version="18.15.0"
-ENV linux_arm_14_binary_filename="node-v$fourteen_version-linux-arm64"
-ENV linux_x64_14_binary_filename="node-v$fourteen_version-linux-x64"
-ENV win_arm_14_binary_filename="node-v$fourteen_version-win-arm64"
-ENV win_x64_14_binary_filename="node-v$fourteen_version-win-x64"
-ENV mac_x64_14_binary_filename="node-v$fourteen_version-macos-x64"
-ENV linux_arm_18_binary_filename="node-v$eighteen_version-linux-arm64"
-ENV linux_x64_18_binary_filename="node-v$eighteen_version-linux-x64"
-ENV win_arm_18_binary_filename="node-v$eighteen_version-win-arm64"
-ENV win_x64_18_binary_filename="node-v$eighteen_version-win-x64"
-ENV mac_x64_18_binary_filename="node-v$eighteen_version-macos-x64"
-ENV linux_arm_14_binary_filename_fetched="fetched-v$fourteen_version-linux-arm64"
-ENV linux_x64_14_binary_filename_fetched="fetched-v$fourteen_version-linux-x64"
-ENV win_arm_14_binary_filename_fetched="fetched-v$fourteen_version-win-arm64"
-ENV win_x64_14_binary_filename_fetched="fetched-v$fourteen_version-win-x64"
-ENV mac_x64_14_binary_filename_fetched="fetched-v$fourteen_version-macos-x64"
-ENV linux_arm_18_binary_filename_fetched="fetched-v$eighteen_version-linux-arm64"
-ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
-ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
-ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
-ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
-RUN mkdir -p ~/.pkg-cache/$binaries_tag
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched
-RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched
-RUN ls ~/.pkg-cache/$binaries_tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ ARG AWS_REGION
 RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY
 RUN aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY
 RUN aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
-# amplify-cli-pkg-fetch-nodejs-binaries
-ENV binaries_bucket_name="testbinaries"
+ENV binaries_bucket_name="amplify-cli-pkg-fetch-nodejs-binaries"
 ENV binaries_tag="v3.4"
 ENV fourteen_version="14.21.3"
 ENV eighteen_version="18.15.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,3 +78,48 @@ RUN dotnet tool install -g amazon.lambda.tools
 RUN dotnet tool install -g amazon.lambda.testtool-3.1
 RUN dotnet tool install -g amazon.lambda.testtool-6.0
 ENV PATH=${PATH}:/home/circleci/.dotnet/tools
+
+# Put Node.js PKG binaries in cache location
+ARG PKG_AWS_ACCESS_KEY
+ARG PKG_AWS_SECRET_ACCESS_KEY
+ARG PKG_AWS_SESSION_TOKEN
+RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY
+RUN aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY
+RUN aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
+# amplify-cli-pkg-fetch-nodejs-binaries
+ENV binaries_bucket_name="testbinaries"
+ENV binaries_tag="v3.4"
+ENV fourteen_version="14.21.3"
+ENV eighteen_version="18.15.0"
+ENV linux_arm_14_binary_filename="node-v$fourteen_version-linux-arm64"
+ENV linux_x64_14_binary_filename="node-v$fourteen_version-linux-x64"
+ENV win_arm_14_binary_filename="node-v$fourteen_version-win-arm64"
+ENV win_x64_14_binary_filename="node-v$fourteen_version-win-x64"
+ENV mac_x64_14_binary_filename="node-v$fourteen_version-macos-x64"
+ENV linux_arm_18_binary_filename="node-v$eighteen_version-linux-arm64"
+ENV linux_x64_18_binary_filename="node-v$eighteen_version-linux-x64"
+ENV win_arm_18_binary_filename="node-v$eighteen_version-win-arm64"
+ENV win_x64_18_binary_filename="node-v$eighteen_version-win-x64"
+ENV mac_x64_18_binary_filename="node-v$eighteen_version-macos-x64"
+ENV linux_arm_14_binary_filename_fetched="fetched-v$fourteen_version-linux-arm64"
+ENV linux_x64_14_binary_filename_fetched="fetched-v$fourteen_version-linux-x64"
+ENV win_arm_14_binary_filename_fetched="fetched-v$fourteen_version-win-arm64"
+ENV win_x64_14_binary_filename_fetched="fetched-v$fourteen_version-win-x64"
+ENV mac_x64_14_binary_filename_fetched="fetched-v$fourteen_version-macos-x64"
+ENV linux_arm_18_binary_filename_fetched="fetched-v$eighteen_version-linux-arm64"
+ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
+ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
+ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
+ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
+RUN mkdir -p ~/.pkg-cache/$binaries_tag
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched
+RUN aws --profile=pkg-binaries-fetcher s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched
+RUN ls ~/.pkg-cache/$binaries_tag


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
These changes fetch the pkg Node.js binaries from a private S3 bucket and include them in the image when it is built.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
