### PR TITLE
ci: e2e image build pkg cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,49 +25,11 @@ RUN sudo apt-get install -y \
 RUN sudo pip install awscli
 
 # Put Node.js PKG binaries in cache location
-ARG PKG_AWS_ACCESS_KEY
-ARG PKG_AWS_SECRET_ACCESS_KEY
-ARG PKG_AWS_SESSION_TOKEN
-ARG AWS_REGION
-RUN aws configure --profile=pkg-binaries-fetcher set aws_access_key_id $PKG_AWS_ACCESS_KEY && \
-  aws configure --profile=pkg-binaries-fetcher set aws_secret_access_key $PKG_AWS_SECRET_ACCESS_KEY  && \
-  aws configure --profile=pkg-binaries-fetcher set aws_session_token $PKG_AWS_SESSION_TOKEN
-ENV binaries_bucket_name="amplify-cli-pkg-fetch-nodejs-binaries"
-ENV binaries_tag="v3.4"
-ENV fourteen_version="14.21.3"
-ENV eighteen_version="18.15.0"
-ENV linux_arm_14_binary_filename="node-v$fourteen_version-linux-arm64"
-ENV linux_x64_14_binary_filename="node-v$fourteen_version-linux-x64"
-ENV win_arm_14_binary_filename="node-v$fourteen_version-win-arm64"
-ENV win_x64_14_binary_filename="node-v$fourteen_version-win-x64"
-ENV mac_x64_14_binary_filename="node-v$fourteen_version-macos-x64"
-ENV linux_arm_18_binary_filename="node-v$eighteen_version-linux-arm64"
-ENV linux_x64_18_binary_filename="node-v$eighteen_version-linux-x64"
-ENV win_arm_18_binary_filename="node-v$eighteen_version-win-arm64"
-ENV win_x64_18_binary_filename="node-v$eighteen_version-win-x64"
-ENV mac_x64_18_binary_filename="node-v$eighteen_version-macos-x64"
-ENV linux_arm_14_binary_filename_fetched="fetched-v$fourteen_version-linux-arm64"
-ENV linux_x64_14_binary_filename_fetched="fetched-v$fourteen_version-linux-x64"
-ENV win_arm_14_binary_filename_fetched="fetched-v$fourteen_version-win-arm64"
-ENV win_x64_14_binary_filename_fetched="fetched-v$fourteen_version-win-x64"
-ENV mac_x64_14_binary_filename_fetched="fetched-v$fourteen_version-macos-x64"
-ENV linux_arm_18_binary_filename_fetched="fetched-v$eighteen_version-linux-arm64"
-ENV linux_x64_18_binary_filename_fetched="fetched-v$eighteen_version-linux-x64"
-ENV win_arm_18_binary_filename_fetched="fetched-v$eighteen_version-win-arm64"
-ENV win_x64_18_binary_filename_fetched="fetched-v$eighteen_version-win-x64"
-ENV mac_x64_18_binary_filename_fetched="fetched-v$eighteen_version-macos-x64"
-RUN mkdir -p ~/.pkg-cache/$binaries_tag && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_14_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_14_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_14_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_14_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_14_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_14_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_arm_18_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$linux_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$linux_x64_18_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_arm_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_arm_18_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$win_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$win_x64_18_binary_filename_fetched && \
-  aws --profile=pkg-binaries-fetcher --region $AWS_REGION s3 cp s3://$binaries_bucket_name/$binaries_tag/$mac_x64_18_binary_filename ~/.pkg-cache/$binaries_tag/$mac_x64_18_binary_filename_fetched && \
-  ls ~/.pkg-cache/$binaries_tag
+RUN mkdir -p ~/.pkg-cache
+
+ADD $CODEBUILD_SRC_DIR/pkg-cache ~/.pkg-cache
+
+RUN ls ~/.pkg-cache
 
 # Install Java
 WORKDIR /tmp

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,6 +7,9 @@ phases:
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
   build:
     commands:
+      - echo $PKG_BINARY_CACHE_BUCKET_NAME
+      - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME $CODEBUILD_SRC_DIR/pkg-cache
+      - ls
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -17,8 +17,6 @@ phases:
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:
-      - mkdir pkg-cache-2
-      - aws s3 cp s3://$PKG_BINARY_CACHE_BUCKET_NAME $CODEBUILD_SRC_DIR/pkg-cache-2 --recursive
       - echo Build completed on `date`
       - echo Pushing the Docker image...
       - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -10,7 +10,7 @@ phases:
       - echo $PKG_BINARY_CACHE_BUCKET_NAME
       - mkdir pkg-cache
       - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME $CODEBUILD_SRC_DIR/pkg-cache
-      - ls
+      - ls $CODEBUILD_SRC_DIR/pkg-cache
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -8,6 +8,7 @@ phases:
   build:
     commands:
       - echo $PKG_BINARY_CACHE_BUCKET_NAME
+      - mkdir pkg-cache
       - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME $CODEBUILD_SRC_DIR/pkg-cache
       - ls
       - echo Build started on `date`
@@ -16,6 +17,8 @@ phases:
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:
+      - mkdir pkg-cache-2
+      - aws s3 cp s3://$PKG_BINARY_CACHE_BUCKET_NAME $CODEBUILD_SRC_DIR/pkg-cache-2 --recursive
       - echo Build completed on `date`
       - echo Pushing the Docker image...
       - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This adds support for pkg cache.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
