### PR TITLE
[Java Lambda] gradle: change compile to implementation

### DIFF
--- a/packages/amplify-java-function-template-provider/resources/lambda/hello-world/build.gradle.ejs
+++ b/packages/amplify-java-function-template-provider/resources/lambda/hello-world/build.gradle.ejs
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile (
+    implementation (
         'com.amazonaws:aws-lambda-java-core:1.2.0',
         'com.amazonaws:aws-lambda-java-events:2.2.7'
     )


### PR DESCRIPTION
#### Description of changes

The current gradle build scripts use the compile directive. This has been deprecated since somewhere in 2018 and have been removed in gradle versions >= 7 (2021). I think switching to use the newer directives would be preferable to those building java lambda's.

I write this PR to check with you guys first. There might be reasons to not upgrade to support newer gradle versions, which Id be interested in hearing then.

If there is interest I will try to see if I can figure out what needs to happen to get a working PR (_this pr is simply changing the first line I found that might do the thing, but I did not dive into if this is all that needs to happen or not in order to not break amplify cli_  ).

Thanks!


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
