### PR TITLE
chore: migrate from deprecated CDK api

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -424,7 +424,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       }
 
       if (configureSMS) {
-        this.userPool.addDependsOn(this.snsRole!);
+        this.userPool.addDependency(this.snsRole!);
       }
 
       // updating Lambda Config when FF is (break circular dependency : false)
@@ -464,7 +464,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         this.userPoolClientWeb.writeAttributes = this._cfnParameterMap.get('userpoolClientWriteAttributes')?.valueAsList;
       }
       this.userPoolClientWeb.refreshTokenValidity = cdk.Fn.ref('userpoolClientRefreshTokenValidity') as unknown as number;
-      this.userPoolClientWeb.addDependsOn(this.userPool);
+      this.userPoolClientWeb.addDependency(this.userPool);
 
       this.userPoolClient = new cognito.CfnUserPoolClient(this, 'UserPoolClient', {
         userPoolId: cdk.Fn.ref('UserPool'),
@@ -479,7 +479,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       }
       this.userPoolClient.refreshTokenValidity = cdk.Fn.ref('userpoolClientRefreshTokenValidity') as unknown as number;
       this.userPoolClient.generateSecret = cdk.Fn.ref('userpoolClientGenerateSecret') as unknown as boolean;
-      this.userPoolClient.addDependsOn(this.userPool);
+      this.userPoolClient.addDependency(this.userPool);
 
       this.createUserPoolClientCustomResource(props);
       if (props.hostedUIDomainName) {
@@ -564,7 +564,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
           authenticated: cdk.Fn.ref('authRoleArn'),
         },
       });
-      this.identityPoolRoleMap.addDependsOn(this.identityPool);
+      this.identityPoolRoleMap.addDependency(this.identityPool);
     }
   };
 
@@ -603,7 +603,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         ],
       },
     });
-    this.userPoolClientRole.addDependsOn(this.userPoolClient!);
+    this.userPoolClientRole.addDependency(this.userPoolClient!);
 
     // lambda function
     this.userPoolClientLambda = new lambda.CfnFunction(this, 'UserPoolClientLambda', {
@@ -615,7 +615,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs16.x',
       timeout: 300,
     });
-    this.userPoolClientLambda.addDependsOn(this.userPoolClientRole);
+    this.userPoolClientLambda.addDependency(this.userPoolClientRole);
 
     // userPool client lambda policy
     /**
@@ -638,7 +638,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.userPoolClientLambdaPolicy.addDependsOn(this.userPoolClientLambda);
+    this.userPoolClientLambdaPolicy.addDependency(this.userPoolClientLambda);
 
     // userPool Client Log policy
 
@@ -661,7 +661,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.userPoolClientLogPolicy.addDependsOn(this.userPoolClientLambdaPolicy);
+    this.userPoolClientLogPolicy.addDependency(this.userPoolClientLambdaPolicy);
 
     // userPoolClient Custom Resource
     this.userPoolClientInputs = new cdk.CustomResource(this, 'UserPoolClientInputs', {
@@ -689,7 +689,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs16.x',
       timeout: 300,
     });
-    this.hostedUICustomResource.addDependsOn(this.userPoolClientRole!);
+    this.hostedUICustomResource.addDependency(this.userPoolClientRole!);
 
     // userPool client lambda policy
     /**
@@ -716,7 +716,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.hostedUICustomResourcePolicy.addDependsOn(this.hostedUICustomResource);
+    this.hostedUICustomResourcePolicy.addDependency(this.hostedUICustomResource);
 
     // userPool Client Log policy
 
@@ -738,7 +738,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.hostedUICustomResourceLogPolicy.addDependsOn(this.hostedUICustomResourcePolicy);
+    this.hostedUICustomResourceLogPolicy.addDependency(this.hostedUICustomResourcePolicy);
 
     // userPoolClient Custom Resource
     this.hostedUICustomResourceInputs = new cdk.CustomResource(this, 'HostedUICustomResourceInputs', {
@@ -770,7 +770,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs16.x',
       timeout: 300,
     });
-    this.hostedUIProvidersCustomResource.addDependsOn(this.userPoolClientRole!);
+    this.hostedUIProvidersCustomResource.addDependency(this.userPoolClientRole!);
 
     // userPool client lambda policy
     /**
@@ -802,7 +802,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.hostedUIProvidersCustomResourcePolicy.addDependsOn(this.hostedUIProvidersCustomResource);
+    this.hostedUIProvidersCustomResourcePolicy.addDependency(this.hostedUIProvidersCustomResource);
 
     // userPool Client Log policy
 
@@ -824,7 +824,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.hostedUIProvidersCustomResourceLogPolicy.addDependsOn(this.hostedUIProvidersCustomResourcePolicy);
+    this.hostedUIProvidersCustomResourceLogPolicy.addDependency(this.hostedUIProvidersCustomResourcePolicy);
 
     // userPoolClient Custom Resource
     this.hostedUIProvidersCustomResourceInputs = new cdk.CustomResource(this, 'HostedUIProvidersCustomResourceInputs', {
@@ -877,7 +877,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.oAuthCustomResourcePolicy.addDependsOn(this.oAuthCustomResource);
+    this.oAuthCustomResourcePolicy.addDependency(this.oAuthCustomResource);
 
     // Oauth Log policy
 
@@ -899,7 +899,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       },
       roles: [cdk.Fn.ref('UserPoolClientRole')],
     });
-    this.oAuthCustomResourceLogPolicy.addDependsOn(this.oAuthCustomResourcePolicy);
+    this.oAuthCustomResourceLogPolicy.addDependency(this.oAuthCustomResourcePolicy);
 
     // oAuth Custom Resource
     this.oAuthCustomResourceInputs = new cdk.CustomResource(this, 'OAuthCustomResourceInputs', {
@@ -972,7 +972,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         },
       ],
     });
-    this.mfaLambdaRole.addDependsOn(this.snsRole!);
+    this.mfaLambdaRole.addDependency(this.snsRole!);
     // lambda function
     /**
      *   Lambda which sets MFA config values
@@ -987,7 +987,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs16.x',
       timeout: 300,
     });
-    this.mfaLambda.addDependsOn(this.mfaLambdaRole);
+    this.mfaLambda.addDependency(this.mfaLambdaRole);
 
     // MFA lambda policy
     /**
@@ -1015,7 +1015,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         ).toString(),
       ],
     });
-    this.mfaLambdaPolicy.addDependsOn(this.mfaLambda);
+    this.mfaLambdaPolicy.addDependency(this.mfaLambda);
 
     // mfa Log policy
 
@@ -1043,7 +1043,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         ).toString(),
       ],
     });
-    this.mfaLogPolicy.addDependsOn(this.mfaLambdaPolicy);
+    this.mfaLogPolicy.addDependency(this.mfaLambdaPolicy);
 
     // mfa Custom Resource
     /**
@@ -1130,7 +1130,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
       runtime: 'nodejs16.x',
       timeout: 300,
     });
-    this.openIdLambda.addDependsOn(this.openIdLambdaRole);
+    this.openIdLambda.addDependency(this.openIdLambdaRole);
 
     // OPenId lambda policy
     /**
@@ -1168,7 +1168,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         ).toString(),
       ],
     });
-    this.openIdLambdaIAMPolicy.addDependsOn(this.openIdLambda);
+    this.openIdLambdaIAMPolicy.addDependency(this.openIdLambda);
 
     // openId Log policy
     /**
@@ -1201,7 +1201,7 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         ).toString(),
       ],
     });
-    this.openIdLogPolicy.addDependsOn(this.openIdLambdaIAMPolicy);
+    this.openIdLogPolicy.addDependency(this.openIdLambdaIAMPolicy);
 
     // openId Custom Resource
     /**

--- a/packages/amplify-category-geo/src/service-utils/prepare-app.ts
+++ b/packages/amplify-category-geo/src/service-utils/prepare-app.ts
@@ -29,7 +29,7 @@ export const cdkV1PrepareAppShim = (root: IConstruct): void => {
 
     for (const target of targetCfnResources) {
       for (const source of sourceCfnResources) {
-        source.addDependsOn(target);
+        source.addDependency(target);
       }
     }
   }

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.ts
@@ -182,7 +182,7 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
       const newLambdaConfigurations = this.buildLambdaConfigFromTriggerParams(triggerLambdaFunctionParams);
       this._addNotificationsLambdaConfigurations(newLambdaConfigurations);
       this.triggerLambdaPermissions = this.createInvokeFunctionS3Permission('TriggerPermissions', this._props.triggerFunction);
-      this.s3Bucket.addDependsOn(this.triggerLambdaPermissions as lambdaCdk.CfnPermission);
+      this.s3Bucket.addDependency(this.triggerLambdaPermissions as lambdaCdk.CfnPermission);
       /**
        * Add Depends On: FUNCTION service
        * s3 Dependency on Lambda to Root Stack
@@ -201,7 +201,7 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
         'AdminTriggerPermissions',
         this._props.adminTriggerFunction.triggerFunction,
       );
-      this.s3Bucket.addDependsOn(this.adminTriggerLambdaPermissions);
+      this.s3Bucket.addDependency(this.adminTriggerLambdaPermissions);
 
       /**
        * Add Depends On: FUNCTION service
@@ -1008,7 +1008,7 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
     policyL1.Properties.policyDocument.Statement = policyStatements;
     const policy = new iamCdk.CfnPolicy(this, policyDefinition.logicalId, policyL1.Properties);
     if (policyDefinition.dependsOn) {
-      policyDefinition.dependsOn.map((dependency) => policy.addDependsOn(dependency));
+      policyDefinition.dependsOn.map((dependency) => policy.addDependency(dependency));
     }
     if (policyDefinition.condition) {
       policy.cfnOptions.condition = policyDefinition.condition;
@@ -1027,7 +1027,7 @@ export class AmplifyS3ResourceCfnStack extends AmplifyResourceCfnStack implement
     };
     const policy = new iamCdk.CfnPolicy(this, policyDefinition.logicalId, props); // bind policy to stack
     if (policyDefinition.dependsOn) {
-      policyDefinition.dependsOn.map((dependency) => policy.addDependsOn(dependency));
+      policyDefinition.dependsOn.map((dependency) => policy.addDependency(dependency));
     }
     if (policyDefinition.condition) {
       policy.cfnOptions.condition = policyDefinition.condition;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Addresses:

```
console.warn
      [WARNING] aws-cdk-lib.CfnResource#addDependsOn is deprecated.
        use addDependency
        This API will be removed in the next major release.
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
