### PR TITLE
fix(amplify-util-uibuilder): update codegen-ui to 2.13.2-ad9ba60.0

### DIFF
--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.0.5",
     "@aws-amplify/amplify-prompts": "2.7.0",
-    "@aws-amplify/codegen-ui": "2.13.1",
-    "@aws-amplify/codegen-ui-react": "2.13.1",
+    "@aws-amplify/codegen-ui": "2.13.2-ad9ba60.0",
+    "@aws-amplify/codegen-ui-react": "2.13.2-ad9ba60.0",
     "amplify-codegen": "^3.4.4",
     "aws-sdk": "^2.1354.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/createUiBuilderComponent.test.ts
@@ -76,7 +76,7 @@ describe('can create a ui builder component', () => {
   it('calls the renderManager for utils file w/ validation, formatter, and fetchByPath helpers if there is a form', () => {
     generateAmplifyUiBuilderUtilFile(context, { hasForms: true, hasViews: false });
     expect(new codegenMock.StudioTemplateRendererManager().renderSchemaToTemplate).toBeCalledWith(
-      expect.arrayContaining(['validation', 'formatter', 'fetchByPath']),
+      expect.arrayContaining(['validation', 'formatter', 'fetchByPath', 'processFile']),
     );
   });
   it('calls the renderManager for utils file w/ formatter helper if there is a view', () => {

--- a/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/codegenResources.ts
@@ -188,6 +188,7 @@ export const generateAmplifyUiBuilderUtilFile = (context: $TSContext, { hasForms
     utils.add('validation');
     utils.add('formatter');
     utils.add('fetchByPath');
+    utils.add('processFile');
   }
 
   if (hasViews) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,21 +175,21 @@
   dependencies:
     "@aws-amplify/core" "4.3.11"
 
-"@aws-amplify/codegen-ui-react@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.13.1.tgz#afaf78ed60d5bfae108d5d2d55f8b493fd5c2c99"
-  integrity sha512-69DpPuIrCfd6HWrrorH/0NnIn/XlBW7M/f6lXLn0NLnUWcn0sGIFIqt08HJccISt+ZlqmGLxAf+a8abZPW4Pmw==
+"@aws-amplify/codegen-ui-react@2.13.2-ad9ba60.0":
+  version "2.13.2-ad9ba60.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui-react/-/codegen-ui-react-2.13.2-ad9ba60.0.tgz#b2559c9204b6717cb68c474a31d6186b6f10e606"
+  integrity sha512-5rKdx8PnpNU0vYvGKcDyR2W01ngbWZX/DV5ay5exvkhoXf9cc72in8fGMXr2LqtKUG9FgBitRjLIEonsfV/jtA==
   dependencies:
-    "@aws-amplify/codegen-ui" "2.13.1"
+    "@aws-amplify/codegen-ui" "2.13.2-ad9ba60.0"
     "@typescript/vfs" "~1.3.5"
     typescript "<=4.5.0"
   optionalDependencies:
     prettier "2.3.2"
 
-"@aws-amplify/codegen-ui@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.13.1.tgz#5ea375cee4b81c60fa3378a55f565055297021e3"
-  integrity sha512-E348akzfNse6vtYMWW1ZFJwmI5km4TUzr7zW+mhw3/7gqqCE5ARG2gy6voL9+w8oC+XAg0g7H3GstpxdLhCVKA==
+"@aws-amplify/codegen-ui@2.13.2-ad9ba60.0":
+  version "2.13.2-ad9ba60.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/codegen-ui/-/codegen-ui-2.13.2-ad9ba60.0.tgz#8fcf39c364318cc241cfb8706790a6a1e86f059d"
+  integrity sha512-RmOcduk8qYkPGMaQFDVJ40cZUScRIVusDvi2yP/rTzGkKMwLXegVEZJq1NL7M/f2TK1FxMQHVqQi3WM5VrwGtQ==
   dependencies:
     change-case "^4.1.2"
     yup "^0.32.11"
@@ -20407,7 +20407,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
 
 pkg-fetch@3.4.2, "pkg-fetch@https://github.com/aws-amplify/pkg-fetch#ad4a21feb533d338bf951e7ba28cea7256aedeff":
   version "3.4.2"
-  uid ad4a21feb533d338bf951e7ba28cea7256aedeff
   resolved "https://github.com/aws-amplify/pkg-fetch#ad4a21feb533d338bf951e7ba28cea7256aedeff"
   dependencies:
     chalk "^4.1.2"


### PR DESCRIPTION

#### Description of changes
[fix: parse operand value when field is number type](https://github.com/aws-amplify/amplify-codegen-ui/pull/1013)

#### Description of how you validated changes
`yarn setup-dev`
amplify pull

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
