### PR TITLE
ci: rename e2e branch to avoid triggering circleci job

### DIFF
--- a/scripts/cloud-e2e.sh
+++ b/scripts/cloud-e2e.sh
@@ -40,7 +40,7 @@ function cloudE2E {
     echo Running Prod E2E Test Suite
     export CLOUD_E2E_PROFILE=AmplifyCLIE2E
     export CLOUD_E2E_ACCOUNT=$E2E_ACCOUNT_PROD
-    export TARGET_BRANCH=run-e2e/$USER/$CURR_BRANCH
+    export TARGET_BRANCH=run-cb-e2e/$USER/$CURR_BRANCH
     git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$TARGET_BRANCH --no-verify --force-with-lease
     authenticate
     triggerBuild

--- a/scripts/cloud-e2e.sh
+++ b/scripts/cloud-e2e.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# this file is used to automate the process of triggering an e2e build for each environment type
+
 # set exit on error to true
 set -e
 # load .env


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Using 'run-e2e' for the upstream branch name causes circleci jobs to trigger. We don't want to cut circleci files yet, so this alternative allows us to trigger codebuild jobs without triggering the circleci jobs.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
