### PR TITLE
feat: display error message instead of object

### DIFF
--- a/packages/amplify-prompts/API.md
+++ b/packages/amplify-prompts/API.md
@@ -19,7 +19,7 @@ export class AmplifyPrinter implements Printer {
     // (undocumented)
     debug: (line: string) => void;
     // (undocumented)
-    error: (line: string) => void;
+    error: (line: string, error?: any) => void;
     // Warning: (ae-forgotten-export) The symbol "Color" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -180,7 +180,7 @@ export type Printer = {
     blankLine: () => void;
     success: (line: string) => void;
     warn: (line: string) => void;
-    error: (line: string) => void;
+    error: (line: string, error?: any) => void;
 };
 
 // @public (undocumented)

--- a/packages/amplify-prompts/src/__tests__/printer.test.ts
+++ b/packages/amplify-prompts/src/__tests__/printer.test.ts
@@ -81,3 +81,9 @@ it('prints error line when silent flag is set', () => {
   printer.error(testInput);
   expect(writeStream_stub.write.mock.calls[0][0].trim()).toMatchInlineSnapshot(`"🛑 [31mthis is a test line[39m"`);
 });
+
+it('prints error message when the error is an object', () => {
+  printer.error('', new Error(testInput));
+
+  expect(writeStream_stub.write.mock.calls[1][0].trim()).toMatchInlineSnapshot(`"[31mthis is a test line[39m"`);
+});

--- a/packages/amplify-prompts/src/printer.ts
+++ b/packages/amplify-prompts/src/printer.ts
@@ -30,8 +30,16 @@ export class AmplifyPrinter implements Printer {
     this.writeLine(`${isHeadless ? '' : '⚠️ '}${chalk.yellow(line)}`);
   };
 
-  error = (line: string): void => {
+  // disable-eslint-next-line @typescript-eslint/no-explicit-any
+  error = (line: string, error?: any): void => {
     this.writeLine(`${isHeadless ? '' : '🛑 '}${chalk.red(line)}`);
+    if (error) {
+      if (error?.message) {
+        this.writeLine(`${chalk.red(error.message)}`);
+      } else {
+        this.writeLine(`${chalk.red(error)}`);
+      }
+    }
   };
 
   private writeSilenceableLine = (line?: string): void => {
@@ -59,7 +67,7 @@ export type Printer = {
   blankLine: () => void;
   success: (line: string) => void;
   warn: (line: string) => void;
-  error: (line: string) => void;
+  error: (line: string, error?: any) => void;
 };
 
 type Color = 'green' | 'blue' | 'yellow' | 'red' | 'reset';

--- a/packages/amplify-prompts/src/printer.ts
+++ b/packages/amplify-prompts/src/printer.ts
@@ -33,12 +33,9 @@ export class AmplifyPrinter implements Printer {
   // disable-eslint-next-line @typescript-eslint/no-explicit-any
   error = (line: string, error?: any): void => {
     this.writeLine(`${isHeadless ? '' : '🛑 '}${chalk.red(line)}`);
-    if (error) {
-      if (error?.message) {
-        this.writeLine(`${chalk.red(error.message)}`);
-      } else {
-        this.writeLine(`${chalk.red(error)}`);
-      }
+    const errorMessage = error?.message ?? error;
+    if (errorMessage) {
+      this.writeLine(`${chalk.red(errorMessage)}`);
     }
   };
 

--- a/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`function start times out function execution at the default time 2`] = `
-"Lambda execution timed out after 10 seconds. Press ctrl + C to exit the process.
+[Error: Lambda execution timed out after 10 seconds. Press ctrl + C to exit the process.
     To increase the lambda timeout use the --timeout parameter to set a value in seconds.
     Note that the maximum Lambda execution time is 15 minutes:
     https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
-"
+]
 `;
 
 exports[`function start times out function execution at the specified time 1`] = `
-"Lambda execution timed out after 1 seconds. Press ctrl + C to exit the process.
+[Error: Lambda execution timed out after 1 seconds. Press ctrl + C to exit the process.
     To increase the lambda timeout use the --timeout parameter to set a value in seconds.
     Note that the maximum Lambda execution time is 15 minutes:
     https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
-"
+]
 `;

--- a/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
+++ b/packages/amplify-util-mock/src/__tests__/func/__snapshots__/index.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`function start times out function execution at the default time 2`] = `
-[Error: Lambda execution timed out after 10 seconds. Press ctrl + C to exit the process.
+"Lambda execution timed out after 10 seconds. Press ctrl + C to exit the process.
     To increase the lambda timeout use the --timeout parameter to set a value in seconds.
     Note that the maximum Lambda execution time is 15 minutes:
     https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
-]
+"
 `;
 
 exports[`function start times out function execution at the specified time 1`] = `
-[Error: Lambda execution timed out after 1 seconds. Press ctrl + C to exit the process.
+"Lambda execution timed out after 1 seconds. Press ctrl + C to exit the process.
     To increase the lambda timeout use the --timeout parameter to set a value in seconds.
     Note that the maximum Lambda execution time is 15 minutes:
     https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
-]
+"
 `;

--- a/packages/amplify-util-mock/src/__tests__/func/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/func/index.test.ts
@@ -66,14 +66,14 @@ describe('function start', () => {
     prompter_mock.pick.mockResolvedValue(['funcName']);
     await start(context_stub);
     expect(printer_mock.error.mock.calls[0][0]).toMatchInlineSnapshot(`"funcName failed with the following error:"`);
-    expect(printer_mock.info.mock.calls[2][0]).toMatchSnapshot();
+    expect(printer_mock.error.mock.calls[0][1]).toMatchSnapshot();
     context_stub.input.options.timeout = 1;
   });
 
   it('times out function execution at the specified time', async () => {
     getInvoker_mock.mockResolvedValueOnce(() => new Promise((resolve) => setTimeout(() => resolve('lambda value'), 2000)));
     await start(context_stub);
-    expect(printer_mock.info.mock.calls[2][0]).toMatchSnapshot();
+    expect(printer_mock.error.mock.calls[0][1]).toMatchSnapshot();
   });
 
   it('triggers a dev build before invoking', async () => {

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -58,7 +58,7 @@ export async function start(context: $TSContext): Promise<void> {
       printer.info(typeof result === 'undefined' ? '' : stringResult);
     } catch (err) {
       printer.error(`${resourceName} failed with the following error:`);
-      printer.info(err.message);
+      printer.info(err?.message);
     } finally {
       printer.info('Finished execution.');
     }

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -57,8 +57,7 @@ export async function start(context: $TSContext): Promise<void> {
       printer.success('Result:');
       printer.info(typeof result === 'undefined' ? '' : stringResult);
     } catch (err) {
-      printer.error(`${resourceName} failed with the following error:`);
-      printer.info(err?.message);
+      printer.error(`${resourceName} failed with the following error:`, err);
     } finally {
       printer.info('Finished execution.');
     }

--- a/packages/amplify-util-mock/src/func/index.ts
+++ b/packages/amplify-util-mock/src/func/index.ts
@@ -58,7 +58,7 @@ export async function start(context: $TSContext): Promise<void> {
       printer.info(typeof result === 'undefined' ? '' : stringResult);
     } catch (err) {
       printer.error(`${resourceName} failed with the following error:`);
-      printer.info(err);
+      printer.info(err.message);
     } finally {
       printer.info('Finished execution.');
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

displays error message instead of object or stack trace 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/12626

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
