### PR TITLE
fix: rework usage data prompt

### DIFF
--- a/packages/amplify-cli-core/src/state-manager/pathManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/pathManager.ts
@@ -11,6 +11,7 @@ export const PathConstants = {
   AWSConfig: 'config',
   DeploymentSecretsFileName: 'deployment-secrets.json',
   AmplifyAdminDirName: 'admin',
+  UsageDataFileName: 'amplify-dev-configuration.json',
 
   // in project root
   AmplifyDirName: 'amplify',
@@ -95,6 +96,8 @@ export class PathManager {
   getHomeDotAmplifyDirPath = (): string => this.homeDotAmplifyDirPath;
 
   getAmplifyAdminDirPath = (): string => this.constructPath(this.getHomeDotAmplifyDirPath(), [PathConstants.AmplifyAdminDirName]);
+
+  getAmplifyUsageDataFilePath = (): string => this.constructPath(this.getHomeDotAmplifyDirPath(), [PathConstants.UsageDataFileName]);
 
   getAmplifyAdminConfigFilePath = (): string =>
     this.constructPath(this.getAmplifyAdminDirPath(), [PathConstants.AmplifyAdminConfigFileName]);

--- a/packages/amplify-cli-core/src/state-manager/stateManager.ts
+++ b/packages/amplify-cli-core/src/state-manager/stateManager.ts
@@ -63,6 +63,17 @@ export class StateManager {
     return data;
   };
 
+  getUsageTrackingConfig = (): $TSAny =>
+    JSONUtilities.readJson<$TSAny>(pathManager.getAmplifyUsageDataFilePath(), {
+      throwIfNotExist: false,
+    });
+
+  toggleUsageTrackingConsentSeen = (): void => {
+    const usageTrackingConfig = this.getUsageTrackingConfig();
+    usageTrackingConfig.usageDataConfig.usageDataPromptSeen = !usageTrackingConfig.usageDataConfig.usageDataPromptSeen;
+    JSONUtilities.writeJson(pathManager.getAmplifyUsageDataFilePath(), usageTrackingConfig);
+  };
+
   getDeploymentSecrets = (): DeploymentSecrets =>
     JSONUtilities.readJson<DeploymentSecrets>(pathManager.getDeploymentSecrets(), {
       throwIfNotExist: false,

--- a/packages/amplify-cli/src/app-config/config.ts
+++ b/packages/amplify-cli/src/app-config/config.ts
@@ -56,9 +56,11 @@ class Config {
 class UsageDataConfig {
   installationUuid: string;
   isUsageTrackingEnabled: boolean;
+  usageDataPromptSeen: boolean;
 
   constructor() {
     this.installationUuid = uuid();
     this.isUsageTrackingEnabled = true;
+    this.usageDataPromptSeen = false;
   }
 }

--- a/packages/amplify-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-e2e-core/src/init/initProjectHelper.ts
@@ -88,17 +88,13 @@ export function initJSProjectWithProfile(cwd: string, settings?: Partial<typeof 
         .wait('Please choose the profile you want to use')
         .sendLine(s.profileName);
     }
-    chain
-      .wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
-      .sendYes()
-      .wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/)
-      .run((err: Error) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
+    chain.wait(/Try "amplify add api" to create a backend API and then "amplify (push|publish)" to deploy everything/).run((err: Error) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
   });
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR moves the usage data prompt on post init to inform developers that we are collecting data to improve the CLI. It also gives them instructions for on how to opt out of this data collection mechanism. This configuration will be stored on a global variable and will only be seen by developers once.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
