### PR TITLE
fix(push): fix push with multiple .graphql files

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/admin-modelgen.test.ts
@@ -79,7 +79,7 @@ it('invokes codegen functions and writes assets to S3', async () => {
 [
   [
     {
-      "Body": "mock body of mock/resource/dir/path/schema.graphql",
+      "Body": "mock body of mock/project/root/amplify-codegen-temp/schema.graphql",
       "Key": "models/testApiName/schema.graphql",
     },
     false,

--- a/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
+++ b/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts
@@ -1,4 +1,5 @@
 import { $TSAny, $TSContext, pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
+import { readSchema } from 'graphql-transformer-core';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -65,7 +66,11 @@ export const adminModelgen = async (context: $TSContext, resources: $TSAny[]): P
     // invokes https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen/src/commands/model-intropection.js#L8
     await context.amplify.invokePluginMethod(context, 'codegen', undefined, 'generateModelIntrospection', [context]);
 
-    const localSchemaPath = path.join(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName), 'schema.graphql');
+    const schema = await readSchema(pathManager.getResourceDirectoryPath(undefined, 'api', resourceName));
+    const schemaContent = schema?.schema || '';
+    const localSchemaPath = path.join(absoluteTempOutputDir, 'schema.graphql');
+    await fs.writeFile(localSchemaPath, schemaContent);
+
     const localSchemaJsPath = path.join(absoluteTempOutputDir, 'models', 'schema.js');
     const localModelIntrospectionPath = path.join(absoluteTempOutputDir, 'model-introspection.json');
 


### PR DESCRIPTION
#### Description of changes
When using multiple `.graphql` files to compose the schema, `amplify push` doesn't generate models for Amplify Studio successfully, but fails with this error:

<img width="1278" alt="Screenshot 2023-05-28 at 20 58 29" src="https://github.com/aws-amplify/amplify-cli/assets/13872213/f476d0a3-6240-406f-9223-2dfc8c9e77a2">

It happens because this models generation process doesn't take into account that there could be multiple `.graphql` files composing the schema.
I guess this also affects the Amplify Studio functionality somehow, but haven't really observed anything.

So I just used the `readProjectSchema` function that considers both configurations (single file / multiple files) and uploaded the output.

#### Issue #, if available
(NA)

#### Description of how you validated changes
Test the `amplify push` command before and after, as well as the deployment bucket and Amplify Studio's `schema.graphql` file.

#### Checklist

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
