### PR TITLE
fix: update notification channel name lookup

### DIFF
--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -26,14 +26,14 @@ export const alias = 'update';
  */
 export const run = async (context: $TSContext): Promise<$TSContext> => {
   const availableChannelViewNames = getAvailableChannelViewNames();
-  const channelName = context.parameters.first;
-  let channelViewName = channelName ? getChannelViewName(channelName) : undefined;
+  let channelViewName = context.parameters.first ? getChannelViewName(context.parameters.first) : undefined;
 
   if (!channelViewName || !availableChannelViewNames.includes(channelViewName)) {
     channelViewName = await prompter.pick('Choose the notification channel to configure', availableChannelViewNames);
   }
-  if (channelViewName && typeof channelName === 'string') {
-    const selectedChannel = getChannelNameFromView(channelViewName);
+
+  if (channelViewName) {
+    const channelName = getChannelNameFromView(channelViewName);
     let pinpointAppStatus = await pinpointHelper.ensurePinpointApp(context, undefined);
     // In-line deployment now requires an amplify-push to create the Pinpoint resource
     if (pinpointHelper.isPinpointDeploymentRequired(channelName, pinpointAppStatus)) {
@@ -55,8 +55,8 @@ export const run = async (context: $TSContext): Promise<$TSContext> => {
         );
       }
     }
-    if (isPinpointAppDeployed(pinpointAppStatus.status) || isChannelDeploymentDeferred(selectedChannel)) {
-      const channelAPIResponse: IChannelAPIResponse | undefined = await notificationManager.configureChannel(context, selectedChannel);
+    if (isPinpointAppDeployed(pinpointAppStatus.status) || isChannelDeploymentDeferred(channelName)) {
+      const channelAPIResponse: IChannelAPIResponse | undefined = await notificationManager.configureChannel(context, channelName);
       await writeData(context, channelAPIResponse);
     }
   } else {

--- a/packages/amplify-e2e-core/src/categories/notifications.ts
+++ b/packages/amplify-e2e-core/src/categories/notifications.ts
@@ -97,7 +97,7 @@ export const updateNotificationChannel = async (
   chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} the ${channel} channel`).sendYes();
 
   return chain
-    .wait(`The ${channel} channel has been successfully ${enable ? 'enabled' : 'disabled'}`)
+    .wait(`The ${channel} channel has been ${enable ? 'enabled' : 'disabled'}`)
     .sendEof()
     .runAsync();
 };

--- a/packages/amplify-e2e-core/src/categories/notifications.ts
+++ b/packages/amplify-e2e-core/src/categories/notifications.ts
@@ -77,3 +77,27 @@ export const addNotificationChannel = async (
 
   return chain.wait(`The ${channel} channel has been successfully enabled`).sendEof().runAsync();
 };
+
+/**
+ * Update notification resource for a given channel
+ *
+ * @param cwd the current working directory to run CLI in
+ * @param settings settings required to add a notification channel
+ * @param settings.resourceName the name to give to the created pinpoint resource
+ * @param channel the channel to add
+ */
+export const updateNotificationChannel = async (
+  cwd: string,
+  channel: string,
+  enable = true,
+  testingWithLatestCodebase = true,
+): Promise<void> => {
+  const chain = spawn(getCLIPath(testingWithLatestCodebase), ['add', 'notification'], { cwd, stripColors: true });
+  chain.wait('Choose the notification channel to configure').sendLine(channel);
+  chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} this channel?`).sendYes();
+
+  return chain
+    .wait(`The ${channel} channel has been successfully ${enable ? 'enabled' : 'disabled'}`)
+    .sendEof()
+    .runAsync();
+};

--- a/packages/amplify-e2e-core/src/categories/notifications.ts
+++ b/packages/amplify-e2e-core/src/categories/notifications.ts
@@ -94,7 +94,7 @@ export const updateNotificationChannel = async (
 ): Promise<void> => {
   const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'notification'], { cwd, stripColors: true });
   chain.wait('Choose the notification channel to configure').sendLine(channel);
-  chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} the ${channel} channel?`).sendYes();
+  chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} the ${channel} channel`).sendYes();
 
   return chain
     .wait(`The ${channel} channel has been successfully ${enable ? 'enabled' : 'disabled'}`)

--- a/packages/amplify-e2e-core/src/categories/notifications.ts
+++ b/packages/amplify-e2e-core/src/categories/notifications.ts
@@ -92,7 +92,7 @@ export const updateNotificationChannel = async (
   enable = true,
   testingWithLatestCodebase = true,
 ): Promise<void> => {
-  const chain = spawn(getCLIPath(testingWithLatestCodebase), ['add', 'notification'], { cwd, stripColors: true });
+  const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'notification'], { cwd, stripColors: true });
   chain.wait('Choose the notification channel to configure').sendLine(channel);
   chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} this channel?`).sendYes();
 

--- a/packages/amplify-e2e-core/src/categories/notifications.ts
+++ b/packages/amplify-e2e-core/src/categories/notifications.ts
@@ -94,7 +94,7 @@ export const updateNotificationChannel = async (
 ): Promise<void> => {
   const chain = spawn(getCLIPath(testingWithLatestCodebase), ['update', 'notification'], { cwd, stripColors: true });
   chain.wait('Choose the notification channel to configure').sendLine(channel);
-  chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} this channel?`).sendYes();
+  chain.wait(`Do you want to ${enable ? 'enable' : 'disable'} the ${channel} channel?`).sendYes();
 
   return chain
     .wait(`The ${channel} channel has been successfully ${enable ? 'enabled' : 'disabled'}`)

--- a/packages/amplify-e2e-tests/src/__tests__/notifications-sms-update.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/notifications-sms-update.test.ts
@@ -1,0 +1,41 @@
+import {
+  addNotificationChannel,
+  amplifyPull,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  getAppId,
+  initJSProjectWithProfile,
+  removeAllNotificationChannel,
+  updateNotificationChannel,
+} from '@aws-amplify/amplify-e2e-core';
+import { getShortId } from '../import-helpers';
+
+describe('notification category update test', () => {
+  const testChannel = 'SMS';
+  const testChannelSelection = 'SMS';
+  const projectPrefix = `notification${testChannel}`.substring(0, 19);
+  const projectSettings = {
+    name: projectPrefix,
+    disableAmplifyAppCreation: false,
+  };
+
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await createNewProjectDir(projectPrefix);
+  });
+
+  afterEach(async () => {
+    await deleteProject(projectRoot);
+    deleteProjectDir(projectRoot);
+  });
+
+  it(`should add and update the ${testChannel} channel`, async () => {
+    await initJSProjectWithProfile(projectRoot, projectSettings);
+
+    const settings = { resourceName: `${projectPrefix}${getShortId()}` };
+    await addNotificationChannel(projectRoot, settings, testChannelSelection);
+    await updateNotificationChannel(projectRoot, testChannelSelection, false);
+  });
+});

--- a/packages/amplify-e2e-tests/src/__tests__/notifications-sms-update.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/notifications-sms-update.test.ts
@@ -1,12 +1,9 @@
 import {
   addNotificationChannel,
-  amplifyPull,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,
-  getAppId,
   initJSProjectWithProfile,
-  removeAllNotificationChannel,
   updateNotificationChannel,
 } from '@aws-amplify/amplify-e2e-core';
 import { getShortId } from '../import-helpers';


### PR DESCRIPTION
#### Description of changes
- when updating the notifications channel without passing the channel name as the command line argument, the customer is prompted to select the channel name, we incorrectly checked that the command line value is also set.

#### Issue #12747 
#### Description of how you validated changes
- manual testing
- e2e added
- e2e tests pass

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
