### PR TITLE
fix: usage data consent being shown on post init success.

### DIFF
--- a/packages/amplify-cli/src/app-config/debug-config.ts
+++ b/packages/amplify-cli/src/app-config/debug-config.ts
@@ -71,7 +71,7 @@ export class DebugConfig {
    * Gets the flag, throws error if not written to file
    */
   getCanSendReport(): boolean {
-    if (this.dirty) {
+    if (this.debug.shareProjectConfig === undefined) {
       throw new DebugConfigValueNotSetError();
     }
 

--- a/packages/amplify-cli/src/commands/diagnose.ts
+++ b/packages/amplify-cli/src/commands/diagnose.ts
@@ -97,7 +97,6 @@ const zipSend = async (context: Context, skipPrompts: boolean, error: Error | un
     DebugConfig.Instance.getCanSendReport();
   } catch (DebugConfigValueNotSetError) {
     const result = await prompter.yesOrNo('Help improve Amplify CLI by sharing non sensitive configurations on failures', false);
-    console.log(result);
     DebugConfig.Instance.setAndWriteShareProject(result);
   }
 

--- a/packages/amplify-cli/src/commands/diagnose.ts
+++ b/packages/amplify-cli/src/commands/diagnose.ts
@@ -1,4 +1,12 @@
-import { stateManager, pathManager, spinner, DiagnoseReportUploadError, projectNotInitializedError } from '@aws-amplify/amplify-cli-core';
+import {
+  CLIContextEnvironmentProvider,
+  FeatureFlags,
+  stateManager,
+  pathManager,
+  spinner,
+  DiagnoseReportUploadError,
+  projectNotInitializedError,
+} from '@aws-amplify/amplify-cli-core';
 import archiver from 'archiver';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -85,6 +93,14 @@ const showLearnMore = (showOptOut: boolean): void => {
 };
 
 const zipSend = async (context: Context, skipPrompts: boolean, error: Error | undefined): Promise<void> => {
+  try {
+    DebugConfig.Instance.getCanSendReport();
+  } catch (DebugConfigValueNotSetError) {
+    const result = await prompter.yesOrNo('Help improve Amplify CLI by sharing non sensitive configurations on failures', false);
+    console.log(result);
+    DebugConfig.Instance.setAndWriteShareProject(result);
+  }
+
   const choices = ['Generate report', 'Nothing'];
   if (!skipPrompts) {
     const diagnoseAction = await prompter.pick('What would you like to do?', choices);

--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -1,15 +1,16 @@
 import * as fs from 'fs-extra';
+import chalk from 'chalk';
 import { join } from 'path';
 import sequential from 'promise-sequential';
 import { CLIContextEnvironmentProvider, FeatureFlags, pathManager, stateManager, $TSContext, $TSAny } from '@aws-amplify/amplify-cli-core';
 import _ from 'lodash';
-import { printer, prompter } from '@aws-amplify/amplify-prompts';
+import { printer } from '@aws-amplify/amplify-prompts';
 import { getFrontendPlugins } from '../extensions/amplify-helpers/get-frontend-plugins';
 import { getProviderPlugins } from '../extensions/amplify-helpers/get-provider-plugins';
 import { insertAmplifyIgnore } from '../extensions/amplify-helpers/git-manager';
 import { writeReadMeFile } from '../extensions/amplify-helpers/docs-manager';
 import { initializeEnv } from '../initialize-env';
-import { DebugConfig } from '../app-config/debug-config';
+import { EOL } from 'os';
 
 /**
  * Executes after headless init
@@ -64,11 +65,13 @@ export const onSuccess = async (context: $TSContext): Promise<void> => {
     }
 
     await FeatureFlags.ensureDefaultFeatureFlags(true);
-    const result = await prompter.yesOrNo('Help improve Amplify CLI by sharing non sensitive configurations on failures', false);
-    const actualResult = context.exeInfo.inputParams.yes ? undefined : result;
-    DebugConfig.Instance.setAndWriteShareProject(actualResult);
-  }
 
+    printer.info(`Amplify CLI collects anonymized usage data, which is used to help understand`);
+    printer.info(`how to improve the product. If you don't wish to send anonymized Amplify CLI`);
+    printer.info(`usage data to AWS, run${EOL}`);
+    printer.info(`${chalk.blue.italic('amplify configure --usage-data-off')}`);
+    printer.info(`Learn more - https://docs.amplify.aws/cli/reference/usage-data${EOL}`);
+  }
   for (const provider of context.exeInfo.projectConfig.providers) {
     // eslint-disable-next-line
     const providerModule = await import(providerPlugins[provider]);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Post install script is no longer running on latest npm version so this change moves the notice of data collection to post init successful. Moving the amplify-dia
<img width="626" alt="Screenshot 2023-05-12 at 9 22 49 AM" src="https://github.com/aws-amplify/amplify-cli/assets/22283303/ec18354b-3db3-4883-b22c-466b1bc5b00c">
<img width="777" alt="Screenshot 2023-05-12 at 10 28 31 AM" src="https://github.com/aws-amplify/amplify-cli/assets/22283303/ebdac807-5b23-428f-ba9c-afd62be0404e">
gnose consent into the diagnose command logic. 



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
