### PR TITLE
chore: store binaries as build artifacts

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -349,6 +349,8 @@ jobs:
           key: amplify-pkg-binaries-linux-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/repo/out
+      - store_artifacts:
+          path: ~/repo/out
 
   build_pkg_binaries_macos:
     <<: *linux-e2e-executor-large
@@ -372,6 +374,8 @@ jobs:
           key: amplify-pkg-binaries-macos-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/repo/out
+      - store_artifacts:
+          path: ~/repo/out
 
   build_pkg_binaries_win:
     <<: *linux-e2e-executor-large
@@ -395,6 +399,8 @@ jobs:
           key: amplify-pkg-binaries-win-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/repo/out
+      - store_artifacts:
+          path: ~/repo/out
 
   build_pkg_binaries_arm:
     <<: *linux-e2e-executor-large
@@ -418,6 +424,8 @@ jobs:
           key: amplify-pkg-binaries-arm-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/repo/out
+      - store_artifacts:
+          path: ~/repo/out
 
   verify_pkg_binaries:
     <<: *linux-e2e-executor-large

--- a/scripts/artifact-storage-path-allow-list.ts
+++ b/scripts/artifact-storage-path-allow-list.ts
@@ -33,6 +33,7 @@
  */
 export const ARTIFACT_STORAGE_PATH_ALLOW_LIST = [
   '~/repo/artifacts',
+  '~/repo/out',
   '~/repo/packages/amplify-util-mock/',
   '~/repo/packages/graphql-transformers-e2e-tests/',
   '~/repo/packages/amplify-e2e-tests/',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Stores built binaries as artifacts for debugging purposes.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
