### PR TITLE
chore: run e2e tests on windows on node18

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -16,7 +16,7 @@ parameters:
 executors:
   w_medium: &windows-e2e-executor-medium
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: 'windows-server-2022-gui:current'
       resource_class: 'windows.medium'
       shell: bash.exe
     working_directory: ~/repo
@@ -26,7 +26,7 @@ executors:
 
   w_xlarge: &windows-e2e-executor-xlarge
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: 'windows-server-2022-gui:current'
       resource_class: 'windows.xlarge'
       shell: bash.exe
     working_directory: ~/repo
@@ -150,7 +150,7 @@ jobs:
           condition:
             equal: [*windows-e2e-executor-xlarge, << parameters.os >>]
           steps:
-            - install_node14_windows
+            - install_node_windows
             - checkout
             - run: yarn config set script-shell $(which bash)
             - run: yarn run production-build
@@ -471,7 +471,7 @@ jobs:
           condition:
             equal: [*windows-e2e-executor-medium, << parameters.os >>]
           steps:
-            - install_node14_windows
+            - install_node_windows
             - attach_workspace:
                 at: ~/.
             - run:
@@ -1413,15 +1413,15 @@ commands:
               exit 1
             fi
           when: always
-  install_node14_windows:
-    description: Install Node 14 on Windows
+  install_node_windows:
+    description: Install Node 18 on Windows
     steps:
       - run:
-          name: Install Node 14
+          name: Install Node 18
           command: |
             nvm version
-            nvm install 14.18
-            nvm use 14.18
+            nvm install 18.15
+            nvm use 18.15
             nvm ls
       - run:
           name: Check Node, install yarn

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1420,8 +1420,8 @@ commands:
           name: Install Node 18
           command: |
             nvm version
-            nvm install 18.15
-            nvm use 18.15
+            nvm install 18.15.0
+            nvm use 18.15.0
             nvm ls
       - run:
           name: Check Node, install yarn

--- a/packages/amplify-e2e-tests/src/__tests__/init_d.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_d.test.ts
@@ -10,6 +10,7 @@ import {
   createNewProjectDir,
   deleteProjectDir,
 } from '@aws-amplify/amplify-e2e-core';
+import { isWindowsPlatform } from 'amplify-cli-core';
 
 describe('amplify init d', () => {
   let projRoot: string;
@@ -32,7 +33,15 @@ describe('amplify init d', () => {
     const localEnvData = fs.readJsonSync(localEnvPath);
     const originalPath = localEnvData.projectPath;
 
-    expect(localEnvData.projectPath).toEqual(fs.realpathSync(projRoot));
+    if (isWindowsPlatform()) {
+      // The project dir created using os.tmpdir() has shortened C:\\Users\\CIRCLE~1.PAC\\ segment
+      // but projectPath comes as C:\\Users\\circleci.PACKER-633B1A5A\\ for example
+      // which is fine but makes comparison harder
+      expect(path.isAbsolute(localEnvData.projectPath)).toBe(true);
+      expect(fs.statSync(localEnvData.projectPath)).toEqual(fs.statSync(projRoot));
+    } else {
+      expect(localEnvData.projectPath).toEqual(fs.realpathSync(projRoot));
+    }
 
     localEnvData.projectPath = path.join('foo', 'bar');
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
- updates windows image
- build e2e workspace on node 18
- executes windows e2e tests on node 18

This change does not affect the build of binary.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Full e2e test suite, including all windows tests.

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/18197/workflows/d6082ea4-d3a5-4280-98eb-9d72480d8c61

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
