### PR TITLE
fix: add min delay to exp backoff

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/exp-backoff-executor.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/ssm-utils/exp-backoff-executor.ts
@@ -1,7 +1,8 @@
 export const executeSdkPromisesWithExponentialBackOff = async <T>(sdkPromises: (() => Promise<T>)[]): Promise<T[]> => {
   const MAX_RETRIES = 5;
   const MAX_BACK_OFF_IN_MS = 10 * 1000; // 10 seconds
-  let backOffSleepTimeInMs = 200;
+  const MIN_BACK_OFF_IN_MS = 1000; // 1 second
+  let backOffSleepTimeInMs = 500;
   let consecutiveRetries = 0;
 
   let i = 0;
@@ -11,7 +12,7 @@ export const executeSdkPromisesWithExponentialBackOff = async <T>(sdkPromises: (
       promiseResults.push(await sdkPromises[i]());
       ++i;
       // In case previously throttled, reset backoff
-      backOffSleepTimeInMs = 200;
+      backOffSleepTimeInMs = 500;
       consecutiveRetries = 0;
     } catch (e) {
       if (e?.code === 'ThrottlingException' || e?.code === 'Throttling') {
@@ -19,7 +20,7 @@ export const executeSdkPromisesWithExponentialBackOff = async <T>(sdkPromises: (
           ++consecutiveRetries;
           await new Promise((resolve) => setTimeout(resolve, backOffSleepTimeInMs));
           backOffSleepTimeInMs = 2 ** consecutiveRetries * backOffSleepTimeInMs;
-          backOffSleepTimeInMs = Math.min(Math.random() * backOffSleepTimeInMs, MAX_BACK_OFF_IN_MS);
+          backOffSleepTimeInMs = Math.max(Math.min(Math.random() * backOffSleepTimeInMs, MAX_BACK_OFF_IN_MS), MIN_BACK_OFF_IN_MS);
           continue;
         }
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR updates the exponential backoff logic for AWS-SDK calls to Parameter Store
- Add a minimum 1 second delay between retried calls
- Increase the base retry delay from 200ms to 500ms

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
