### PR TITLE
chore: use prefixed core in functions category

### DIFF
--- a/packages/amplify-category-function/API.md
+++ b/packages/amplify-category-function/API.md
@@ -4,12 +4,12 @@
 
 ```ts
 
-import { $TSAny } from 'amplify-cli-core';
-import { $TSContext } from 'amplify-cli-core';
-import { $TSObject } from 'amplify-cli-core';
+import { $TSAny } from '@aws-amplify/amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { $TSObject } from '@aws-amplify/amplify-cli-core';
 import { BuildType } from '@aws-amplify/amplify-function-plugin-interface';
 import { FunctionParameters } from '@aws-amplify/amplify-function-plugin-interface';
-import { ResourceTuple } from 'amplify-cli-core';
+import { ResourceTuple } from '@aws-amplify/amplify-cli-core';
 
 // @public (undocumented)
 export const add: (context: any, providerName: any, service: any, parameters: any) => Promise<string>;

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -26,10 +26,10 @@
     "access": "public"
   },
   "dependencies": {
+    "@aws-amplify/amplify-cli-core": "4.0.1",
     "@aws-amplify/amplify-environment-parameters": "1.4.1",
     "@aws-amplify/amplify-function-plugin-interface": "1.10.0",
     "@aws-amplify/amplify-prompts": "2.6.6",
-    "amplify-cli-core": "4.0.1",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.1233.0",
     "chalk": "^4.1.1",

--- a/packages/amplify-category-function/src/__tests__/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import sequential from 'promise-sequential';
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
 import { initEnv, isMockable } from '..';
 import { getLocalFunctionSecretNames } from '../provider-utils/awscloudformation/secrets/functionSecretsStateManager';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/index.test.ts
@@ -1,6 +1,6 @@
 import { openConsole, isMockable } from '../../../provider-utils/awscloudformation';
 import { ServiceName } from '../../../provider-utils/awscloudformation/utils/constants';
-import { open, $TSContext, stateManager } from 'amplify-cli-core';
+import { open, $TSContext, stateManager } from '@aws-amplify/amplify-cli-core';
 import { buildFunction } from '../../../provider-utils/awscloudformation/utils/buildFunction';
 import { getBuilder } from '../../..';
 import { BuildType } from '@aws-amplify/amplify-function-plugin-interface';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/secrets/functionSecretsStateManager.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/secrets/functionSecretsStateManager.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, stateManager, pathManager, AmplifyError } from 'amplify-cli-core';
+import { $TSContext, stateManager, pathManager, AmplifyError } from '@aws-amplify/amplify-cli-core';
 import { mocked } from 'ts-jest/utils';
 import * as path from 'path';
 import { getEnvParamManager } from '@aws-amplify/amplify-environment-parameters';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, stateManager } from 'amplify-cli-core';
+import { $TSContext, stateManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency, LambdaLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import { addLayersToFunctionWalkthrough } from '../../../../provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough';
 import {

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import {
   getResourcesForCfn,
   generateEnvVariablesForCfn,
@@ -8,7 +8,7 @@ import {
   constructCFModelTableNameComponent,
   constructCFModelTableArnComponent,
 } from '../../../../provider-utils/awscloudformation/utils/cloudformationHelpers';
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { CRUDOperation } from '../../../../constants';
 import inquirer from 'inquirer';
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/addLayerToFunctionUtil.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency, LambdaLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import enquirer from 'enquirer';
 import inquirer, { CheckboxQuestion, InputQuestion } from 'inquirer';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildFunction.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildFunction.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, pathManager } from 'amplify-cli-core';
+import { $TSContext, pathManager } from '@aws-amplify/amplify-cli-core';
 import { BuildType, FunctionRuntimeLifecycleManager } from '@aws-amplify/amplify-function-plugin-interface';
 import { buildFunction } from '../../../../provider-utils/awscloudformation/utils/buildFunction';
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/buildLayer.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, pathManager } from 'amplify-cli-core';
+import { $TSContext, pathManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionRuntimeLifecycleManager } from '@aws-amplify/amplify-function-plugin-interface';
 import { buildLayer } from '../../../../provider-utils/awscloudformation/utils/buildLayer';
 import { loadLayerConfigurationFile } from '../../../../provider-utils/awscloudformation/utils/layerConfiguration';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.test.ts
@@ -1,4 +1,4 @@
-import { pathManager, stateManager, readCFNTemplate, writeCFNTemplate, CFNTemplateFormat } from 'amplify-cli-core';
+import { pathManager, stateManager, readCFNTemplate, writeCFNTemplate, CFNTemplateFormat } from '@aws-amplify/amplify-cli-core';
 import { ensureLambdaExecutionRoleOutputs } from '../../../../provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs';
 
 jest.mock('amplify-cli-core');

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/environmentVariablesHelper.test.ts
@@ -1,4 +1,4 @@
-import { stateManager, JSONUtilities, $TSContext, pathManager } from 'amplify-cli-core';
+import { stateManager, JSONUtilities, $TSContext, pathManager } from '@aws-amplify/amplify-cli-core';
 import { prompter } from '@aws-amplify/amplify-prompts';
 import * as envVarHelper from '../../../../provider-utils/awscloudformation/utils/environmentVariablesHelper';
 import * as uuid from 'uuid';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/getDependentFunction.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/getDependentFunction.test.ts
@@ -1,6 +1,6 @@
 import { lambdasWithApiDependency } from '../../../../provider-utils/awscloudformation/utils/getDependentFunction';
 import { loadFunctionParameters } from '../../../../provider-utils/awscloudformation/utils/loadFunctionParameters';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 
 jest.mock('fs-extra');
 jest.mock('../../../../provider-utils/awscloudformation/utils/loadFunctionParameters');

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
@@ -1,4 +1,4 @@
-import { pathManager, stateManager } from 'amplify-cli-core';
+import { pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { ServiceName } from '../../../../provider-utils/awscloudformation/utils/constants';
 import { generateLayerCfnObj } from '../../../../provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template';
 import { isMultiEnvLayer } from '../../../../provider-utils/awscloudformation/utils/layerHelpers';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/loadFunctionParameters.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/loadFunctionParameters.test.ts
@@ -1,4 +1,4 @@
-import { JSONUtilities } from 'amplify-cli-core';
+import { JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { loadFunctionParameters } from '../../../../provider-utils/awscloudformation/utils/loadFunctionParameters';
 
 jest.mock('amplify-cli-core', () => ({

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageFunction.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageFunction.test.ts
@@ -1,5 +1,5 @@
 import { getRuntimeManager } from '../../../../provider-utils/awscloudformation/utils/functionPluginLoader';
-import { $TSContext, getFolderSize, pathManager } from 'amplify-cli-core';
+import { $TSContext, getFolderSize, pathManager } from '@aws-amplify/amplify-cli-core';
 import { packageFunction } from '../../../../provider-utils/awscloudformation/utils/packageFunction';
 import { PackageRequestMeta } from '../../../../provider-utils/awscloudformation/types/packaging-types';
 import { zipPackage } from '../../../../provider-utils/awscloudformation/utils/zipResource';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/packageLayer.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, convertNumBytes, getFolderSize, pathManager } from 'amplify-cli-core';
+import { $TSContext, convertNumBytes, getFolderSize, pathManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionRuntimeLifecycleManager } from '@aws-amplify/amplify-function-plugin-interface';
 import { packageLayer } from '../../../../provider-utils/awscloudformation/utils/packageLayer';
 import { PackageRequestMeta } from '../../../../provider-utils/awscloudformation/types/packaging-types';

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/storeResources.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/storeResources.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, JSONUtilities, pathManager } from 'amplify-cli-core';
+import { $TSContext, JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
 import { LambdaLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import { saveMutableState } from '../../../../provider-utils/awscloudformation/utils/storeResources';
 

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/updateDependentFunctionCfn.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/updateDependentFunctionCfn.test.ts
@@ -4,7 +4,7 @@ import {
   getResourcesForCfn,
   generateEnvVariablesForCfn,
 } from '../../../../provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency } from '@aws-amplify/amplify-function-plugin-interface/src';
 import { updateCFNFileForResourcePermissions } from '../../../../provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough';
 jest.mock('fs-extra');

--- a/packages/amplify-category-function/src/commands/function/build.ts
+++ b/packages/amplify-category-function/src/commands/function/build.ts
@@ -1,11 +1,11 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { prompter } from '@aws-amplify/amplify-prompts';
 import { ServiceName } from '../..';
 import { categoryName } from '../../constants';
 import { PackageRequestMeta } from '../../provider-utils/awscloudformation/types/packaging-types';
 import { buildFunction } from '../../provider-utils/awscloudformation/utils/buildFunction';
 import { packageResource } from '../../provider-utils/awscloudformation/utils/package';
-import { AmplifyError } from 'amplify-cli-core';
+import { AmplifyError } from '@aws-amplify/amplify-cli-core';
 export const name = 'build';
 
 /**

--- a/packages/amplify-category-function/src/commands/function/help.ts
+++ b/packages/amplify-category-function/src/commands/function/help.ts
@@ -1,4 +1,4 @@
-import { $TSContext, runHelp, commandsInfo } from 'amplify-cli-core';
+import { $TSContext, runHelp, commandsInfo } from '@aws-amplify/amplify-cli-core';
 
 export const run = (context: $TSContext) => {
   runHelp(context, commandsInfo);

--- a/packages/amplify-category-function/src/commands/function/remove.ts
+++ b/packages/amplify-category-function/src/commands/function/remove.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { categoryName } from '../../constants';
 import {
   FunctionSecretsStateManager,

--- a/packages/amplify-category-function/src/events/postEnvRemoveHandler.ts
+++ b/packages/amplify-category-function/src/events/postEnvRemoveHandler.ts
@@ -1,5 +1,5 @@
 import { printer } from '@aws-amplify/amplify-prompts';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { FunctionSecretsStateManager } from '../provider-utils/awscloudformation/secrets/functionSecretsStateManager';
 
 export const postEnvRemoveHandler = async (context: $TSContext, envName: string) => {

--- a/packages/amplify-category-function/src/events/postPushHandler.ts
+++ b/packages/amplify-category-function/src/events/postPushHandler.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { FunctionSecretsStateManager } from '../provider-utils/awscloudformation/secrets/functionSecretsStateManager';
 
 export const postPushHandler = async (context: $TSContext) => {

--- a/packages/amplify-category-function/src/events/prePushHandler.ts
+++ b/packages/amplify-category-function/src/events/prePushHandler.ts
@@ -1,5 +1,5 @@
 import { printer } from '@aws-amplify/amplify-prompts';
-import { $TSContext, stateManager } from 'amplify-cli-core';
+import { $TSContext, stateManager } from '@aws-amplify/amplify-cli-core';
 import { categoryName } from '../constants';
 import {
   FunctionSecretsStateManager,

--- a/packages/amplify-category-function/src/index.ts
+++ b/packages/amplify-category-function/src/index.ts
@@ -1,5 +1,5 @@
 import { ensureEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
-import { $TSAny, $TSContext, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { BuildType, FunctionBreadcrumbs, FunctionRuntimeLifecycleManager } from '@aws-amplify/amplify-function-plugin-interface';
 import _ from 'lodash';
 import * as path from 'path';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/index.ts
@@ -8,7 +8,7 @@ import {
   readCFNTemplate,
   stateManager,
   writeCFNTemplate,
-} from 'amplify-cli-core';
+} from '@aws-amplify/amplify-cli-core';
 import {
   FunctionParameters,
   FunctionTemplate,
@@ -35,7 +35,7 @@ import {
   saveMutableState,
   updateLayerArtifacts,
 } from './utils/storeResources';
-import { createDefaultCustomPoliciesFile } from 'amplify-cli-core';
+import { createDefaultCustomPoliciesFile } from '@aws-amplify/amplify-cli-core';
 
 /**
  * Entry point for creating a new function

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/cloneSecretsOnEnvInitHandler.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/cloneSecretsOnEnvInitHandler.ts
@@ -1,4 +1,4 @@
-import { $TSContext, ResourceName, stateManager } from 'amplify-cli-core';
+import { $TSContext, ResourceName, stateManager } from '@aws-amplify/amplify-cli-core';
 import { SecretDeltas } from '@aws-amplify/amplify-function-plugin-interface';
 import { categoryName } from '../../../constants';
 import { cloneEnvWalkthrough } from '../service-walkthroughs/secretValuesWalkthrough';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/functionSecretsStateManager.ts
@@ -1,4 +1,4 @@
-import { $TSContext, AmplifyError, JSONUtilities, pathManager, ResourceName, stateManager } from 'amplify-cli-core';
+import { $TSContext, AmplifyError, JSONUtilities, pathManager, ResourceName, stateManager } from '@aws-amplify/amplify-cli-core';
 import { removeSecret, retainSecret, SecretDeltas, SecretName, setSecret } from '@aws-amplify/amplify-function-plugin-interface';
 import * as path from 'path';
 import * as fs from 'fs-extra';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/secretName.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/secretName.ts
@@ -5,7 +5,7 @@
  * WARNING: be extremely careful changing anything about how secrets are named in SSM! (AKA you should probably never change this).
  * This format is standardized with other Amplify Console SSM parameters and is expected by customer functions when fetching secrets at runtime
  */
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { Fn } from 'cloudform-types';
 import * as path from 'path';
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import type { SSM } from 'aws-sdk';
 
 /**

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSContext, stateManager } from 'amplify-cli-core';
+import { $TSContext, stateManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency, FunctionParameters, FunctionRuntime, LambdaLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import { askCustomArnQuestion, askLayerOrderQuestion, askLayerSelection } from '../utils/addLayerToFunctionUtils';
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/autogeneratedParameters.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/autogeneratedParameters.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { FunctionParameters } from '@aws-amplify/amplify-function-plugin-interface';
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 
 /**
  * Populates FunctionParameters that do not require any additional input

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/execPermissionsWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, AmplifyError, FeatureFlags, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyError, FeatureFlags, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency, FunctionParameters } from '@aws-amplify/amplify-function-plugin-interface';
 import { printer } from '@aws-amplify/amplify-prompts';
 import * as TransformPackage from 'graphql-transformer-core';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambda-walkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionParameters, ProjectLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import inquirer from 'inquirer';
 import _ from 'lodash';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/lambdaLayerWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSContext, exitOnNextTick, ResourceDoesNotExistError } from 'amplify-cli-core';
+import { $TSContext, exitOnNextTick, ResourceDoesNotExistError } from '@aws-amplify/amplify-cli-core';
 import inquirer, { InputQuestion } from 'inquirer';
 import _ from 'lodash';
 import { ServiceName } from '../utils/constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeFunctionWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeFunctionWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSAny, stateManager, getAmplifyResourceByCategories, AmplifyError } from 'amplify-cli-core';
+import { $TSAny, stateManager, getAmplifyResourceByCategories, AmplifyError } from '@aws-amplify/amplify-cli-core';
 import inquirer from 'inquirer';
 import _ from 'lodash';
 import { categoryName } from '../../../constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/removeLayerWalkthrough.ts
@@ -1,4 +1,4 @@
-import { $TSContext, $TSObject, pathManager, spinner, stateManager } from 'amplify-cli-core';
+import { $TSContext, $TSObject, pathManager, spinner, stateManager } from '@aws-amplify/amplify-cli-core';
 import chalk from 'chalk';
 import inquirer, { QuestionCollection } from 'inquirer';
 import { categoryName } from '../../../constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/secretValuesWalkthrough.ts
@@ -2,7 +2,7 @@
  * Contains all of the logic for the various secret prompts
  */
 
-import { ResourceName } from 'amplify-cli-core';
+import { ResourceName } from '@aws-amplify/amplify-cli-core';
 import { FunctionParameters, removeSecret, SecretDeltas, setSecret } from '@aws-amplify/amplify-function-plugin-interface';
 import inquirer from 'inquirer';
 import { getExistingSecrets, hasExistingSecrets } from '../secrets/secretDeltaUtilities';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/types/packaging-types.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/types/packaging-types.ts
@@ -1,4 +1,4 @@
-import { $TSContext, ResourceTuple } from 'amplify-cli-core';
+import { $TSContext, ResourceTuple } from '@aws-amplify/amplify-cli-core';
 
 export type PackageRequestMeta = ResourceTuple & {
   service: string;

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/addLayerToFunctionUtils.ts
@@ -1,4 +1,4 @@
-import { $TSContext, $TSMeta } from 'amplify-cli-core';
+import { $TSContext, $TSMeta } from '@aws-amplify/amplify-cli-core';
 import {
   ExternalLayer,
   FunctionDependency,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/appSyncHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/appSyncHelper.ts
@@ -1,4 +1,4 @@
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 
 export function getAppSyncResourceName(): string {
   const amplifyMeta = stateManager.getMeta();

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/build.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/build.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from 'amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { buildFunction, BuildRequestMeta } from './buildFunction';
 import { buildLayer } from './buildLayer';
 import { ServiceName } from './constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildFunction.ts
@@ -1,7 +1,7 @@
-import { $TSContext, pathManager } from 'amplify-cli-core';
+import { $TSContext, pathManager } from '@aws-amplify/amplify-cli-core';
 import { BuildRequest, BuildType, FunctionRuntimeLifecycleManager } from '@aws-amplify/amplify-function-plugin-interface';
 import { categoryName } from '../../../constants';
-import { AmplifyError } from 'amplify-cli-core';
+import { AmplifyError } from '@aws-amplify/amplify-cli-core';
 
 export const buildFunction = async (
   context: $TSContext,

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/buildLayer.ts
@@ -1,4 +1,4 @@
-import { $TSContext, AmplifyError, pathManager } from 'amplify-cli-core';
+import { $TSContext, AmplifyError, pathManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionRuntimeLifecycleManager, BuildRequest, BuildType } from '@aws-amplify/amplify-function-plugin-interface';
 import * as path from 'path';
 import { categoryName } from '../../../constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cloudformationHelpers.ts
@@ -1,7 +1,7 @@
 import { appsyncTableSuffix } from './constants';
 import { getAppSyncResourceName } from './appSyncHelper';
 import * as path from 'path';
-import { $TSAny, pathManager, readCFNTemplate, writeCFNTemplate } from 'amplify-cli-core';
+import { $TSAny, pathManager, readCFNTemplate, writeCFNTemplate } from '@aws-amplify/amplify-cli-core';
 import { categoryName } from '../../../constants';
 import { getTableNameForModel, readProjectConfiguration } from 'graphql-transformer-core';
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/consolidateDependsOn.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/consolidateDependsOn.ts
@@ -1,4 +1,4 @@
-import { $TSMeta } from 'amplify-cli-core';
+import { $TSMeta } from '@aws-amplify/amplify-cli-core';
 import { FunctionDependency } from '@aws-amplify/amplify-function-plugin-interface';
 import { lambdaLayerSetting, resourceAccessSetting, ServiceName } from './constants';
 

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
@@ -1,4 +1,11 @@
-import { AmplifyCategories, AmplifySupportedService, pathManager, readCFNTemplate, stateManager, writeCFNTemplate } from 'amplify-cli-core';
+import {
+  AmplifyCategories,
+  AmplifySupportedService,
+  pathManager,
+  readCFNTemplate,
+  stateManager,
+  writeCFNTemplate,
+} from '@aws-amplify/amplify-cli-core';
 import * as path from 'path';
 
 /**

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/environmentVariablesHelper.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import _ from 'lodash';
 import * as uuid from 'uuid';
-import { $TSContext, stateManager, pathManager, JSONUtilities, $TSAny, $TSObject, AmplifyError } from 'amplify-cli-core';
+import { $TSContext, stateManager, pathManager, JSONUtilities, $TSAny, $TSObject, AmplifyError } from '@aws-amplify/amplify-cli-core';
 import { byValue, maxLength, printer, prompter } from '@aws-amplify/amplify-prompts';
 import { getEnvParamManager, ensureEnvParamManager } from '@aws-amplify/amplify-environment-parameters';
 import { functionParametersFileName } from './constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/funcionStateUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/funcionStateUtils.ts
@@ -1,4 +1,4 @@
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { categoryName } from '../../../constants';
 
 export const isFunctionPushed = (functionName: string): boolean =>

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/functionPluginLoader.ts
@@ -12,7 +12,7 @@ import {
 import { ServiceName } from './constants';
 import _ from 'lodash';
 import { LayerParameters } from './layerParams';
-import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { $TSAny, $TSContext } from '@aws-amplify/amplify-cli-core';
 import { categoryName } from '../../../constants';
 /*
  * This file contains the logic for loading, selecting and executing function plugins (currently runtime and template plugins)

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/getDependentFunction.ts
@@ -1,4 +1,4 @@
-import { $TSContext, $TSObject } from 'amplify-cli-core';
+import { $TSContext, $TSObject } from '@aws-amplify/amplify-cli-core';
 import * as path from 'path';
 import { loadFunctionParameters } from './loadFunctionParameters';
 import { ServiceName } from './constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/lambda-layer-cloudformation-template.ts
@@ -1,4 +1,4 @@
-import { stateManager } from 'amplify-cli-core';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 import { DeletionPolicy, Fn, IntrinsicFunction, Refs } from 'cloudform-types';
 import Lambda from 'cloudform-types/types/lambda';
 import _ from 'lodash';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerCloudState.ts
@@ -1,4 +1,4 @@
-import { $TSContext, exitOnNextTick, spinner } from 'amplify-cli-core';
+import { $TSContext, exitOnNextTick, spinner } from '@aws-amplify/amplify-cli-core';
 import { LayerCfnLogicalNamePrefix } from './constants';
 // eslint-disable-next-line import/no-cycle
 import { isMultiEnvLayer } from './layerHelpers';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerConfiguration.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerConfiguration.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSObject, JSONUtilities, pathManager, recursiveOmit, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSObject, JSONUtilities, pathManager, recursiveOmit, stateManager } from '@aws-amplify/amplify-cli-core';
 import _ from 'lodash';
 import * as path from 'path';
 import { deleteVersionsField, ephemeralField, layerConfigurationFileName, updateVersionPermissionsField } from './constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerHelpers.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSMeta, $TSObject, getPackageManager, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSMeta, $TSObject, getPackageManager, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import crypto from 'crypto';
 import { hashElement, HashElementOptions } from 'folder-hash';
 import * as fs from 'fs-extra';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/layerMigrationUtils.ts
@@ -1,4 +1,4 @@
-import { $TSContext, exitOnNextTick, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSContext, exitOnNextTick, JSONUtilities, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { printer } from '@aws-amplify/amplify-prompts';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/loadFunctionParameters.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/loadFunctionParameters.ts
@@ -1,4 +1,4 @@
-import { $TSAny, JSONUtilities } from 'amplify-cli-core';
+import { $TSAny, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import _ from 'lodash';
 import * as path from 'path';
 import { functionParametersFileName } from './constants';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageFunction.ts
@@ -1,4 +1,4 @@
-import { AmplifyError, convertNumBytes, getFolderSize, pathManager } from 'amplify-cli-core';
+import { AmplifyError, convertNumBytes, getFolderSize, pathManager } from '@aws-amplify/amplify-cli-core';
 import { LambdaLayer } from '@aws-amplify/amplify-function-plugin-interface';
 import * as fs from 'fs-extra';
 import * as path from 'path';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/packageLayer.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, convertNumBytes, getFolderSize, pathManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, convertNumBytes, getFolderSize, pathManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionRuntimeLifecycleManager, ZipEntry } from '@aws-amplify/amplify-function-plugin-interface';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/storeResources.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-cycle */
-import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager, stateManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionBreadcrumbs, FunctionParameters, FunctionTriggerParameters } from '@aws-amplify/amplify-function-plugin-interface';
 import * as fs from 'fs-extra';
 import _ from 'lodash';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateDependentFunctionCfn.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateDependentFunctionCfn.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager } from 'amplify-cli-core';
+import { $TSAny, $TSContext, $TSObject, JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
 import { FunctionParameters } from '@aws-amplify/amplify-function-plugin-interface';
 import { getResourcesForCfn, generateEnvVariablesForCfn } from '../service-walkthroughs/execPermissionsWalkthrough';
 import { updateCFNFileForResourcePermissions } from '../service-walkthroughs/lambda-walkthrough';

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
@@ -3,7 +3,7 @@ import { EOL } from 'os';
 import path from 'path';
 import { categoryName, topLevelCommentPrefix, topLevelCommentSuffix } from '../../../constants';
 import _ from 'lodash';
-import { pathManager } from 'amplify-cli-core';
+import { pathManager } from '@aws-amplify/amplify-cli-core';
 /**
  * This is legacy code that has been copied here.
  * In the future we either need to get rid of the top level comment entirely, or create a template hook to modify it

--- a/packages/amplify-category-function/src/provider-utils/supportedServicesType.ts
+++ b/packages/amplify-category-function/src/provider-utils/supportedServicesType.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext } from 'amplify-cli-core';
+import { $TSAny, $TSContext } from '@aws-amplify/amplify-cli-core';
 import { FunctionParameters } from '@aws-amplify/amplify-function-plugin-interface';
 import { LayerParameters } from './awscloudformation/utils/layerParams';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
1. Replace all imports in main sources, (`from 'amplify-cli-core'` -> `from '@aws-amplify/amplify-cli-core'`)
2. Replace all imports in unit test sources, (`from 'amplify-cli-core'` -> `from '@aws-amplify/amplify-cli-core'`)
3. Keep `jest.mock('amplify-cli-core');` as is until we're ready to remove proxy package '@aws-amplify/amplify-cli-core' and add prefix to real core.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
