### PR TITLE
fix: added extra case when local env function has secrets

### DIFF
--- a/packages/amplify-category-function/src/__tests__/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/index.test.ts
@@ -39,6 +39,7 @@ describe('function category provider', () => {
               {
                 category: 'function',
                 resourceName: 'testFunction',
+                service: 'Lambda',
               },
             ],
             resourcesToBeCreated: [],

--- a/packages/amplify-cli/src/initialize-env.ts
+++ b/packages/amplify-cli/src/initialize-env.ts
@@ -160,6 +160,7 @@ export const initializeEnv = async (
     }
 
     if (context.exeInfo.forcePush) {
+      // environment parameters verification after initializing environment
       await verifyExpectedEnvParams(context);
       // raising PrePush event here because init with --forcePush will do a push after initializing
       await raisePrePushEvent(context as unknown as Context);

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -389,6 +389,27 @@ export const getPermissionsBoundary = async (roleName: string, region) => {
   return (await iamClient.getRole({ RoleName: roleName }).promise())?.Role?.PermissionsBoundary?.PermissionsBoundaryArn;
 };
 
+export const putSSMParameter = async (
+  region: string,
+  appId: string,
+  envName: string,
+  funcName: string,
+  parameterName: string,
+  parameterValue: string,
+) => {
+  const ssmClient = new SSM({ region });
+  if (!parameterName) {
+    throw new Error('no parameterNames specified');
+  }
+  return await ssmClient
+    .putParameter({
+      Name: parameterName,
+      Value: parameterValue,
+      Type: 'SecureString',
+    })
+    .promise();
+};
+
 export const getSSMParameters = async (region: string, appId: string, envName: string, funcName: string, parameterNames: string[]) => {
   const ssmClient = new SSM({ region });
   if (!parameterNames || parameterNames.length === 0) {

--- a/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
@@ -1,0 +1,129 @@
+import {
+  addAuthWithDefaultSocial,
+  addFunction,
+  amplifyPushAuth,
+  checkIfBucketExists,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  generateRandomShortId,
+  getAmplifyInitConfig,
+  getAwsProviderConfig,
+  getProjectConfig,
+  getProjectMeta,
+  initJSProjectWithProfile,
+  invokeFunction,
+  nonInteractiveInitAttach,
+  nonInteractiveInitWithForcePushAttach,
+  overrideFunctionCodeNode,
+  putSSMParameter,
+  updateFunction,
+} from '@aws-amplify/amplify-e2e-core';
+import { addEnvironmentYes, listEnvironment, checkoutEnvironment } from '../environment/env';
+
+const validateSecretWithLambda = async (projRoot: string, funcName: string, envName: string): Promise<void> => {
+  const lambdaEvent = {
+    secretNames: ['TEST_SECRET'],
+  };
+
+  const meta = getProjectMeta(projRoot);
+  const { Region: region } = (Object.values(meta.function)[0] as any).output;
+
+  // check that the lambda response includes the secret value
+  const response = await invokeFunction(`${funcName}-${envName}`, JSON.stringify(lambdaEvent), region);
+  expect(JSON.parse(response.Payload.toString())[0]?.Value).toEqual('testsecretvalue');
+};
+
+describe('environment commands with functions secrets handling', () => {
+  let projRoot: string;
+  const enva = 'dev';
+  const envb = 'test';
+  const funcName = `secretsTest${generateRandomShortId()}`;
+  const funcName1 = `secretsTest${generateRandomShortId()}`;
+  beforeAll(async () => {
+    projRoot = await createNewProjectDir('env-test');
+    // add func with secret
+    await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, envName: enva });
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'Hello World',
+        name: funcName,
+        secretsConfig: {
+          operation: 'add',
+          name: 'TEST_SECRET',
+          value: 'testsecretvalue',
+        },
+      },
+      'nodejs',
+    );
+    // override lambda code to fetch the secret and return the value
+    overrideFunctionCodeNode(projRoot, funcName, 'retrieve-secret.js');
+    await amplifyPushAuth(projRoot);
+    await validateSecretWithLambda(projRoot, funcName, 'dev');
+  });
+
+  afterAll(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('headless case', async () => {
+    await addEnvironmentYes(projRoot, { envName: 'next' });
+    await listEnvironment(projRoot, { numEnv: 2 });
+    const { projectName } = getProjectConfig(projRoot);
+    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, 'next'), getAwsProviderConfig());
+    await validateSecretWithLambda(projRoot, funcName, 'next');
+    // add a new function with secrets
+    await addFunction(
+      projRoot,
+      {
+        functionTemplate: 'Hello World',
+        name: funcName1,
+        secretsConfig: {
+          operation: 'add',
+          name: 'TEST_SECRET1',
+          value: 'testsecretvalue1',
+        },
+      },
+      'nodejs',
+    );
+
+    // remove the previous function
+    await updateFunction(
+      projRoot,
+      {
+        name: funcName,
+        secretsConfig: {
+          operation: 'delete',
+          name: 'TEST_SECRET',
+        },
+      },
+      'nodejs',
+    );
+    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, 'next'), getAwsProviderConfig());
+    await checkoutEnvironment(projRoot, { envName: 'dev' });
+    // should fail
+    await expect(
+      nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, 'dev'), getAwsProviderConfig()),
+    ).rejects.toThrow();
+    // add secret in parameter store
+    await addParameterToParameterStore(projRoot, 'dev', funcName1, 'TEST_SECRET1', 'testsecretvalue1');
+    // should pass
+    await nonInteractiveInitWithForcePushAttach(projRoot, getAmplifyInitConfig(projectName, 'dev'), getAwsProviderConfig());
+  });
+});
+
+const addParameterToParameterStore = async (
+  projRoot: string,
+  envName: string,
+  funcName: string,
+  parameterName: string,
+  parameterValue: string,
+) => {
+  const meta = getProjectMeta(projRoot);
+  const { AmplifyAppId: appId, Region: region } = meta?.providers?.awscloudformation;
+  expect(appId).toBeDefined();
+  const key = `/amplify/${appId}/${envName}/AMPLIFY_${funcName}_${parameterName}`;
+  await putSSMParameter(region, appId, envName, funcName, key, parameterValue);
+};

--- a/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
@@ -1,8 +1,6 @@
 import {
-  addAuthWithDefaultSocial,
   addFunction,
   amplifyPushAuth,
-  checkIfBucketExists,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
@@ -13,13 +11,12 @@ import {
   getProjectMeta,
   initJSProjectWithProfile,
   invokeFunction,
-  nonInteractiveInitAttach,
   nonInteractiveInitWithForcePushAttach,
   overrideFunctionCodeNode,
   putSSMParameter,
   updateFunction,
 } from '@aws-amplify/amplify-e2e-core';
-import { addEnvironmentYes, listEnvironment, checkoutEnvironment } from '../environment/env';
+import { addEnvironmentYes, checkoutEnvironment, listEnvironment } from '../environment/env';
 
 const validateSecretWithLambda = async (projRoot: string, funcName: string, envName: string): Promise<void> => {
   const lambdaEvent = {

--- a/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/env-6.test.ts
@@ -34,7 +34,6 @@ const validateSecretWithLambda = async (projRoot: string, funcName: string, envN
 describe('environment commands with functions secrets handling', () => {
   let projRoot: string;
   const enva = 'dev';
-  const envb = 'test';
   const funcName = `secretsTest${generateRandomShortId()}`;
   const funcName1 = `secretsTest${generateRandomShortId()}`;
   beforeAll(async () => {

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -4,7 +4,9 @@
 
 ```ts
 
+import { BackendParameters } from './backend-parameters';
 import { IAmplifyResource } from '@aws-amplify/amplify-cli-core';
+import { ResourceTuple } from '@aws-amplify/amplify-cli-core';
 
 // @public (undocumented)
 export const cloneEnvParamManager: (srcEnvParamManager: IEnvironmentParameterManager, destEnvName: string) => Promise<void>;
@@ -16,6 +18,20 @@ export const ensureEnvParamManager: (envName?: string) => Promise<{
 
 // @public (undocumented)
 export const getEnvParamManager: (envName?: string) => IEnvironmentParameterManager;
+
+// @public (undocumented)
+export const getParametersControllerInstance: () => IBackendParametersController;
+
+// @public (undocumented)
+export type IBackendParametersController = {
+    save: () => Promise<void>;
+    addParameter: (name: string, usedBy: ResourceTuple[]) => IBackendParametersController;
+    addAllParameters: (parameterMap: BackendParameters) => IBackendParametersController;
+    removeParameter: (name: string) => IBackendParametersController;
+    removeAllParameters: () => IBackendParametersController;
+    getParameters: () => Readonly<BackendParameters>;
+    hasParameter: (name: string) => boolean;
+};
 
 // @public (undocumented)
 export type IEnvironmentParameterManager = {

--- a/packages/amplify-environment-parameters/API.md
+++ b/packages/amplify-environment-parameters/API.md
@@ -61,6 +61,9 @@ export const saveAll: (serviceUploadHandler?: ServiceUploadHandler) => Promise<v
 export type ServiceDownloadHandler = (parameters: string[]) => Promise<Record<string, string | number | boolean>>;
 
 // @public (undocumented)
+export type ServiceParameterCheckHandler = (key: string) => Promise<boolean>;
+
+// @public (undocumented)
 export type ServiceUploadHandler = (key: string, value: string | number | boolean) => Promise<void>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-environment-parameters/src/backend-config-parameters-controller.ts
+++ b/packages/amplify-environment-parameters/src/backend-config-parameters-controller.ts
@@ -13,6 +13,7 @@ export type IBackendParametersController = {
   removeParameter: (name: string) => IBackendParametersController;
   removeAllParameters: () => IBackendParametersController;
   getParameters: () => Readonly<BackendParameters>;
+  hasParameter: (name: string) => boolean;
 };
 
 let localBackendParametersController: IBackendParametersController;
@@ -75,6 +76,13 @@ class LocalBackendParametersController implements IBackendParametersController {
 
   getParameters(): Readonly<BackendParameters> {
     return this.parameterMap;
+  }
+
+  /**
+   * Whether the given parameter is defined
+   */
+  hasParameter(name: string): boolean {
+    return !!this.parameterMap[name];
   }
 }
 

--- a/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
+++ b/packages/amplify-environment-parameters/src/environment-parameter-manager.ts
@@ -229,6 +229,7 @@ export type IEnvironmentParameterManager = {
 
 export type ServiceUploadHandler = (key: string, value: string | number | boolean) => Promise<void>;
 export type ServiceDownloadHandler = (parameters: string[]) => Promise<Record<string, string | number | boolean>>;
+export type ServiceParameterCheckHandler = (key: string) => Promise<boolean>;
 
 const getFullParameterStorePath = (categoryName: string, resourceName: string, paramName: string, appId: string, envName: string) =>
   `/amplify/${appId}/${envName}/${getParameterStoreKey(categoryName, resourceName, paramName)}`;

--- a/packages/amplify-environment-parameters/src/index.ts
+++ b/packages/amplify-environment-parameters/src/index.ts
@@ -1,3 +1,4 @@
 export * from './environment-parameter-manager';
 export { ResourceParameterManager } from './resource-parameter-manager';
 export * from './clone-env-param-manager';
+export { getParametersControllerInstance, IBackendParametersController } from './backend-config-parameters-controller';

--- a/packages/amplify-provider-awscloudformation/API.md
+++ b/packages/amplify-provider-awscloudformation/API.md
@@ -34,6 +34,9 @@ export function getConfiguredLocationServiceClient(context: $TSContext, options?
 export function getConfiguredSSMClient(context: any): Promise<SSM>;
 
 // @public (undocumented)
+export const getEnvParametersCheckHandler: (context: $TSContext) => Promise<(key: string, value: string | boolean | number) => Promise<boolean>>;
+
+// @public (undocumented)
 export const getEnvParametersDownloadHandler: (context: $TSContext) => Promise<DownloadHandler>;
 
 // @public (undocumented)

--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -55,13 +55,17 @@ import { getApiKeyConfig } from './utils/api-key-helpers';
 import { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete-ssm-parameters';
 export { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete-ssm-parameters';
 
-import { getEnvParametersUploadHandler, getEnvParametersDownloadHandler, getEnvParametersCheckHandler } from './utils/ssm-utils/env-parameter-ssm-helpers';
+import {
+  getEnvParametersUploadHandler,
+  getEnvParametersDownloadHandler,
+  getEnvParametersCheckHandler,
+} from './utils/ssm-utils/env-parameter-ssm-helpers';
 export {
   getEnvParametersUploadHandler,
   getEnvParametersDownloadHandler,
   DownloadHandler,
   PrimitiveRecord,
-  getEnvParametersCheckHandler
+  getEnvParametersCheckHandler,
 } from './utils/ssm-utils/env-parameter-ssm-helpers';
 
 function init(context) {

--- a/packages/amplify-provider-awscloudformation/src/index.ts
+++ b/packages/amplify-provider-awscloudformation/src/index.ts
@@ -54,12 +54,14 @@ import { prePushCfnTemplateModifier } from './pre-push-cfn-processor/pre-push-cf
 import { getApiKeyConfig } from './utils/api-key-helpers';
 import { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete-ssm-parameters';
 export { deleteEnvironmentParametersFromService } from './utils/ssm-utils/delete-ssm-parameters';
-import { getEnvParametersUploadHandler, getEnvParametersDownloadHandler } from './utils/ssm-utils/env-parameter-ssm-helpers';
+
+import { getEnvParametersUploadHandler, getEnvParametersDownloadHandler, getEnvParametersCheckHandler } from './utils/ssm-utils/env-parameter-ssm-helpers';
 export {
   getEnvParametersUploadHandler,
   getEnvParametersDownloadHandler,
   DownloadHandler,
   PrimitiveRecord,
+  getEnvParametersCheckHandler
 } from './utils/ssm-utils/env-parameter-ssm-helpers';
 
 function init(context) {
@@ -195,6 +197,7 @@ module.exports = {
   hashDirectory,
   prePushCfnTemplateModifier,
   getApiKeyConfig,
+  getEnvParametersCheckHandler,
   getEnvParametersDownloadHandler,
   getEnvParametersUploadHandler,
   deleteEnvironmentParametersFromService,

--- a/scripts/split-e2e-tests-v2.ts
+++ b/scripts/split-e2e-tests-v2.ts
@@ -112,6 +112,7 @@ const TEST_EXCLUSIONS: { l: string[]; w: string[] } = {
     'src/__tests__/diagnose.test.ts',
     'src/__tests__/env-2.test.ts',
     'src/__tests__/pr-previews-multi-env-1.test.ts',
+    'src/__tests__/env-6.test.ts',
     'src/__tests__/export.test.ts',
     'src/__tests__/function_3a.test.ts',
     'src/__tests__/function_3b.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
-  moved prePush and verification on env parameters after env init and before deploy
- handling function secrets when checking out environments

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #10764 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
- added unit test
- added e2e test
- manual testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
