### PR TITLE
fix: set registry in build steps

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -132,6 +132,7 @@ jobs:
     executor: l_xlarge
     steps:
       - checkout
+      - run: yarn config set registry https://registry.npmjs.org
       - run: yarn config set script-shell $(which bash)
       - run: yarn install
       - run:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -107,6 +107,7 @@ jobs:
     executor: l_xlarge
     steps:
       - checkout
+      - run: yarn config set registry https://registry.npmjs.org
       - run: yarn config set script-shell $(which bash)
       - run: yarn run production-build
       - run:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Force registry in build jobs to fix:

![image](https://user-images.githubusercontent.com/5849952/227386922-943b32f1-d8d7-4d8b-926a-78bbd61c4dad.png)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
