### PR TITLE
fix: deploy category resources when calling amplify push <categoryName>

### DIFF
--- a/packages/amplify-cli/src/commands/build.ts
+++ b/packages/amplify-cli/src/commands/build.ts
@@ -44,9 +44,19 @@ export const run = async (context: $TSContext): Promise<void> => {
 /**
  * Returns resources in create or update state
  */
-export const getChangedResources = async (context: $TSContext, category?: string, resourceName?: string, filteredResources?: { category: string; resourceName: string }[]): Promise<IAmplifyResource[]> => {
+export const getChangedResources = async (
+  context: $TSContext,
+  category?: string,
+  resourceName?: string,
+  filteredResources?: { category: string; resourceName: string }[],
+): Promise<IAmplifyResource[]> => {
   const resources: IAmplifyResource[] = [];
-  const { resourcesToBeCreated, resourcesToBeUpdated } = await context.amplify.getResourceStatus(category, resourceName,'awscloudformation', filteredResources);
+  const { resourcesToBeCreated, resourcesToBeUpdated } = await context.amplify.getResourceStatus(
+    category,
+    resourceName,
+    'awscloudformation',
+    filteredResources,
+  );
   resourcesToBeCreated.forEach((resourceCreated: IAmplifyResource) => {
     resources.push({
       service: resourceCreated.service,

--- a/packages/amplify-cli/src/commands/build.ts
+++ b/packages/amplify-cli/src/commands/build.ts
@@ -44,9 +44,9 @@ export const run = async (context: $TSContext): Promise<void> => {
 /**
  * Returns resources in create or update state
  */
-export const getChangedResources = async (context: $TSContext): Promise<IAmplifyResource[]> => {
+export const getChangedResources = async (context: $TSContext, category?: string, resourceName?: string, filteredResources?: { category: string; resourceName: string }[]): Promise<IAmplifyResource[]> => {
   const resources: IAmplifyResource[] = [];
-  const { resourcesToBeCreated, resourcesToBeUpdated } = await context.amplify.getResourceStatus();
+  const { resourcesToBeCreated, resourcesToBeUpdated } = await context.amplify.getResourceStatus(category, resourceName,'awscloudformation', filteredResources);
   resourcesToBeCreated.forEach((resourceCreated: IAmplifyResource) => {
     resources.push({
       service: resourceCreated.service,

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -44,7 +44,7 @@ export const pushResources = async (
     }
     context.exeInfo.iterativeRollback = true;
   }
-  // amplify push <envName> ?
+
   if (context.parameters.options?.env) {
     const envName: string = context.parameters.options.env;
     const allEnvs = context.amplify.getAllEnvs();

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -44,7 +44,7 @@ export const pushResources = async (
     }
     context.exeInfo.iterativeRollback = true;
   }
-// amplify push <envName> ?
+  // amplify push <envName> ?
   if (context.parameters.options?.env) {
     const envName: string = context.parameters.options.env;
     const allEnvs = context.amplify.getAllEnvs();

--- a/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/push-resources.ts
@@ -44,7 +44,7 @@ export const pushResources = async (
     }
     context.exeInfo.iterativeRollback = true;
   }
-
+// amplify push <envName> ?
   if (context.parameters.options?.env) {
     const envName: string = context.parameters.options.env;
     const allEnvs = context.amplify.getAllEnvs();
@@ -73,7 +73,7 @@ export const pushResources = async (
 
   // building all CFN stacks here to get the resource Changes
   await generateDependentResourcesType();
-  const resourcesToBuild: IAmplifyResource[] = await getChangedResources(context);
+  const resourcesToBuild: IAmplifyResource[] = await getChangedResources(context, category, resourceName, filteredResources);
   await context.amplify.executeProviderUtils(context, 'awscloudformation', 'buildOverrides', {
     resourcesToBuild,
     forceCompile: true,

--- a/packages/amplify-e2e-core/src/init/amplifyPush.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPush.ts
@@ -244,6 +244,26 @@ export const amplifyPushFunction = async (cwd: string, testingWithLatestCode = f
 };
 
 /**
+ * amplify push command for pushing amplify category resources
+ */
+export const amplifyPushCategoryWithYesFlag = async (
+  cwd: string,
+  category: string,
+  changesDetected: boolean,
+  testingWithLatestCode = false,
+): Promise<void> => {
+  const chain = spawn(getCLIPath(testingWithLatestCode), ['push', `${category}`], {
+    cwd,
+    stripColors: true,
+    noOutputTimeout: pushTimeoutMS,
+  });
+  if (changesDetected) {
+    chain.wait('Are you sure you want to continue?').sendCarriageReturn();
+  }
+  return chain.runAsync();
+};
+
+/**
  * Function to test amplify push with allowDestructiveUpdates flag and when dependent function is removed from schema.graphql
  */
 export function amplifyPushUpdateForDependentModel(

--- a/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
@@ -1,49 +1,64 @@
-import { generateRandomShortId, initJSProjectWithProfile, addApi, updateApiSchema, getBackendConfig, addFunction, functionBuild, amplifyPush, getProjectMeta, getFunction, invokeFunction, createNewProjectDir, deleteProject, deleteProjectDir, amplifyPushFunction, removeFunction } from "@aws-amplify/amplify-e2e-core";
-
+import {
+  generateRandomShortId,
+  initJSProjectWithProfile,
+  addApi,
+  updateApiSchema,
+  getBackendConfig,
+  addFunction,
+  functionBuild,
+  amplifyPush,
+  getProjectMeta,
+  getFunction,
+  invokeFunction,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  amplifyPushFunction,
+  removeFunction,
+} from '@aws-amplify/amplify-e2e-core';
 
 describe('amplify push function cases:', () => {
-    let projRoot: string;
-  
-    beforeEach(async () => {
-      projRoot = await createNewProjectDir('lambda-appsync-nodejs');
-    });
-  
-    afterEach(async () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('lambda-appsync-nodejs');
+  });
+
+  afterEach(async () => {
     //   await deleteProject(projRoot);
     //   deleteProjectDir(projRoot);
-    });
+  });
 
-    it('Test case when IAM is set as default auth', async () => {
-        const projName = `iammodel${generateRandomShortId()}`;
+  it('Test case when IAM is set as default auth', async () => {
+    const projName = `iammodel${generateRandomShortId()}`;
 
-        await initJSProjectWithProfile(projRoot, { name: projName });
+    await initJSProjectWithProfile(projRoot, { name: projName });
 
-        await addApi(projRoot, { IAM: {}, transformerVersion: 2 });
-        await updateApiSchema(projRoot, projName, 'iam_simple_model.graphql');
+    await addApi(projRoot, { IAM: {}, transformerVersion: 2 });
+    await updateApiSchema(projRoot, projName, 'iam_simple_model.graphql');
 
-        expect(getBackendConfig(projRoot)).toBeDefined();
+    expect(getBackendConfig(projRoot)).toBeDefined();
 
-        const beforeMeta = getBackendConfig(projRoot);
-        const apiName = Object.keys(beforeMeta.api)[0];
+    const beforeMeta = getBackendConfig(projRoot);
+    const apiName = Object.keys(beforeMeta.api)[0];
 
-        expect(apiName).toBeDefined();
+    expect(apiName).toBeDefined();
 
-        await addFunction(
-        projRoot,
-        {
-            functionTemplate: 'AppSync - GraphQL API request (with IAM)',
-            additionalPermissions: {
-            permissions: ['api'],
-            choices: ['api'],
-            resources: [apiName],
-            operations: ['Query'],
-            name: 'functoosh'
-            },
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'AppSync - GraphQL API request (with IAM)',
+        additionalPermissions: {
+          permissions: ['api'],
+          choices: ['api'],
+          resources: [apiName],
+          operations: ['Query'],
+          name: 'functoosh',
         },
-        'nodejs',
-        );
-        // should fail
-        await amplifyPushFunction(projRoot);
-        
-    });
+      },
+      'nodejs',
+    );
+    // should fail
+    await amplifyPushFunction(projRoot);
+  });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
@@ -25,8 +25,8 @@ describe('amplify push function cases:', () => {
   });
 
   afterEach(async () => {
-    //   await deleteProject(projRoot);
-    //   deleteProjectDir(projRoot);
+      await deleteProject(projRoot);
+      deleteProjectDir(projRoot);
   });
 
   it('Test case when IAM is set as default auth', async () => {
@@ -36,29 +36,6 @@ describe('amplify push function cases:', () => {
 
     await addApi(projRoot, { IAM: {}, transformerVersion: 2 });
     await updateApiSchema(projRoot, projName, 'iam_simple_model.graphql');
-
-    expect(getBackendConfig(projRoot)).toBeDefined();
-
-    const beforeMeta = getBackendConfig(projRoot);
-    const apiName = Object.keys(beforeMeta.api)[0];
-
-    expect(apiName).toBeDefined();
-
-    await addFunction(
-      projRoot,
-      {
-        functionTemplate: 'AppSync - GraphQL API request (with IAM)',
-        additionalPermissions: {
-          permissions: ['api'],
-          choices: ['api'],
-          resources: [apiName],
-          operations: ['Query'],
-          name: 'functoosh',
-        },
-      },
-      'nodejs',
-    );
-    // should fail
     await amplifyPushFunction(projRoot);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_12.test.ts
@@ -1,0 +1,49 @@
+import { generateRandomShortId, initJSProjectWithProfile, addApi, updateApiSchema, getBackendConfig, addFunction, functionBuild, amplifyPush, getProjectMeta, getFunction, invokeFunction, createNewProjectDir, deleteProject, deleteProjectDir, amplifyPushFunction, removeFunction } from "@aws-amplify/amplify-e2e-core";
+
+
+describe('amplify push function cases:', () => {
+    let projRoot: string;
+  
+    beforeEach(async () => {
+      projRoot = await createNewProjectDir('lambda-appsync-nodejs');
+    });
+  
+    afterEach(async () => {
+    //   await deleteProject(projRoot);
+    //   deleteProjectDir(projRoot);
+    });
+
+    it('Test case when IAM is set as default auth', async () => {
+        const projName = `iammodel${generateRandomShortId()}`;
+
+        await initJSProjectWithProfile(projRoot, { name: projName });
+
+        await addApi(projRoot, { IAM: {}, transformerVersion: 2 });
+        await updateApiSchema(projRoot, projName, 'iam_simple_model.graphql');
+
+        expect(getBackendConfig(projRoot)).toBeDefined();
+
+        const beforeMeta = getBackendConfig(projRoot);
+        const apiName = Object.keys(beforeMeta.api)[0];
+
+        expect(apiName).toBeDefined();
+
+        await addFunction(
+        projRoot,
+        {
+            functionTemplate: 'AppSync - GraphQL API request (with IAM)',
+            additionalPermissions: {
+            permissions: ['api'],
+            choices: ['api'],
+            resources: [apiName],
+            operations: ['Query'],
+            name: 'functoosh'
+            },
+        },
+        'nodejs',
+        );
+        // should fail
+        await amplifyPushFunction(projRoot);
+        
+    });
+});

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -191,11 +191,14 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
     /**
      * calling transform schema here to support old project with out overrides
      */
-    await ApiCategoryFacade.transformGraphQLSchema(context, {
-      handleMigration: (opts) => updateStackForAPIMigration(context, 'api', undefined, opts),
-      minify: options.minify || context.input.options?.minify,
-      promptApiKeyCreation: true,
-    });
+    const appSyncAPIPresent = resources.filter((resource: { service: string }) => resource.service === 'AppSync');
+    if(appSyncAPIPresent.length > 0){
+      await ApiCategoryFacade.transformGraphQLSchema(context, {
+        handleMigration: (opts) => updateStackForAPIMigration(context, 'api', undefined, opts),
+        minify: options.minify || context.input.options?.minify,
+        promptApiKeyCreation: true,
+      });
+    }
 
     await prePushLambdaLayerPrompt(context, resources);
     await context.amplify.invokePluginMethod(

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -192,7 +192,7 @@ export const run = async (context: $TSContext, resourceDefinition: $TSObject, re
      * calling transform schema here to support old project with out overrides
      */
     const appSyncAPIPresent = resources.filter((resource: { service: string }) => resource.service === 'AppSync');
-    if(appSyncAPIPresent.length > 0){
+    if (appSyncAPIPresent.length > 0) {
       await ApiCategoryFacade.transformGraphQLSchema(context, {
         handleMigration: (opts) => updateStackForAPIMigration(context, 'api', undefined, opts),
         minify: options.minify || context.input.options?.minify,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- passed resource and category info to nested functions 
- only calling schema transform if api is getting deployed

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #12348 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/19710/workflows/3677e12c-cc33-4b2e-a195-782485133701

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
