### PR TITLE
fix: throw message when adding lambda function with same name

### DIFF
--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.test.ts
@@ -1,0 +1,37 @@
+const inquirer = require('inquirer');
+import { generalQuestionsWalkthrough } from '../../../../provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough';
+
+jest.mock('inquirer', () => ({
+  prompt: jest.fn(),
+}));
+jest.mock('uuid', () => ({
+  v4: () => 'mock-uuid',
+}));
+
+describe('generalQuestionsWalkthrough', () => {
+  it('should fail validation when function name already exists', async () => {
+    const mockContext = {
+      amplify: {
+        getResourceStatus: jest.fn().mockResolvedValue({
+          allResources: [{ resourceName: 'existingFunction' }],
+        }),
+        inputValidation: () => jest.fn(),
+        getProjectDetails: () => ({
+          projectConfig: {
+            projectName: 'testProject',
+          },
+        }),
+      },
+    };
+
+    inquirer.prompt.mockImplementation(async (questions) => {
+      const { validate } = questions[0];
+      const validationResult = await validate('existingFunction');
+      return { functionName: validationResult };
+    });
+
+    const result = await generalQuestionsWalkthrough(mockContext);
+
+    expect(result.functionName).toBe('A function with this name already exists.');
+  });
+});

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/service-walkthroughs/generalQuestionsWalkthrough.ts
@@ -17,12 +17,19 @@ function generalQuestions(context: any): object[] {
       type: 'input',
       name: 'functionName',
       message: 'Provide an AWS Lambda function name:',
-      validate: context.amplify.inputValidation({
-        operator: 'regex',
-        value: '^[a-zA-Z0-9]+$',
-        onErrorMsg: 'You can use the following characters: a-z A-Z 0-9',
-        required: true,
-      }),
+      validate: async (input: string) => {
+        const lambdaFunctions = await context.amplify.getResourceStatus('function');
+        const functionExists = lambdaFunctions.allResources.some((resource) => resource.resourceName === input);
+        if (functionExists) {
+          return 'A function with this name already exists.';
+        }
+        return context.amplify.inputValidation({
+          operator: 'regex',
+          value: '^[a-zA-Z0-9]+$',
+          onErrorMsg: 'You can use the following characters: a-z A-Z 0-9',
+          required: true,
+        })(input);
+      },
       default: () => {
         const appName = context.amplify
           .getProjectDetails()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

when adding a function with the same name as an existing function, the cli throws errors that are not helpful.
<img width="679" alt="image" src="https://github.com/aws-amplify/amplify-cli/assets/87995712/bfeadbc1-2f28-4045-b14e-019f4fedd6ea">

debug:
```
Error: test is present in amplify-meta.json
    at AmplifyToolkit.updateamplifyMetaAfterResourceAdd (/snapshot/repo/build/node_modules/@aws-amplify/cli-internal/lib/extensions/amplify-helpers/update-amplify-meta.js:127:15)
    at createFunctionResources (/snapshot/repo/build/node_modules/@aws-amplify/amplify-category-function/lib/provider-utils/awscloudformation/utils/storeResources.js:47:21)
    at addFunctionResource (/snapshot/repo/build/node_modules/@aws-amplify/amplify-category-function/lib/provider-utils/awscloudformation/index.js:88:56)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Object.executeAmplifyCommand (/snapshot/repo/build/node_modules/@aws-amplify/amplify-category-function/lib/index.js:277:5)
    at async executePluginModuleCommand (/snapshot/repo/build/node_modules/@aws-amplify/cli-internal/lib/execution-manager.js:135:5)
    at async executeCommand (/snapshot/repo/build/node_modules/@aws-amplify/cli-internal/lib/execution-manager.js:33:9)
    at async Object.run (/snapshot/repo/build/node_modules/@aws-amplify/cli-internal/lib/index.js:117:5)
There was an error adding the function resource
```


The PR provides a warning rather than error out after 

https://github.com/aws-amplify/amplify-cli/assets/87995712/d15a27f9-4eea-4044-a62f-1c03224cb93f

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/12554

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
