### PR TITLE
test: fix e2e pinpoint client region

### DIFF
--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -20,42 +20,17 @@ const settings = {
   pinpointResourceName: 'testpinpoint',
 };
 
-const defaultPinpointRegion = 'us-east-1';
-const serviceRegionMap = {
-  'us-east-1': 'us-east-1',
-  'us-east-2': 'us-east-1',
-  'sa-east-1': 'us-east-1',
-  'ca-central-1': 'ca-central-1',
-  'us-west-1': 'us-west-2',
-  'us-west-2': 'us-west-2',
-  'cn-north-1': 'us-west-2',
-  'cn-northwest-1': 'us-west-2',
-  'ap-south-1': 'ap-south-1',
-  'ap-northeast-3': 'us-west-2',
-  'ap-northeast-2': 'ap-northeast-2',
-  'ap-southeast-1': 'ap-southeast-1',
-  'ap-southeast-2': 'ap-southeast-2',
-  'ap-northeast-1': 'ap-northeast-1',
-  'eu-central-1': 'eu-central-1',
-  'eu-north-1': 'eu-central-1',
-  'eu-south-1': 'eu-central-1',
-  'eu-west-1': 'eu-west-1',
-  'eu-west-2': 'eu-west-2',
-  'eu-west-3': 'eu-west-1',
-  'me-south-1': 'ap-south-1',
-};
-
 /**
  * checks to see if the pinpoint app exists
  */
-export async function pinpointAppExist(pinpointProjectId: string): Promise<boolean> {
+export async function pinpointAppExist(pinpointProjectId: string, region: string): Promise<boolean> {
   let result = false;
 
   const pinpointClient = new Pinpoint({
     accessKeyId: settings.accessKeyId,
     secretAccessKey: settings.secretAccessKey,
     sessionToken: settings.sessionToken,
-    region: _.get(serviceRegionMap, settings.region, defaultPinpointRegion),
+    region,
   });
 
   try {

--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -60,12 +60,13 @@ describe('amplify delete', () => {
     const pinpointResourceName = await addPinpointAnalytics(projRoot);
     await pushToCloud(projRoot);
     const amplifyMeta = getProjectMeta(projRoot);
-    const pintpointAppId = amplifyMeta.analytics[pinpointResourceName].output.Id;
-    let pinpointAppExists = await pinpointAppExist(pintpointAppId);
+    const pinpointAppId = amplifyMeta.analytics[pinpointResourceName].output.Id;
+    const pinpointRegion = amplifyMeta.analytics[pinpointResourceName].Region;
+    let pinpointAppExists = await pinpointAppExist(pinpointAppId, pinpointRegion);
     expect(pinpointAppExists).toBeTruthy();
     await amplifyDelete(projRoot);
     await timeout(4 * 1000);
-    pinpointAppExists = await pinpointAppExist(pintpointAppId);
+    pinpointAppExists = await pinpointAppExist(pinpointAppId, pinpointRegion);
     expect(pinpointAppExists).toBeFalsy();
   });
 


### PR DESCRIPTION
#### Description of changes
- fixes pinpoint e2e client to use the region from amplifyMeta instead of a hardcoded region mapping

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
