### PR TITLE
fix: don't throw for missing backend-config in prepush function handler

### DIFF
--- a/packages/amplify-category-function/src/events/prePushHandler.ts
+++ b/packages/amplify-category-function/src/events/prePushHandler.ts
@@ -35,7 +35,9 @@ export const prePushHandler = async (context: $TSContext): Promise<void> => {
 };
 
 const ensureFunctionSecrets = async (context: $TSContext): Promise<void> => {
-  const backendConfig = stateManager.getBackendConfig();
+  const backendConfig = stateManager.getBackendConfig(undefined, {
+    throwIfNotExist: false,
+  });
   const functionNames = Object.keys(backendConfig?.[categoryName] || {});
   for (const funcName of functionNames) {
     if (getLocalFunctionSecretNames(funcName).length > 0) {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/ensure-lambda-arn-outputs.ts
@@ -12,7 +12,9 @@ import * as path from 'path';
  * updates function cfn stack with lambda execution role arn parameter
  */
 export const ensureLambdaExecutionRoleOutputs = async (): Promise<void> => {
-  const backendConfig = stateManager.getBackendConfig();
+  const backendConfig = stateManager.getBackendConfig(undefined, {
+    throwIfNotExist: false,
+  });
   const functionNames = Object.keys(backendConfig?.[AmplifyCategories.FUNCTION] ?? []);
   // filter lambda layer from lambdas in function
   const lambdaFunctionNames = functionNames.filter((functionName) => {


### PR DESCRIPTION
#### Description of changes

don't throw for missing backend-config.json in prepush function handler

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
