### PR TITLE
chore: undo custom resource exclusions on windows

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -12,7 +12,6 @@ import {
   getAppId,
   addAuthWithDefault,
   addS3WithGuestAccess,
-  useLatestExtensibilityHelper,
 } from '@aws-amplify/amplify-e2e-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -42,9 +41,6 @@ describe('adding custom resources test', () => {
     const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack-with-storage.ts');
     const destCustomResourceFilePath = path.join(projRoot, 'amplify', 'backend', 'custom', cdkResourceName, 'cdk-stack.ts');
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
-    // TODO: this is required to jump over breaking change between 2.53 and 2.68 of CDK.
-    // Remove after we ship new extensibility helper.
-    useLatestExtensibilityHelper(projRoot, cdkResourceName);
     await buildCustomResources(projRoot);
     await amplifyPushAuth(projRoot);
     await gitCleanFdX(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
@@ -64,9 +64,6 @@ describe('adding custom resources test', () => {
     const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack.ts');
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
 
-    // TODO: this is required to jump over breaking change between 2.53 and 2.68 of CDK.
-    // Remove after we ship new extensibility helper.
-    useLatestExtensibilityHelper(projRoot, cdkResourceName);
     await buildCustomResources(projRoot);
 
     // check if latest @aws-amplify/cli-extensibility-helper works

--- a/scripts/cci-utils.ts
+++ b/scripts/cci-utils.ts
@@ -34,6 +34,7 @@ export const AWS_REGIONS_TO_RUN_TESTS = [
 // Some services (eg. amazon lex) are not available in all regions
 // Tests added to this list will always run in us-west-2
 export const FORCE_US_WEST_2 = [
+  'src/__tests__/custom-resource-with-storage.test.ts',
   'src/__tests__/interactions.test.ts',
   'src/__tests__/interactions-1.test.ts',
   'src/__tests__/interactions-2.test.ts',

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -104,10 +104,6 @@ const TEST_EXCLUSIONS: { l: string[]; w: string[] } = {
     'src/__tests__/opensearch-simulator/opensearch-simulator.test.ts',
     'src/__tests__/storage-simulator/S3server.test.ts',
     'src/__tests__/amplify-app.test.ts',
-    // TODO: this is required to jump over breaking change between 2.53 and 2.68 of CDK.
-    // Remove exclusion for both custom resource tests after we ship new extensibility helper.
-    'src/__tests__/custom_resources.test.ts',
-    'src/__tests__/custom-resource-with-storage.test.ts',
     'src/__tests__/datastore-modelgen.test.ts',
     'src/__tests__/diagnose.test.ts',
     'src/__tests__/env-2.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This brings back custom resource tests previously included on windows.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
