### PR TITLE
ci: separate codebuild & cci differences

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -267,8 +267,19 @@ function setAwsAccountCredentials {
         useChildAccountCredentials
     fi
 }
-
 function runE2eTest {
+    FAILED_TEST_REGEX_FILE="./amplify-e2e-reports/amplify-e2e-failed-test.txt"
+
+    if [ -f  $FAILED_TEST_REGEX_FILE ]; then
+        # read the content of failed tests
+        failedTests=$(<$FAILED_TEST_REGEX_FILE)
+        yarn e2e --forceExit --no-cache --maxWorkers=4 $TEST_SUITE -t "$failedTests"
+    else
+        yarn e2e --forceExit --no-cache --maxWorkers=4 $TEST_SUITE
+    fi
+}
+
+function runE2eTestCb {
     _setupCoverage
     FAILED_TEST_REGEX_FILE="./amplify-e2e-reports/amplify-e2e-failed-test.txt"
 

--- a/codebuild_specs/scripts-windows/run-e2e-windows.sh
+++ b/codebuild_specs/scripts-windows/run-e2e-windows.sh
@@ -20,4 +20,4 @@ cd packages/amplify-e2e-tests
 
 _loadTestAccountCredentials
 
-retry runE2eTest
+retry runE2eTestCb

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -289,7 +289,7 @@ function _runE2ETestsLinux {
     amplify version
     cd packages/amplify-e2e-tests
     _loadTestAccountCredentials
-    retry runE2eTest
+    retry runE2eTestCb
 }
 function _unassumeTestAccountCredentials {
     echo "Unassume Role"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a small change that prevents any changes to the circleci e2e script, while supporting both circleci/codebuild during the transition.

CircleCI e2e: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e/aluja/codebuild-cleanup

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
