### PR TITLE
ci: add e2e coverage clover reports and cast artifacts

### DIFF
--- a/codebuild_specs/run_e2e_tests_linux.yml
+++ b/codebuild_specs/run_e2e_tests_linux.yml
@@ -34,16 +34,21 @@ phases:
       - source ./shared-scripts.sh && _runE2ETestsLinux
   post_build:
     commands:
+      - source ./shared-scripts.sh && _convertCoverage # && _uploadCoverageLinux (disabled while troubleshooting E2E test failures during initial CodeBuild setup)
       - source ./shared-scripts.sh && _scanArtifacts
-      - source ./shared-scripts.sh && storeCache packages/amplify-e2e-tests/$E2E_TEST_COVERAGE_DIR e2e-test-coverage-raw
       - source ./shared-scripts.sh && _uploadReportsToS3 $CODEBUILD_SOURCE_VERSION $CODEBUILD_BATCH_BUILD_IDENTIFIER amplify-e2e-tests
 artifacts:
   files:
-    - '**/*'
-  base-directory: packages/amplify-e2e-tests/$E2E_TEST_COVERAGE_DIR
+    - '$E2E_TEST_COVERAGE_DIR/*'
+    - amplify-e2e-reports/*
+  base-directory: packages/amplify-e2e-tests/
 reports:
   e2e-reports:
     files:
       - '*.xml'
     file-format: 'JUNITXML'
     base-directory: '$CODEBUILD_SRC_DIR/packages/amplify-e2e-tests/reports/junit'
+  e2e-coverage-report:
+    files:
+      - 'packages/amplify-e2e-tests/coverage/clover.xml'
+    file-format: CLOVERXML

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -250,8 +250,9 @@ function _convertCoverage {
     # assuming e2e tests are run from the amplify-e2e-tests directory:
     # .../amplify-e2e-tests/$NODE_V8_COVERAGE - generated with setting NODE_V8_COVERAGE env var
     # .../amplify-e2e-tests/coverage/<reporter> - generated with c8 command
-    loadCache e2e-test-coverage-raw $E2E_TEST_COVERAGE_DIR
+    pushd packages/amplify-e2e-tests
     npx c8 report --temp-directory $E2E_TEST_COVERAGE_DIR --all --src ./packages -x "**/node_modules/**" -x "**/__tests__/**" --exclude-after-remap "**/node_modules/**" -x "**/amplify-e2e-*/**" -x "**/.yarn/**" --allow-external --reporter clover
+    popd
 }
 # https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
 function _uploadCoverageLinux {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Adds cast artifact capturing to E2E tests and adjusts the convert coverage call to be part of the post-build section of the e2e test run instead of being in its own job. CodeCov support line is included, but commented out as is currently failing to find the CodeCov token properly.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran beta full build to verify that casts objects were picked up and that nothing else broke.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
