### PR TITLE
fix: fix yarn path

### DIFF
--- a/packages/amplify-console-integration-tests/src/setup-tests.ts
+++ b/packages/amplify-console-integration-tests/src/setup-tests.ts
@@ -1,7 +1,7 @@
 const removeYarnPaths = () => {
   // Remove yarn's temporary PATH modifications as they affect the yarn version used by jest tests when building the lambda functions
   process.env.PATH = process.env.PATH.split(':')
-    .filter((p) => !p.includes('/tmp/xfs-') && !p.includes('\\Temp\\xfs-'))
+    .filter((p) => !p.includes('/xfs-') && !p.includes('\\Temp\\xfs-'))
     .join(':');
 };
 

--- a/packages/amplify-e2e-tests/src/setup-tests.ts
+++ b/packages/amplify-e2e-tests/src/setup-tests.ts
@@ -3,7 +3,7 @@ import { toBeIAMRoleWithArn, toHaveValidPolicyConditionMatchingIdpId, toBeAS3Buc
 const removeYarnPaths = () => {
   // Remove yarn's temporary PATH modifications as they affect the yarn version used by jest tests when building the lambda functions
   process.env.PATH = process.env.PATH.split(':')
-    .filter((p) => !p.includes('/tmp/xfs-') && !p.includes('\\Temp\\xfs-'))
+    .filter((p) => !p.includes('/xfs-') && !p.includes('\\Temp\\xfs-'))
     .join(':');
 };
 

--- a/packages/amplify-migration-tests/src/setup-tests.ts
+++ b/packages/amplify-migration-tests/src/setup-tests.ts
@@ -1,7 +1,7 @@
 const removeYarnPaths = () => {
   // Remove yarn's temporary PATH modifications as they affect the yarn version used by jest tests when building the lambda functions
   process.env.PATH = process.env.PATH.split(':')
-    .filter((p) => !p.includes('/tmp/xfs-') && !p.includes('\\Temp\\xfs-'))
+    .filter((p) => !p.includes('/xfs-') && !p.includes('\\Temp\\xfs-'))
     .join(':');
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
When yarn script is run, it adds a temporary path to `PATH`. During the migration tests, this path is removed. The pattern matching on macOS did not cover all scenarios, so this removes the `/tmp` from the pattern to just look for `/xfs-`.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
#### Description of how you validated changes

Tested on my personal computer (macOS, M1). Run e2e tests to confirm migration tests pass.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
