### PR TITLE
fix: apply overrides when forcePush is set with init

### DIFF
--- a/packages/amplify-e2e-tests/overrides/override-root.ts
+++ b/packages/amplify-e2e-tests/overrides/override-root.ts
@@ -4,7 +4,35 @@ function getRandomInt(max) {
   return Math.floor(Math.random() * max);
 }
 export function override(props: AmplifyRootStackTemplate, amplifyProjectInfo: AmplifyProjectInfo): void {
-  props.authRole.roleName = `mockRole-${getRandomInt(10000)}`;
+  props.authRole!.roleName = `mockRole-${getRandomInt(10000)}`;
+  const apiGatewayPolicy = {
+    policyName: 'ApiGatewayPolicy',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 'execute-api:*',
+          Resource: '*',
+        },
+      ],
+    },
+  };
+  const rekognitionPolicy = {
+    policyName: 'RekognitionPolicy',
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: '*',
+          Resource: '*',
+        },
+      ],
+    },
+  };
+
+  props.authRole!.policies = [apiGatewayPolicy, rekognitionPolicy];
 
   if (!amplifyProjectInfo || !amplifyProjectInfo.envName || !amplifyProjectInfo.projectName) {
     throw new Error(`Project info is missing in override: ${JSON.stringify(amplifyProjectInfo)}`);

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -1,25 +1,24 @@
 /* eslint-disable spellcheck/spell-checker */
 /* eslint-disable import/no-extraneous-dependencies */
 
-import * as fs from 'fs-extra';
-import * as path from 'path';
 import {
-  initJSProjectWithProfile,
-  deleteProject,
   amplifyOverrideRoot,
   amplifyPushOverride,
   createNewProjectDir,
+  deleteProject,
   deleteProjectDir,
-  getProjectMeta,
-  replaceOverrideFileWithProjectInfo,
-  getProjectConfig,
-  gitInit,
-  gitCommitAll,
-  gitCleanFdx,
-  nonInteractiveInitWithForcePushAttach,
   getAmplifyInitConfig,
+  getProjectMeta,
+  gitCleanFdx,
+  gitCommitAll,
+  gitInit,
+  initJSProjectWithProfile,
   listRolePolicies,
+  nonInteractiveInitWithForcePushAttach,
+  replaceOverrideFileWithProjectInfo,
 } from '@aws-amplify/amplify-e2e-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 
 import { addEnvironment } from '../environment/env';
 

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -44,7 +44,7 @@ export class AmplifyRootStackTransform {
 
     // apply override on Amplify Object having CDK Constructs for Root Stack
     // enabling overrides for hosting when forcepush flag is used with init
-    if (context.input.command !== 'init' || (context.input.command !== 'init' && context?.input?.options?.forcePush === true)) {
+    if (context.input.command !== 'init' || (context.input.command === 'init' && context?.input?.options?.forcePush === true)) {
       await this.applyOverride();
     }
 

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-transform.ts
@@ -43,7 +43,8 @@ export class AmplifyRootStackTransform {
     await this.generateRootStackTemplate();
 
     // apply override on Amplify Object having CDK Constructs for Root Stack
-    if (context.input.command !== 'init') {
+    // enabling overrides for hosting when forcepush flag is used with init
+    if (context.input.command !== 'init' || (context.input.command !== 'init' && context?.input?.options?.forcePush === true)) {
       await this.applyOverride();
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- added a specific check to apply overrides when init is 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- manually tested
- updated an e2e test to check for specific conditions

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
