### PR TITLE
chore: don't show deprecation warnings in binary

### DIFF
--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -4,6 +4,10 @@
 // this file should be a duplicate of amplify.production.template except for the CLI_ENV value
 process.env.CLI_ENV = 'development';
 
+// suppress deprecation warnings
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
+process['noDeprecation'] = true;
+
 const startTime = Date.now();
 if (process.pkg) {
   require('../lib/utils/copy-override').copyOverride();

--- a/packages/amplify-cli/bin/amplify.production.template
+++ b/packages/amplify-cli/bin/amplify.production.template
@@ -4,6 +4,10 @@
 // this file should be a duplicate of amplify except for the CLI_ENV value
 process.env.CLI_ENV = 'production';
 
+// suppress deprecation warnings
+process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
+process['noDeprecation'] = true;
+
 const startTime = Date.now();
 if (process.pkg) {
   require('../lib/utils/copy-override').copyOverride();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR suppresses deprecation warnings, i.e.:
- AWS SDK message that's coming when we decide to upgrade it.
- Cloudform deprecated package.json (for the NodeJS 18 upgrade).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
