### PR TITLE
fix: add type for error in scan artifacts

### DIFF
--- a/.circleci/scan_artifacts_codebuild.ts
+++ b/.circleci/scan_artifacts_codebuild.ts
@@ -13,7 +13,7 @@ export const hasMatchingContentInFolder = (patterns: string[], folder: string, e
   try {
     execa.sync('grep', ['-r', `--exclude-dir=${excludeFolder}`, ...patternParam, folder]);
     return true;
-  } catch (e) {
+  } catch (e: any) {
     // When there is no match exit code is set to 1
     if (e.exitCode === 1) {
       return false;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The lack of a type here is causing the Typescript to fail compilation on CodeBuild. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
