### PR TITLE
fix: env param fail-fast checks don't fatal on missing appId or envName

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
@@ -82,7 +82,7 @@ describe('ensureEnvironmentVariableValues', () => {
 
     prompterMock.input.mockResolvedValueOnce('testVal2').mockResolvedValueOnce('testVal3');
 
-    await envVarHelper.ensureEnvironmentVariableValues({ usageData: { emitError: jest.fn() } } as unknown as $TSContext);
+    await envVarHelper.ensureEnvironmentVariableValues({ usageData: { emitError: jest.fn() } } as unknown as $TSContext, 'testAppId');
     expect(getEnvParamManager().getResourceParamManager('function', 'testFunc').getAllParams()).toEqual({
       envVarOne: 'testVal1',
       envVarTwo: 'testVal2',

--- a/packages/amplify-category-function/src/events/prePushHandler.ts
+++ b/packages/amplify-category-function/src/events/prePushHandler.ts
@@ -19,7 +19,7 @@ export const prePushHandler = async (context: $TSContext): Promise<void> => {
     (stateManager.getMeta(undefined, { throwIfNotExist: false }) || {})?.providers?.awscloudformation?.AmplifyAppId ||
     context?.exeInfo?.inputParams?.amplify?.appId;
   if (envName && appId) {
-    await ensureEnvironmentVariableValues(context);
+    await ensureEnvironmentVariableValues(context, appId);
     await ensureFunctionSecrets(context);
   } else {
     printer.warn(

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
@@ -107,7 +107,7 @@ export class FunctionSecretsStateManager {
     if (!this.isInteractive()) {
       const resolution =
         `Run 'amplify push' interactively to specify values.\n` +
-        `Alternatively, manually add values in SSM ParameterStore for the following parameter names:\n\n` +
+        `Alternatively, manually add SecureString values in SSM ParameterStore for the following parameter names:\n\n` +
         `${addedSecrets.map((secretName) => getFullyQualifiedSecretName(secretName, functionName)).join('\n')}\n`;
       throw new AmplifyError('EnvironmentConfigurationError', {
         message: `Function ${functionName} is missing secret values in this environment.`,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
@@ -1,4 +1,4 @@
-import { $TSContext, AmplifyError, JSONUtilities, pathManager, ResourceName } from 'amplify-cli-core';
+import { $TSContext, AmplifyError, JSONUtilities, pathManager, ResourceName, stateManager } from 'amplify-cli-core';
 import { removeSecret, retainSecret, SecretDeltas, SecretName, setSecret } from '@aws-amplify/amplify-function-plugin-interface';
 import * as path from 'path';
 import * as fs from 'fs-extra';
@@ -105,13 +105,15 @@ export class FunctionSecretsStateManager {
       return;
     }
     if (!this.isInteractive()) {
+      const inputEnvName = this.context?.exeInfo?.inputParams?.amplify?.envName;
+      const inputAppId = this.context?.exeInfo?.inputParams?.amplify?.appId;
       const resolution =
         `Run 'amplify push' interactively to specify values.\n` +
         `Alternatively, manually add SecureString values in SSM ParameterStore for the following parameter names:\n\n` +
-        `${addedSecrets.map((secretName) => getFullyQualifiedSecretName(secretName, functionName)).join('\n')}\n`;
+        `${addedSecrets.map((secretName) => getFullyQualifiedSecretName(secretName, functionName, inputEnvName, inputAppId)).join('\n')}\n`;
       throw new AmplifyError('EnvironmentConfigurationError', {
         message: `Function ${functionName} is missing secret values in this environment.`,
-        details: `[${addedSecrets}] ${addedSecrets.length > 1 ? 'does' : 'do'} not have values.`,
+        details: `[${addedSecrets}] ${addedSecrets.length > 1 ? 'do' : 'does'} not have values.`,
         resolution,
         link: 'https://docs.amplify.aws/cli/reference/ssm-parameter-store/#manually-creating-parameters',
       });
@@ -184,7 +186,10 @@ export class FunctionSecretsStateManager {
    * @returns string[] of all secret names for the function
    */
   private getCloudFunctionSecretNames = async (functionName: string, envName?: string): Promise<string[]> => {
-    const prefix = getFunctionSecretPrefix(functionName, envName);
+    if (envName === undefined) {
+      envName = stateManager.getCurrentEnvName() || this.context?.exeInfo?.inputParams?.amplify?.envName;
+    }
+    const prefix = getFunctionSecretPrefix(functionName, envName, this.context?.exeInfo?.inputParams?.amplify?.appId);
     const parts = path.parse(prefix);
     const unfilteredSecrets = await this.ssmClientWrapper.getSecretNamesByPath(parts.dir);
     return unfilteredSecrets.filter((secretName) => secretName.startsWith(prefix)).map((secretName) => secretName.slice(prefix.length));

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/secretName.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/secretName.ts
@@ -16,27 +16,27 @@ export const secretsPathAmplifyAppIdKey = 'secretsPathAmplifyAppId';
  *
  * If envName is not specified, the current env is assumed
  */
-export const getFullyQualifiedSecretName = (secretName: string, functionName: string, envName?: string) =>
-  `${getFunctionSecretPrefix(functionName, envName)}${secretName}`;
+export const getFullyQualifiedSecretName = (secretName: string, functionName: string, envName?: string, appId?: string) =>
+  `${getFunctionSecretPrefix(functionName, envName, appId)}${secretName}`;
 
 /**
  * Returns the SSM parameter name prefix for all secrets for the given function in the given env
  *
  * If envName is not specified, the current env is assumed
  */
-export const getFunctionSecretPrefix = (functionName: string, envName?: string) =>
-  path.posix.join(getEnvSecretPrefix(envName), `AMPLIFY_${functionName}_`);
+export const getFunctionSecretPrefix = (functionName: string, envName?: string, appId?: string) =>
+  path.posix.join(getEnvSecretPrefix(envName, appId), `AMPLIFY_${functionName}_`);
 
 /**
  * Returns the SSM parameter name prefix for all secrets in the given env.
  *
  * If envName is not specified, the current env is assumed
  */
-export const getEnvSecretPrefix = (envName: string = stateManager.getLocalEnvInfo()?.envName) => {
+export const getEnvSecretPrefix = (envName: string = stateManager.getCurrentEnvName(), appId: string = getAppId()) => {
   if (!envName) {
     throw new Error('Could not determine the current Amplify environment name. Try running `amplify env checkout`.');
   }
-  return path.posix.join('/amplify', getAppId(), envName);
+  return path.posix.join('/amplify', appId, envName);
 };
 
 // NOTE: Even though the following 2 functions are CFN specific, I'm putting them here to colocate all of the secret naming logic

--- a/packages/amplify-cli/src/__tests__/commands/env.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/env.test.ts
@@ -1,15 +1,15 @@
-describe('amplify env: ', () => {
-  const mockExit = jest.fn();
-  jest.mock('amplify-cli-core', () => ({
-    exitOnNextTick: mockExit,
-    pathManager: { getAmplifyMetaFilePath: jest.fn().mockReturnValue('test_file_does_not_exist') },
-    constants: jest.requireActual('amplify-cli-core').constants,
-  }));
-  const { run: runEnvCmd } = require('../../commands/env');
-  const { run: runAddEnvCmd } = require('../../commands/env/add');
-  const envList = require('../../commands/env/list');
-  jest.mock('../../commands/env/list');
+import { $TSContext, pathManager, AmplifyError } from 'amplify-cli-core';
+jest.mock('../../commands/init');
+jest.mock('amplify-cli-core');
+import { run as runEnvCmd } from '../../commands/env';
+import { run as runAddEnvCmd } from '../../commands/env/add';
+import * as envList from '../../commands/env/list';
 
+const AmplifyErrorMock = AmplifyError as jest.MockedClass<typeof AmplifyError>;
+
+AmplifyErrorMock.mockImplementation(() => new Error('test error') as AmplifyError);
+
+describe('amplify env: ', () => {
   it('env run method should exist', () => {
     expect(runEnvCmd).toBeDefined();
   });
@@ -18,24 +18,28 @@ describe('amplify env: ', () => {
     expect(runAddEnvCmd).toBeDefined();
   });
 
-  it('env add method should throw if meta file does not exist', () => {
-    expect(async () => await runAddEnvCmd()).rejects.toThrow();
+  it('env add method should throw if meta file does not exist', async () => {
+    await expect(runAddEnvCmd({} as $TSContext)).rejects.toThrow();
   });
 
   it('env ls is an alias for env list', async () => {
     const mockEnvListRun = jest.spyOn(envList, 'run');
-    await runEnvCmd({
+    const mockContext = {
+      print: {
+        table: jest.fn(),
+      },
+      amplify: {
+        getAllEnvs: jest.fn().mockReturnValue(['testa', 'testb']),
+        getEnvInfo: jest.fn().mockReturnValue({ envName: 'testa' }),
+      },
       input: {
         subCommands: ['list'],
       },
       parameters: {},
-    });
-    await runEnvCmd({
-      input: {
-        subCommands: ['ls'],
-      },
-      parameters: {},
-    });
+    };
+    await runEnvCmd(mockContext);
+    mockContext.input.subCommands = ['ls'];
+    await runEnvCmd(mockContext);
     expect(mockEnvListRun).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/amplify-cli/src/__tests__/utils/verify-expected-env-params.test.ts
+++ b/packages/amplify-cli/src/__tests__/utils/verify-expected-env-params.test.ts
@@ -7,6 +7,8 @@ import { $TSContext } from 'amplify-cli-core';
 jest.mock('../../commands/build');
 jest.mock('@aws-amplify/amplify-prompts');
 jest.mock('@aws-amplify/amplify-environment-parameters');
+jest.mock('@aws-amplify/amplify-provider-awscloudformation');
+jest.mock('amplify-cli-core');
 
 const getResourcesMock = getChangedResources as jest.MockedFunction<typeof getChangedResources>;
 const ensureEnvParamManagerMock = ensureEnvParamManager as jest.MockedFunction<typeof ensureEnvParamManager>;
@@ -62,7 +64,7 @@ describe('verifyExpectedEnvParams', () => {
   });
   it('filters parameters based on category and resourceName if specified', async () => {
     await verifyExpectedEnvParams(contextStub, 'storage');
-    expect(verifyExpectedEnvParametersMock).toHaveBeenCalledWith([resourceList[0]]);
+    expect(verifyExpectedEnvParametersMock).toHaveBeenCalledWith([resourceList[0]], undefined, undefined);
   });
 
   it('calls verify expected parameters if in non-interactive mode', async () => {

--- a/packages/amplify-cli/src/commands/env/list.ts
+++ b/packages/amplify-cli/src/commands/env/list.ts
@@ -8,7 +8,7 @@ import { printEnvInfo } from '../helpers/envUtils';
 export const run = async (context): Promise<void> => {
   const { envName } = context.amplify.getEnvInfo();
 
-  if (context.parameters.options.details) {
+  if (context?.parameters?.options?.details) {
     const allEnvs = context.amplify.getEnvDetails();
     if (context.parameters.options.json) {
       printer.info(JSONUtilities.stringify(allEnvs) as string);
@@ -25,7 +25,7 @@ export const run = async (context): Promise<void> => {
     });
   } else {
     const allEnvs = context.amplify.getAllEnvs();
-    if (context.parameters.options.json) {
+    if (context?.parameters?.options?.json) {
       printer.info(JSONUtilities.stringify({ envs: allEnvs }) as string);
       return;
     }

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -158,6 +158,8 @@ export const run = async (startTime: number): Promise<void> => {
     notify({ defer: true, isGlobal: true });
   }
 
+  const isHeadlessPull = context?.input?.command === 'pull' && context?.input?.options?.yes === true;
+
   if (context.input.command === 'push') {
     const { providers } = stateManager.getProjectConfig(undefined, { throwIfNotExist: false, default: {} });
     const CloudFormationProviderName = 'awscloudformation';
@@ -172,6 +174,8 @@ export const run = async (startTime: number): Promise<void> => {
       );
     }
     await saveAllEnvParams(uploadHandler);
+  } else if (isHeadlessPull) {
+    // tpi and backend-config should not be modified on a headless pull
   } else {
     await saveAllEnvParams();
   }

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -158,8 +158,6 @@ export const run = async (startTime: number): Promise<void> => {
     notify({ defer: true, isGlobal: true });
   }
 
-  const isHeadlessPull = context?.input?.command === 'pull' && context?.input?.options?.yes === true;
-
   if (context.input.command === 'push') {
     const { providers } = stateManager.getProjectConfig(undefined, { throwIfNotExist: false, default: {} });
     const CloudFormationProviderName = 'awscloudformation';
@@ -174,8 +172,6 @@ export const run = async (startTime: number): Promise<void> => {
       );
     }
     await saveAllEnvParams(uploadHandler);
-  } else if (isHeadlessPull) {
-    // tpi and backend-config should not be modified on a headless pull
   } else {
     await saveAllEnvParams();
   }

--- a/packages/amplify-cli/src/utils/verify-expected-env-params.ts
+++ b/packages/amplify-cli/src/utils/verify-expected-env-params.ts
@@ -2,6 +2,7 @@ import { $TSContext, IAmplifyResource, stateManager, constants } from 'amplify-c
 import { ensureEnvParamManager, IEnvironmentParameterManager, ServiceDownloadHandler } from '@aws-amplify/amplify-environment-parameters';
 import { printer, prompter } from '@aws-amplify/amplify-prompts';
 import { getChangedResources, getAllResources } from '../commands/build';
+import { resolveAppId } from '@aws-amplify/amplify-provider-awscloudformation';
 
 export const verifyExpectedEnvParams = async (context: $TSContext, category?: string, resourceName?: string) => {
   const envParamManager = stateManager.localEnvInfoExists()
@@ -27,7 +28,9 @@ export const verifyExpectedEnvParams = async (context: $TSContext, category?: st
   });
 
   if (context?.exeInfo?.inputParams?.yes || context?.exeInfo?.inputParams?.headless) {
-    await envParamManager.verifyExpectedEnvParameters(parametersToCheck);
+    const appId = resolveAppId(context);
+    const envName = stateManager.getCurrentEnvName() || context?.exeInfo?.inputParams?.amplify?.envName;
+    await envParamManager.verifyExpectedEnvParameters(parametersToCheck, appId, envName);
   } else {
     const missingParameters = await envParamManager.getMissingParameters(parametersToCheck);
     if (missingParameters.length > 0) {

--- a/packages/amplify-cli/src/utils/verify-expected-env-params.ts
+++ b/packages/amplify-cli/src/utils/verify-expected-env-params.ts
@@ -28,7 +28,14 @@ export const verifyExpectedEnvParams = async (context: $TSContext, category?: st
   });
 
   if (context?.exeInfo?.inputParams?.yes || context?.exeInfo?.inputParams?.headless) {
-    const appId = resolveAppId(context);
+    let appId: string | undefined = undefined;
+    try {
+      appId = resolveAppId(context);
+    } catch {
+      // If AppId can't be resolved, this only affects the error message of verifyExpectedEnvParameters in the case that parameters are
+      // actually missing. So we let appId be undefined here and verifyExpectedEnvParameters will print a different error message based
+      // on the information available to it
+    }
     const envName = stateManager.getCurrentEnvName() || context?.exeInfo?.inputParams?.amplify?.envName;
     await envParamManager.verifyExpectedEnvParameters(parametersToCheck, appId, envName);
   } else {

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -335,7 +335,7 @@ export const amplifyPushIterativeRollback = (cwd: string, testingWithLatestCodeb
  */
 export const amplifyPushMissingEnvVar = (cwd: string, newEnvVarValue: string) =>
   spawn(getCLIPath(), ['push'], { cwd, stripColors: true })
-    .wait('Enter the missing environment variable value of')
+    .wait('Enter a value for')
     .sendLine(newEnvVarValue)
     .wait('Are you sure you want to continue?')
     .sendYes()

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -31,7 +31,7 @@ export type IEnvironmentParameterManager = {
     init: () => Promise<void>;
     removeResourceParamManager: (category: string, resource: string) => void;
     save: (serviceUploadHandler?: ServiceUploadHandler) => Promise<void>;
-    verifyExpectedEnvParameters: (resourceFilterList?: IAmplifyResource[]) => Promise<void>;
+    verifyExpectedEnvParameters: (resourceFilterList?: IAmplifyResource[], appId?: string, envName?: string) => Promise<void>;
 };
 
 // @public (undocumented)

--- a/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
@@ -1,4 +1,4 @@
-import { pathManager, stateManager } from 'amplify-cli-core';
+import { pathManager, stateManager, AmplifyError } from 'amplify-cli-core';
 import { IEnvironmentParameterManager, saveAll } from '../environment-parameter-manager';
 
 jest.mock('amplify-cli-core');
@@ -23,6 +23,9 @@ stateManagerMock.backendConfigFileExists.mockReturnValue(true);
 
 const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;
 pathManagerMock.findProjectRoot.mockReturnValue('test/project/root');
+
+const AmplifyErrorMock = AmplifyError as jest.MockedClass<typeof AmplifyError>;
+AmplifyErrorMock.mockImplementation(() => new Error('test error') as AmplifyError);
 
 let ensureEnvParamManager: () => Promise<{ instance: IEnvironmentParameterManager }>;
 
@@ -58,7 +61,7 @@ describe('save', () => {
     const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
     funcParamManager.deleteParam('envVar1');
     funcParamManager.deleteParam('envVar2');
-    envParamManager.save();
+    await envParamManager.save();
     expect(stateManagerMock.setTeamProviderInfo).toHaveBeenCalledWith(undefined, {
       testEnv: {
         categories: {
@@ -73,17 +76,17 @@ describe('save', () => {
   it('does not store empty categories', async () => {
     const envParamManager = (await ensureEnvParamManager()).instance;
     envParamManager.removeResourceParamManager('function', 'funcName');
-    envParamManager.save();
+    await envParamManager.save();
     expect(stateManagerMock.setTeamProviderInfo).toHaveBeenCalledWith(undefined, {
       testEnv: {},
     });
   });
 
-  it('calls IParameterMapController.save if in the current environment', async () => {
+  it('calls IParameterMapController.save if in the current environment and serviceUploadHandler defined', async () => {
     const envParamManager = (await ensureEnvParamManager()).instance;
     const resourceParamManager = envParamManager.getResourceParamManager('function', 'funcName');
     resourceParamManager.setParam('testParam', 'testValue');
-    envParamManager.save();
+    await envParamManager.save(jest.fn());
     expect(stateManagerMock.setBackendConfig.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
         "parameters": Object {
@@ -104,7 +107,7 @@ describe('save', () => {
 describe('verifyExpectedEnvParameters', () => {
   it('does not throw when nothing is missing', async () => {
     const envParamManager = (await ensureEnvParamManager()).instance;
-    envParamManager.save();
+    await envParamManager.save();
     await envParamManager.verifyExpectedEnvParameters();
   });
 
@@ -113,7 +116,7 @@ describe('verifyExpectedEnvParameters', () => {
     const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
 
     funcParamManager.setParam('missingParam', 'missingValue');
-    envParamManager.save();
+    await envParamManager.save(jest.fn());
     funcParamManager.deleteParam('missingParam');
 
     let error = undefined;
@@ -130,7 +133,7 @@ describe('verifyExpectedEnvParameters', () => {
     const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
 
     funcParamManager.setParam('missingParam', 'missingValue');
-    envParamManager.save();
+    await envParamManager.save();
     funcParamManager.deleteParam('missingParam');
 
     let error = undefined;
@@ -146,7 +149,7 @@ describe('verifyExpectedEnvParameters', () => {
 describe('getMissingParameters', () => {
   it('returns an empty array when nothing is missing', async () => {
     const envParamManager = (await ensureEnvParamManager()).instance;
-    envParamManager.save();
+    await envParamManager.save();
     expect(await envParamManager.getMissingParameters()).toEqual([]);
   });
 
@@ -155,7 +158,7 @@ describe('getMissingParameters', () => {
     const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
 
     funcParamManager.setParam('missingParam', 'missingValue');
-    envParamManager.save();
+    await envParamManager.save(jest.fn());
     funcParamManager.deleteParam('missingParam');
 
     expect(await envParamManager.getMissingParameters()).toEqual([
@@ -168,7 +171,7 @@ describe('getMissingParameters', () => {
     const funcParamManager = envParamManager.getResourceParamManager('function', 'funcName');
 
     funcParamManager.setParam('missingParam', 'missingValue');
-    envParamManager.save();
+    await envParamManager.save();
     funcParamManager.deleteParam('missingParam');
 
     expect(await envParamManager.getMissingParameters([{ category: 'auth', resourceName: 'mockAuth', service: 'Cognito' }])).toEqual([]);

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -1,4 +1,4 @@
-import { AmplifyError, AmplifyFault, IAmplifyResource, pathManager, stateManager } from 'amplify-cli-core';
+import { AmplifyCategories, AmplifyError, AmplifyFault, IAmplifyResource, pathManager, stateManager } from 'amplify-cli-core';
 import _ from 'lodash';
 import { getParametersControllerInstance, IBackendParametersController } from './backend-config-parameters-controller';
 import { ResourceParameterManager } from './resource-parameter-manager';
@@ -166,6 +166,10 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
         resourceFilterList &&
         !resourceFilterList.some(({ category, resourceName: resource }) => categoryName === category && resource === resourceName)
       ) {
+        return;
+      }
+      // filter out functions that have a missing deploymentBucketName and/or s3Key. These values will be regenerated on the next push
+      if (categoryName === AmplifyCategories.FUNCTION && (parameterName === 'deploymentBucketName' || parameterName === 's3Key')) {
         return;
       }
       if (!allEnvParams.has(`${categoryName}_${resourceName}_${parameterName}`)) {

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -248,10 +248,12 @@ const getMissingParametersError = (
   appId: string | undefined,
   envName: string | undefined,
 ): AmplifyError => {
+  const message = `This environment is missing some parameter values.`;
+  const missingNames = missingParameters.map((param) => param.parameterName);
   if (appId === undefined) {
     return new AmplifyError('EnvironmentConfigurationError', {
-      message: `This environment is missing some parameter values.`,
-      details: `[${missingParameters}] ${missingParameters.length > 1 ? 'do' : 'does'} not have values.`,
+      message,
+      details: `[${missingNames}] ${missingNames.length > 1 ? 'do' : 'does'} not have values.`,
       resolution: `Amplify AppId could not be determined for fetching missing parameters. Make sure your project is initialized using "amplify init"`,
       link: 'https://docs.amplify.aws/cli/usage/headless/#amplify-init-parameters',
     });
@@ -259,8 +261,8 @@ const getMissingParametersError = (
 
   if (envName === undefined) {
     return new AmplifyError('EnvironmentConfigurationError', {
-      message: `This environment is missing some parameter values.`,
-      details: `[${missingParameters}] ${missingParameters.length > 1 ? 'do' : 'does'} not have values.`,
+      message,
+      details: `[${missingNames}] ${missingNames.length > 1 ? 'do' : 'does'} not have values.`,
       resolution: `A current environment name could not be determined for fetching missing parameters. Make sure your project is initialized using "amplify init"`,
       link: 'https://docs.amplify.aws/cli/usage/headless/#amplify-init-parameters',
     });
@@ -279,7 +281,7 @@ const getMissingParametersError = (
     `Alternatively, manually add values in SSM ParameterStore for the following parameter names:\n\n` +
     `${missingFullPaths.join('\n')}\n`;
   return new AmplifyError('EnvironmentConfigurationError', {
-    message: `This environment is missing some parameter values.`,
+    message,
     details: `[${missingParameterNames}] ${missingParameterNames.length > 1 ? 'do' : 'does'} not have values.`,
     resolution,
     link: 'https://docs.amplify.aws/cli/reference/ssm-parameter-store/#manually-creating-parameters',

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -119,9 +119,10 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
       return;
     }
 
-    if (!serviceUploadHandler) {
-      return;
-    }
+    // TODO see if this works
+    // if (!serviceUploadHandler) {
+    //   return;
+    // }
 
     // update param mapping
     this.parameterMapController.removeAllParameters();

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -239,7 +239,7 @@ export type ServiceUploadHandler = (key: string, value: string | number | boolea
 export type ServiceDownloadHandler = (parameters: string[]) => Promise<Record<string, string | number | boolean>>;
 
 const getFullParameterStorePath = (categoryName: string, resourceName: string, paramName: string) =>
-  `${stateManager.getAppID()}/${stateManager.getCurrentEnvName()}/${getParameterStoreKey(categoryName, resourceName, paramName)}`;
+  `amplify/${stateManager.getAppID()}/${stateManager.getCurrentEnvName()}/${getParameterStoreKey(categoryName, resourceName, paramName)}`;
 const getParameterStoreKey = (categoryName: string, resourceName: string, paramName: string): string =>
   `AMPLIFY_${categoryName}_${resourceName}_${paramName}`;
 

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -119,6 +119,10 @@ class EnvironmentParameterManager implements IEnvironmentParameterManager {
       return;
     }
 
+    if (!serviceUploadHandler) {
+      return;
+    }
+
     // update param mapping
     this.parameterMapController.removeAllParameters();
     for (const [resourceKey, paramManager] of Object.entries(this.resourceParamManagers)) {

--- a/packages/amplify-provider-awscloudformation/API.md
+++ b/packages/amplify-provider-awscloudformation/API.md
@@ -17,6 +17,9 @@ export const cfnRootStackFileName = "root-cloudformation-stack.json";
 // @public (undocumented)
 export const deleteEnvironmentParametersFromService: (context: $TSContext, envName: string) => Promise<void>;
 
+// @public (undocumented)
+export type DownloadHandler = (keys: string[]) => Promise<PrimitiveRecord>;
+
 // Warning: (ae-forgotten-export) The symbol "LocationService" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -28,7 +31,7 @@ export function getConfiguredLocationServiceClient(context: $TSContext, options?
 export function getConfiguredSSMClient(context: any): Promise<SSM>;
 
 // @public (undocumented)
-export const getEnvParametersDownloadHandler: (context: $TSContext) => Promise<(keys: string[]) => Promise<Record<string, string | number | boolean>>>;
+export const getEnvParametersDownloadHandler: (context: $TSContext) => Promise<DownloadHandler>;
 
 // @public (undocumented)
 export const getEnvParametersUploadHandler: (context: $TSContext) => Promise<(key: string, value: string | boolean | number) => Promise<void>>;
@@ -43,6 +46,9 @@ export const getLocationSupportedRegion: (region: string) => string;
 //
 // @public (undocumented)
 export function loadConfigurationForEnv(context: $TSContext, env: string, appId?: string): Promise<AwsSdkConfig>;
+
+// @public (undocumented)
+export type PrimitiveRecord = Record<string, string | number | boolean>;
 
 // @public (undocumented)
 export const resolveAppId: (context: $TSContext) => string;

--- a/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/configuration-manager.ts
@@ -542,6 +542,11 @@ function getConfigForEnv(context: $TSContext, envName: string) {
     configLevel: 'general',
     config: {},
   };
+  if (typeof context?.exeInfo?.inputParams?.awscloudformation === 'object') {
+    const config = context?.exeInfo?.inputParams?.awscloudformation;
+    projectConfigInfo.configLevel = config.configLevel || 'general';
+    projectConfigInfo.config = config;
+  }
   const dotConfigDirPath = pathManager.getDotConfigDirPath();
   const configInfoFilePath = path.join(dotConfigDirPath, constants.LocalAWSInfoFileName);
 
@@ -595,7 +600,7 @@ function removeProjectConfig(envName: string) {
 }
 
 export async function loadConfiguration(context: $TSContext): Promise<AwsSecrets> {
-  const { envName } = context.amplify.getEnvInfo();
+  const envName = stateManager.getCurrentEnvName() || context?.exeInfo?.inputParams?.amplify?.envName;
   const config = await loadConfigurationForEnv(context, envName);
   return config;
 }

--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -56,7 +56,12 @@ import { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete
 export { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete-ssm-parameters';
 
 import { getEnvParametersUploadHandler, getEnvParametersDownloadHandler } from './utils/ssm-utils/env-parameter-ssm-helpers';
-export { getEnvParametersUploadHandler, getEnvParametersDownloadHandler } from './utils/ssm-utils/env-parameter-ssm-helpers';
+export {
+  getEnvParametersUploadHandler,
+  getEnvParametersDownloadHandler,
+  DownloadHandler,
+  PrimitiveRecord,
+} from './utils/ssm-utils/env-parameter-ssm-helpers';
 
 function init(context) {
   return initializer.run(context);

--- a/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/env-parameter-ssm-helpers.ts
@@ -55,9 +55,9 @@ const uploadParameterToParameterStore = (
   };
 };
 
-type PrimitiveRecord = Record<string, string | number | boolean>;
-
-type DownloadHandler = (keys: string[]) => Promise<PrimitiveRecord>;
+// some utility types for the functions below
+export type PrimitiveRecord = Record<string, string | number | boolean>;
+export type DownloadHandler = (keys: string[]) => Promise<PrimitiveRecord>;
 
 /**
  * Higher order function for downloading CloudFormation parameters from the service


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixes a few issues discovered with https://github.com/aws-amplify/amplify-cli/pull/12279. All of the issues boiled down to trying to resolve parameters or print error messages when an appId or envName could not be resolved. This PR adds defensive logic in several places to exit the parameter check early and print a more generic error message if an AppId or env name cannot be resolved.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Existing e2e tests passing, updated unit tests, manual testing using tagged releases in hosting.
Some additional tests can come in a follow up PR

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
