### PR TITLE
refactor: move e2e test helpers to e2e-core package

### DIFF
--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.0.5",
     "amplify-headless-interface": "1.17.3",
+    "aws-amplify": "^4.2.8",
+    "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1354.0",
     "chalk": "^4.1.1",
     "dotenv": "^8.2.0",

--- a/packages/amplify-e2e-core/src/utils/auth-utils.ts
+++ b/packages/amplify-e2e-core/src/utils/auth-utils.ts
@@ -1,5 +1,5 @@
 import { CognitoIdentityServiceProvider } from 'aws-sdk';
-import { getProjectMeta, getBackendAmplifyMeta } from '@aws-amplify/amplify-e2e-core';
+import { getProjectMeta, getBackendAmplifyMeta } from './projectMeta';
 import Amplify, { Auth } from 'aws-amplify';
 import fs from 'fs-extra';
 import path from 'path';

--- a/packages/amplify-e2e-core/src/utils/auth-utils.ts
+++ b/packages/amplify-e2e-core/src/utils/auth-utils.ts
@@ -64,7 +64,7 @@ export function getConfiguredCognitoClient(): CognitoIdentityServiceProvider {
   return cognitoClient;
 }
 
-export function getConfiguredAppsyncClientCognitoAuth(url: string, region: string, user: any): any {
+export function getConfiguredAppsyncClientCognitoAuth(url: string, region: string, user: any) {
   return new AWSAppSyncClient({
     url,
     region,
@@ -76,7 +76,7 @@ export function getConfiguredAppsyncClientCognitoAuth(url: string, region: strin
   });
 }
 
-export function getConfiguredAppsyncClientOIDCAuth(url: string, region: string, user: any): any {
+export function getConfiguredAppsyncClientOIDCAuth(url: string, region: string, user: any) {
   return new AWSAppSyncClient({
     url,
     region,
@@ -100,7 +100,7 @@ export function getConfiguredAppsyncClientAPIKeyAuth(url: string, region: string
   });
 }
 
-export function getConfiguredAppsyncClientIAMAuth(url: string, region: string): any {
+export function getConfiguredAppsyncClientIAMAuth(url: string, region: string) {
   return new AWSAppSyncClient({
     url,
     region,
@@ -136,25 +136,25 @@ export function getAWSExports(projectDir: string) {
 
 export function getUserPoolId(projectDir: string): string {
   const amplifyMeta = getProjectMeta(projectDir);
-  const cognitoResource = Object.values(amplifyMeta.auth).find((res: any) => {
+  const cognitoResource = Object.values<{ service: string; output: { UserPoolId: string } }>(amplifyMeta.auth).find((res) => {
     return res.service === 'Cognito';
-  }) as any;
+  });
   return cognitoResource.output.UserPoolId;
 }
 
 export function getCognitoResourceName(projectDir: string): string {
   const amplifyMeta = getBackendAmplifyMeta(projectDir);
-  const cognitoResourceName = Object.keys(amplifyMeta.auth).find((key: any) => {
+  const cognitoResourceName = Object.keys(amplifyMeta.auth).find((key: string) => {
     return amplifyMeta.auth[key].service === 'Cognito';
-  }) as any;
+  });
   return cognitoResourceName;
 }
 
 export function getApiKey(projectDir: string): string {
   const amplifyMeta = getProjectMeta(projectDir);
-  const appsyncResource = Object.values(amplifyMeta.api).find((res: any) => {
+  const appsyncResource = Object.values<{ service: string; output: { GraphQLAPIKeyOutput: string } }>(amplifyMeta.api).find((res) => {
     return res.service === 'AppSync';
-  }) as any;
+  });
   return appsyncResource.output.GraphQLAPIKeyOutput;
 }
 
@@ -168,9 +168,9 @@ export async function authenticateUser(username: string, tempPassword: string, p
 
 export function getUserPoolIssUrl(projectDir: string) {
   const amplifyMeta = getProjectMeta(projectDir);
-  const cognitoResource = Object.values(amplifyMeta.auth).find((res: any) => {
+  const cognitoResource = Object.values<{ service: string; output: { UserPoolId: string } }>(amplifyMeta.auth).find((res) => {
     return res.service === 'Cognito';
-  }) as any;
+  });
 
   const userPoolId = cognitoResource.output.UserPoolId;
   const region = amplifyMeta.providers.awscloudformation.Region;
@@ -180,9 +180,9 @@ export function getUserPoolIssUrl(projectDir: string) {
 
 export function getAppClientIDWeb(projectDir: string) {
   const amplifyMeta = getProjectMeta(projectDir);
-  const cognitoResource = Object.values(amplifyMeta.auth).find((res: any) => {
+  const cognitoResource = Object.values<{ service: string; output: { AppClientIDWeb: string } }>(amplifyMeta.auth).find((res) => {
     return res.service === 'Cognito';
-  }) as any;
+  });
 
   return cognitoResource.output.AppClientIDWeb;
 }

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -10,6 +10,7 @@ import { getLayerDirectoryName, LayerDirectoryType } from '..';
 export * from './add-circleci-tags';
 export * from './api';
 export * from './appsync';
+export * from './auth-utils';
 export * from './envVars';
 export * from './getAppId';
 export * from './headless';

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1a.test.ts
@@ -10,6 +10,7 @@ import {
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
+  getCognitoResourceName,
   initJSProjectWithProfile,
 } from '@aws-amplify/amplify-e2e-core';
 import * as fs from 'fs-extra';
@@ -29,7 +30,6 @@ import {
   readRootStack,
   removeImportedAuthWithDefault,
 } from '../import-helpers';
-import { getCognitoResourceName } from '../schema-api-directives/authHelper';
 import { randomizedFunctionName } from '../schema-api-directives/functionTester';
 
 describe('auth import userpool only', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
@@ -8,6 +8,7 @@ import {
   deleteProject,
   deleteProjectDir,
   getAppId,
+  getCognitoResourceName,
   getEnvVars,
   getTeamProviderInfo,
   initJSProjectWithProfile,
@@ -30,7 +31,6 @@ import {
   getShortId,
   importUserPoolOnly,
 } from '../import-helpers';
-import { getCognitoResourceName } from '../schema-api-directives/authHelper';
 import { randomizedFunctionName } from '../schema-api-directives/functionTester';
 
 describe('auth import userpool only', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/pinpoint/analytics-pinpoint-config-util.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pinpoint/analytics-pinpoint-config-util.ts
@@ -6,12 +6,12 @@ import {
   amplifyPushAuth,
   createNewProjectDir,
   deleteProjectDir,
+  getAmplifyFlutterConfig,
   getAppId,
+  getAWSExports,
   removeAnalytics,
 } from '@aws-amplify/amplify-e2e-core';
 import { JSONUtilities, $TSAny } from '@aws-amplify/amplify-cli-core';
-import { getAmplifyFlutterConfig } from '@aws-amplify/amplify-e2e-core';
-import { getAWSExports } from '../../schema-api-directives/authHelper';
 
 export const runPinpointConfigTest = async (
   projectRoot: string,

--- a/packages/amplify-e2e-tests/src/__tests__/pinpoint/notifications-pinpoint-config-util.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pinpoint/notifications-pinpoint-config-util.ts
@@ -6,13 +6,13 @@ import {
   deleteProjectDir,
   getAmplifyFlutterConfig,
   getAppId,
+  getAWSExports,
   removeAllNotificationChannel,
 } from '@aws-amplify/amplify-e2e-core';
 import { $TSAny, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { getShortId } from '../../import-helpers';
-import { getAWSExports } from '../../schema-api-directives';
 
 const pinpointSettings = { resourceName: `notifications${getShortId()}` };
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
@@ -1,32 +1,28 @@
 import {
-  initJSProjectWithProfile,
-  deleteProject,
+  addApiWithoutSchema,
+  addFeatureFlag,
   amplifyPush,
   amplifyPushUpdate,
-  addFeatureFlag,
-  createRandomName,
-  updateApiSchema,
+  configureAmplify,
   createNewProjectDir,
+  createRandomName,
+  deleteProject,
   deleteProjectDir,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  getConfiguredAppsyncClientCognitoAuth,
+  getConfiguredAppsyncClientIAMAuth,
+  getUserPoolId,
+  initJSProjectWithProfile,
+  setupUser,
+  signInUser,
+  updateApiSchema,
   updateApiWithMultiAuth,
-  addApiWithoutSchema,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
 import gql from 'graphql-tag';
-import { default as CognitoClient } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { Auth } from 'aws-amplify';
 import moment from 'moment';
 import { IAM } from 'aws-sdk';
-import {
-  configureAmplify,
-  getUserPoolId,
-  getConfiguredAppsyncClientCognitoAuth,
-  getConfiguredAppsyncClientAPIKeyAuth,
-  getApiKey,
-  getConfiguredAppsyncClientIAMAuth,
-  setupUser,
-  signInUser,
-} from '../../schema-api-directives';
 
 (global as any).fetch = require('node-fetch');
 

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
@@ -1,16 +1,18 @@
 import {
-  initJSProjectWithProfile,
-  deleteProject,
-  createNewProjectDir,
-  deleteProjectDir,
+  addApi,
   addFeatureFlag,
   amplifyPush,
-  addApi,
   amplifyPushUpdate,
+  configureAmplify,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  initJSProjectWithProfile,
 } from '@aws-amplify/amplify-e2e-core';
+import { testQueries, updateSchemaInTestProject } from '../../schema-api-directives/common';
 import { addSimpleFunction, updateFunctionNameInSchema } from '../../schema-api-directives/functionTester';
-import { updateSchemaInTestProject, testQueries } from '../../schema-api-directives/common';
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../../schema-api-directives/authHelper';
 
 describe('api directives @function v1 to v2 migration', () => {
   let projectDir: string;

--- a/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
@@ -1,19 +1,19 @@
 /* eslint-disable */
-import path from 'path';
-import fs from 'fs-extra';
-import _ from 'lodash';
-import gql from 'graphql-tag';
-import { addApi, amplifyPush, updateAuthAddUserGroups } from '@aws-amplify/amplify-e2e-core';
-
 import {
-  setupUser,
-  getUserPoolId,
-  getApiKey,
+  addApi,
+  amplifyPush,
   configureAmplify,
-  signInUser,
+  getApiKey,
   getConfiguredAppsyncClientAPIKeyAuth,
   getConfiguredAppsyncClientCognitoAuth,
-} from './authHelper';
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
+import fs from 'fs-extra';
+import gql from 'graphql-tag';
+import path from 'path';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
@@ -1,11 +1,16 @@
+import {
+  addApi,
+  addFunction,
+  amplifyPush,
+  configureAmplify,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+} from '@aws-amplify/amplify-e2e-core';
+import fs from 'fs-extra';
 import path from 'path';
 import { v4 as uuid } from 'uuid';
-import fs from 'fs-extra';
-import { amplifyPush, addFunction, addApi } from '@aws-amplify/amplify-e2e-core';
 
-import { configureAmplify, getApiKey, getConfiguredAppsyncClientAPIKeyAuth } from './authHelper';
-
-import { updateSchemaInTestProject, testQueries } from './common';
+import { testQueries, updateSchemaInTestProject } from './common';
 
 export async function runFunctionTest(projectDir: string, testModule: any) {
   const functionName = await addSimpleFunction(projectDir, testModule, 'func');

--- a/packages/amplify-e2e-tests/src/schema-api-directives/index.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/index.ts
@@ -53,5 +53,3 @@ export async function testSchema(projectDir: string, directive: string, section:
     return false;
   }
 }
-
-export * from './authHelper';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
@@ -1,15 +1,18 @@
-import path from 'path';
-import fs from 'fs-extra';
 import {
-  addAuthWithPreTokenGenerationTrigger,
   addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
-  updateAuthAddUserGroups,
+  addAuthWithPreTokenGenerationTrigger,
   amplifyPush,
+  configureAmplify,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
+import fs from 'fs-extra';
+import path from 'path';
 
-import { getUserPoolId, configureAmplify, setupUser, signInUser, getConfiguredAppsyncClientCognitoAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testMutation } from '../common';
+import { testMutation, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Moderator';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims2.ts
@@ -1,16 +1,18 @@
 /* eslint-disable */
-import path from 'path';
-import fs from 'fs-extra';
 import {
-  addAuthWithPreTokenGenerationTrigger,
   addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
-  updateAuthAddUserGroups,
+  addAuthWithPreTokenGenerationTrigger,
   amplifyPush,
+  configureAmplify,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-
-import { getUserPoolId, configureAmplify, setupUser, signInUser, getConfiguredAppsyncClientCognitoAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testMutation } from '../common';
+import fs from 'fs-extra';
+import path from 'path';
+import { testMutation, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Moderator';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner10.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner10.ts
@@ -1,8 +1,16 @@
 /* eslint-disable */
-import { addApi, amplifyPush, updateAuthAddUserGroups, getAwsIOSConfig } from '@aws-amplify/amplify-e2e-core';
+import {
+  addApi,
+  amplifyPush,
+  getAwsIOSConfig,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
 import Amplify from 'aws-amplify';
-import { signInUser, getConfiguredAppsyncClientCognitoAuth, setupUser, getUserPoolId } from '../authHelper';
-import { updateSchemaInTestProject, testMutations, testQueries, testSubscriptions } from '../common';
+import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner11.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner11.ts
@@ -1,8 +1,16 @@
 /* eslint-disable */
-import { addApi, amplifyPushWithoutCodegen, updateAuthAddUserGroups, getAmplifyFlutterConfig } from '@aws-amplify/amplify-e2e-core';
-import { signInUser, getConfiguredAppsyncClientCognitoAuth, setupUser, getUserPoolId } from '../authHelper';
-import { updateSchemaInTestProject, testMutations, testQueries, testSubscriptions } from '../common';
+import {
+  addApi,
+  amplifyPushWithoutCodegen,
+  getAmplifyFlutterConfig,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
 import Amplify from 'aws-amplify';
+import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner8.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner8.ts
@@ -1,7 +1,15 @@
 /* eslint-disable */
-import { addApi, amplifyPush, updateAuthAddUserGroups } from '@aws-amplify/amplify-e2e-core';
-import { setupUser, getUserPoolId, configureAmplify, signInUser, getConfiguredAppsyncClientCognitoAuth } from '../authHelper';
-import { updateSchemaInTestProject, testMutations, testQueries, testSubscriptions } from '../common';
+import {
+  addApi,
+  amplifyPush,
+  configureAmplify,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
+import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
@@ -1,8 +1,16 @@
 /* eslint-disable */
-import { addApi, amplifyPush, updateAuthAddUserGroups, getAwsAndroidConfig } from '@aws-amplify/amplify-e2e-core';
+import {
+  addApi,
+  amplifyPush,
+  getAwsAndroidConfig,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
 import Amplify from 'aws-amplify';
-import { signInUser, getConfiguredAppsyncClientCognitoAuth, setupUser, getUserPoolId } from '../authHelper';
-import { updateSchemaInTestProject, testMutations, testQueries, testSubscriptions } from '../common';
+import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
@@ -1,6 +1,4 @@
-import { addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
-
-import { configureAmplify, getConfiguredAppsyncClientIAMAuth } from '../authHelper';
+import { addApi, amplifyPush, configureAmplify, getConfiguredAppsyncClientIAMAuth } from '@aws-amplify/amplify-e2e-core';
 
 import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
@@ -1,8 +1,6 @@
-import { addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
+import { addApi, amplifyPush, configureAmplify, getApiKey, getConfiguredAppsyncClientAPIKeyAuth } from '@aws-amplify/amplify-e2e-core';
 
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
+import { testMutations, testQueries, updateSchemaInTestProject } from '../common';
 
 export async function runTest(projectDir: string, testModule: any) {
   await addApi(projectDir, { transformerVersion: 1 });

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
@@ -1,6 +1,4 @@
-import { addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
-
-import { configureAmplify, getConfiguredAppsyncClientIAMAuth } from '../authHelper';
+import { addApi, amplifyPush, configureAmplify, getConfiguredAppsyncClientIAMAuth } from '@aws-amplify/amplify-e2e-core';
 
 import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
@@ -1,17 +1,20 @@
-import { addAuthWithDefault, amplifyPushWithoutCodegen, addApi, updateAuthAddUserGroups, amplifyPush } from '@aws-amplify/amplify-e2e-core';
-
 import {
-  getAppClientIDWeb,
-  getUserPoolId,
+  addApi,
+  addAuthWithDefault,
+  amplifyPush,
+  amplifyPushWithoutCodegen,
   configureAmplify,
+  getAppClientIDWeb,
+  getConfiguredAppsyncClientIAMAuth,
+  getConfiguredAppsyncClientOIDCAuth,
+  getUserPoolId,
   getUserPoolIssUrl,
   setupUser,
   signInUser,
-  getConfiguredAppsyncClientIAMAuth,
-  getConfiguredAppsyncClientOIDCAuth,
-} from '../authHelper';
+  updateAuthAddUserGroups,
+} from '@aws-amplify/amplify-e2e-core';
 
-import { updateSchemaInTestProject, testMutation } from '../common';
+import { testMutation, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
 const USERNAME = 'user1';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
@@ -1,8 +1,6 @@
-import { addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
+import { addApi, amplifyPush, configureAmplify, getApiKey, getConfiguredAppsyncClientAPIKeyAuth } from '@aws-amplify/amplify-e2e-core';
 
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testQueries } from '../common';
+import { testQueries, updateSchemaInTestProject } from '../common';
 
 import { addSimpleFunction, updateFunctionNameInSchema } from '../functionTester';
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
@@ -1,21 +1,22 @@
 //special handling needed becasue we need to set up the function in a differnt region
-import path from 'path';
 import fs from 'fs-extra';
+import path from 'path';
 
 import {
-  getProjectMeta,
-  deleteProject,
-  deleteProjectDir,
   addApi,
+  addFunction,
   amplifyPush,
   amplifyPushWithoutCodegen,
-  addFunction,
+  configureAmplify,
+  deleteProject,
+  deleteProjectDir,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  getProjectMeta,
   initProjectWithAccessKey,
 } from '@aws-amplify/amplify-e2e-core';
 
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testQueries } from '../common';
+import { testQueries, updateSchemaInTestProject } from '../common';
 
 import { randomizedFunctionName } from '../functionTester';
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
@@ -1,26 +1,23 @@
 //special handling needed becasue we need to set up the function in a differnt region
-import path from 'path';
-import fs from 'fs-extra';
 import {
-  amplifyPush,
-  addFunction,
   addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
-  updateAuthAddUserGroups,
   addAuthWithDefault,
+  addFunction,
+  amplifyPush,
+  configureAmplify,
+  getCognitoResourceName,
+  getConfiguredAppsyncClientCognitoAuth,
+  getUserPoolId,
+  setupUser,
+  signInUser,
+  updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
+import fs from 'fs-extra';
+import path from 'path';
 
 import { updateFunctionNameInSchema } from '../functionTester';
 
-import {
-  configureAmplify,
-  getUserPoolId,
-  getCognitoResourceName,
-  setupUser,
-  signInUser,
-  getConfiguredAppsyncClientCognitoAuth,
-} from '../authHelper';
-
-import { updateSchemaInTestProject, testQueries } from '../common';
+import { testQueries, updateSchemaInTestProject } from '../common';
 
 import { randomizedFunctionName } from '../functionTester';
 

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
@@ -1,6 +1,12 @@
-import { addApiWithBlankSchemaAndConflictDetection, amplifyPush, updateApiSchema } from '@aws-amplify/amplify-e2e-core';
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
-import { testQueries, testMutations } from '../common';
+import {
+  addApiWithBlankSchemaAndConflictDetection,
+  amplifyPush,
+  configureAmplify,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+  updateApiSchema,
+} from '@aws-amplify/amplify-e2e-core';
+import { testMutations, testQueries } from '../common';
 
 //schema
 export const schemaName = 'selective_sync.graphql';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -1,9 +1,16 @@
 //special handling needed to test prediction
 //This test will faile due to a possible AppSync bug, see details below the test code
+import {
+  addApi,
+  addAuthWithDefault,
+  addS3Storage,
+  amplifyPush,
+  configureAmplify,
+  getApiKey,
+  getConfiguredAppsyncClientAPIKeyAuth,
+} from '@aws-amplify/amplify-e2e-core';
 import gql from 'graphql-tag';
-import { addAuthWithDefault, addS3Storage, addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
 
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 import { updateSchemaInTestProject } from '../common';
 
 export async function runTest(projectDir: string, testModule: any) {

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
@@ -1,8 +1,6 @@
-import { addApi, amplifyPush } from '@aws-amplify/amplify-e2e-core';
+import { addApi, amplifyPush, configureAmplify, getApiKey, getConfiguredAppsyncClientAPIKeyAuth } from '@aws-amplify/amplify-e2e-core';
 
-import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
-
-import { updateSchemaInTestProject, testMutations, testQueries } from '../common';
+import { testMutations, testQueries, updateSchemaInTestProject } from '../common';
 
 export async function runTest(projectDir: string, testModule: any) {
   await addApi(projectDir, { transformerVersion: 1 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR moves auth related e2e helper functions to `amplify-e2e-core` so that they can also be used in the `amplify-migration-tests` package.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
