### PR TITLE
feat: generate S3 and DynamoDB triggers for node18 runtime

### DIFF
--- a/packages/amplify-category-storage/resources/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/resources/triggers/dynamoDB/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs16.x",
+            "Runtime": "nodejs18.x",
             "Timeout": 25
           }
         },

--- a/packages/amplify-category-storage/resources/triggers/s3/lambda-cloudformation-template.json.ejs
+++ b/packages/amplify-category-storage/resources/triggers/s3/lambda-cloudformation-template.json.ejs
@@ -52,7 +52,7 @@
                 }
             },
             "Role": { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-            "Runtime": "nodejs16.x",
+            "Runtime": "nodejs18.x",
             "Timeout": 25
           }
         },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR will generate S3 and Lambda triggers in `amplify add storage` flow with node 18.

These functions are plain JS without any dependencies.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
