### PR TITLE
chore: add linter to tagged e2e process

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -991,7 +991,6 @@ workflows:
                 - beta
                 - release
                 - /release_rc\/.*/
-                - /tagged-release-without-e2e-tests\/.*/
                 - /run-e2e\/.*/
       - verify-api-extract:
           requires:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
I recently created a tagged release that I left a debugger, and since the build doesn't run the linter (or yarn test), it wasn't caught until further down the QA process. We should add at least a few checkpoints to ensure the build is successful at runtime.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
