### PR TITLE
fix: yarn failures

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -135,7 +135,7 @@ jobs:
       - checkout
       - run: yarn config set registry https://registry.npmjs.org
       - run: yarn config set script-shell $(which bash)
-      - run: yarn install
+      - run: yarn install --network-concurrency 1
       - run:
           name: Build tests
           command: yarn build-tests

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier-check": "yarn prettier --check .",
     "prettier-changes": "git diff --name-only --diff-filter MRA dev | xargs yarn prettier --write",
     "prettier-write": "yarn prettier --write .",
-    "production-build": "yarn --frozen-lockfile --cache-folder ~/.cache/yarn && nx run-many --target=build --all",
+    "production-build": "yarn --frozen-lockfile --network-concurrency 1 --cache-folder ~/.cache/yarn && nx run-many --target=build --all",
     "promote-rc": "./scripts/promote-rc.sh",
     "publish-to-verdaccio": "lerna publish --yes --no-commit-hooks --no-push --exact --dist-tag=latest --conventional-commits --no-git-tag-version --no-verify-access",
     "release-rc": "./scripts/release-rc.sh",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Sets yarn concurrency to potentially mitigate 

```
#!/bin/bash -eo pipefail
yarn run production-build
yarn run v1.22.19
$ yarn --frozen-lockfile --cache-folder ~/.cache/yarn && nx run-many --target=build --all
[1/4] Resolving packages...
[2/4] Fetching packages...
[1/4] Resolving packages...
[2/4] Fetching packages...
error https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz: Extracting tar content of undefined failed, the file appears to be corrupt: "ENOENT: no such file or directory, chmod '/home/circleci/.cache/yarn/v6/npm-cosmiconfig-7.0.1-714d756522cace867867ccb4474c5d01bbae5d6d-integrity/node_modules/cosmiconfig/dist/Explorer.d.ts'"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 1
CircleCI received exit code 1
```

Inspired by:
https://stackoverflow.com/questions/70401380/heroku-build-error-extracting-tar-content-of-undefined-failed
and
https://community.atlassian.com/t5/Bitbucket-questions/Yarn-install-fails/qaq-p/1555419

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
