### PR TITLE
fix: do not throw when localEnvInfo is missing on pull (fixes 12492)

### DIFF
--- a/packages/amplify-cli/src/commands/pull.ts
+++ b/packages/amplify-cli/src/commands/pull.ts
@@ -32,7 +32,7 @@ export const run = async (context: $TSContext): Promise<void> => {
 
   if (stateManager.currentMetaFileExists(projectPath)) {
     const { appId: inputAppId, envName: inputEnvName } = inputParams.amplify;
-    const { envName } = stateManager.getLocalEnvInfo(projectPath);
+    const { envName } = stateManager.getLocalEnvInfo(projectPath, { throwIfNotExist: false }) || {};
 
     const appId = getAmplifyAppId();
 

--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -173,3 +173,35 @@ export const amplifyStudioHeadlessPull = (
   const args = ['pull', '--amplify', JSON.stringify({ appId, envName }), '--providers', JSON.stringify(providersConfig), '--yes'];
   return spawn(getCLIPath(useDevCLI), args, { cwd, stripColors: true }).wait('Successfully pulled backend environment').runAsync();
 };
+
+/**
+ * Interrupt amplify pull command with Ctrl + C
+ */
+export const amplifyPullWithCtrlCOnFrameworkPrompt = (
+  cwd: string,
+  settings: {
+    appId: string;
+    envName?: string;
+  },
+  testingWithLatestCodebase = false,
+): Promise<void> => {
+  const args = ['pull', '--appId', settings.appId];
+
+  if (settings.envName) {
+    args.push('--envName', settings.envName);
+  }
+
+  const chain = spawn(getCLIPath(testingWithLatestCodebase), args, { cwd, stripColors: true })
+    .wait('Select the authentication method you want to use:')
+    .sendCarriageReturn()
+    .wait('Please choose the profile you want to use')
+    .sendCarriageReturn()
+    .wait('Choose your default editor:')
+    .sendCarriageReturn()
+    .wait("Choose the type of app that you're building")
+    .sendLine('javascript')
+    .wait('What javascript framework are you using')
+    .sendCtrlC();
+
+  return chain.runAsync();
+};

--- a/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull.test.ts
@@ -14,6 +14,7 @@ import {
   getBackendAmplifyMeta,
   getTeamProviderInfo,
   amplifyPullNonInteractive,
+  amplifyPullWithCtrlCOnFrameworkPrompt,
 } from '@aws-amplify/amplify-e2e-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -43,6 +44,18 @@ describe('amplify pull in two directories', () => {
     const appId = getAppId(projRoot);
     await amplifyPull(projRoot2, { appId, emptyDir: true, noUpdateBackend: true });
     await amplifyPull(projRoot2, { appId, noUpdateBackend: true });
+  });
+
+  it('works if previous pull is interrupted', async () => {
+    const envName = 'integtest';
+    await initJSProjectWithProfile(projRoot, {
+      disableAmplifyAppCreation: false,
+      envName,
+      name: 'testapi',
+    });
+    const appId = getAppId(projRoot);
+    await amplifyPullWithCtrlCOnFrameworkPrompt(projRoot2, { appId, envName });
+    await amplifyPull(projRoot2, { appId, envName, emptyDir: true });
   });
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Do not throw error if `amplify/.config/local-env-info.json` is missing when executing `amplify pull`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes #12492

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
e2e test passes locally, tested manually

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
