### PR TITLE
fix: update defaults for hosting S3 and remove dev option

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -448,9 +448,6 @@ jobs:
       - restore_cache:
           key: amplify-pkg-binaries-{{ .Branch }}-{{ .Revision }}
       - run:
-          name: Update OS Packages
-          command: sudo apt-get update
-      - run:
           name: Start verdaccio and Install Amplify CLI as sudo
           command: |
             source .circleci/local_publish_helpers.sh

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -64,7 +64,7 @@ function publish(context, service, args) {
       // checks if hosting with S3 and CloudFront and has a secure URL otherwise,
       // the user is hosting from S3 without CloudFront distribution and should throw an error
       if (service === 'S3AndCloudFront') {
-        const cfnOutput = context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output;
+        const cfnOutput = context.exeInfo?.amplifyMeta?.hosting?.S3AndCloudFront?.output;
         if (typeof cfnOutput === 'object' && cfnOutput.CloudFrontSecureURL === undefined) {
           throw new AmplifyError('ProjectPublishError', {
             message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -10,7 +10,6 @@ async function add(context) {
   const { availableServices, disabledServices } = categoryManager.getCategoryStatus(context);
 
   if (availableServices.length > 0) {
-    console.log(disabledServices.length);
     if (disabledServices.length > 1) {
       const selectedServices = await prompter.pick('Please select the service(s) to add.', disabledServices, {
         initial: 0,

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -62,12 +62,15 @@ function publish(context, service, args) {
 
   if (enabledServices.length > 0) {
     if (enabledServices.includes(service)) {
-      if (service === 'S3AndCloudFront' && context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output.CloudFrontSecureURL === undefined) {
-        throw new AmplifyError('ProjectPublishError', {
-          message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',
-          details: 'You will need to deploy your application to PROD or use this workaround for non-public dev apps only.',
-          link: 'https://github.com/aws-amplify/amplify-cli/issues/12503',
-        });
+      context.print.info(context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output);
+      if (service === 'S3AndCloudFront' && context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output) {
+        if (context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output['CloudFrontSecureURL'] === undefined) {
+          throw new AmplifyError('ProjectPublishError', {
+            message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',
+            details: 'You will need to deploy your application to PROD or use this workaround for non-public dev apps only.',
+            link: 'https://github.com/aws-amplify/amplify-cli/issues/12503',
+          });
+        }
       }
       return categoryManager.runServiceAction(context, service, 'publish', args);
     }

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -63,8 +63,9 @@ function publish(context, service, args) {
     if (enabledServices.includes(service)) {
       // checks if hosting with S3 and CloudFront and has a secure URL otherwise,
       // the user is hosting from S3 without CloudFront distribution and should throw an error
-      if (service === 'S3AndCloudFront' && context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output) {
-        if (context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output['CloudFrontSecureURL'] === undefined) {
+      if (service === 'S3AndCloudFront') {
+        let cfnOutput = context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output;
+        if (typeof cfnOutput === 'object' && cfnOutput.CloudFrontSecureURL === undefined) {
           throw new AmplifyError('ProjectPublishError', {
             message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',
             details: 'You will need to deploy your application to PROD or use this workaround for non-public dev apps only.',

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -64,7 +64,7 @@ function publish(context, service, args) {
       // checks if hosting with S3 and CloudFront and has a secure URL otherwise,
       // the user is hosting from S3 without CloudFront distribution and should throw an error
       if (service === 'S3AndCloudFront') {
-        let cfnOutput = context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output;
+        const cfnOutput = context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output;
         if (typeof cfnOutput === 'object' && cfnOutput.CloudFrontSecureURL === undefined) {
           throw new AmplifyError('ProjectPublishError', {
             message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -10,6 +10,7 @@ async function add(context) {
   const { availableServices, disabledServices } = categoryManager.getCategoryStatus(context);
 
   if (availableServices.length > 0) {
+    console.log(disabledServices.length);
     if (disabledServices.length > 1) {
       const selectedServices = await prompter.pick('Please select the service(s) to add.', disabledServices, {
         initial: 0,

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -1,3 +1,4 @@
+const { AmplifyError } = require('amplify-cli-core');
 const { prompter } = require('@aws-amplify/amplify-prompts');
 const sequential = require('promise-sequential');
 const path = require('path');
@@ -61,6 +62,13 @@ function publish(context, service, args) {
 
   if (enabledServices.length > 0) {
     if (enabledServices.includes(service)) {
+      if (service === 'S3AndCloudFront' && context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output.CloudFrontSecureURL === undefined) {
+        throw new AmplifyError('ProjectPublishError', {
+          message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',
+          details: 'You will need to deploy your application to PROD or use this workaround for non-public dev apps only.',
+          link: 'https://github.com/aws-amplify/amplify-cli/issues/12503',
+        });
+      }
       return categoryManager.runServiceAction(context, service, 'publish', args);
     }
     throw new Error(`Hosting service ${service} is NOT enabled.`);

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -59,11 +59,9 @@ async function configure(context) {
 
 function publish(context, service, args) {
   const { enabledServices } = categoryManager.getCategoryStatus(context);
-
   if (enabledServices.length > 0) {
     if (enabledServices.includes(service)) {
-      context.print.info(context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output);
-      if (service === 'S3AndCloudFront' && context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output) {
+      if (service === 'S3AndCloudFront' && context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output) {
         if (context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output['CloudFrontSecureURL'] === undefined) {
           throw new AmplifyError('ProjectPublishError', {
             message: 'You are trying to host an application without a CloudFront distribution. This is not supported on S3 by default.',

--- a/packages/amplify-category-hosting/index.js
+++ b/packages/amplify-category-hosting/index.js
@@ -61,6 +61,8 @@ function publish(context, service, args) {
   const { enabledServices } = categoryManager.getCategoryStatus(context);
   if (enabledServices.length > 0) {
     if (enabledServices.includes(service)) {
+      // checks if hosting with S3 and CloudFront and has a secure URL otherwise,
+      // the user is hosting from S3 without CloudFront distribution and should throw an error
       if (service === 'S3AndCloudFront' && context.exeInfo?.amplifyMeta.hosting.S3AndCloudFront.output) {
         if (context.exeInfo.amplifyMeta.hosting.S3AndCloudFront.output['CloudFrontSecureURL'] === undefined) {
           throw new AmplifyError('ProjectPublishError', {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -6,29 +6,24 @@ const sequential = require('promise-sequential');
 const fileScanner = require('./file-scanner');
 const constants = require('../../constants');
 
-const category = 'hosting';
 const serviceName = 'S3AndCloudFront';
 const providerName = 'awscloudformation';
 
 async function run(context, distributionDirPath) {
   const { WebsiteConfiguration } = context.exeInfo.template.Resources.S3Bucket.Properties;
-  const { output } = context.exeInfo.amplifyMeta[category][serviceName];
   const fileList = fileScanner.scan(context, distributionDirPath, WebsiteConfiguration);
 
   const uploadFileTasks = [];
   const s3Client = await getS3Client(context, 'update');
   const hostingBucketName = getHostingBucketName(context);
 
-  let cloudFrontS3CanonicalUserId;
-  if (context.exeInfo.template.Resources.OriginAccessIdentity && output.CloudFrontOriginAccessIdentity) {
-    const cloudFrontClient = await getCloudFrontClient(context, 'retrieve');
-    const params = { Id: output.CloudFrontOriginAccessIdentity };
-    const originAccessIdentity = await cloudFrontClient.getCloudFrontOriginAccessIdentity(params).promise();
-    cloudFrontS3CanonicalUserId = originAccessIdentity.S3CanonicalUserId;
+  let hasCloudFront = false;
+  if (context.exeInfo.template.Resources.CloudFrontDistribution) {
+    hasCloudFront = true;
   }
 
-  fileList.forEach((filePath) => {
-    uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, cloudFrontS3CanonicalUserId));
+  fileList.forEach(filePath => {
+    uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
   });
 
   const spinner = new Ora('Uploading files.');
@@ -49,19 +44,12 @@ async function getS3Client(context, action) {
   return new aws.S3();
 }
 
-async function getCloudFrontClient(context, action) {
-  const providerPlugins = context.amplify.getProviderPlugins(context);
-  const provider = require(providerPlugins[providerName]);
-  const aws = await provider.getConfiguredAWSClient(context, constants.CategoryName, action);
-  return new aws.CloudFront();
-}
-
 function getHostingBucketName(context) {
   const { amplifyMeta } = context.exeInfo;
   return amplifyMeta[constants.CategoryName][serviceName].output.HostingBucketName;
 }
 
-async function uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, cloudFrontS3CanonicalUserId) {
+async function uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront) {
   let relativeFilePath = path.relative(distributionDirPath, filePath);
   // make Windows-style relative paths compatible to S3
   relativeFilePath = relativeFilePath.replace(/\\/g, '/');
@@ -75,9 +63,7 @@ async function uploadFile(s3Client, hostingBucketName, distributionDirPath, file
     ContentType: contentType || 'text/plain',
   };
 
-  if (cloudFrontS3CanonicalUserId) {
-    uploadParams.GrantRead = `id=${cloudFrontS3CanonicalUserId}`;
-  } else {
+  if (!hasCloudFront) {
     uploadParams.ACL = 'public-read';
   }
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -17,7 +17,7 @@ async function run(context, distributionDirPath) {
   const s3Client = await getS3Client(context, 'update');
   const hostingBucketName = getHostingBucketName(context);
 
-  const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution
+  const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution;
 
   fileList.forEach(filePath => {
     uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -17,10 +17,7 @@ async function run(context, distributionDirPath) {
   const s3Client = await getS3Client(context, 'update');
   const hostingBucketName = getHostingBucketName(context);
 
-  let hasCloudFront = false;
-  if (context.exeInfo.template.Resources.CloudFrontDistribution) {
-    hasCloudFront = true;
-  }
+  const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution
 
   fileList.forEach(filePath => {
     uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -13,9 +13,9 @@ const providerPlugin = 'awscloudformation';
 const templateFileName = 'template.json';
 const parametersFileName = 'parameters.json';
 
-const DEV = 'DEV (S3 only with HTTP)';
+// const DEV = 'DEV (S3 only with HTTP)';
 const PROD = 'PROD (S3 with CloudFront using HTTPS)';
-const Environments = [DEV, PROD];
+const Environments = [PROD];
 
 async function enable(context) {
   let templateFilePath = path.join(__dirname, templateFileName);
@@ -53,23 +53,19 @@ async function enable(context) {
 }
 
 async function checkCDN(context) {
-  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(DEV) });
-  if (answer === DEV) {
-    removeCDN(context);
-  } else {
-    makeBucketPrivate(context);
-  }
+  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(PROD) });
+  makeBucketPrivate(context);
 }
 
-function removeCDN(context) {
-  delete context.exeInfo.template.Resources.OriginAccessIdentity;
-  delete context.exeInfo.template.Resources.CloudFrontDistribution;
-  delete context.exeInfo.template.Resources.PrivateBucketPolicy;
-  delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
-  delete context.exeInfo.template.Outputs.CloudFrontDomainName;
-  delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
-  delete context.exeInfo.template.Outputs.CloudFrontOriginAccessIdentity;
-}
+// function removeCDN(context) {
+//   delete context.exeInfo.template.Resources.OriginAccessIdentity;
+//   delete context.exeInfo.template.Resources.CloudFrontDistribution;
+//   delete context.exeInfo.template.Resources.PrivateBucketPolicy;
+//   delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
+//   delete context.exeInfo.template.Outputs.CloudFrontDomainName;
+//   delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
+//   delete context.exeInfo.template.Outputs.CloudFrontOriginAccessIdentity;
+// }
 
 function makeBucketPrivate(context) {
   delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -52,7 +52,6 @@ async function enable(context) {
 }
 
 async function checkCDN(context) {
-  await prompter.pick('Select the environment setup:', Environments, { initial: byValue(PROD) });
   makeBucketPrivate(context);
 }
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -13,7 +13,6 @@ const providerPlugin = 'awscloudformation';
 const templateFileName = 'template.json';
 const parametersFileName = 'parameters.json';
 
-// const DEV = 'DEV (S3 only with HTTP)';
 const PROD = 'PROD (S3 with CloudFront using HTTPS)';
 const Environments = [PROD];
 
@@ -53,19 +52,9 @@ async function enable(context) {
 }
 
 async function checkCDN(context) {
-  const answer = await prompter.pick('Select the environment setup:', Environments, { initial: byValue(PROD) });
+  await prompter.pick('Select the environment setup:', Environments, { initial: byValue(PROD) });
   makeBucketPrivate(context);
 }
-
-// function removeCDN(context) {
-//   delete context.exeInfo.template.Resources.OriginAccessIdentity;
-//   delete context.exeInfo.template.Resources.CloudFrontDistribution;
-//   delete context.exeInfo.template.Resources.PrivateBucketPolicy;
-//   delete context.exeInfo.template.Outputs.CloudFrontDistributionID;
-//   delete context.exeInfo.template.Outputs.CloudFrontDomainName;
-//   delete context.exeInfo.template.Outputs.CloudFrontSecureURL;
-//   delete context.exeInfo.template.Outputs.CloudFrontOriginAccessIdentity;
-// }
 
 function makeBucketPrivate(context) {
   delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -19,9 +19,6 @@ async function enable(context) {
   let parametersFilePath = path.join(__dirname, parametersFileName);
   context.exeInfo.parameters = context.amplify.readJsonFile(parametersFilePath);
 
-  // will take this out once cloudformation invoke and wait are separated;
-  await checkCDN(context);
-
   await configManager.init(context);
 
   if (context.parameters.options.p) {
@@ -45,14 +42,6 @@ async function enable(context) {
     providerPlugin,
   };
   return context.amplify.updateamplifyMetaAfterResourceAdd(constants.CategoryName, serviceName, metaData);
-}
-
-async function checkCDN(context) {
-  makeBucketPrivate(context);
-}
-
-function makeBucketPrivate(context) {
-  delete context.exeInfo.template.Resources.S3Bucket.Properties.AccessControl;
 }
 
 async function configure(context) {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/index.js
@@ -6,15 +6,11 @@ const configManager = require('./configuration-manager');
 const fileUPloader = require('./helpers/file-uploader');
 const cloudFrontManager = require('./helpers/cloudfront-manager');
 const constants = require('../constants');
-const { prompter, byValue } = require('amplify-prompts');
 
 const serviceName = 'S3AndCloudFront';
 const providerPlugin = 'awscloudformation';
 const templateFileName = 'template.json';
 const parametersFileName = 'parameters.json';
-
-const PROD = 'PROD (S3 with CloudFront using HTTPS)';
-const Environments = [PROD];
 
 async function enable(context) {
   let templateFilePath = path.join(__dirname, templateFileName);

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -198,11 +198,6 @@
         {
           "name": "hosting",
           "type": "category",
-          "packageName": "@aws-amplify/amplify-category-hosting"
-        },
-        {
-          "name": "hosting",
-          "type": "category",
           "packageName": "@aws-amplify/amplify-console-hosting"
         },
         {

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -198,6 +198,11 @@
         {
           "name": "hosting",
           "type": "category",
+          "packageName": "@aws-amplify/amplify-category-hosting"
+        },
+        {
+          "name": "hosting",
+          "type": "category",
           "packageName": "@aws-amplify/amplify-console-hosting"
         },
         {

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -5,30 +5,6 @@ import _ from 'lodash';
 import { spawnSync } from 'child_process';
 import { getBackendAmplifyMeta } from '../utils';
 
-export function addDEVHosting(cwd: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true })
-      .wait('Select the plugin module to execute')
-      .send(KEY_DOWN_ARROW)
-      .sendCarriageReturn()
-      .wait('Select the environment setup:')
-      .sendCarriageReturn()
-      .wait('hosting bucket name')
-      .sendCarriageReturn()
-      .wait('index doc for the website')
-      .sendCarriageReturn()
-      .wait('error doc for the website')
-      .sendCarriageReturn()
-      .run((err: Error) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(err);
-        }
-      });
-  });
-}
-
 export function enableContainerHosting(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['configure', 'project'], { cwd, stripColors: true })

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -49,9 +49,6 @@ export function addPRODHosting(cwd: string): Promise<void> {
       .wait('Select the plugin module to execute')
       .send(KEY_DOWN_ARROW)
       .sendCarriageReturn()
-      .wait('Select the environment setup:')
-      .send(KEY_DOWN_ARROW)
-      .sendCarriageReturn()
       .wait('hosting bucket name')
       .sendCarriageReturn()
       .run((err: Error) => {

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
@@ -5,7 +5,7 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addDEVHosting,
+  addPRODHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,
@@ -60,7 +60,6 @@ describe('amplify export pull a', () => {
   const AddandPushCategories = async (frontend?: string): Promise<void> => {
     await addAuthWithMaxOptions(projRoot, { frontend });
     await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
-    await addDEVHosting(projRoot);
     await addS3StorageWithIdpAuth(projRoot);
     await addConvert(projRoot);
     if (frontend === 'flutter') {

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
@@ -5,7 +5,6 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addPRODHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
@@ -5,7 +5,6 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addPRODHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
@@ -5,7 +5,7 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addDEVHosting,
+  addPRODHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,
@@ -64,7 +64,6 @@ describe('amplify export pull b', () => {
   const AddandPushCategories = async (frontend?: string): Promise<void> => {
     await addAuthWithMaxOptions(projRoot, { frontend });
     await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
-    await addDEVHosting(projRoot);
     await addS3StorageWithIdpAuth(projRoot);
     await addConvert(projRoot);
     if (frontend === 'flutter') {

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-c.test.ts
@@ -5,7 +5,6 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addDEVHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,
@@ -64,7 +63,6 @@ describe('amplify export pull c', () => {
   const AddandPushCategories = async (frontend?: string): Promise<void> => {
     await addAuthWithMaxOptions(projRoot, { frontend });
     await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
-    await addDEVHosting(projRoot);
     await addS3StorageWithIdpAuth(projRoot);
     await addConvert(projRoot);
     if (frontend === 'flutter') {

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-d.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-d.test.ts
@@ -5,7 +5,6 @@ import {
   addApiWithoutSchema,
   addAuthWithMaxOptions,
   addConvert,
-  addDEVHosting,
   addS3StorageWithIdpAuth,
   amplifyPush,
   amplifyPushWithoutCodegen,
@@ -59,7 +58,6 @@ describe('amplify export pull d', () => {
   const AddandPushCategories = async (frontend?: string): Promise<void> => {
     await addAuthWithMaxOptions(projRoot, { frontend });
     await addApiWithoutSchema(projRoot, { transformerVersion: 1 });
-    await addDEVHosting(projRoot);
     await addS3StorageWithIdpAuth(projRoot);
     await addConvert(projRoot);
     if (frontend === 'flutter') {

--- a/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hosting.test.ts
@@ -5,7 +5,7 @@ import {
   resetBuildCommand,
   initJSProjectWithProfile,
   deleteProject,
-  addDEVHosting,
+  addPRODHosting,
   removeHosting,
   amplifyPushWithoutCodegen,
   extractHostingBucketInfo,
@@ -23,7 +23,7 @@ describe('amplify add hosting', () => {
   beforeAll(async () => {
     projRoot = await createReactTestProject();
     await initJSProjectWithProfile(projRoot, {});
-    await addDEVHosting(projRoot);
+    await addPRODHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
   });
 

--- a/packages/amplify-e2e-tests/src/__tests__/s3-sse.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/s3-sse.test.ts
@@ -1,6 +1,5 @@
 import {
   addAuthWithDefault,
-  addDEVHosting,
   addS3,
   amplifyPushAuth,
   createNewProjectDir,
@@ -26,7 +25,6 @@ describe('amplify always enables SSE on S3 buckets', () => {
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addS3(projRoot);
-    await addDEVHosting(projRoot);
     await amplifyPushAuth(projRoot);
 
     const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/s3-sse.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/s3-sse.test.ts
@@ -1,5 +1,6 @@
 import {
   addAuthWithDefault,
+  addPRODHosting,
   addS3,
   amplifyPushAuth,
   createNewProjectDir,
@@ -25,6 +26,7 @@ describe('amplify always enables SSE on S3 buckets', () => {
     await initJSProjectWithProfile(projRoot, {});
     await addAuthWithDefault(projRoot);
     await addS3(projRoot);
+    await addPRODHosting(projRoot);
     await amplifyPushAuth(projRoot);
 
     const meta = getProjectMeta(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
@@ -7,6 +7,7 @@ import {
   getProjectMeta,
   getProjectTags,
   describeCloudFormationStack,
+  addPRODHosting,
   deleteS3Bucket,
   removeHosting,
   extractHostingBucketInfo,
@@ -37,6 +38,7 @@ describe('generated tags test', () => {
     const projName = 'tagsTest';
     const envName = 'devtag';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
+    await addPRODHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 
     // This block of code gets the necessary info to compare the values of both the local tags from the JSON file and tags on the stack

--- a/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
@@ -7,7 +7,6 @@ import {
   getProjectMeta,
   getProjectTags,
   describeCloudFormationStack,
-  addDEVHosting,
   deleteS3Bucket,
   removeHosting,
   extractHostingBucketInfo,
@@ -38,7 +37,6 @@ describe('generated tags test', () => {
     const projName = 'tagsTest';
     const envName = 'devtag';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
-    await addDEVHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
 
     // This block of code gets the necessary info to compare the values of both the local tags from the JSON file and tags on the stack


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->
#### Description of changes
Due to S3's new security changes, amplify-category-hosting's ability to use an S3 bucket to host a dev site no longer works by default. When a user runs `amplify publish`, they run into a `The bucket does not allow ACLs` error.

![Screenshot 2023-04-27 at 8 43 10 AM](https://user-images.githubusercontent.com/22283303/234902616-d26d5ce5-0640-4d6d-a6fd-e34fb1ab1fae.png)
![Screenshot 2023-04-27 at 8 43 17 AM](https://user-images.githubusercontent.com/22283303/234902652-e54d9343-dce9-45a4-88c4-f2d7d503630a.png)

The new experience would not allow developers to use Dev mode and attaches a CloudFront distribution by default.

![Screenshot 2023-04-27 at 9 02 02 AM](https://user-images.githubusercontent.com/22283303/234903006-54d7a04a-1e8b-47e7-b2af-e977c25ff549.png)
<img width="1158" alt="Screenshot 2023-04-27 at 10 58 13 AM" src="https://user-images.githubusercontent.com/22283303/234903807-55c8bef2-ea65-46c6-a550-39a8eb8f39d8.png">
<img width="589" alt="Screenshot 2023-04-27 at 10 58 21 AM" src="https://user-images.githubusercontent.com/22283303/234903804-087cb5ff-53b7-49e4-ab5c-66b3a797c75f.png">

If a user has a dev bucket with hosting enabled in HTTP, there's a workaround for that listed in #12503 

Info on S3 Change: S3 bucket with Access Control Lists enabled is removed and the ability to https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
#12503 
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
