### PR TITLE
ci: Add codeowners for CI/CD files & folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Add folks focused on reviewing changes to CI/CD scripts/buildspecs
 
-/.circleci/ @awsluja @sobolk
-/scripts/ @awsluja @sobolk
-/shared-scripts.sh @awsluja @goldbez
-/codebuild_specs/ @awsluja @goldbez
+/.circleci/ @awsluja @sobolk @aws-amplify/amplify-cli-admins 
+/scripts/ @awsluja @sobolk @aws-amplify/amplify-cli-admins 
+/shared-scripts.sh @awsluja @goldbez @aws-amplify/amplify-cli-admins 
+/codebuild_specs/ @awsluja @goldbez @aws-amplify/amplify-cli-admins 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Add folks focused on reviewing changes to CI/CD scripts/buildspecs
 
-/.circleci/ @awsluja @sobolk @aws-amplify/amplify-cli-admins 
-/scripts/ @awsluja @sobolk @aws-amplify/amplify-cli-admins 
-/shared-scripts.sh @awsluja @goldbez @aws-amplify/amplify-cli-admins 
-/codebuild_specs/ @awsluja @goldbez @aws-amplify/amplify-cli-admins 
+/.circleci/ @aws-amplify/amplify-cli-admins 
+/scripts/ @aws-amplify/amplify-cli-admins 
+/shared-scripts.sh @aws-amplify/amplify-cli-admins 
+/codebuild_specs/ @aws-amplify/amplify-cli-admins 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,15 @@
 # Amplify CLI Team owns the full repo by default.
-* @aws-amplify/amplify-cli
+
+- @aws-amplify/amplify-cli
 
 # Add Data team folks focused on GQL transform/codegen to ownership for packages which will be migrated, in addition to the existing cli team.
+
 /packages/amplify-graphiql-explorer @aws-amplify/amplify-cli @aws-amplify/amplify-data-buildtime
 /packages/amplify-velocity-template @aws-amplify/amplify-cli @aws-amplify/amplify-data-buildtime
+
+# Add folks focused on reviewing changes to CI/CD scripts/buildspecs
+
+/.circleci/ @awsluja @sobolk
+/scripts/ @awsluja @sobolk
+/shared-scripts.sh @awsluja @goldbez
+/codebuild_specs/ @awsluja @goldbez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Amplify CLI Team owns the full repo by default.
 
-- @aws-amplify/amplify-cli
+* @aws-amplify/amplify-cli
 
 # Add Data team folks focused on GQL transform/codegen to ownership for packages which will be migrated, in addition to the existing cli team.
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add codeowners to ensure that CI/CD files and folders are reviewed by certain members of our team.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
