### PR TITLE
test: add e2e tests for push, init, pull, env with help flag

### DIFF
--- a/packages/amplify-e2e-core/src/utils/help.ts
+++ b/packages/amplify-e2e-core/src/utils/help.ts
@@ -1,6 +1,7 @@
 import { getCLIPath, nspawn as spawn } from '..';
 
-export const statusWithHelp = async (cwd: string, expectedContents: Array<string>): Promise<void> => {
+export const statusWithHelp = async (cwd: string): Promise<void> => {
+  const expectedContents = ['USAGE', 'amplify status [-v | --verbose]'];
   const chain = spawn(getCLIPath(), ['status', '-h'], { cwd, stripColors: true });
   for (const expectedLine of expectedContents) {
     chain.wait(expectedLine);
@@ -8,8 +9,54 @@ export const statusWithHelp = async (cwd: string, expectedContents: Array<string
   await chain.runAsync();
 };
 
-export const statusForCategoryWithHelp = async (cwd: string, category: string, expectedContents: Array<string>): Promise<void> => {
+export const statusForCategoryWithHelp = async (cwd: string, category: string): Promise<void> => {
+  const expectedContents = ['USAGE', `amplify ${category} status`];
   const chain = spawn(getCLIPath(), ['status', category, '-h'], { cwd, stripColors: true });
+  for (const expectedLine of expectedContents) {
+    chain.wait(expectedLine);
+  }
+  await chain.runAsync();
+};
+
+export const pushWithHelp = async (cwd: string): Promise<void> => {
+  const expectedContents = [
+    'USAGE',
+    'amplify push [category] [--codegen] [--debug] [-f | --force] [-y | --yes] [--allow-destructive-graphql-schema-updates]',
+  ];
+  const chain = spawn(getCLIPath(), ['push', '-h'], { cwd, stripColors: true });
+  for (const expectedLine of expectedContents) {
+    chain.wait(expectedLine);
+  }
+  await chain.runAsync();
+};
+
+export const initWithHelp = async (cwd: string): Promise<void> => {
+  const expectedContents = [
+    'USAGE',
+    'amplify init [-y | --yes] [--amplify <payload>] [--envName <env-name>] [--debug] [--frontend <payload>] [--providers <payload>] [--categories <payload>] [--app <git-url>] [--permissions-boundary <ARN>]',
+  ];
+  const chain = spawn(getCLIPath(), ['init', '-h'], { cwd, stripColors: true });
+  for (const expectedLine of expectedContents) {
+    chain.wait(expectedLine);
+  }
+  await chain.runAsync();
+};
+
+export const pullWithHelp = async (cwd: string): Promise<void> => {
+  const expectedContents = [
+    'USAGE',
+    'amplify pull [--appId <app-id>] [--envName <env-name>] [--debug] [-y | --yes] [--restore] [--amplify <payload>] [--frontend <payload>] [--providers <payload>] [--categories <payload>]',
+  ];
+  const chain = spawn(getCLIPath(), ['pull', '-h'], { cwd, stripColors: true });
+  for (const expectedLine of expectedContents) {
+    chain.wait(expectedLine);
+  }
+  await chain.runAsync();
+};
+
+export const envWithHelp = async (cwd: string): Promise<void> => {
+  const expectedContents = ['USAGE', 'amplify env <subcommand>'];
+  const chain = spawn(getCLIPath(), ['env', '-h'], { cwd, stripColors: true });
   for (const expectedLine of expectedContents) {
     chain.wait(expectedLine);
   }

--- a/packages/amplify-e2e-tests/src/__tests__/help.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/help.test.ts
@@ -5,8 +5,10 @@ import {
   deleteProjectDir,
   statusWithHelp,
   statusForCategoryWithHelp,
-  addS3AndAuthWithAuthOnlyAccess,
-  amplifyPushAuth,
+  pushWithHelp,
+  initWithHelp,
+  pullWithHelp,
+  envWithHelp,
 } from '@aws-amplify/amplify-e2e-core';
 
 describe('help happy paths', () => {
@@ -14,8 +16,6 @@ describe('help happy paths', () => {
   beforeAll(async () => {
     projRoot = await createNewProjectDir('help-happy-paths');
     await initJSProjectWithProfile(projRoot, {});
-    await addS3AndAuthWithAuthOnlyAccess(projRoot);
-    await amplifyPushAuth(projRoot);
   });
 
   afterAll(async () => {
@@ -24,10 +24,26 @@ describe('help happy paths', () => {
   });
 
   test('amplify status', async () => {
-    await statusWithHelp(projRoot, ['USAGE', 'amplify status [-v | --verbose]']);
+    await statusWithHelp(projRoot);
   });
 
   test('amplify status storage', async () => {
-    await statusForCategoryWithHelp(projRoot, 'storage', ['USAGE', 'amplify storage status']);
+    await statusForCategoryWithHelp(projRoot, 'storage');
+  });
+
+  test('amplify push', async () => {
+    await pushWithHelp(projRoot);
+  });
+
+  test('amplify init', async () => {
+    await initWithHelp(projRoot);
+  });
+
+  test('amplify pull', async () => {
+    await pullWithHelp(projRoot);
+  });
+
+  test('amplify env', async () => {
+    await envWithHelp(projRoot);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR adds e2e tests for push, init, pull, and env with the help flag. The chain.waits expect a certain output. If that output is not given, then the tests will fail.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
