### PR TITLE
fix: double hooks invocation (fixes #9996)

### DIFF
--- a/packages/amplify-cli-core/src/hooks/hooksExecutor.ts
+++ b/packages/amplify-cli-core/src/hooks/hooksExecutor.ts
@@ -34,17 +34,15 @@ export const executeHooks = async (hooksMetadata: HooksMeta): Promise<void> => {
 
   const hooksConfig: HooksConfig = stateManager.getHooksConfigJson(projectPath) ?? {};
 
-  const { commandHookFileMeta, subCommandHookFileMeta } = getHookFileMetadata(hooksDirPath, hooksMetadata.getHookEvent(), hooksConfig);
-
-  const executionQueue = [commandHookFileMeta, subCommandHookFileMeta];
-
   if (hooksMetadata.getHookEvent().forcePush) {
     // we want to run push related hooks when forcePush flag is enabled
     hooksMetadata.setEventCommand('push');
     hooksMetadata.setEventSubCommand(undefined);
-    const { commandHookFileMeta } = getHookFileMetadata(hooksDirPath, hooksMetadata.getHookEvent(), hooksConfig);
-    executionQueue.push(commandHookFileMeta);
   }
+
+  const { commandHookFileMeta, subCommandHookFileMeta } = getHookFileMetadata(hooksDirPath, hooksMetadata.getHookEvent(), hooksConfig);
+
+  const executionQueue = [commandHookFileMeta, subCommandHookFileMeta];
 
   for (const execFileMeta of executionQueue) {
     if (!execFileMeta) {

--- a/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
@@ -1,12 +1,10 @@
 import {
   addFunction,
-  amplifyPullNonInteractive,
   amplifyPushAuth,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
   getAmplifyInitConfig,
-  getBackendAmplifyMeta,
   getHooksDirPath,
   gitCleanFdX,
   gitCommitAll,
@@ -66,7 +64,7 @@ describe('runtime hooks', () => {
     await gitCleanFdX(projRoot);
 
     // simulate hosting deployment
-    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projRoot, 'integtest'))
+    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projRoot, 'integtest'));
     expect(fs.existsSync(hooksDirPath)).toBe(true);
     expect(fs.existsSync(prePushOutputFilePath)).toBe(true);
     expect(fs.existsSync(postPushOutputFilePath)).toBe(true);

--- a/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
@@ -16,7 +16,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 const appendHook = (pathToFile: string) =>
-`const fs = require('fs');
+  `const fs = require('fs');
 fs.appendFileSync('${pathToFile}', 'a');
 `;
 

--- a/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hooks-c.test.ts
@@ -1,0 +1,76 @@
+import {
+  addFunction,
+  amplifyPullNonInteractive,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getAmplifyInitConfig,
+  getBackendAmplifyMeta,
+  getHooksDirPath,
+  gitCleanFdX,
+  gitCommitAll,
+  gitInit,
+  initJSProjectWithProfile,
+  nonInteractiveInitWithForcePushAttach,
+} from '@aws-amplify/amplify-e2e-core';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+const appendHook = (pathToFile: string) =>
+`const fs = require('fs');
+fs.appendFileSync('${pathToFile}', 'a');
+`;
+
+describe('runtime hooks', () => {
+  let projRoot: string;
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('hooks');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('hooks should execute a single time on push and init --forcePush', async () => {
+    const prePushOutputFilename = 'pre-push-count.txt';
+    const postPushOutputFilename = 'post-push-count.txt';
+
+    await initJSProjectWithProfile(projRoot, { envName: 'integtest' });
+    await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'nodejs');
+
+    const hooksDirPath = getHooksDirPath(projRoot);
+    expect(fs.existsSync(hooksDirPath)).toBe(true);
+    fs.removeSync(path.join(hooksDirPath, 'pre-push.js.sample'));
+    fs.removeSync(path.join(hooksDirPath, 'post-push.sh.sample'));
+    const prePushOutputFilePath = path.join(hooksDirPath, prePushOutputFilename);
+    const postPushOutputFilePath = path.join(hooksDirPath, postPushOutputFilename);
+    fs.writeFileSync(path.join(hooksDirPath, 'pre-push.js'), appendHook(prePushOutputFilePath));
+    fs.writeFileSync(path.join(hooksDirPath, 'post-push.js'), appendHook(postPushOutputFilePath));
+    await amplifyPushAuth(projRoot);
+    expect(fs.existsSync(prePushOutputFilePath)).toBe(true);
+    expect(fs.existsSync(postPushOutputFilePath)).toBe(true);
+    expect(fs.readFileSync(prePushOutputFilePath, 'utf-8').length).toEqual(1);
+    expect(fs.readFileSync(postPushOutputFilePath, 'utf-8').length).toEqual(1);
+
+    // remove the output files
+    fs.removeSync(prePushOutputFilePath);
+    fs.removeSync(postPushOutputFilePath);
+    expect(fs.existsSync(prePushOutputFilePath)).toBe(false);
+    expect(fs.existsSync(postPushOutputFilePath)).toBe(false);
+
+    // init and commit to repository, remove files ignored by git
+    await gitInit(projRoot);
+    await gitCommitAll(projRoot);
+    await gitCleanFdX(projRoot);
+
+    // simulate hosting deployment
+    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projRoot, 'integtest'))
+    expect(fs.existsSync(hooksDirPath)).toBe(true);
+    expect(fs.existsSync(prePushOutputFilePath)).toBe(true);
+    expect(fs.existsSync(postPushOutputFilePath)).toBe(true);
+    expect(fs.readFileSync(prePushOutputFilePath, 'utf-8').length).toEqual(1);
+    expect(fs.readFileSync(postPushOutputFilePath, 'utf-8').length).toEqual(1);
+  });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
An error in the logic was causing post-push hooks to be invoked twice in hosting builds.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes #9996

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually tested both pre and post hooks with `amplify-dev init --envName dev --forcePush --yes`, added e2e test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
