### PR TITLE
fix: check mismatched parameters before push

### DIFF
--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -140,7 +140,7 @@ const updateFunctionCore = (cwd: string, chain: ExecutionContext, settings: Core
     chain.wait('What do you want to do?');
     chain.sendCarriageReturn(); // "I'm done"
   }
-  if (settings.environmentVariables.operation && settings.environmentVariables.operation == 'remove') {
+  if (settings.environmentVariables?.operation && settings.environmentVariables.operation == 'remove') {
     const actions = [
       'Add new environment variable',
       'Update existing environment variables',

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -140,6 +140,21 @@ const updateFunctionCore = (cwd: string, chain: ExecutionContext, settings: Core
     chain.wait('What do you want to do?');
     chain.sendCarriageReturn(); // "I'm done"
   }
+  if (settings.environmentVariables.operation && settings.environmentVariables.operation == 'remove') {
+    const actions = [
+      'Add new environment variable',
+      'Update existing environment variables',
+      'Remove existing environment variables',
+      "I'm done",
+    ];
+    const action = 'Remove existing environment variables';
+    chain.wait(/Select what you want to do with environment variables:*/);
+    singleSelect(chain, action, actions);
+    chain.wait('Which environment variable do you want to remove:');
+    chain.sendCarriageReturn(); // assumes only one variable
+    chain.wait(/Select what you want to do with environment variables:*/);
+    chain.sendCarriageReturn(); // I'm done
+  }
 };
 
 export type CoreFunctionSettings = {

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -147,9 +147,8 @@ const updateFunctionCore = (cwd: string, chain: ExecutionContext, settings: Core
       'Remove existing environment variables',
       "I'm done",
     ];
-    const action = 'Remove existing environment variables';
     chain.wait(/Select what you want to do with environment variables:*/);
-    singleSelect(chain, action, actions);
+    singleSelect(chain, actions[2], actions);
     chain.wait('Which environment variable do you want to remove:');
     chain.sendCarriageReturn(); // assumes only one variable
     chain.wait(/Select what you want to do with environment variables:*/);

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -393,3 +393,11 @@ export const amplifyPushOverride = async (cwd: string, testingWithLatestCodebase
     .wait(/.*/)
     .runAsync();
 };
+
+export const amplifyPushExpectError = async (cwd: string, expectErrorMessage: string): Promise<void> => {
+  await spawn(getCLIPath(), ['push'], { cwd, stripColors: true, noOutputTimeout: pushTimeoutMS })
+    .wait('Are you sure you want to continue?')
+    .sendYes()
+    .wait(expectErrorMessage)
+    .runAsync((err) => !!err);
+};

--- a/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
@@ -25,7 +25,6 @@ describe('mismatched-parameters-fast-fail', () => {
     deleteProjectDir(projRoot);
   });
 
-  jest.retryTimes(0);
   it('fast fail when mismatched parameters', async () => {
     await initJSProjectWithProfile(projRoot, { envName: firstEnvName, disableAmplifyAppCreation: false });
     const functionName = `testfunction${generateRandomShortId()}`;

--- a/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@aws-amplify/amplify-e2e-core';
 import { addEnvironmentCarryOverEnvVars, checkoutEnvironment } from '../environment/env';
 
-describe('mismatched-parameters-fast-fail', () => {
+describe('mismatched parameters', () => {
   const firstEnvName = 'dev';
   const secondEnvName = 'prod';
   const envVarKey = 'myvar';

--- a/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
@@ -7,6 +7,7 @@ import {
   generateRandomShortId,
   addFunction,
   updateFunction,
+  amplifyPushExpectError,
 } from '@aws-amplify/amplify-e2e-core';
 import { addEnvironmentCarryOverEnvVars, checkoutEnvironment } from '../environment/env';
 
@@ -44,42 +45,6 @@ describe('mismatched-parameters-fast-fail', () => {
     await updateFunction(projRoot, { environmentVariables: { key: envVarKey, value: '', operation: 'remove' } }, 'nodejs');
     await amplifyPushAuth(projRoot);
     await checkoutEnvironment(projRoot, { envName: firstEnvName });
-    let threwError = false;
-    try {
-      await amplifyPushAuth(projRoot);
-    } catch (error) {
-      threwError = true;
-      expect(error).toBeDefined();
-      //   expect(error.message).toContain('Your environments have inconsistent parameters');
-    }
-    expect(threwError).toBeTruthy();
-  });
-
-  it('succeed when matched parameters', async () => {
-    await initJSProjectWithProfile(projRoot, { envName: firstEnvName, disableAmplifyAppCreation: false });
-    const functionName = `testfunction${generateRandomShortId()}`;
-    await addFunction(
-      projRoot,
-      {
-        functionTemplate: 'Hello World',
-        name: functionName,
-        environmentVariables: {
-          key: envVarKey,
-          value: 'myval',
-        },
-      },
-      'nodejs',
-    );
-    await addEnvironmentCarryOverEnvVars(projRoot, { envName: secondEnvName });
-    // don't update function here
-    await amplifyPushAuth(projRoot);
-    await checkoutEnvironment(projRoot, { envName: firstEnvName });
-    let threwError = false;
-    try {
-      await amplifyPushAuth(projRoot);
-    } catch (error) {
-      threwError = true;
-    }
-    expect(threwError).toBeFalsy();
+    await amplifyPushExpectError(projRoot, 'Your environments have inconsistent parameters');
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/mismatched-parameters-fast-fail.test.ts
@@ -1,0 +1,57 @@
+import {
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  initJSProjectWithProfile,
+  generateRandomShortId,
+  addFunction,
+  updateFunction,
+} from '@aws-amplify/amplify-e2e-core';
+import { addEnvironmentCarryOverEnvVars, checkoutEnvironment } from '../environment/env';
+
+describe('mismatched-parameters-fast-fail', () => {
+  let projRoot: string;
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('push-test');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  jest.retryTimes(0);
+  it('fast fail when mismatched parameters', async () => {
+    const firstEnvName = 'dev';
+    const secondEnvName = 'prod';
+    const envVarKey = 'myvar';
+    await initJSProjectWithProfile(projRoot, { envName: firstEnvName, disableAmplifyAppCreation: false });
+    const functionName = `testfunction${generateRandomShortId()}`;
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'Hello World',
+        name: functionName,
+        environmentVariables: {
+          key: envVarKey,
+          value: 'myval',
+        },
+      },
+      'nodejs',
+    );
+    await addEnvironmentCarryOverEnvVars(projRoot, { envName: secondEnvName });
+    await updateFunction(projRoot, { environmentVariables: { key: envVarKey, value: '', operation: 'remove' } }, 'nodejs');
+    await amplifyPushAuth(projRoot);
+    await checkoutEnvironment(projRoot, { envName: firstEnvName });
+    let threwError = false;
+    try {
+      await amplifyPushAuth(projRoot);
+    } catch (error) {
+      threwError = true;
+      expect(error).toBeDefined();
+      expect(error.message).toContain('Your environments have inconsistent parameters');
+    }
+    expect(threwError).toBeTruthy();
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1207,10 +1207,9 @@ export const formNestedStack = async (
             const misMatchedParams = Object.keys(parameters).filter(
               (parameter) => !nonCustomParameters.includes(parameter) && !urlParameters.includes(parameter),
             );
-            if (misMatchedParams.length) {
+            if (!context.exeInfo?.forcePush && misMatchedParams.length) {
               throw new AmplifyFault('DeploymentFault', {
                 message: 'Your environments have inconsistent parameters',
-                code: 400,
                 details: `Use 'amplify pull' to pull the backend or remove these parameters: ${misMatchedParams.toString()}`,
               });
             }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1193,18 +1193,10 @@ export const formNestedStack = async (
         }
         if (resourceDetails.providerMetadata) {
           templateURL = resourceDetails.providerMetadata.s3TemplateURL;
-
-          // retrieve parameters from resource stack
-          // compare to parameters object
-          // if mismatch, fast fail and instruct user to clean up local state
-          // instruct to pull or to make vars consistant
-          // throw amplify error
-
-          // put debugger and see how it is fetching parameters
-
+          const urlParameters = Object.keys(urlMap[templateURL].Parameters);
           const nonCustomParameters = ['CloudWatchRule', 'deploymentBucketName', 'env', 's3Key'];
-          const misMatchedParams = Object.keys(urlMap[templateURL].Parameters).filter(
-            (parameter) => !nonCustomParameters.includes(parameter) && !Object.keys(parameters).includes(parameter),
+          const misMatchedParams = Object.keys(parameters).filter(
+            (parameter) => !nonCustomParameters.includes(parameter) && !urlParameters.includes(parameter),
           );
 
           if (misMatchedParams.length) {

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1208,9 +1208,10 @@ export const formNestedStack = async (
               (parameter) => !nonCustomParameters.includes(parameter) && !urlParameters.includes(parameter),
             );
             if (misMatchedParams.length) {
-              throw new AmplifyError('EnvironmentConfigurationError', {
+              throw new AmplifyFault('DeploymentFault', {
                 message: 'Your environments have inconsistent parameters',
-                resolution: `Use 'amplify pull' to pull the backend or remove these parameters: ${misMatchedParams.toString()}`,
+                code: 400,
+                details: `Use 'amplify pull' to pull the backend or remove these parameters: ${misMatchedParams.toString()}`,
               });
             }
           }

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1059,7 +1059,7 @@ export const formNestedStack = async (
 
   const s3 = await S3.getInstance(context);
   const currentEnvName = context.amplify.getEnvInfo().envName;
-  const urlMap = {};
+  const urlParametersMap = {};
   for (const category of categories) {
     const resources = Object.keys(amplifyMeta[category]);
     for (const resource of resources) {
@@ -1068,7 +1068,7 @@ export const formNestedStack = async (
         const templateURL = resourceDetails.providerMetadata.s3TemplateURL;
         const key = templateURL.replace('https://s3.amazonaws.com/', '').split(resourceDetails.s3Bucket.deploymentBucketName + '/')[1];
         const jsonBody = await s3.getFile({ Key: key }, currentEnvName);
-        urlMap[templateURL] = JSON.parse(jsonBody.toString());
+        urlParametersMap[templateURL] = Object.keys(JSON.parse(jsonBody.toString()).Parameters);
       }
     }
   }
@@ -1193,7 +1193,7 @@ export const formNestedStack = async (
         }
         if (resourceDetails.providerMetadata) {
           templateURL = resourceDetails.providerMetadata.s3TemplateURL;
-          const urlParameters = Object.keys(urlMap[templateURL].Parameters);
+          const urlParameters = urlParametersMap[templateURL];
           const nonCustomParameters = ['CloudWatchRule', 'deploymentBucketName', 'env', 's3Key'];
           const misMatchedParams = Object.keys(parameters).filter(
             (parameter) => !nonCustomParameters.includes(parameter) && !urlParameters.includes(parameter),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
A lot of pushes fail because parameters in a nested stack do not match parameters in the root stack. This PR adds logic to compare the parameters in the root stack with the parameters in each nested stack. If there are inconsistencies, push will fast-fail before starting the build the stacks in CloudFormation. The error instructs users to remedy these inconsistencies manually or by pulling a previous backend before continuing. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#12114

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
I wrote 2 E2E tests to validate this change. One ensures that the fast-fail works with inconsistent parameters and the other ensures that push still works with consistent parameters. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
