### PR TITLE
fix: skip adding cfn params when user pool inputs are absent

### DIFF
--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-stack-transform.ts
@@ -569,7 +569,11 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
         this.addCfnParameterWithNoEcho('signinwithappleAuthorizeScopes', providerMeta.authorize_scopes, true);
         this.addCfnParameterWithNoEcho('signinwithappleClientIdUserPool', providerCreds.client_id, !props.signinwithappleClientIdUserPool);
         this.addCfnParameterWithNoEcho('signinwithappleKeyIdUserPool', providerCreds.key_id, !props.signinwithappleKeyIdUserPool);
-        this.addCfnParameterWithNoEcho('signinwithapplePrivateKeyUserPool', providerCreds.private_key, !props.signinwithapplePrivateKeyUserPool);
+        this.addCfnParameterWithNoEcho(
+          'signinwithapplePrivateKeyUserPool',
+          providerCreds.private_key,
+          !props.signinwithapplePrivateKeyUserPool,
+        );
         this.addCfnParameterWithNoEcho('signinwithappleTeamIdUserPool', providerCreds.team_id, !props.signinwithappleTeamIdUserPool);
       } else if (ProviderName === 'Facebook' && 'client_id' in providerCreds) {
         this.addCfnParameterWithNoEcho('facebookAuthorizeScopes', providerMeta.authorize_scopes, true);
@@ -582,7 +586,11 @@ export class AmplifyAuthTransform extends AmplifyCategoryTransform {
       } else if (ProviderName === 'LoginWithAmazon' && 'client_id' in providerCreds) {
         this.addCfnParameterWithNoEcho('loginwithamazonAuthorizeScopes', providerMeta.authorize_scopes, true);
         this.addCfnParameterWithNoEcho('loginwithamazonAppIdUserPool', providerCreds.client_id, !props.loginwithamazonAppIdUserPool);
-        this.addCfnParameterWithNoEcho('loginwithamazonAppSecretUserPool', providerCreds.client_secret, !props.loginwithamazonAppSecretUserPool);
+        this.addCfnParameterWithNoEcho(
+          'loginwithamazonAppSecretUserPool',
+          providerCreds.client_secret,
+          !props.loginwithamazonAppSecretUserPool,
+        );
       }
     });
   };

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/types.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/types.ts
@@ -4,6 +4,15 @@ export interface ProviderMeta {
   AttributeMapping: { [key: string]: string | undefined };
 }
 
+export interface ProviderCreds {
+  ProviderName: string;
+  client_id: string;
+  client_secret?: string;
+  team_id?: string;
+  key_id?: string;
+  private_key?: string;
+}
+
 export type OAuthMetaData = {
   AllowedOAuthFlows?: Array<string>;
   AllowedOAuthFlowsUserPoolClient?: boolean;

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/constants.ts
@@ -87,19 +87,6 @@ export const privateKeys = [
   'additionalQuestions',
 ];
 
-export const socialSignInKeys: { [key: string]: string[] } = {
-  Facebook: ['facebookAppIdUserPool', 'facebookAuthorizeScopes', 'facebookAppSecretUserPool'],
-  Google: ['googleAppIdUserPool', 'googleAuthorizeScopes', 'googleAppSecretUserPool'],
-  LoginWithAmazon: ['loginwithamazonAppIdUserPool', 'loginwithamazonAuthorizeScopes', 'loginwithamazonAppSecretUserPool'],
-  SignInWithApple: [
-    'signinwithappleAuthorizeScopes',
-    'signinwithappleClientIdUserPool',
-    'signinwithappleKeyIdUserPool',
-    'signinwithapplePrivateKeyUserPool',
-    'signinwithappleTeamIdUserPool',
-  ],
-};
-
 export const SignInWithApple = 'SignInWithApple';
 
 // amplify console auth options


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Fixes the instance when:
- user 1 creates auth
- user 1 pushes
- user 2 pulls auth
- user 2 force pushes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

This will be covered by an e2e test for switching directories.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
