### PR TITLE
fix: warn about multiple schema files in admin modelgen task

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
@@ -72,10 +72,10 @@ describe('project with single schema file that exists', () => {
     } as unknown as $TSContext;
     fsMock.existsSync.mockReturnValue(true);
   });
-  
+
   it('invokes codegen functions and writes assets to S3', async () => {
     await adminModelgen(contextStub, resources);
-  
+
     expect(invokePluginMock.mock.calls.length).toBe(2);
     expect(invokePluginMock.mock.calls[0][3]).toBe('generateModels');
     expect(invokePluginMock.mock.calls[1][3]).toBe('generateModelIntrospection');
@@ -105,27 +105,27 @@ describe('project with single schema file that exists', () => {
       ]
     `);
   });
-  
+
   it('resets js config on error', async () => {
     invokePluginMock.mockRejectedValue(new Error('test error'));
     await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
     expect(stateManagerMock.setProjectConfig.mock.calls.length).toBe(2);
     expect(stateManagerMock.setProjectConfig.mock.calls[1][1]).toBe(originalProjectConfig);
   });
-  
+
   it('resets stdout on error', async () => {
     const initialStdoutWriter = process.stdout.write;
     invokePluginMock.mockRejectedValue(new Error('test error'));
     await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
     expect(process.stdout.write).toBe(initialStdoutWriter);
   });
-  
+
   it('removes temp dir on error', async () => {
     invokePluginMock.mockRejectedValue(new Error('test error'));
     await expect(adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
     expect(fsMock.remove.mock.calls.length).toBe(1);
     expect(fsMock.remove.mock.calls[0][0]).toMatchInlineSnapshot(`"mock/project/root/amplify-codegen-temp"`);
-  });  
+  });
 });
 
 describe('project without a single schema file or with multiple schema files', () => {
@@ -138,12 +138,14 @@ describe('project without a single schema file or with multiple schema files', (
     } as unknown as $TSContext;
     fsMock.existsSync.mockReturnValue(false);
   });
-  
+
   it('early returns and throws appropriate warning', async () => {
     await adminModelgen(contextStub, resources);
-  
+
     expect(invokePluginMock.mock.calls.length).toBe(0);
     expect(s3Mock.uploadFile.mock.calls.length).toBe(0);
-    expect(printer.warn).toBeCalledWith(`Could not find the GraphQL schema file at \"mock/resource/dir/path/schema.graphql\". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`);
+    expect(printer.warn).toBeCalledWith(
+      `Could not find the GraphQL schema file at \"mock/resource/dir/path/schema.graphql\". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`,
+    );
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
@@ -83,23 +83,23 @@ describe('project with single schema file that exists', () => {
     expect(invokePluginMock.mock.calls[0][3]).toBe('generateModels');
     expect(invokePluginMock.mock.calls[1][3]).toBe('generateModelIntrospection');
     expect(s3Mock.uploadFile.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
+      [
+        [
+          {
             "Body": "mock body of mock/resource/dir/path/schema.graphql",
             "Key": "models/testApiName/schema.graphql",
           },
           false,
         ],
-        Array [
-          Object {
+        [
+          {
             "Body": "mock body of mock/project/root/amplify-codegen-temp/models/schema.js",
             "Key": "models/testApiName/schema.js",
           },
           false,
         ],
-        Array [
-          Object {
+        [
+          {
             "Body": "mock body of mock/project/root/amplify-codegen-temp/model-introspection.json",
             "Key": "models/testApiName/modelIntrospection.json",
           },

--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
@@ -2,12 +2,14 @@ import { $TSContext, stateManager, pathManager } from '@aws-amplify/amplify-cli-
 import * as fs from 'fs-extra';
 import { adminModelgen } from '../admin-modelgen';
 import { S3 } from '../aws-utils/aws-s3';
+import { printer } from '@aws-amplify/amplify-prompts';
 
 jest.mock('fs-extra');
 jest.mock('../aws-utils/aws-s3');
 jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('graphql-transformer-core');
 jest.mock('../utils/admin-helpers');
+jest.mock('@aws-amplify/amplify-prompts');
 
 const fsMock = fs as jest.Mocked<typeof fs>;
 const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
@@ -60,65 +62,88 @@ const invokePluginMock = jest.fn();
 
 let contextStub: $TSContext;
 
-beforeEach(() => {
-  jest.clearAllMocks();
-  contextStub = {
-    amplify: {
-      invokePluginMethod: invokePluginMock,
-    },
-  } as unknown as $TSContext;
+describe('project with single schema file that exists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    contextStub = {
+      amplify: {
+        invokePluginMethod: invokePluginMock,
+      },
+    } as unknown as $TSContext;
+    fsMock.existsSync.mockReturnValue(true);
+  });
+  
+  it('invokes codegen functions and writes assets to S3', async () => {
+    await adminModelgen(contextStub, resources);
+  
+    expect(invokePluginMock.mock.calls.length).toBe(2);
+    expect(invokePluginMock.mock.calls[0][3]).toBe('generateModels');
+    expect(invokePluginMock.mock.calls[1][3]).toBe('generateModelIntrospection');
+    expect(s3Mock.uploadFile.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "Body": "mock body of mock/resource/dir/path/schema.graphql",
+            "Key": "models/testApiName/schema.graphql",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "Body": "mock body of mock/project/root/amplify-codegen-temp/models/schema.js",
+            "Key": "models/testApiName/schema.js",
+          },
+          false,
+        ],
+        Array [
+          Object {
+            "Body": "mock body of mock/project/root/amplify-codegen-temp/model-introspection.json",
+            "Key": "models/testApiName/modelIntrospection.json",
+          },
+          false,
+        ],
+      ]
+    `);
+  });
+  
+  it('resets js config on error', async () => {
+    invokePluginMock.mockRejectedValue(new Error('test error'));
+    await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
+    expect(stateManagerMock.setProjectConfig.mock.calls.length).toBe(2);
+    expect(stateManagerMock.setProjectConfig.mock.calls[1][1]).toBe(originalProjectConfig);
+  });
+  
+  it('resets stdout on error', async () => {
+    const initialStdoutWriter = process.stdout.write;
+    invokePluginMock.mockRejectedValue(new Error('test error'));
+    await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
+    expect(process.stdout.write).toBe(initialStdoutWriter);
+  });
+  
+  it('removes temp dir on error', async () => {
+    invokePluginMock.mockRejectedValue(new Error('test error'));
+    await expect(adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
+    expect(fsMock.remove.mock.calls.length).toBe(1);
+    expect(fsMock.remove.mock.calls[0][0]).toMatchInlineSnapshot(`"mock/project/root/amplify-codegen-temp"`);
+  });  
 });
 
-it('invokes codegen functions and writes assets to S3', async () => {
-  await adminModelgen(contextStub, resources);
-
-  expect(invokePluginMock.mock.calls.length).toBe(2);
-  expect(invokePluginMock.mock.calls[0][3]).toBe('generateModels');
-  expect(invokePluginMock.mock.calls[1][3]).toBe('generateModelIntrospection');
-  expect(s3Mock.uploadFile.mock.calls).toMatchInlineSnapshot(`
-[
-  [
-    {
-      "Body": "mock body of mock/resource/dir/path/schema.graphql",
-      "Key": "models/testApiName/schema.graphql",
-    },
-    false,
-  ],
-  [
-    {
-      "Body": "mock body of mock/project/root/amplify-codegen-temp/models/schema.js",
-      "Key": "models/testApiName/schema.js",
-    },
-    false,
-  ],
-  [
-    {
-      "Body": "mock body of mock/project/root/amplify-codegen-temp/model-introspection.json",
-      "Key": "models/testApiName/modelIntrospection.json",
-    },
-    false,
-  ],
-]
-`);
-});
-
-it('resets js config on error', async () => {
-  invokePluginMock.mockRejectedValue(new Error('test error'));
-  await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
-  expect(stateManagerMock.setProjectConfig.mock.calls.length).toBe(2);
-  expect(stateManagerMock.setProjectConfig.mock.calls[1][1]).toBe(originalProjectConfig);
-});
-
-it('resets stdout on error', async () => {
-  const initialStdoutWriter = process.stdout.write;
-  invokePluginMock.mockRejectedValue(new Error('test error'));
-  await expect(() => adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
-  expect(process.stdout.write).toBe(initialStdoutWriter);
-});
-
-it('removes temp dir on error', async () => {
-  invokePluginMock.mockRejectedValue(new Error('test error'));
-  await expect(adminModelgen(contextStub, resources)).rejects.toThrowErrorMatchingInlineSnapshot(`"test error"`);
-  expect(fsMock.remove.mock.calls.length).toBe(1);
-  expect(fsMock.remove.mock.calls[0][0]).toMatchInlineSnapshot(`"mock/project/root/amplify-codegen-temp"`);
+describe('project without a single schema file or with multiple schema files', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    contextStub = {
+      amplify: {
+        invokePluginMethod: invokePluginMock,
+      },
+    } as unknown as $TSContext;
+    fsMock.existsSync.mockReturnValue(false);
+  });
+  
+  it('early returns and throws appropriate warning', async () => {
+    await adminModelgen(contextStub, resources);
+  
+    expect(invokePluginMock.mock.calls.length).toBe(0);
+    expect(s3Mock.uploadFile.mock.calls.length).toBe(0);
+    expect(printer.warn).toBeCalledWith(`Could not find the GraphQL schema file at \"mock/resource/dir/path/schema.graphql\". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`);
+  });
 });

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import * as path from 'path';
 import { S3 } from './aws-utils/aws-s3';
 import { ProviderName as providerName } from './constants';
+import { printer } from '@aws-amplify/amplify-prompts';
 
 /**
  * Generates DataStore Models for Admin UI CMS to consume
@@ -23,6 +24,13 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
   const appId = amplifyMeta?.providers?.[providerName]?.AmplifyAppId;
 
   if (!appId) {
+    return;
+  }
+
+  const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
+  // Early return with useful warning if the schema file does not exist
+  if (!fs.existsSync(localSchemaPath)) {
+    printer.warn(`Could not find the GraphQL schema file at "${localSchemaPath}". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`);
     return;
   }
 
@@ -65,7 +73,6 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/model-intropection.js#L8
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModelIntrospection', [context]);
 
-    const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
     const localSchemaJsPath = path.join(absoluteTempOutputDir, 'models', 'schema.js');
     const localModelIntrospectionPath = path.join(absoluteTempOutputDir, 'model-introspection.json');
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -30,7 +30,9 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
   const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
   // Early return with useful warning if the schema file does not exist
   if (!fs.existsSync(localSchemaPath)) {
-    printer.warn(`Could not find the GraphQL schema file at "${localSchemaPath}". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`);
+    printer.warn(
+      `Could not find the GraphQL schema file at "${localSchemaPath}". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`,
+    );
     return;
   }
 

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { S3 } from './aws-utils/aws-s3';
 import { ProviderName as providerName } from './constants';
 import { printer } from '@aws-amplify/amplify-prompts';
+import { isAmplifyAdminApp } from './utils/admin-helpers';
 
 /**
  * Generates DataStore Models for Admin UI CMS to consume
@@ -28,11 +29,14 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
   }
 
   const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
-  // Early return with useful warning if the schema file does not exist
+  // Early return with a warning if the schema file does not exist
   if (!fs.existsSync(localSchemaPath)) {
-    printer.warn(
-      `Could not find the GraphQL schema file at "${localSchemaPath}". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`,
-    );
+    const { isAdminApp } = await isAmplifyAdminApp(appId);
+    if (isAdminApp) {
+      printer.warn(
+        `Could not find the GraphQL schema file at "${localSchemaPath}". Amplify Studio's schema editor might not work as intended if you're using multiple schema files.`,
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
If the customer is using multiple GraphQL schema files located at `<amplify/backend/api/<api_name>/schema>` folder instead of a single `schema.graphql` file, the current behavior is to fail softly by throwing the following error:
```
ENOENT: no such file or directory... schema.graphql
```
This error message occurs during the admin modelgen flow where we upload the Studio CMS artifacts to deployment S3 bucket. 
The current behavior is that we fail to update the schema, but generate and update the modelgen files in S3 bucket. When customer tries to open the Schema editor in Studio console, it fails to load.
With this change, we check and early return if we detect that there is no single schema file. In addition we display a warning message.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-category-api/issues/1074

#### Description of how you validated changes
Added unit test.
Tested from a JS app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
