### PR TITLE
fix: use and operator instead of semicolon to run unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
     "split-e2e-tests-codebuild": "yarn ts-node ./scripts/split-e2e-tests-codebuild.ts",
     "test-changed": "nx affected --target=test",
-    "test-ci": "nx run-many --parallel=4 --target=test --all --exclude='@aws-amplify/amplify-provider-awscloudformation' -- --ci --runInBand; nx run-many --target=test --projects='@aws-amplify/amplify-provider-awscloudformation' -- -ci --runInBand",
+    "test-ci": "nx run-many --parallel=4 --target=test --all --exclude='@aws-amplify/amplify-provider-awscloudformation' -- --ci --runInBand && nx run-many --target=test --projects='@aws-amplify/amplify-provider-awscloudformation' -- -ci --runInBand",
     "test": "nx run-many --target=test --all -- --runInBand",
     "update-data-packages": "./scripts/update-data-dependencies.sh && yarn",
     "update-test-timing-data": "ts-node ./scripts/cci-get-job-metrics.ts && ts-node ./scripts/cci-extract-test-timings-from-job-metrics.ts",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
