### PR TITLE
fix: parse empty array when provider meta is undefined

### DIFF
--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/__snapshots__/auth-add-all.migration.test.ts.snap
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/__snapshots__/auth-add-all.migration.test.ts.snap
@@ -62,11 +62,19 @@ Resources
 [-] AWS::IAM::Policy HostedUICustomResourcePolicy destroy
 [-] AWS::IAM::Policy HostedUICustomResourceLogPolicy destroy
 [-] Custom::LambdaCallout HostedUICustomResourceInputs destroy
+[-] AWS::Lambda::Function HostedUIProvidersCustomResource destroy
+[-] AWS::IAM::Policy HostedUIProvidersCustomResourcePolicy destroy
+[-] AWS::IAM::Policy HostedUIProvidersCustomResourceLogPolicy destroy
+[-] Custom::LambdaCallout HostedUIProvidersCustomResourceInputs destroy
 [-] AWS::Lambda::Function OAuthCustomResource destroy
 [-] AWS::IAM::Policy OAuthCustomResourcePolicy destroy
 [-] AWS::IAM::Policy OAuthCustomResourceLogPolicy destroy
 [-] Custom::LambdaCallout OAuthCustomResourceInputs destroy
 [+] AWS::Cognito::UserPoolDomain HostedUIDomainResource 
+[+] AWS::Cognito::UserPoolIdentityProvider HostedUIFacebookProviderResource 
+[+] AWS::Cognito::UserPoolIdentityProvider HostedUIGoogleProviderResource 
+[+] AWS::Cognito::UserPoolIdentityProvider HostedUILoginWithAmazonProviderResource 
+[+] AWS::Cognito::UserPoolIdentityProvider HostedUISignInWithAppleProviderResource 
 [~] AWS::Cognito::UserPoolClient UserPoolClientWeb 
  ├─ [+] AllowedOAuthFlows
  │   └─ [\\"code\\"]
@@ -78,14 +86,8 @@ Resources
  │   └─ [\\"https://signin1/\\"]
  ├─ [+] LogoutURLs
  │   └─ [\\"https://signout1/\\"]
- ├─ [+] SupportedIdentityProviders
- │   └─ [\\"Facebook\\",\\"Google\\",\\"LoginWithAmazon\\",\\"SignInWithApple\\",\\"COGNITO\\"]
- └─ [~] DependsOn
-     └─ @@ -1,3 +1,4 @@
-        [ ] [
-        [+]   \\"HostedUIProvidersCustomResourceInputs\\",
-        [ ]   \\"UserPool\\"
-        [ ] ]
+ └─ [+] SupportedIdentityProviders
+     └─ [\\"Facebook\\",\\"Google\\",\\"LoginWithAmazon\\",\\"SignInWithApple\\",\\"COGNITO\\"]
 [~] AWS::Cognito::UserPoolClient UserPoolClient 
  ├─ [+] AllowedOAuthFlows
  │   └─ [\\"code\\"]

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -1200,7 +1200,7 @@ export const formNestedStack = async (
         }
 
         if (category === AmplifyCategories.AUTH && parameters.hostedUIProviderCreds && parameters.hostedUIProviderCreds !== '[]') {
-          const hostedUIProviderMeta = JSON.parse(parameters.hostedUIProviderMeta);
+          const hostedUIProviderMeta = JSON.parse(parameters.hostedUIProviderMeta || '[]');
           const hostedUIProviderCreds = JSON.parse(parameters.hostedUIProviderCreds);
 
           Object.assign(parameters, generateAuthNestedStackParameters(hostedUIProviderMeta, hostedUIProviderCreds));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Passes in an empty array to the parser when hosted provider meta is `undefined`.

This happens in some scenarios when auth is imported. Example failures:
- https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/19803/workflows/7cdaa460-1252-4856-82b9-e0c87a11e43b/jobs/943841/tests#failed-test-0
- https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/19803/workflows/7cdaa460-1252-4856-82b9-e0c87a11e43b/jobs/943845/tests#failed-test-0

This PR also adds some of the snapshot changes for the migration tests that show adding identity providers and removing the custom lambda callouts.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Fixed e2e tests will confirm the change works.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
