### PR TITLE
chore: some QoL improvements for locally debugging e2e tests

### DIFF
--- a/packages/amplify-e2e-core/src/asciinema-recorder.ts
+++ b/packages/amplify-e2e-core/src/asciinema-recorder.ts
@@ -53,6 +53,9 @@ export class Recorder {
     if (this.exitCode !== undefined) {
       throw new Error('Already executed. Please start a new instance');
     }
+    if (process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED) {
+      console.log(`Executing command [${this.cmd} ${this.args.join(' ')}]`);
+    }
     this.childProcess = pty.spawn(this.cmd, this.args, {
       name: 'xterm-color',
       cols: this.cols,

--- a/packages/amplify-e2e-core/src/asciinema-recorder.ts
+++ b/packages/amplify-e2e-core/src/asciinema-recorder.ts
@@ -1,5 +1,6 @@
 import * as pty from 'node-pty';
 import chalk from 'chalk';
+import { isCI } from './utils';
 
 export type RecordingHeader = {
   version: 2;
@@ -53,7 +54,7 @@ export class Recorder {
     if (this.exitCode !== undefined) {
       throw new Error('Already executed. Please start a new instance');
     }
-    if (process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED) {
+    if (process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED || !isCI()) {
       console.log(`Executing command [${this.cmd} ${this.args.join(' ')}]`);
     }
     this.childProcess = pty.spawn(this.cmd, this.args, {

--- a/packages/amplify-e2e-core/src/index.ts
+++ b/packages/amplify-e2e-core/src/index.ts
@@ -12,6 +12,7 @@ import { v4 as uuid } from 'uuid';
 import { pathManager } from 'amplify-cli-core';
 import { gt } from 'semver';
 import { sleep } from '.';
+import { isCI } from './utils';
 
 export * from './diagnose';
 export * from './configure';
@@ -120,8 +121,10 @@ export async function createNewProjectDir(
 
   fs.ensureDirSync(projectDir);
 
-  const initialDelay = Math.floor(Math.random() * 180 * 1000);
-  await sleep(initialDelay);
+  if (isCI()) {
+    const initialDelay = Math.floor(Math.random() * 180 * 1000);
+    await sleep(initialDelay);
+  }
 
   console.log(projectDir);
   return projectDir;

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -11,10 +11,8 @@ import strip = require('strip-ansi');
 import { EOL } from 'os';
 import retimer = require('retimer');
 import { join, parse } from 'path';
-import * as fs from 'fs-extra';
-import * as os from 'os';
 import { Recorder } from '../asciinema-recorder';
-import { generateRandomShortId, getScriptRunnerPath, isTestingWithLatestCodebase } from '..';
+import { getScriptRunnerPath, isTestingWithLatestCodebase } from '..';
 
 declare global {
   /* eslint-disable @typescript-eslint/no-namespace */

--- a/packages/amplify-e2e-core/src/utils/verbose-logging.ts
+++ b/packages/amplify-e2e-core/src/utils/verbose-logging.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { tmpdir, EOL } from 'os';
+import { tmpdir } from 'os';
 import { Writable } from 'stream';
 import { generateRandomShortId } from '.';
 import strip from 'strip-ansi';

--- a/packages/amplify-e2e-core/src/utils/verbose-logging.ts
+++ b/packages/amplify-e2e-core/src/utils/verbose-logging.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { tmpdir, EOL } from 'os';
+import { Writable } from 'stream';
+import { generateRandomShortId } from '.';
+import strip from 'strip-ansi';
+
+/**
+ * Returns a Writable instance based on the current verbose logging config.
+ * Note that if the config is set to "files" each invocation of this method will return a write stream to a new file
+ * @returns
+ */
+export const getVerboseLogTarget = (): Writable => {
+  switch (process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED) {
+    case undefined:
+      return new NoopWritable();
+    case 'stdout':
+      return new StdoutWritable();
+    case 'files':
+      return new FileWritable();
+    default:
+      throw new Error(
+        `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED must be either "stdout" or "files". Found [${process.env.VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED}]`,
+      );
+  }
+};
+
+class NoopWritable extends Writable {
+  _write() {
+    /* noop */
+  }
+}
+
+// Creating this wrapper so the caller can call stdoutWrapper.end without actually closing stdout
+class StdoutWritable extends Writable {
+  _write = process.stdout._write;
+}
+
+// wrapper around a file write stream that strips out spinner logs before writing
+class FileWritable extends Writable {
+  private readonly writeStream: Writable;
+  private readonly spinnerRegex = new RegExp(/.*(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏).*/);
+
+  constructor() {
+    super();
+    const logdir = path.join(tmpdir(), 'amplify_e2e_logs');
+    fs.ensureDirSync(logdir);
+    const filename = path.join(logdir, `amplify_e2e_log_${generateRandomShortId()}`);
+    console.log(`CLI test logs at [${filename}]`);
+    this.writeStream = fs.createWriteStream(filename);
+  }
+  end(...args) {
+    this.writeStream.end(...args);
+  }
+  _write(chunk: string, encoding: BufferEncoding, callback: (error?: Error) => void): void {
+    if (this.spinnerRegex.test(chunk) === false && strip(chunk).trim().length > 0) {
+      this.writeStream._write(`${chunk}${EOL}`, encoding, callback);
+    }
+  }
+}

--- a/packages/amplify-e2e-tests/Readme.md
+++ b/packages/amplify-e2e-tests/Readme.md
@@ -28,7 +28,7 @@ E2E tests internally use a forked version of [nexpect](https://www.npmjs.com/pac
 
 If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to either `stdout` or `files`. Setting to `stdout` will pipe CLI output to stdout of the test harness. Setting to `files` will create a log file for each CLI command and pipe output to the file. The created files will be printed to stdout so you can find them.
 
-> Note: it is not recommended to set this option if you are running multiple tests at once. This would cause the output from multiple tests to be interleaved together.
+> Note: it is not recommended to set this option to `stdout` if you are running multiple tests at once. This would cause the output from multiple tests to be interleaved together.
 
 ```sh
 export VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=stdout

--- a/packages/amplify-e2e-tests/Readme.md
+++ b/packages/amplify-e2e-tests/Readme.md
@@ -26,23 +26,25 @@ npm run e2e src/__tests__/init.test.ts
 
 E2E tests internally use a forked version of [nexpect](https://www.npmjs.com/package/nexpect) to run the CLI. There are helper methods that helps you to set up and delete project. The recommended pattern is to create a helper method that creates a resources as a helper method so these method could be used in other tests. For instance, `initJSProjectWithProfile` is a helper method that is used in `init` tests and also used in all the other tests to initalize a new Javascript project. The tests should have all the assertions to make sure the resource created by the helper method is setup correctly. We recommend using `aws-sdk` to make assert the resource configuration.
 
-To configure the amount of time nexpect will wait for CLI responses, you can set the `AMPLIFY_TEST_TIMEOUT_SEC` environment variable. It is helpful to set this to a low value (10 seconds or so) when writing new tests so that you don't spend unnecessary time waiting for nexpect to error out on a misconfigured wait() block
+If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to `true` and CLI output will be piped to stdout of the test harness. This will allow you to see CLI output as if you had run the test commands directly.
 
-If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to `true` and output logs will be written to temp files. The temp file paths will be printed as the tests run and you can `cat` or `tail` the logs to see the CLI output
+> Note: it is not recommended to set this option if you are running multiple tests at once. This would cause the output from multiple tests to be interleaved together.
 
 ```sh
-env VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=true yarn e2e
+env VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=true yarn e2e <path/to/test/file> -t 'name of individual test'
 ```
 
 ```typescript
 import { amplifyPush, deleteProject, initJSProjectWithProfile } from '../init';
 import { createNewProjectDir, deleteProjectDir, getProjectMeta } from '../utils';
 
-describe('amplify your test', () => {
+describe('name of component or feature', () => {
   let projRoot: string;
   beforeEach(() => {
     projRoot = createNewProjectDir(); // create a new project for each test
-    jest.setTimeout(1000 * 60 * 60); // 1 hour timeout as pushing might be slow
+    // initialize an Amplify Project in the directory
+    // If you are testing a specific init behavior, this step might be different, but most e2e tests initialize in this way.
+    await initJSProjectWithProfile(projRoot, { name: '<project-name>' });
   });
 
   afterEach(async () => {
@@ -50,13 +52,14 @@ describe('amplify your test', () => {
     deleteProjectDir(projRoot); // delete the project directory
   });
 
-  it('<your test>', async () => {
-    await initJSProjectWithProfile(projRoot, { name: '<project-name>' });
+  it('specific behavior description', async () => {
     // add resources that you want to test
+    await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'nodejs');
     await amplifyPush(projRoot); // Push it to the cloud
-    const { output } = getProjectMeta(projRoot).api.simplemodel;
 
-    // TODO - assertion to make sure the resources are pushed. Use matcher
+    // add normal jest assertions about project state
+    const { output } = getProjectMeta(projRoot).api.simplemodel;
+    expect(output).toBeDefined();
   });
 });
 ```
@@ -72,4 +75,4 @@ There are two scenarios when this approach can cause trouble:
 1. Locally running two or more test suites in parallel with this test included, the other tests might fail because test project can not be init'ed when the above mentioned config and credential files are missing.
 2. In the middle of execution, the test is interrupted by Ctrl+C, then the hidden config and credential files are not renamed back.
 
-So, You should NOT run multiple tests in parallel locally with the `init-special-case` test included. And, if you use Ctrl+C to interrupt the `init-special-case` test, you need to go to the `~/.aws/c` folder and rename the config and credential files to their original names.
+So, You should NOT run multiple tests in parallel locally with the `init-special-case` test included. And, if you use Ctrl+C to interrupt the `init-special-case` test, you need to go to the `~/.aws` folder and rename the config and credential files to their original names.

--- a/packages/amplify-e2e-tests/Readme.md
+++ b/packages/amplify-e2e-tests/Readme.md
@@ -26,12 +26,13 @@ npm run e2e src/__tests__/init.test.ts
 
 E2E tests internally use a forked version of [nexpect](https://www.npmjs.com/package/nexpect) to run the CLI. There are helper methods that helps you to set up and delete project. The recommended pattern is to create a helper method that creates a resources as a helper method so these method could be used in other tests. For instance, `initJSProjectWithProfile` is a helper method that is used in `init` tests and also used in all the other tests to initalize a new Javascript project. The tests should have all the assertions to make sure the resource created by the helper method is setup correctly. We recommend using `aws-sdk` to make assert the resource configuration.
 
-If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to `true` and CLI output will be piped to stdout of the test harness. This will allow you to see CLI output as if you had run the test commands directly.
+If you want to log the test results for debugging, set the environment variable `VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED` to either `stdout` or `files`. Setting to `stdout` will pipe CLI output to stdout of the test harness. Setting to `files` will create a log file for each CLI command and pipe output to the file. The created files will be printed to stdout so you can find them.
 
 > Note: it is not recommended to set this option if you are running multiple tests at once. This would cause the output from multiple tests to be interleaved together.
 
 ```sh
-env VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=true yarn e2e <path/to/test/file> -t 'name of individual test'
+export VERBOSE_LOGGING_DO_NOT_USE_IN_CI_OR_YOU_WILL_BE_FIRED=stdout
+yarn e2e <path/to/test/file> -t 'name of individual test'
 ```
 
 ```typescript

--- a/packages/amplify-e2e-tests/src/setup-tests.ts
+++ b/packages/amplify-e2e-tests/src/setup-tests.ts
@@ -1,3 +1,4 @@
+import { isCI } from '@aws-amplify/amplify-e2e-core';
 import { toBeIAMRoleWithArn, toHaveValidPolicyConditionMatchingIdpId, toBeAS3Bucket } from './aws-matchers';
 
 expect.extend({ toBeIAMRoleWithArn });
@@ -7,4 +8,6 @@ expect.extend({ toBeAS3Bucket });
 const JEST_TIMEOUT = 1000 * 60 * 60; // 1 hour
 
 jest.setTimeout(JEST_TIMEOUT);
-jest.retryTimes(1);
+if (isCI()) {
+  jest.retryTimes(1);
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
1. Changes VERBOSE_LOGGING env var to accept "stdout" or "files" instead of true/false. When "stdout" is set, CLI output is piped to the test harness stdout. When "files" is set, CLI output is piped to log files (existing behavior)
3. Only jitters the test start delay when `isCI()` returns true (to avoid unnecessary delays when running tests locally)
4. Only sets the jest retry if `isCI()` is true
6. Updates the e2e test readme with some notes about this new behavior

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually running e2e tests locally
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
