### PR TITLE
chore: bump codegen version to 3.4.4

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -68,7 +68,7 @@
     "@aws-amplify/graphql-auth-transformer": "^2.1.3",
     "@aws-amplify/graphql-transformer-core": "^1.2.1",
     "@aws-cdk/cloudformation-diff": "~2.68.0",
-    "amplify-codegen": "^4.0.0",
+    "amplify-codegen": "^3.4.4",
     "amplify-dotnet-function-runtime-provider": "1.7.7",
     "amplify-go-function-runtime-provider": "2.3.17",
     "amplify-java-function-runtime-provider": "2.3.17",

--- a/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
+++ b/packages/amplify-e2e-tests/src/__tests__/__snapshots__/studio-modelgen.test.ts.snap
@@ -49,7 +49,7 @@ exports[`upload Studio CMS assets on push uploads expected CMS assets to shared 
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"3.4.3\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"6f85ca0ee370ac8e0674a44cc5a4f6a6\\"
 };"
 `;
@@ -161,7 +161,7 @@ exports[`upload Studio CMS assets on push uploads expected CMS assets to shared 
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"3.4.3\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"6f85ca0ee370ac8e0674a44cc5a4f6a6\\"
 };"
 `;
@@ -273,7 +273,7 @@ exports[`upload Studio CMS assets on push uploads expected CMS assets to shared 
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"3.4.3\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"6f85ca0ee370ac8e0674a44cc5a4f6a6\\"
 };"
 `;

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -37,7 +37,7 @@
     "@aws-amplify/cli-extensibility-helper": "3.0.4",
     "@aws-amplify/graphql-transformer-core": "^1.2.1",
     "@aws-amplify/graphql-transformer-interfaces": "^2.1.1",
-    "amplify-codegen": "^4.0.0",
+    "amplify-codegen": "^3.4.4",
     "archiver": "^5.3.0",
     "aws-cdk-lib": "~2.68.0",
     "aws-sdk": "^2.1354.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -40,7 +40,7 @@
     "@aws-amplify/amplify-prompts": "2.6.8",
     "@aws-amplify/amplify-provider-awscloudformation": "8.1.0",
     "@hapi/topo": "^5.0.0",
-    "amplify-codegen": "^4.0.0",
+    "amplify-codegen": "^3.4.4",
     "amplify-dynamodb-simulator": "2.6.0",
     "amplify-storage-simulator": "1.8.0",
     "chokidar": "^3.5.3",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -18,14 +18,14 @@
     "@aws-amplify/amplify-prompts": "2.6.8",
     "@aws-amplify/codegen-ui": "2.13.1",
     "@aws-amplify/codegen-ui-react": "2.13.1",
-    "amplify-codegen": "^4.0.0",
+    "amplify-codegen": "^3.4.4",
     "aws-sdk": "^2.1354.0",
     "fs-extra": "^8.1.0",
     "ora": "^4.0.3",
     "tiny-async-pool": "^2.1.0"
   },
   "devDependencies": {
-    "@aws-amplify/appsync-modelgen-plugin": "^2.4.0",
+    "@aws-amplify/appsync-modelgen-plugin": "^2.4.4",
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "^26.0.20",
     "@types/semver": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,10 +141,10 @@
     "@aws-amplify/api-graphql" "2.2.18"
     "@aws-amplify/api-rest" "2.0.29"
 
-"@aws-amplify/appsync-modelgen-plugin@2.4.3":
-  version "2.4.3"
-  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.4.3.tgz#6a5b456990df11c07e4a56d189a6212d191548e0"
-  integrity sha512-BIsPar7n3Zml0M8KqSbgUroRN24y+9CeZXvzp9zGw8NGYW0erDti5YOXIe0wGgznwfSsfBXze4OZJCt7omuAvQ==
+"@aws-amplify/appsync-modelgen-plugin@2.4.4", "@aws-amplify/appsync-modelgen-plugin@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.4.4.tgz#a4f49fa964e3ae83aca4f8e7c19e9c5788679644"
+  integrity sha512-+eFyuT0j9b35Vk+fI64uE50JCtMFCwp5J5XutFmZPXqR8LLnh4Zgpae7pULehj+HqDwAoiG5ZWbb3QjjfrpChg==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^1.18.8"
     "@graphql-codegen/visitor-plugin-common" "^1.22.0"
@@ -153,25 +153,6 @@
     "@types/pluralize" "0.0.29"
     chalk "^3.0.0"
     change-case "^4.1.1"
-    dart-style "1.3.2-dev"
-    lower-case-first "^2.0.1"
-    pluralize "^8.0.0"
-    strip-indent "^3.0.0"
-    ts-dedent "^1.1.0"
-
-"@aws-amplify/appsync-modelgen-plugin@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.4.0.tgz#0448d2d5938f7fa411ff34bb5b525e17f050bf30"
-  integrity sha512-cOXsQ9qcvc7q31riKJL7kYYQFpriFws6rAO2GG7xRwT+0Dqn5LACSAgPHXBMx8vXI4nQcEYZ/EtxTchD845U6Q==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.18.8"
-    "@graphql-codegen/visitor-plugin-common" "^1.22.0"
-    "@graphql-tools/utils" "^6.0.18"
-    "@types/node" "^12.12.6"
-    "@types/pluralize" "0.0.29"
-    chalk "^3.0.0"
-    change-case "^4.1.1"
-    dart-style "1.3.2-dev"
     lower-case-first "^2.0.1"
     pluralize "^8.0.0"
     strip-indent "^3.0.0"
@@ -282,10 +263,10 @@
     graphql-transformer-common "4.24.5"
     libphonenumber-js "1.9.47"
 
-"@aws-amplify/graphql-docs-generator@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.0.0.tgz#4ab5b47a88f53755b777d0ff5c48ed4d17d575a1"
-  integrity sha512-tjSxhi2IOrcskGdZEjzN3z4vmgWeLRO5XQovH8HQ3tDDvc8/F28iJ1F4P7NK9ognBJa8jGX7AHEoTuOvDjOccQ==
+"@aws-amplify/graphql-docs-generator@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.0.1.tgz#50ad04ab0d88d45408adf93d3ab2fc9969ac69bc"
+  integrity sha512-7K+9pJZnUwUAiLeOo0adrOzS2IDPFHYhsiDdJCnYP++wzQCc6JF60AEdluE+N9HbyeGaIYw9g4XoQV91RRPTIQ==
   dependencies:
     graphql "^15.5.0"
     handlebars "4.7.7"
@@ -437,10 +418,10 @@
     graphql-transformer-common "4.24.5"
     lodash "^4.17.21"
 
-"@aws-amplify/graphql-types-generator@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.0.1.tgz#739e98505687e21da2938e3e9e7b0d8444aefe3f"
-  integrity sha512-g9iUquLGiy2XLrOuJwFLSgnDmzOOpfakuKmanWMCV/u+GG5zCipsfU3SOyhhRCAF9JJwxOMhMYBoquJw/vrsiA==
+"@aws-amplify/graphql-types-generator@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.0.2.tgz#bf0a0ef54ea263408b0991484dcde7a3ffefd60a"
+  integrity sha512-jgZak4VWWhwAKMvyzGsGvqp+FYqb1zMb9yQPADgk4cBb5FIaMdP/bwvtB9hJJDWZlY0Vnbgtwwz+yQ0elBT13w==
   dependencies:
     "@babel/generator" "7.0.0-beta.4"
     "@babel/types" "7.0.0-beta.4"
@@ -10004,14 +9985,14 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-amplify-codegen@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-4.0.0.tgz#6b4a3516e86ef77181a0b3f93539468b8a222174"
-  integrity sha512-PpmLwpSc44R9/eqIcT4sCJp8Qju4nFvQQdu3iWW2iB3z7RSfVJsCJsufimff85UlzXDb51ePjtY2Mv9cVt3oUQ==
+amplify-codegen@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.npmjs.org/amplify-codegen/-/amplify-codegen-3.4.4.tgz#3ab60344932dc4209f7b698f6fbb6f6c888c65b8"
+  integrity sha512-cz5XcQcn+wgnoMpAVmFeHyk7OZl4gyvUSLyj3iv8bby8cc3wj3DkMabBikJvAYqdugR+bCYDMuYOEwkLwrmquA==
   dependencies:
-    "@aws-amplify/appsync-modelgen-plugin" "2.4.3"
-    "@aws-amplify/graphql-docs-generator" "4.0.0"
-    "@aws-amplify/graphql-types-generator" "3.0.1"
+    "@aws-amplify/appsync-modelgen-plugin" "2.4.4"
+    "@aws-amplify/graphql-docs-generator" "4.0.1"
+    "@aws-amplify/graphql-types-generator" "3.0.2"
     "@graphql-codegen/core" "2.6.6"
     chalk "^3.0.0"
     fs-extra "^8.1.0"
@@ -12928,11 +12909,6 @@ dargs@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
-
-dart-style@1.3.2-dev:
-  version "1.3.2-dev"
-  resolved "https://registry.npmjs.org/dart-style/-/dart-style-1.3.2-dev.tgz#d21a80ff0b7f9d800584ec6a6a659ac3242ac855"
-  integrity sha512-NFI4UQYvG32t/cEkQAdkXT2ZT72tjF61tMWoALmnGwj03d2Co94zwGfbnFfdQUQvrhUNx8Wz2jKSVxGrmFaVJQ==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Revert the `__typename` change in doc generator
- Downgrade amplify codegen to version 3 to avoid version mismatch error from JS datastore so that the CI jobs can stay healthy

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
