### PR TITLE
chore: revise net6 baseline

### DIFF
--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR lowers required baseline net6 version to `6.0.100` in lambda templates. So that users who install net6 via apt-get on ubuntu can use it without modifying their lambda projects.

This setting does not control what customer's net6 version is it just widens allowed range of versions.

See more here https://devblogs.microsoft.com/dotnet/dotnet-6-is-now-in-ubuntu-2204/

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
