### PR TITLE
chore: update stunnel download in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,10 @@ FROM core AS tools
 
 # Install stunnel
 RUN set -ex \
-   && STUNNEL_VERSION=5.67 \
+   && STUNNEL_VERSION=5.69 \
    && STUNNEL_TAR=stunnel-$STUNNEL_VERSION.tar.gz \
-   && STUNNEL_SHA256="3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456" \
-   && curl -o $STUNNEL_TAR https://www.usenix.org.uk/mirrors/stunnel/archive/5.x/$STUNNEL_TAR && echo "$STUNNEL_SHA256 $STUNNEL_TAR" | sha256sum --check && tar xfz $STUNNEL_TAR \
+   && STUNNEL_SHA256="1ff7d9f30884c75b98c8a0a4e1534fa79adcada2322635e6787337b4e38fdb81" \
+   && curl -o $STUNNEL_TAR https://www.stunnel.org/archive/5.x/$STUNNEL_TAR && echo "$STUNNEL_SHA256 $STUNNEL_TAR" | sha256sum --check && tar xfz $STUNNEL_TAR \
    && cd stunnel-$STUNNEL_VERSION \
    && ./configure \
    && make -j4 \


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- bump stunnel to 5.69
- update to use North American download server

Taken from stunnel patch [notes](https://www.stunnel.org/NEWS.html):
```md
Version 5.69, 2023.03.04, urgency: MEDIUM

    New features
        Improved logging performance with the "output" option.
        Improved file read performance on the WIN32 platform.
        DH and kDHEPSK ciphersuites removed from FIPS defaults.
        Set the LimitNOFILE ulimit in stunnel.service to allow for up to 10,000 concurrent clients.
    Bugfixes
        Fixed the "CApath" option on the WIN32 platform by applying https://github.com/openssl/openssl/pull/20312.
        Fixed stunnel.spec used for building rpm packages.
        Fixed tests on some OSes and architectures by merging Debian 07-tests-errmsg.patch (thx to Peter Pentchev).

Version 5.68, 2023.02.07, urgency: HIGH

    Security bugfixes
        OpenSSL DLLs updated to version 3.0.8.
    New features
        Added the new 'CAengine' service-level option to load a trusted CA certificate from an engine.
        Added requesting client certificates in server mode with 'CApath' besides 'CAfile'.
        Improved file read performance.
        Improved logging performance.
    Bugfixes
        Fixed EWOULDBLOCK errors in protocol negotiation.
        Fixed handling TLS errors in protocol negotiation.
        Prevented following fatal TLS alerts with TCP resets.
        Improved OpenSSL initialization on WIN32.
        Improved testing suite stability.

```

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
