### PR TITLE
chore: add e2e test for studio-modelgen using schema with connected PK

### DIFF
--- a/packages/amplify-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-e2e-core/src/categories/codegen.ts
@@ -14,12 +14,14 @@ export function generateModels(cwd: string): Promise<void> {
 
 export function generateModelIntrospection(cwd: string, outputDir?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['codegen', 'model-introspection', '--output-dir', outputDir || cwd], { cwd, stripColors: true }).run((err: Error) => {
-      if (!err) {
-        resolve();
-      } else {
-        reject(err);
-      }
-    });
+    spawn(getCLIPath(), ['codegen', 'model-introspection', '--output-dir', outputDir || cwd], { cwd, stripColors: true }).run(
+      (err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      },
+    );
   });
 }

--- a/packages/amplify-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-e2e-core/src/categories/codegen.ts
@@ -11,3 +11,15 @@ export function generateModels(cwd: string): Promise<void> {
     });
   });
 }
+
+export function generateModelIntrospection(cwd: string, outputDir?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['codegen', 'model-introspection', '--output-dir', outputDir || cwd], { cwd, stripColors: true }).run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}

--- a/packages/amplify-e2e-tests/schemas/modelgen/schema_with_connected_pk.graphql
+++ b/packages/amplify-e2e-tests/schemas/modelgen/schema_with_connected_pk.graphql
@@ -1,0 +1,10 @@
+type Post @model {
+  postId: ID! @primaryKey
+  node: PostNode! @belongsTo(fields: ["postId"])
+  title: String!
+}
+
+type PostNode @model {
+  id: ID!
+  post: Post! @hasOne
+}

--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
@@ -1,5 +1,304 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`upload Studio CMS assets on push of Studio enabled project able to generate and upload Codegen model artifacts for schema with connected PK 1`] = `
+"type Post @model {
+  postId: ID! @primaryKey
+  node: PostNode! @belongsTo(fields: [\\"postId\\"])
+  title: String!
+}
+
+type PostNode @model {
+  id: ID!
+  post: Post! @hasOne
+}
+"
+`;
+
+exports[`upload Studio CMS assets on push of Studio enabled project able to generate and upload Codegen model artifacts for schema with connected PK 2`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"node\\": {
+                    \\"name\\": \\"node\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"PostNode\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"PostNode\\": {
+            \\"name\\": \\"PostNode\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"postNodePostPostId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postNodePostPostId\\": {
+                    \\"name\\": \\"postNodePostPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"PostNodes\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.0\\",
+    \\"version\\": \\"fafa7133cfec88f3e9d66076b888372a\\"
+};"
+`;
+
+exports[`upload Studio CMS assets on push of Studio enabled project able to generate and upload Codegen model artifacts for schema with connected PK 3`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"node\\": {
+                    \\"name\\": \\"node\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"PostNode\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": true,
+                \\"primaryKeyFieldName\\": \\"postId\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"PostNode\\": {
+            \\"name\\": \\"PostNode\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"postNodePostPostId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postNodePostPostId\\": {
+                    \\"name\\": \\"postNodePostPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"PostNodes\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}"
+`;
+
 exports[`upload Studio CMS assets on push of Studio enabled project uploads expected CMS assets to shared location in S3 bucket 2`] = `
 "export const schema = {
     \\"models\\": {

--- a/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
@@ -69,7 +69,7 @@ describe('upload Studio CMS assets on push of Studio enabled project', () => {
 
   it('able to generate and upload Codegen model artifacts for schema with connected PK', async () => {
     // eslint-disable-next-line spellcheck/spell-checker
-    const name = 'studiocmstestwithconnectedpk';
+    const name = 'pkmodelgen';
     const schemaName = 'modelgen/schema_with_connected_pk.graphql';
     const defaultsSettings = {
       disableAmplifyAppCreation: false,

--- a/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
@@ -11,6 +11,9 @@ import {
   updateApiSchema,
   getDeploymentBucketObject,
   getProjectConfig,
+  addFeatureFlag,
+  generateModels,
+  generateModelIntrospection
 } from '@aws-amplify/amplify-e2e-core';
 
 describe('upload Studio CMS assets on push of Studio enabled project', () => {
@@ -77,6 +80,7 @@ describe('upload Studio CMS assets on push of Studio enabled project', () => {
     };
     // init an android project to check that studio modelgen generates JS types even with other frontend config
     await initAndroidProjectWithProfile(projRoot, defaultsSettings);
+    await addFeatureFlag(projRoot, 'graphqltransformer', 'respectprimarykeyattributesonconnectionfield', false);
 
     const originalProjectConfig = getProjectConfig(projRoot);
 
@@ -94,6 +98,8 @@ describe('upload Studio CMS assets on push of Studio enabled project', () => {
 
     await addApiWithBlankSchemaAndConflictDetection(projRoot, { transformerVersion: 2 });
     await updateApiSchema(projRoot, name, schemaName);
+    await expect(generateModels(projRoot)).resolves.not.toThrow();
+    await expect(generateModelIntrospection(projRoot)).resolves.not.toThrow();
     await amplifyPush(projRoot);
 
     // expect CMS assets to be present in S3

--- a/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/studio-modelgen.test.ts
@@ -13,7 +13,7 @@ import {
   getProjectConfig,
   addFeatureFlag,
   generateModels,
-  generateModelIntrospection
+  generateModelIntrospection,
 } from '@aws-amplify/amplify-e2e-core';
 
 describe('upload Studio CMS assets on push of Studio enabled project', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add e2e test for Studio modelgen job using a schema that has primary key as a connected field.
This added test will fail if the below linked issue exists. I've confirmed this by running the same test with CLI `11.0.4` and it fails during generation of introspection schema.

![Screen Shot 2023-04-17 at 7 47 44 PM](https://user-images.githubusercontent.com/55896475/232657683-c3bcd956-3d19-4625-9dd5-55d1b982071f.png)


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/1399

#### Description of how you validated changes
Running the full e2e suite - please follow the PR checks below to see e2e test status.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
