### PR TITLE
fix: return login token error to studio

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/admin-login-server.ts
@@ -98,7 +98,10 @@ export class AdminLoginServer {
         delete req.body;
         res.sendStatus(200);
       } catch (err) {
-        res.sendStatus(500);
+        res.sendStatus(500).send({
+          errorName: 'AmplifyStudioLoginError',
+          errorMessage: `Failed to receive expected authentication tokens. Error: ${err}`,
+        });
         throw new AmplifyError(
           'AmplifyStudioLoginError',
           {


### PR DESCRIPTION
#### Description of changes
Return the error message to studio if storing tokens fails during the login flow.

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
