### PR TITLE
fix: handle bucket exists check for s3 buckets in opt in regions

### DIFF
--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -90,7 +90,7 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "testRegex": "(src/__tests__/.*.test.(t|j)s)$",
+    "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
@@ -1,25 +1,50 @@
 import { $TSContext } from 'amplify-cli-core';
 import { createS3Service } from '../../aws-utils/S3Service';
-import * as AWS from 'aws-sdk';
 
-jest.setTimeout(10 * 1000);
+jest.mock('aws-sdk', () => {
+  const mockHeadBucketForUsEast1 = jest.fn().mockImplementation((params: { Bucket: string }) => {
+    return {
+      promise: jest.fn().mockImplementation(() => {
+        if (params.Bucket.includes('us-east-1')) {
+          return Promise.resolve({});
+        }
+        return Promise.reject({ code: 'BadRequest', region: 'eu-south-1' });
+      }),
+    };
+  });
+
+  const mockHeadBucketForEuSouth1 = jest.fn().mockImplementation((params) => {
+    return {
+      promise: jest.fn().mockImplementation(() => {
+        if (params.Bucket.includes('eu-south-1')) {
+          return Promise.resolve({});
+        }
+        return Promise.reject({ code: 'BadRequest', region: 'us-east-1' });
+      }),
+    };
+  });
+
+  return {
+    S3: jest.fn((options) => {
+      const region = options.region || 'us-east-1';
+      if (region === 'eu-south-1') {
+        return {
+          headBucket: mockHeadBucketForEuSouth1,
+        };
+      }
+      return {
+        config: {
+          region,
+        },
+        headBucket: mockHeadBucketForUsEast1,
+      };
+    }),
+  };
+});
 
 describe('S3Service', () => {
-  const usEastS3 = new AWS.S3({ region: 'us-east-1' });
-  const euSouthS3 = new AWS.S3({ region: 'eu-south-1' });
-
   const bucketNameUsEast = `test-bucket-us-east-1-${Math.floor(Math.random() * 100000)}`;
   const bucketNameEuSouth = `test-bucket-eu-south-1-${Math.floor(Math.random() * 100000)}`;
-
-  beforeAll(async () => {
-    await usEastS3.createBucket({ Bucket: bucketNameUsEast }).promise();
-    await euSouthS3.createBucket({ Bucket: bucketNameEuSouth }).promise();
-  });
-
-  afterAll(async () => {
-    await usEastS3.deleteBucket({ Bucket: bucketNameUsEast }).promise();
-    await euSouthS3.deleteBucket({ Bucket: bucketNameEuSouth }).promise();
-  });
 
   it('should correctly return if bucket exists in NON opt-in region', async () => {
     const s3service = await createS3Service({} as unknown as $TSContext);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
@@ -2,6 +2,8 @@ import { $TSContext } from 'amplify-cli-core';
 import { createS3Service } from '../../aws-utils/S3Service';
 import * as AWS from 'aws-sdk';
 
+jest.setTimeout(10 * 1000);
+
 describe('S3Service', () => {
   const usEastS3 = new AWS.S3({ region: 'us-east-1' });
   const euSouthS3 = new AWS.S3({ region: 'eu-south-1' });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/S3Service.test.ts
@@ -1,0 +1,33 @@
+import { $TSContext } from 'amplify-cli-core';
+import { createS3Service } from '../../aws-utils/S3Service';
+import * as AWS from 'aws-sdk';
+
+describe('S3Service', () => {
+  const usEastS3 = new AWS.S3({ region: 'us-east-1' });
+  const euSouthS3 = new AWS.S3({ region: 'eu-south-1' });
+
+  const bucketNameUsEast = `test-bucket-us-east-1-${Math.floor(Math.random() * 100000)}`;
+  const bucketNameEuSouth = `test-bucket-eu-south-1-${Math.floor(Math.random() * 100000)}`;
+
+  beforeAll(async () => {
+    await usEastS3.createBucket({ Bucket: bucketNameUsEast }).promise();
+    await euSouthS3.createBucket({ Bucket: bucketNameEuSouth }).promise();
+  });
+
+  afterAll(async () => {
+    await usEastS3.deleteBucket({ Bucket: bucketNameUsEast }).promise();
+    await euSouthS3.deleteBucket({ Bucket: bucketNameEuSouth }).promise();
+  });
+
+  it('should correctly return if bucket exists in NON opt-in region', async () => {
+    const s3service = await createS3Service({} as unknown as $TSContext);
+    const bucketExists = await s3service.bucketExists(bucketNameUsEast);
+    expect(bucketExists).toBe(true);
+  });
+
+  it('should correctly return if bucket exists in opt-in region', async () => {
+    const s3service = await createS3Service({} as unknown as $TSContext);
+    const bucketExists = await s3service.bucketExists(bucketNameEuSouth);
+    expect(bucketExists).toBe(true);
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -1,6 +1,7 @@
 import { $TSContext, AmplifyFault } from 'amplify-cli-core';
 import { IS3Service } from '@aws-amplify/amplify-util-import';
-import S3, { Bucket } from 'aws-sdk/clients/s3';
+import { S3 } from 'aws-sdk';
+import { Bucket } from 'aws-sdk/clients/s3';
 import { AwsSecrets, loadConfiguration } from '../configuration-manager';
 
 export const createS3Service = async (context: $TSContext): Promise<S3Service> => {

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -62,6 +62,7 @@ export class S3Service implements IS3Service {
     return response.LocationConstraint;
   }
 }
+
 const handleS3Error = (error: { code: string; message: string }): boolean => {
   if (error.code === 'NotFound') {
     return false;

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -1,18 +1,11 @@
-import { $TSAny, $TSContext, AmplifyFault } from 'amplify-cli-core';
+import { $TSContext, AmplifyFault } from 'amplify-cli-core';
 import { IS3Service } from '@aws-amplify/amplify-util-import';
 import S3, { Bucket } from 'aws-sdk/clients/s3';
-import { loadConfiguration } from '../configuration-manager';
+import { AwsSecrets, loadConfiguration } from '../configuration-manager';
 
-export const createS3Service = async (context: $TSContext, options: $TSAny): Promise<S3Service> => {
-  let credentials = {};
-
-  try {
-    credentials = await loadConfiguration(context);
-  } catch (e) {
-    // could not load credentials
-  }
-
-  const s3 = new S3({ ...credentials, ...options });
+export const createS3Service = async (context: $TSContext): Promise<S3Service> => {
+  const credentials = await tryGetCredentials(context);
+  const s3 = new S3({ ...credentials });
 
   return new S3Service(s3);
 };
@@ -27,33 +20,25 @@ export class S3Service implements IS3Service {
       const response = await this.s3.listBuckets().promise();
 
       if (response.Buckets) {
-        this.cachedBucketList.push(...response.Buckets!);
+        this.cachedBucketList.push(...response.Buckets);
       }
     }
 
     return this.cachedBucketList;
   }
 
-  public async bucketExists(bucketName: string): Promise<boolean> {
+  public async bucketExists(bucketName: string, s3?: S3): Promise<boolean> {
+    const s3Client = s3 ?? this.s3;
     try {
-      const response = await this.s3
-        .headBucket({
-          Bucket: bucketName,
-        })
-        .promise();
+      const response = await s3Client.headBucket({ Bucket: bucketName }).promise();
       // If the return object has no keys then it means successful empty object was returned.
       return Object.keys(response).length === 0;
     } catch (error) {
-      if (error.code === 'NotFound') {
-        return false;
+      if (error.region !== s3Client.config.region) {
+        return this.bucketExists(bucketName, new S3({ ...s3Client.config?.credentials, region: error.region }));
       }
-      throw new AmplifyFault(
-        'UnknownFault',
-        {
-          message: error.message,
-        },
-        error,
-      );
+
+      return handleS3Error(error);
     }
   }
 
@@ -72,3 +57,25 @@ export class S3Service implements IS3Service {
     return response.LocationConstraint;
   }
 }
+const handleS3Error = (error: { code: string; message: string }): boolean => {
+  if (error.code === 'NotFound') {
+    return false;
+  }
+  throw new AmplifyFault(
+    'UnknownFault',
+    {
+      message: error.message,
+    },
+    error as unknown as Error,
+  );
+};
+
+const tryGetCredentials = async (context: $TSContext): Promise<AwsSecrets> => {
+  try {
+    return await loadConfiguration(context);
+  } catch (e) {
+    // could not load credentials
+  }
+
+  return {};
+};

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/S3Service.ts
@@ -34,7 +34,7 @@ export class S3Service implements IS3Service {
       // If the return object has no keys then it means successful empty object was returned.
       return Object.keys(response).length === 0;
     } catch (error) {
-      // workaround for aws-sdk bug causing headBucket for a opt-in region bucket to throw if s3 client is initialized with a different region
+      // workaround for S3 service bug causing headBucket for a opt-in region bucket to respond with BadRequest if s3 client is initialized with a different region
       if (error.region !== s3Client.config.region && error.code === 'BadRequest') {
         return this.checkIfBucketExists(bucketName, new S3({ ...s3Client.config?.credentials, region: error.region }));
       }

--- a/packages/amplify-util-import/src/IS3Service.ts
+++ b/packages/amplify-util-import/src/IS3Service.ts
@@ -1,7 +1,7 @@
-import S3, { Buckets } from 'aws-sdk/clients/s3';
+import { Buckets } from 'aws-sdk/clients/s3';
 
 export interface IS3Service {
   listBuckets(): Promise<Buckets>;
-  bucketExists(bucketName: string, s3?: S3): Promise<boolean>;
+  bucketExists(bucketName: string): Promise<boolean>;
   getBucketLocation(bucketName: string): Promise<string>;
 }

--- a/packages/amplify-util-import/src/IS3Service.ts
+++ b/packages/amplify-util-import/src/IS3Service.ts
@@ -1,7 +1,7 @@
-import { Buckets } from 'aws-sdk/clients/s3';
+import S3, { Buckets } from 'aws-sdk/clients/s3';
 
 export interface IS3Service {
   listBuckets(): Promise<Buckets>;
-  bucketExists(bucketName: string): Promise<boolean>;
+  bucketExists(bucketName: string, s3?: S3): Promise<boolean>;
   getBucketLocation(bucketName: string): Promise<string>;
 }


### PR DESCRIPTION
#### Description of changes
- workaround for aws-sdk bug where calling `headBucket` for a opt-in region bucket will throw and error if s3 client is initialized with a different region
- retry headBucket call on error with the bucket region as s3 client option

#### Issue [#12295](https://github.com/aws-amplify/amplify-cli/issues/12295)

#### Description of how you validated changes
- manual testing
- unit and e2e tests pass

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
