### PR TITLE
fix: reset readline terminal property on close

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-login.test.ts
@@ -1,5 +1,5 @@
-import { $TSContext } from 'amplify-cli-core';
-import { adminLoginFlow } from '../admin-login';
+import { $TSContext, $TSAny } from 'amplify-cli-core';
+import * as adminLogin from '../admin-login';
 import { AmplifySpinner } from '@aws-amplify/amplify-prompts';
 
 jest.mock('amplify-cli-core', () => {
@@ -43,12 +43,22 @@ describe('adminLoginFlow', () => {
     const spinnerStartMock = jest.spyOn(AmplifySpinner.prototype, 'start');
     const spinnerStopMock = jest.spyOn(AmplifySpinner.prototype, 'stop');
 
-    await adminLoginFlow(contextStub, appId, undefined, region);
+    await adminLogin.adminLoginFlow(contextStub, appId, undefined, region);
 
     expect(spinnerStartMock).toBeCalledTimes(1);
     expect(spinnerStartMock).toBeCalledWith('Manually enter your CLI login key:\n');
 
     expect(spinnerStopMock).toBeCalledTimes(1);
     expect(spinnerStopMock).toBeCalledWith('Successfully received Amplify Studio tokens.');
+  });
+
+  it('should call closeReadline', async () => {
+    const appId = 'appid';
+    const region = 'us-east-2';
+
+    const closeReadlineSpy = jest.spyOn(adminLogin as $TSAny, 'closeReadline');
+    await adminLogin.adminLoginFlow(contextStub, appId, undefined, region);
+    expect(closeReadlineSpy).toBeCalledTimes(1);
+    closeReadlineSpy.mockRestore();
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -138,7 +138,7 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
   }
 };
 
-const closeReadline = (rl: readline.Interface): void => {
+export const closeReadline = (rl: readline.Interface): void => {
   (rl as $TSAny).terminal = false;
   rl.close();
 };

--- a/packages/amplify-provider-awscloudformation/src/admin-login.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-login.ts
@@ -1,7 +1,7 @@
 import util from 'util';
 import readline from 'readline';
 import { Writable } from 'stream';
-import { $TSContext, AmplifyError, AMPLIFY_DOCS_URL, open } from 'amplify-cli-core';
+import { $TSContext, AmplifyError, AMPLIFY_DOCS_URL, open, $TSAny } from 'amplify-cli-core';
 import { printer, AmplifySpinner } from '@aws-amplify/amplify-prompts';
 import { adminVerifyUrl, adminBackendMap, isAmplifyAdminApp } from './utils/admin-helpers'; // eslint-disable-line
 import { AdminLoginServer } from './utils/admin-login-server';
@@ -100,12 +100,12 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
               await adminLoginServer.storeTokens(tokenJson, appId);
             } catch (e) {
               printer.error('Provided token was invalid.');
-              rl.close();
+              closeReadline(rl);
               reject(new Error('Provided token was invalid.'));
               return;
             }
             finished = true;
-            rl.close();
+            closeReadline(rl);
             resolve();
           })
           .catch(reject);
@@ -115,7 +115,7 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
             return;
           }
           finished = true;
-          rl.close();
+          closeReadline(rl);
           reject();
         };
       });
@@ -136,4 +136,9 @@ export const adminLoginFlow = async (context: $TSContext, appId: string, envName
     spinner.stop();
     printer.error(`Failed to authenticate with Amplify Studio: ${e?.message || e}`);
   }
+};
+
+const closeReadline = (rl: readline.Interface): void => {
+  (rl as $TSAny).terminal = false;
+  rl.close();
 };


### PR DESCRIPTION
#### Description of changes
- resets `readline.terminal` property on close
- workaround for this readline related issue: https://github.com/nodejs/node/issues/31762#issuecomment-671208044

#### Issue [#10897](https://github.com/aws-amplify/amplify-cli/issues/10897)

#### Description of how you validated changes
- manual test in windows env

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
