### PR TITLE
fix: failing util-mock tests for yarn2 migration

### DIFF
--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -22,7 +22,7 @@
     "e2e": "yarn e2e_v1 && yarn e2e_v2",
     "e2e_v2": "jest --runInBand --forceExit ./src/__e2e_v2__/*.test.ts",
     "e2e_v1": "jest --runInBand --forceExit ./src/__e2e__/*.test.ts",
-    "test": "jest --logHeapUsage src/__tests__/*/*.test.ts",
+    "test": "jest --logHeapUsage src/__tests__/**/*.test.ts",
     "test-watch": "jest --watch",
     "build": "tsc",
     "watch": "tsc -w",

--- a/packages/amplify-util-mock/src/__tests__/mockAll.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/mockAll.test.ts
@@ -17,7 +17,7 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
 }));
 
 const prompterMock = prompter as jest.Mocked<typeof prompter>;
-prompterMock.pick.mockResolvedValueOnce(['AppSync', 'Lambda', 'S3']);
+prompterMock.pick.mockResolvedValueOnce(['GraphQL API', 'Function', 'Storage']);
 const apiServerStartMock = apiServerStart as jest.MockedFunction<typeof apiServerStart>;
 const storageServerStartMock = storageServerStart as jest.MockedFunction<typeof storageServerStart>;
 const lambdaServerStartMock = lambdaServerStart as jest.MockedFunction<typeof lambdaServerStart>;

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/index.test.ts
@@ -9,6 +9,7 @@ import { CreateTableInput, GlobalSecondaryIndex } from 'aws-sdk/clients/dynamodb
 jest.mock('../../../utils/dynamo-db/utils');
 
 describe('createAndUpdateTable', () => {
+  const describeTablesMock = jest.fn();
   const table1Input: CreateTableInput = {
     TableName: 'table1',
     AttributeDefinitions: [
@@ -68,47 +69,38 @@ describe('createAndUpdateTable', () => {
     TableName: 'table2',
     GlobalSecondaryIndexes: [indexByName, indexByContent],
   };
-  const listTablesMock = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.useFakeTimers();
     AWSMock.setSDKInstance(AWS);
-    AWSMock.mock('DynamoDB', 'listTables', listTablesMock);
   });
 
   it('should create new tables when they are missing', async () => {
     const mockDDBConfig: MockDynamoDBConfig = {
-      tables: [{ Properties: table1Input }],
+      tables: [{ Properties: table1Input, isNewlyAdded: true }],
     };
-    listTablesMock.mockImplementation((cb) => {
-      cb(null, {
-        TableNames: [],
-      });
+
+    const mockListTables = jest.fn().mockReturnValue({
+      promise: jest.fn().mockResolvedValue({ TableNames: [] }),
     });
-    (describeTables as jest.Mock).mockReturnValue({});
-    const client = new DynamoDB();
-    await createAndUpdateTable(client, mockDDBConfig);
-    expect(createTables).toHaveBeenCalledWith(client, [table1Input]);
+
+    describeTablesMock.mockReturnValue({});
+
+    const ddbClient = {
+      describeTables: describeTablesMock,
+      listTables: mockListTables,
+    };
+    await createAndUpdateTable(ddbClient as unknown as DynamoDB, mockDDBConfig);
+    expect(createTables).toHaveBeenCalledWith(ddbClient, [table1Input]);
     expect(getUpdateTableInput).not.toHaveBeenCalled();
-    expect(updateTables).toHaveBeenCalledWith(client, []);
+    expect(updateTables).toHaveBeenCalledWith(ddbClient, []);
   });
 
   it('should update existing table with new GSI', async () => {
-    const mockDDBConfig: MockDynamoDBConfig = {
-      tables: [{ Properties: table1Input }, { Properties: table2Input }],
-    };
+    const createTablesMock = jest.fn();
+    const mockListTables = jest.fn();
 
-    listTablesMock.mockImplementation((cb) => {
-      cb(null, {
-        TableNames: [table1Input.TableName, table2Input.TableName],
-      });
-    });
-
-    (describeTables as jest.Mock).mockReturnValue({
-      [table1Input.TableName]: table1Input.TableName,
-      [table2Input.TableName]: { ...table2Input, GlobalSecondaryIndex: [] },
-    });
     const getUpdateTableInputResult = [
       {
         ...table2Input,
@@ -124,12 +116,36 @@ describe('createAndUpdateTable', () => {
       },
     ];
 
+    createTablesMock.mockReturnValue(() => {
+      jest.fn().mockResolvedValue([]);
+    });
+
+    mockListTables.mockReturnValue({
+      promise: jest.fn().mockResolvedValue({ TableNames: [table1Input.TableName, table2Input.TableName] }),
+    });
+
     (getUpdateTableInput as jest.Mock).mockImplementation((input) => (input === table2Input ? getUpdateTableInputResult : []));
 
-    const client = new DynamoDB();
-    await createAndUpdateTable(client, mockDDBConfig);
-    expect(createTables).toHaveBeenCalledWith(client, []);
+    (describeTables as jest.Mock).mockReturnValue({
+      [table1Input.TableName]: table1Input.TableName,
+      [table2Input.TableName]: { ...table2Input, GlobalSecondaryIndex: [] },
+    });
+
+    const mockDDBConfig: MockDynamoDBConfig = {
+      tables: [
+        { Properties: table1Input, isNewlyAdded: false },
+        { Properties: table2Input, isNewlyAdded: false },
+      ],
+    };
+    const ddbClient = {
+      createTables: createTablesMock,
+      listTables: mockListTables,
+      getUpdateTableInput,
+    };
+
+    await createAndUpdateTable(ddbClient as unknown as DynamoDB, mockDDBConfig);
+    expect(createTables).toHaveBeenCalledWith(ddbClient, []);
     expect(getUpdateTableInput).toHaveBeenCalledWith(table2Input, { ...table2Input, GlobalSecondaryIndex: [] });
-    expect(updateTables).toHaveBeenCalledWith(client, getUpdateTableInputResult);
+    expect(updateTables).toHaveBeenCalledWith(ddbClient, getUpdateTableInputResult);
   });
 });

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-cfn-params.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-cfn-params.test.ts
@@ -1,6 +1,7 @@
 import { stateManager } from '@aws-amplify/amplify-cli-core';
 import _ from 'lodash';
 import { populateCfnParams } from '../../../utils/lambda/populate-cfn-params';
+import { printer } from '@aws-amplify/amplify-prompts';
 
 jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('../../../api/api', () => ({
@@ -19,6 +20,15 @@ stateManager_mock.getLocalEnvInfo.mockReturnValue({
 const teamProviderParam = {
   anotherCfnParam: 'testValue',
 };
+stateManager_mock.getMeta.mockReturnValue({
+  providers: {
+    awscloudformation: {
+      Region: 'test-region',
+      StackId: 'arn:aws:cloudformation:us-test-1:1234:stack/my-test-stack',
+      StackName: 'test-stack-name',
+    },
+  },
+});
 stateManager_mock.getTeamProviderInfo.mockReturnValue({
   test: {
     awscloudformation: {
@@ -69,8 +79,17 @@ const meta_stub = {
   },
 };
 
+let ensureEnvParamManager;
 describe('populate cfn params', () => {
-  it('includes CFN pseudo parameters', () => {
+  beforeAll(async () => {
+    ({ ensureEnvParamManager } = await import('@aws-amplify/amplify-environment-parameters'));
+    await ensureEnvParamManager('test');
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+  it('includes CFN pseudo parameters', async () => {
     expect(populateCfnParams('test')).toMatchObject({
       env: 'test',
       'AWS::Region': 'test-region',
@@ -81,14 +100,13 @@ describe('populate cfn params', () => {
     });
   });
 
-  it('falls back to default pseudo params when not in team provider', () => {
-    stateManager_mock.getTeamProviderInfo.mockReturnValueOnce({
-      test: {
+  it('falls back to default pseudo params when not in team provider', async () => {
+    stateManager_mock.getMeta.mockReturnValueOnce({
+      providers: {
         awscloudformation: {},
       },
     });
-
-    expect(populateCfnParams(undefined)).toMatchObject({
+    expect(populateCfnParams('test')).toMatchObject({
       env: 'test',
       'AWS::Region': 'us-test-1',
       'AWS::AccountId': '12345678910',
@@ -98,8 +116,8 @@ describe('populate cfn params', () => {
     });
   });
 
-  it('gets dependsOn params from amplify-meta', () => {
-    stateManager_mock.getMeta.mockReturnValueOnce(meta_stub);
+  it('gets dependsOn params from amplify-meta', async () => {
+    stateManager_mock.getMeta.mockReturnValue(meta_stub);
     expect(populateCfnParams('func1')).toMatchObject({
       apimyApiapiName: 'testApiName',
       storagemytabletableName: 'testTableName',
@@ -107,45 +125,45 @@ describe('populate cfn params', () => {
     });
   });
 
-  it('overwrites api endpoint url when specified', () => {
+  it('overwrites api endpoint url when specified', async () => {
     const meta_stub_copy = _.cloneDeep(meta_stub);
     meta_stub_copy.function.func1.dependsOn[1].attributes.push('GraphQLAPIEndpointOutput');
-    stateManager_mock.getMeta.mockReturnValueOnce(meta_stub_copy);
+    stateManager_mock.getMeta.mockReturnValue(meta_stub_copy);
     expect(populateCfnParams('func1', true)).toMatchObject({
       apimyApiGraphQLAPIEndpointOutput: `http://localhost:666/graphql`,
     });
   });
 
-  it('overwrites api key when specified', () => {
+  it('overwrites api key when specified', async () => {
     const meta_stub_copy = _.cloneDeep(meta_stub);
     meta_stub_copy.function.func1.dependsOn[1].attributes.push('GraphQLAPIKeyOutput');
-    stateManager_mock.getMeta.mockReturnValueOnce(meta_stub_copy);
+    stateManager_mock.getMeta.mockReturnValue(meta_stub_copy);
     expect(populateCfnParams('func1', true)).toMatchObject({
       apimyApiGraphQLAPIKeyOutput: 'da2-fakeApiId123456',
     });
   });
 
-  it('prints warning when no value found', () => {
+  it('prints warning when no value found', async () => {
     const meta_stub_copy = _.cloneDeep(meta_stub);
+    stateManager_mock.getMeta.mockReturnValue(meta_stub_copy);
     meta_stub_copy.function.func1.dependsOn[1].attributes.push('GraphQLAPIEndpointOutput');
-    stateManager_mock.getMeta.mockReturnValueOnce(meta_stub_copy);
-    const warningMock = jest.fn();
+    const warningSpy = jest.spyOn(printer, 'warn');
     const result = populateCfnParams('func1');
     expect(typeof result).toBe('object');
     expect(result.apimyApiGraphQLAPIEndpointOutput).toBeUndefined();
-    expect(warningMock.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "No output found for attribute 'GraphQLAPIEndpointOutput' on resource 'myApi' in category 'api'",
-        ],
-        Array [
-          "This attribute will be undefined in the mock environment until you run \`amplify push\`",
-        ],
-      ]
-    `);
+    expect(warningSpy.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "No output found for attribute 'GraphQLAPIEndpointOutput' on resource 'myApi' in category 'api'",
+      ],
+      [
+        "This attribute will be undefined in the mock environment until you run \`amplify push\`",
+      ],
+    ]
+  `);
   });
 
-  it('includes params from parameters.json', () => {
+  it('includes params from parameters.json', async () => {
     const expectedMap = {
       someOtherParam: 'this is the value',
     };

--- a/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-lambda-mock-env-vars.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/lambda/populate-lambda-mock-env-vars.test.ts
@@ -25,7 +25,7 @@ pathManager_mock.getBackendDirPath.mockReturnValue('backend/path');
 
 const dotenv_mock = dotenv as jest.Mocked<typeof dotenv>;
 
-describe('populate labmda mock env vars', () => {
+describe('populate lambda mock env vars', () => {
   beforeEach(() => jest.clearAllMocks());
   it('populates AWS credential variables', async () => {
     const processedLambda: ProcessedLambdaFunction = {
@@ -50,8 +50,8 @@ describe('populate labmda mock env vars', () => {
       handler: 'test.handler',
       environment: {},
     };
-    stateManager_mock.getTeamProviderInfo.mockReturnValueOnce({
-      test: {
+    stateManager_mock.getMeta.mockReturnValue({
+      providers: {
         awscloudformation: {
           Region: 'test-region',
         },

--- a/packages/amplify-util-mock/src/utils/dynamo-db/helpers.ts
+++ b/packages/amplify-util-mock/src/utils/dynamo-db/helpers.ts
@@ -19,13 +19,16 @@ export async function waitTillTableStateIsActive(
         resolve();
       }
     };
-    intervalHandle = setInterval(void checkStatus, 1000);
+    intervalHandle = setInterval(() => {
+      void (async () => {
+        await checkStatus();
+      })();
+    }, 1000);
     timeoutHandle = setTimeout(() => {
+      console.log('timed out');
       clearTimeout(timeoutHandle);
       clearInterval(intervalHandle);
       reject(new Error('Waiting for table status to turn ACTIVE timed out'));
     }, maximumWait);
-
-    void checkStatus();
   });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Make changes to support yarn 2 including jest 29.5 for the amplify-util-mock package.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
