### PR TITLE
fix(amplify-util-uibuilder): fix icon regression

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-prompts": "2.6.8",
-    "@aws-amplify/codegen-ui": "2.12.1",
-    "@aws-amplify/codegen-ui-react": "2.12.1",
+    "@aws-amplify/codegen-ui": "2.12.2",
+    "@aws-amplify/codegen-ui-react": "2.12.2",
     "amplify-cli-core": "4.0.3",
     "amplify-codegen": "3.4.2",
     "aws-sdk": "^2.1233.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,21 +194,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.12.1":
-  version "2.12.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.12.1.tgz#7fe833c0845462072a29612cff5aebb0a9e42b71"
-  integrity sha512-gmAVSxt9EPkqW7Ti1zFPIMUqFWQSbrBrRU04fKBp5vpnRTlS2G9su1+lKxmja33CCk8mSUPVpd35nI/GF2iKeA==
+"@aws-amplify/codegen-ui-react@2.12.2":
+  version "2.12.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.12.2.tgz#5ced006240fd71d82ec25a19f46703320465becb"
+  integrity sha512-NqBcgDmCfjMiBV8CrSTLv5nREMPXk/uMV/6aA7G9y3CRtbexiHUwuU0x4C8AiEFO3rUxI5h7YRBOi0d+8XUw3g==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.12.1"
+    "@aws-amplify/codegen-ui" "2.12.2"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.12.1":
-  version "2.12.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.12.1.tgz#d6a991e3db6883e14f835af4f88b1bcfe5af2072"
-  integrity sha512-4uqzNA2xyaKjzMFfntzvwZEmJzKAumqVnXV0S+XPsrqreDfnzfxldYv/v3JQsQE4e5NjK/08BsWxm0jCkifAHw==
+"@aws-amplify/codegen-ui@2.12.2":
+  version "2.12.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.12.2.tgz#7b07a86a04c3dfbc1940f877a6af45280fdb4e85"
+  integrity sha512-Km1EY3yJKTPlx2prAktZv5NktIBO98ydLygBQ+FA3eNgJdpw7N55+FEt/eZyoeUPthA9KnzzENuMN8RV+v5Ppw==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Icon processing is broken because the schemas are saved with lower-cased "object" as the value type. We had added a condition that starts rendering this type as a string instead of an actual array.

#### Description of how you validated changes
Testing in the codegen-ui repo.
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/19080/workflows/be8d34f8-3fa5-419e-88a9-0240a6511161

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
