### PR TITLE
fix: graceful fallback if us-east-1 AppState unavailable

### DIFF
--- a/packages/amplify-cli/src/commands/console.ts
+++ b/packages/amplify-cli/src/commands/console.ts
@@ -10,31 +10,25 @@ const providerName = 'awscloudformation';
 export const run = async (context: $TSContext): Promise<void> => {
   let consoleUrl = getDefaultURL();
 
-  try {
-    const localEnvInfo = stateManager.getLocalEnvInfo(undefined, {
-      throwIfNotExist: false,
-      default: {},
-    });
+  const localEnvInfo = stateManager.getLocalEnvInfo(undefined, {
+    throwIfNotExist: false,
+    default: {},
+  });
 
-    const { envName } = localEnvInfo;
-    const { Region, AmplifyAppId } = stateManager.getMeta()?.providers?.[providerName];
+  const { envName } = localEnvInfo;
+  const { Region, AmplifyAppId } = stateManager.getMeta()?.providers?.[providerName];
 
-    if (envName && AmplifyAppId) {
-      consoleUrl = constructStatusURL(Region, AmplifyAppId, envName);
-      const providerPlugin = await import(context.amplify.getProviderPlugins(context).awscloudformation);
-      if (await providerPlugin.isAmplifyAdminApp(AmplifyAppId)) {
-        const choice = await prompter.pick('Which site do you want to open?', ['Amplify Studio', 'AWS console']);
-        if (choice === 'Amplify Studio') {
-          const baseUrl = providerPlugin.adminBackendMap[Region].amplifyAdminUrl;
-          consoleUrl = constructAdminURL(baseUrl, AmplifyAppId, envName);
-        }
+  if (envName && AmplifyAppId) {
+    consoleUrl = constructStatusURL(Region, AmplifyAppId, envName);
+    const providerPlugin = await import(context.amplify.getProviderPlugins(context).awscloudformation);
+    const { isAdminApp } = await providerPlugin.isAmplifyAdminApp(AmplifyAppId);
+    if (isAdminApp) {
+      const choice = await prompter.pick('Which site do you want to open?', ['Amplify Studio', 'AWS console']);
+      if (choice === 'Amplify Studio') {
+        const baseUrl = providerPlugin.adminBackendMap[Region].amplifyAdminUrl;
+        consoleUrl = constructAdminURL(baseUrl, AmplifyAppId, envName);
       }
     }
-  } catch (e) {
-    printer.error(e.message);
-    void context.usageData.emitError(e);
-    process.exitCode = 1;
-    return;
   }
 
   printer.info(chalk.green(consoleUrl));

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-helpers.test.ts
@@ -1,0 +1,66 @@
+import { prompter } from '@aws-amplify/amplify-prompts';
+import { isAmplifyAdminApp } from '../../utils/admin-helpers';
+import fetch, { Response } from 'node-fetch';
+import { AmplifyFault } from '@aws-amplify/amplify-cli-core';
+
+jest.mock('node-fetch');
+jest.mock('@aws-amplify/amplify-prompts');
+
+const prompterMock = prompter as jest.Mocked<typeof prompter>;
+const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+
+describe('isAmplifyAdminApp', () => {
+  const testUserPoolId = 'testUserPoolId';
+  // the only reason this needs to be a real region is becuase the test uses the region to look up a regional URL. But it does not actually query the URL
+  const testRegion = 'eu-south-1';
+  it('uses us-east-1 response to determine true region', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          appId: '1234',
+          region: testRegion,
+        }),
+      } as unknown as Response)
+      .mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          appId: '1234',
+          region: testRegion,
+          loginAuthConfig: JSON.stringify({ aws_user_pools_id: testUserPoolId }),
+        }),
+      } as unknown as Response);
+    await expect(isAmplifyAdminApp('1234')).resolves.toEqual({ isAdminApp: true, region: testRegion, userPoolID: testUserPoolId });
+  });
+
+  it('prompts for fallback region if us-east-1 AppState unavailable', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, // simulates us-east-1 AppState unavailable
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          appId: '1234',
+          region: testRegion,
+          loginAuthConfig: JSON.stringify({ aws_user_pools_id: `${testUserPoolId}1` }),
+        }),
+      } as unknown as Response);
+    prompterMock.pick.mockResolvedValueOnce(testRegion);
+    await expect(isAmplifyAdminApp('1234')).resolves.toEqual({ isAdminApp: true, region: testRegion, userPoolID: `${testUserPoolId}1` });
+  });
+
+  it('throws AmplifyFault if AppState unavailable in supplied region', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, // simulates us-east-1 AppState unavailable
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false, // simulates actual region unavailable
+      } as unknown as Response);
+    prompterMock.pick.mockResolvedValueOnce(testRegion);
+    await expect(isAmplifyAdminApp('1234')).rejects.toMatchInlineSnapshot(
+      `[ServiceCallFault: AppState in region eu-south-1 returned status undefined]`,
+    );
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-helpers.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-helpers.test.ts
@@ -1,29 +1,40 @@
 import { prompter } from '@aws-amplify/amplify-prompts';
 import { isAmplifyAdminApp } from '../../utils/admin-helpers';
 import fetch, { Response } from 'node-fetch';
-import { AmplifyFault } from '@aws-amplify/amplify-cli-core';
+import { stateManager, AmplifyFault } from '@aws-amplify/amplify-cli-core';
 
 jest.mock('node-fetch');
 jest.mock('@aws-amplify/amplify-prompts');
+jest.mock('@aws-amplify/amplify-cli-core');
 
 const prompterMock = prompter as jest.Mocked<typeof prompter>;
 const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
 
+const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
+
+const AmplifyFaultMock = AmplifyFault as jest.MockedClass<typeof AmplifyFault>;
+
+const amplifyFaultMockImpl = { name: 'AmplifyFaultMock' } as unknown as AmplifyFault;
+AmplifyFaultMock.mockImplementation(() => amplifyFaultMockImpl);
+
 describe('isAmplifyAdminApp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   const testUserPoolId = 'testUserPoolId';
   // the only reason this needs to be a real region is becuase the test uses the region to look up a regional URL. But it does not actually query the URL
   const testRegion = 'eu-south-1';
   it('uses us-east-1 response to determine true region', async () => {
     fetchMock
       .mockResolvedValueOnce({
-        ok: true,
+        status: 200,
         json: jest.fn().mockResolvedValue({
           appId: '1234',
           region: testRegion,
         }),
       } as unknown as Response)
       .mockResolvedValue({
-        ok: true,
+        status: 200,
         json: jest.fn().mockResolvedValue({
           appId: '1234',
           region: testRegion,
@@ -33,19 +44,40 @@ describe('isAmplifyAdminApp', () => {
     await expect(isAmplifyAdminApp('1234')).resolves.toEqual({ isAdminApp: true, region: testRegion, userPoolID: testUserPoolId });
   });
 
-  it('prompts for fallback region if us-east-1 AppState unavailable', async () => {
+  it('gets fallback region from stateManager if us-east-1 AppState unavailable', async () => {
     fetchMock
       .mockResolvedValueOnce({
-        ok: false, // simulates us-east-1 AppState unavailable
+        status: 500, // simulates us-east-1 AppState unavailable
       } as unknown as Response)
       .mockResolvedValueOnce({
-        ok: true,
+        status: 200,
         json: jest.fn().mockResolvedValue({
           appId: '1234',
           region: testRegion,
           loginAuthConfig: JSON.stringify({ aws_user_pools_id: `${testUserPoolId}1` }),
         }),
       } as unknown as Response);
+    stateManagerMock.getCurrentRegion.mockReturnValueOnce(testRegion);
+    await expect(isAmplifyAdminApp('1234')).resolves.toEqual({ isAdminApp: true, region: testRegion, userPoolID: `${testUserPoolId}1` });
+    expect(prompterMock.pick).not.toHaveBeenCalled();
+  });
+
+  it('prompts for fallback region if us-east-1 AppState unavailable and amplify-meta unavailable', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 500, // simulates us-east-1 AppState unavailable
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+          appId: '1234',
+          region: testRegion,
+          loginAuthConfig: JSON.stringify({ aws_user_pools_id: `${testUserPoolId}1` }),
+        }),
+      } as unknown as Response);
+    stateManagerMock.getCurrentRegion.mockImplementationOnce(() => {
+      throw new Error('test error');
+    });
     prompterMock.pick.mockResolvedValueOnce(testRegion);
     await expect(isAmplifyAdminApp('1234')).resolves.toEqual({ isAdminApp: true, region: testRegion, userPoolID: `${testUserPoolId}1` });
   });
@@ -53,14 +85,15 @@ describe('isAmplifyAdminApp', () => {
   it('throws AmplifyFault if AppState unavailable in supplied region', async () => {
     fetchMock
       .mockResolvedValueOnce({
-        ok: false, // simulates us-east-1 AppState unavailable
+        status: 500, // simulates us-east-1 AppState unavailable
       } as unknown as Response)
       .mockResolvedValueOnce({
-        ok: false, // simulates actual region unavailable
+        status: 500, // simulates actual region unavailable
       } as unknown as Response);
+    stateManagerMock.getCurrentRegion.mockImplementationOnce(() => {
+      throw new Error('test error');
+    });
     prompterMock.pick.mockResolvedValueOnce(testRegion);
-    await expect(isAmplifyAdminApp('1234')).rejects.toMatchInlineSnapshot(
-      `[ServiceCallFault: AppState in region eu-south-1 returned status undefined]`,
-    );
+    await expect(isAmplifyAdminApp('1234')).rejects.toEqual(amplifyFaultMockImpl);
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -30,7 +30,8 @@ export function doAdminTokensExist(appId: string): boolean {
 /**
   This logic queries AppState in the us-east-1 region which acts as a "global" region for all AppState data. The response of this query
   is used to determine the "actual" region of the app and then query AppState in that region.
-  If AppState is unavailable in the us-east-1 region for some reason, we fallback to prompting for the Amplify app region
+  If AppState is unavailable in the us-east-1 region for some reason, we fallback looking for a region in amplify-meta.json.
+  If amplify-meta.json is not present, we prompt for a region.
 */
 export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string; userPoolID: string }> {
   if (!appId) {

--- a/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-helpers.ts
@@ -1,10 +1,11 @@
-import { stateManager, $TSContext, AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { stateManager, $TSContext, AmplifyError, AmplifyFault } from '@aws-amplify/amplify-cli-core';
 import aws from 'aws-sdk';
 import _ from 'lodash';
 import fetch from 'node-fetch';
 import proxyAgent from 'proxy-agent';
 import { adminLoginFlow } from '../admin-login';
 import { AdminAuthConfig, AwsSdkConfig, CognitoAccessToken, CognitoIdToken } from './auth-types';
+import { printer, prompter } from '@aws-amplify/amplify-prompts';
 
 /**
  *
@@ -27,17 +28,29 @@ export function doAdminTokensExist(appId: string): boolean {
 }
 
 /**
- *
- */
+  This logic queries AppState in the us-east-1 region which acts as a "global" region for all AppState data. The response of this query
+  is used to determine the "actual" region of the app and then query AppState in that region.
+  If AppState is unavailable in the us-east-1 region for some reason, we fallback to prompting for the Amplify app region
+*/
 export async function isAmplifyAdminApp(appId: string): Promise<{ isAdminApp: boolean; region: string; userPoolID: string }> {
   if (!appId) {
     throw new AmplifyError('AmplifyStudioError', {
       message: `Failed to check if Amplify Studio is enabled: appId is undefined`,
     });
   }
-  let appState = await getAdminAppState(appId, 'us-east-1');
-  if (appState.appId && appState.region && appState.region !== 'us-east-1') {
+  let appState: AppStateResponse | undefined = undefined;
+  let fallbackRegion: string | undefined = undefined;
+  try {
+    appState = await getAdminAppState(appId, 'us-east-1');
+  } catch {
+    printer.warn('The region of this Amplify app could not be determined.');
+    fallbackRegion = await prompter.pick('Select the Amplify app region:', Object.keys(adminBackendMap));
+  }
+
+  if (appState && appState.appId && appState.region && appState.region !== 'us-east-1') {
     appState = await getAdminAppState(appId, appState.region);
+  } else if (fallbackRegion) {
+    appState = await getAdminAppState(appId, fallbackRegion);
   }
   const userPoolID = appState.loginAuthConfig ? JSON.parse(appState.loginAuthConfig).aws_user_pools_id : '';
   return { isAdminApp: !!appState.appId, region: appState.region, userPoolID };
@@ -62,12 +75,24 @@ export async function getTempCredsWithAdminTokens(context: $TSContext, appId: st
   return await getAdminStsCredentials(idToken, region);
 }
 
-async function getAdminAppState(appId: string, region: string) {
+type AppStateResponse = {
+  appId: string;
+  region: string;
+  loginAuthConfig: string; // JSON string that parses to { aws_user_pools_id: string }
+};
+
+async function getAdminAppState(appId: string, region: string): Promise<AppStateResponse> {
   // environment variable AMPLIFY_CLI_APPSTATE_BASE_URL useful for development against beta/gamma appstate endpoints
   const appStateBaseUrl = process.env.AMPLIFY_CLI_APPSTATE_BASE_URL ?? adminBackendMap[region].appStateUrl;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
   const fetchOptions = httpProxy ? { agent: proxyAgent(httpProxy) } : {};
   const res = await fetch(`${appStateBaseUrl}/AppState/?appId=${appId}`, fetchOptions);
+  if (!res.ok) {
+    throw new AmplifyFault('ServiceCallFault', {
+      message: `AppState in region ${region} returned status ${res.status}`,
+      details: `Status: [${res.statusText}]`,
+    });
+  }
   return res.json();
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds some graceful fallback logic to the function that determines if an app has studio enabled. Specifically, if AppState is not available in us-east-1 (the "global" region), the logic will now fallback to looking for a region in `amplify-meta.json` and if not found there will finally prompt for a region.

It also fixes a bug in our console open logic that was not properly accounting for the return type of `isAmplifyAdminApp`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests and simulated this failure locally by modifying `/etc/hosts` to make AppState appear unavailable
E2E is running now: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/foyleef/no-appstate
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
