### PR TITLE
fix(amplify-frontend-ios): encapsulate path option values with quotes

### DIFF
--- a/packages/amplify-frontend-ios/lib/amplify-xcode.js
+++ b/packages/amplify-frontend-ios/lib/amplify-xcode.js
@@ -33,7 +33,7 @@ const amplifyXcodePath = () => path.join(pathManager.getAmplifyPackageLibDirPath
 async function importConfig(params) {
   let command = `${amplifyXcodePath()} import-config`;
   if (params['path']) {
-    command += ` --path=${params['path']}`;
+    command += ` --path="${params['path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -46,7 +46,7 @@ async function importConfig(params) {
 async function importModels(params) {
   let command = `${amplifyXcodePath()} import-models`;
   if (params['path']) {
-    command += ` --path=${params['path']}`;
+    command += ` --path="${params['path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -59,7 +59,7 @@ async function importModels(params) {
 async function generateSchema(params) {
   let command = `${amplifyXcodePath()} generate-schema`;
   if (params['output-path']) {
-    command += ` --output-path=${params['output-path']}`;
+    command += ` --output-path="${params['output-path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

adds quotes to `--path` option values to prevent breaking when absolute path to amplify project contains spaces

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

fixes #12593

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
