### PR TITLE
chore: enable deprecation warnings in non-prod CLI

### DIFF
--- a/packages/amplify-cli/bin/amplify
+++ b/packages/amplify-cli/bin/amplify
@@ -6,7 +6,6 @@ process.env.CLI_ENV = 'development';
 
 // suppress deprecation warnings
 process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1';
-process['noDeprecation'] = true;
 
 const startTime = Date.now();
 if (process.pkg) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

`cloudform` (not `cloudform-types` ! ) is now gone from all `package.json` files and `yarn.lock`. Therefore we bring back deprecation warnings when `amplify-dev` is used.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Green E2E test run

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
