### PR TITLE
fix: yarn failures during dev-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commit": "git-cz",
     "coverage:collect": "ts-node ./scripts/collect-test-coverage.ts",
     "coverage": "codecov || exit 0",
-    "dev-build": "yarn --cache-folder ~/.cache/yarn && nx run-many --target=build --all",
+    "dev-build": "yarn --network-concurrency 1 --cache-folder ~/.cache/yarn && nx run-many --target=build --all",
     "e2e": "nx run e2e",
     "extract-api": "nx run-many --target=extract-api --all",
     "extract-formatting-changes": "yarn ts-node ./scripts/extract-formatting-changes.ts",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Inspired by https://github.com/aws-amplify/amplify-cli/commit/4d058e35c4a97785ffcda768bfcb9fff2ad46f11 --
In the [aws-amplify/codegen-ui repo](https://github.com/aws-amplify/amplify-codegen-ui), we run integration tests that call `yarn setup-dev`. It's been failing at this step ([see example log](https://github.com/aws-amplify/amplify-codegen-ui/actions/runs/4619674637/jobs/8168733246)), and this is an attempt to mitigate.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Successfully ran `yarn setup-dev`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
