### PR TITLE
chore: import from clodform-types instead of cloudform

### DIFF
--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -43,7 +43,6 @@
     "aws-sdk": "^2.1233.0",
     "bottleneck": "2.19.5",
     "chalk": "^4.1.1",
-    "cloudform": "^4.2.0",
     "cloudform-types": "^4.2.0",
     "columnify": "^1.5.4",
     "constructs": "^10.0.5",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/diff-test-helper.ts
@@ -1,5 +1,5 @@
 import { diff as getDiffs } from 'deep-diff';
-import { DynamoDB } from 'cloudform';
+import { DynamoDB } from 'cloudform-types';
 import { $TSAny } from 'amplify-cli-core';
 import * as gsiTestHelper from './gsi-test-helpers';
 import { DiffableProject } from '../../graphql-resource-manager/utils';

--- a/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/gsi-test-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/graphql-resource-manager/gsi-test-helpers.ts
@@ -1,4 +1,4 @@
-import { DynamoDB } from 'cloudform';
+import { DynamoDB } from 'cloudform-types';
 import { GlobalSecondaryIndex, AttributeDefinition } from 'cloudform-types/types/dynamoDb/table';
 
 export type GSIDefinition = {

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/dynamodb-gsi-helpers.ts
@@ -1,5 +1,5 @@
 import { AttributeDefinition, GlobalSecondaryIndex, KeySchema } from 'cloudform-types/types/dynamoDb/table';
-import { DynamoDB, IntrinsicFunction } from 'cloudform';
+import { DynamoDB, IntrinsicFunction } from 'cloudform-types';
 
 import _ from 'lodash';
 import { AmplifyError, AMPLIFY_SUPPORT_DOCS } from 'amplify-cli-core';

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/gsi-diff-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/gsi-diff-helpers.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 
-import { DynamoDB, IntrinsicFunction } from 'cloudform';
+import { DynamoDB, IntrinsicFunction } from 'cloudform-types';
 
 import { GlobalSecondaryIndex } from 'cloudform-types/types/dynamoDb/table';
 import { diff as getDiffs } from 'deep-diff';

--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/utils.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import * as path from 'path';
 import { JSONUtilities } from 'amplify-cli-core';
-import { Template } from 'cloudform';
+import { Template } from 'cloudform-types';
 import { Diff, diff as getDiffs } from 'deep-diff';
 
 const ROOT_STACK_FILE_NAME = 'cloudformation-template.json';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR changes imports of types from `cloudform` to import from `cloudform-types`.
This is to drop dependency on `cloudform` which gives DEP-xx warnings on Node 18 as it has incompatible statement in `package.json`.
The companion PR on data side - https://github.com/aws-amplify/amplify-category-api/pull/1365 .

This is a minimal change that solves the warning problem. However this PR does not re-enable warning yet, we need both CLI and data changes in and release cycle.

Alternatives considered but not pursued:
- Updating `cloudform` to latest. While it solves the original problem, the latest version includes one TS file in the package and would make us create custom ignore-transform rule in every package that has dependency (direct or transitive) on cloud-types.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

E2E tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
