### PR TITLE
fix: use all settled promise method to wait until deletes are attempted

### DIFF
--- a/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
@@ -21,15 +21,14 @@ exports.handler = (event, context) => {
 
     hostedUIProviderMeta.forEach(({ ProviderName }) => providerPromises.push(deleteIdentityProvider(ProviderName)));
 
-    Promise.allSettled(providerPromises)
-      .then((results) => {
-        if (results.every(deleteSuccessOrNotFound)) {
-          response.send(event, context, response.SUCCESS);
-        } else {
-          const firstFailure = results.find((result) => result.status === 'rejected');
-          response.send(event, context, response.FAILED, firstFailure);
-        }
-      });
+    Promise.allSettled(providerPromises).then((results) => {
+      if (results.every(deleteSuccessOrNotFound)) {
+        response.send(event, context, response.SUCCESS);
+      } else {
+        const firstFailure = results.find((result) => result.status === 'rejected');
+        response.send(event, context, response.FAILED, firstFailure);
+      }
+    });
   } catch (err) {
     console.log(err.stack);
     response.send(event, context, response.FAILED, { err });

--- a/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/hostedUIProviderLambda.js
@@ -13,23 +13,22 @@ exports.handler = (event, context) => {
       return identity.deleteIdentityProvider(params).promise();
     };
 
+    const deleteSuccessOrNotFound = (promiseResult) => {
+      return promiseResult.status === 'fulfilled' || promiseResult.reason.toString().match(/NotFoundException/);
+    };
+
     const providerPromises = [];
 
     hostedUIProviderMeta.forEach(({ ProviderName }) => providerPromises.push(deleteIdentityProvider(ProviderName)));
 
-    Promise.all(providerPromises)
-      .then(() => {
-        response.send(event, context, response.SUCCESS);
-      })
-      .catch((err) => {
-        console.log(err.stack);
-
-        if (err.name === 'NotFoundException') {
+    Promise.allSettled(providerPromises)
+      .then((results) => {
+        if (results.every(deleteSuccessOrNotFound)) {
           response.send(event, context, response.SUCCESS);
-          return;
+        } else {
+          const firstFailure = results.find((result) => result.status === 'rejected');
+          response.send(event, context, response.FAILED, firstFailure);
         }
-
-        response.send(event, context, response.FAILED, { err });
       });
   } catch (err) {
     console.log(err.stack);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This changes this from `all` to `allSettled` to make sure that all the promises are resolved, and that the promise does not terminate on the first failure.

#### Description of how you validated changes

This will need to happen in the follow up e2e tests. An e2e test will be written that will delete the provider resource manually before the migration, then test that the stack update is successful. (@jhockett is working on that test)

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
