### PR TITLE
fix: add custom resource dependency to the newly created provider resources

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/__snapshots__/auth-stack-transform.test.ts.snap
@@ -1319,6 +1319,10 @@ Object {
     },
     "UserPoolClient": Object {
       "DependsOn": Array [
+        "HostedUIFacebookProviderResource",
+        "HostedUIGoogleProviderResource",
+        "HostedUILoginWithAmazonProviderResource",
+        "HostedUISignInWithAppleProviderResource",
         "UserPool",
       ],
       "Properties": Object {
@@ -1420,6 +1424,10 @@ Object {
     },
     "UserPoolClientWeb": Object {
       "DependsOn": Array [
+        "HostedUIFacebookProviderResource",
+        "HostedUIGoogleProviderResource",
+        "HostedUILoginWithAmazonProviderResource",
+        "HostedUISignInWithAppleProviderResource",
         "UserPool",
       ],
       "Properties": Object {

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/lambda-callout-migrations/__snapshots__/auth-cognito-stack-builder.test.ts.snap
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/lambda-callout-migrations/__snapshots__/auth-cognito-stack-builder.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`migrate step for removing lambda callouts createOpenIdcResource when create/update lambda callouts exist creates delete lambda callout and cfn-code-created provider 1`] = `
+"const response = require('cfn-response');
+const aws = require('aws-sdk');
+const iam = new aws.IAM();
+
+exports.handler = (event) => {
+  iam
+    .listOpenIDConnectProviders({})
+    .promise()
+    .then(async (data) => {
+      let providerArn;
+
+      if (data.OpenIDConnectProviderList && data.OpenIDConnectProviderList.length > 0) {
+        const providerArns = data.OpenIDConnectProviderList.map((x) => x.Arn);
+        providerArn = providerArns.find((i) => i.split('/')[1] === params.Url.split('//')[1]);
+      }
+
+      if (providerArn) {
+        await iam
+          .deleteOpenIDConnectProvider({ OpenIDConnectProviderArn: providerArn })
+          .promise()
+          .catch((err) => {
+            console.log(err);
+
+            if (err.name === 'NotFoundException') {
+              return response.send(event, context, response.SUCCESS);
+            }
+
+            response.send(event, context, response.FAILED, { err });
+          });
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+      response.send(event, context, response.FAILED, { err });
+    });
+};
+"
+`;

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/lambda-callout-migrations/auth-cognito-stack-builder.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/lambda-callout-migrations/auth-cognito-stack-builder.test.ts
@@ -163,9 +163,7 @@ describe('migrate step for removing lambda callouts', () => {
         const { openIdLambda, openIdcResource } = cognitoStack;
 
         expect(openIdLambda?.cfnResourceType).toBe('AWS::Lambda::Function');
-        expect((openIdLambda?.code as CfnFunction.CodeProperty).zipFile).toMatch(
-          'await iam.deleteOpenIDConnectProvider({ OpenIDConnectProviderArn: providerArn }).promise();',
-        );
+        expect((openIdLambda?.code as CfnFunction.CodeProperty).zipFile).toMatchSnapshot();
 
         expect(openIdcResource?.url).toEqual('https://accounts.google.com');
       });

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -1277,6 +1277,10 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
 
     const provider = new cognito.CfnUserPoolIdentityProvider(this, `HostedUI${ProviderName}ProviderResource`, resourceParams);
     this.hostedUIProviderResources.push(provider);
+
+    if (this.hostedUIProvidersCustomResource) {
+      provider.addDependency(this.hostedUIProvidersCustomResource);
+    }
   };
 
   createHostedUIProviderDetails = (providerName: string) => {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -1281,6 +1281,14 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
     if (this.hostedUIProvidersCustomResource) {
       provider.addDependency(this.hostedUIProvidersCustomResource);
     }
+
+    if (this.userPoolClient) {
+      this.userPoolClient.addDependency(provider);
+    }
+
+    if (this.userPoolClientWeb) {
+      this.userPoolClientWeb.addDependency(provider);
+    }
   };
 
   createHostedUIProviderDetails = (providerName: string) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Since there is a reference to the providers, this adds a dependency on the new Cognito third party provider resources for the clients.

This also fixes a test to capture a snapshot instead of the code snippet.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Updated the snapshots to include the dependencies. e2e tests are in progress on another branch.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
