### PR TITLE
ci: allow custom image tag & use branch name to determine default tag

### DIFF
--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -6,21 +6,21 @@ phases:
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
   build:
     commands:
-      - export IMAGE_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
-      - export IMAGE_TAGTEST=${CUSTOM_TAG:=$IMAGE_TAG}
-      - echo $IMAGE_TAGTEST
-      # - echo $PKG_BINARY_CACHE_BUCKET_NAME
-      # - mkdir pkg-cache
-      # - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME pkg-cache
-      # - /bin/bash ./rename_to_fetched.sh
-      # - ls pkg-cache/*
-      # - echo Build started on `date`
-      # - echo Building the Docker image...
-      # - echo $CODEBUILD_SRC_DIR
-      # - docker build --tag $IMAGE_REPO_NAME:$IMAGE_TAG .
-      # - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - export BRANCH_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
+      - export IMAGE_TAG=${CUSTOM_TAG:=$BRANCH_TAG}
+      - echo $IMAGE_TAG
+      - echo $PKG_BINARY_CACHE_BUCKET_NAME
+      - mkdir pkg-cache
+      - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME pkg-cache
+      - /bin/bash ./rename_to_fetched.sh
+      - ls pkg-cache/*
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - echo $CODEBUILD_SRC_DIR
+      - docker build --tag $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      # - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -6,11 +6,9 @@ phases:
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
   build:
     commands:
-      - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | md5sum | cut -c 1-7)
-      - export IMAGE_TAGTEST=${COMMIT_HASH:=latest}
-      - echo $IMAGE_TAGTEST
       - export IMAGE_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
-      - echo $IMAGE_TAG
+      - export IMAGE_TAGTEST=${CUSTOM_TAG:=IMAGE_TAG}
+      - echo $IMAGE_TAGTEST
       # - echo $PKG_BINARY_CACHE_BUCKET_NAME
       # - mkdir pkg-cache
       # - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME pkg-cache

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -6,18 +6,23 @@ phases:
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
   build:
     commands:
-      - echo $PKG_BINARY_CACHE_BUCKET_NAME
-      - mkdir pkg-cache
-      - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME pkg-cache
-      - /bin/bash ./rename_to_fetched.sh
-      - ls pkg-cache/*
-      - echo Build started on `date`
-      - echo Building the Docker image...
-      - echo $CODEBUILD_SRC_DIR
-      - docker build --tag $IMAGE_REPO_NAME:$IMAGE_TAG .
-      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | md5sum | cut -c 1-7)
+      - export IMAGE_TAGTEST=\${COMMIT_HASH:=latest}
+      - echo $IMAGE_TAGTEST
+      - export IMAGE_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
+      - echo $IMAGE_TAG
+      # - echo $PKG_BINARY_CACHE_BUCKET_NAME
+      # - mkdir pkg-cache
+      # - aws s3 sync s3://$PKG_BINARY_CACHE_BUCKET_NAME pkg-cache
+      # - /bin/bash ./rename_to_fetched.sh
+      # - ls pkg-cache/*
+      # - echo Build started on `date`
+      # - echo Building the Docker image...
+      # - echo $CODEBUILD_SRC_DIR
+      # - docker build --tag $IMAGE_REPO_NAME:$IMAGE_TAG .
+      # - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      # - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
       - export IMAGE_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
-      - export IMAGE_TAGTEST=${CUSTOM_TAG:=IMAGE_TAG}
+      - export IMAGE_TAGTEST=${CUSTOM_TAG:=$IMAGE_TAG}
       - echo $IMAGE_TAGTEST
       # - echo $PKG_BINARY_CACHE_BUCKET_NAME
       # - mkdir pkg-cache

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
       - export COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | md5sum | cut -c 1-7)
-      - export IMAGE_TAGTEST=\${COMMIT_HASH:=latest}
+      - export IMAGE_TAGTEST=${COMMIT_HASH:=latest}
       - echo $IMAGE_TAGTEST
       - export IMAGE_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
       - echo $IMAGE_TAG


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Codebuild images will be tagged with the branch name <tag> portion.
For example,
codebuild-image/latest will produce an image with a tag of "latest"
codebuild-image/<tag> will produce an image with a tag of <tag>

We can manually override the default branch tag by running manual CodeBuild job with overrides, specifying a CUSTOM_TAG parameter of the tag that we would like to use.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
