### PR TITLE
fix: adjust path finding for schemas in codebuild

### DIFF
--- a/.circleci/scan_artifacts_codebuild.ts
+++ b/.circleci/scan_artifacts_codebuild.ts
@@ -13,7 +13,7 @@ export const hasMatchingContentInFolder = (patterns: string[], folder: string, e
   try {
     execa.sync('grep', ['-r', `--exclude-dir=${excludeFolder}`, ...patternParam, folder]);
     return true;
-  } catch (e) {
+  } catch (e: any) {
     // When there is no match exit code is set to 1
     if (e.exitCode === 1) {
       return false;

--- a/codebuild_specs/run_e2e_tests_windows.yml
+++ b/codebuild_specs/run_e2e_tests_windows.yml
@@ -29,3 +29,8 @@ phases:
       - bash ./codebuild_specs/scripts-windows/load-e2e-cache.sh
       - bash ./codebuild_specs/scripts-windows/rename-packaged-cli.sh
       - bash ./codebuild_specs/scripts-windows/run-e2e-windows.sh
+artifacts:
+  files:
+    - '$E2E_TEST_COVERAGE_DIR/*'
+    - amplify-e2e-reports/*
+  base-directory: packages/amplify-e2e-tests/

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -22,11 +22,11 @@ import { multiSelect, singleSelect } from '../utils/selectors';
 import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
 
-// const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
+const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 export function getSchemaPath(schemaName: string): string {
   // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
-  if (process.env.CODEBUILD_SRC_DIR /*&& isWindowsPlatform()*/) {
+  if (process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()) {
     return path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'schemas', schemaName);
   }
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -22,11 +22,11 @@ import { multiSelect, singleSelect } from '../utils/selectors';
 import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
 
-const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
+// const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 export function getSchemaPath(schemaName: string): string {
   // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
-  if (process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()) {
+  if (process.env.CODEBUILD_SRC_DIR /*&& isWindowsPlatform()*/) {
     return path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'schemas', schemaName);
   }
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -23,6 +23,9 @@ import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
 
 export function getSchemaPath(schemaName: string): string {
+  if (process.env.CODEBUILD_SRC_DIR) {
+    return path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'schemas', schemaName);
+  }
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);
 }
 

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -23,6 +23,7 @@ import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
 
 export function getSchemaPath(schemaName: string): string {
+  // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
   if (process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()) {
     return path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'schemas', schemaName);
   }

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -4,7 +4,7 @@
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { $TSAny } from '@aws-amplify/amplify-cli-core';
+import { $TSAny, isWindowsPlatform } from '@aws-amplify/amplify-cli-core';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -23,7 +23,7 @@ import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
 
 export function getSchemaPath(schemaName: string): string {
-  if (process.env.CODEBUILD_SRC_DIR) {
+  if (process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()) {
     return path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'schemas', schemaName);
   }
   return path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'schemas', schemaName);

--- a/packages/amplify-e2e-core/src/categories/api.ts
+++ b/packages/amplify-e2e-core/src/categories/api.ts
@@ -4,7 +4,7 @@
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 /* eslint-disable func-style */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { $TSAny, isWindowsPlatform } from '@aws-amplify/amplify-cli-core';
+import { $TSAny } from '@aws-amplify/amplify-cli-core';
 import * as fs from 'fs-extra';
 import _ from 'lodash';
 import * as path from 'path';
@@ -21,6 +21,8 @@ import {
 import { multiSelect, singleSelect } from '../utils/selectors';
 import { selectRuntime, selectTemplate } from './lambda-function';
 import { modifiedApi } from './resources/modified-api-index';
+
+const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 export function getSchemaPath(schemaName: string): string {
   // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -6,7 +6,6 @@ import { config } from 'dotenv';
 import execa from 'execa';
 import { v4 as uuid } from 'uuid';
 import { getLayerDirectoryName, LayerDirectoryType } from '..';
-import { isWindowsPlatform } from '@aws-amplify/amplify-cli-core';
 
 export * from './add-circleci-tags';
 export * from './api';
@@ -175,6 +174,8 @@ export const getFunctionSrcNode = (root: string, functionName: string, fileName 
 
   return fs.readFileSync(indexPath).toString();
 };
+
+const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 const getTestFileNamePath = (fileName: string): string =>
   process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -175,10 +175,10 @@ export const getFunctionSrcNode = (root: string, functionName: string, fileName 
   return fs.readFileSync(indexPath).toString();
 };
 
-// const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
+const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 const getTestFileNamePath = (fileName: string): string =>
-  process.env.CODEBUILD_SRC_DIR // && isWindowsPlatform()
+  process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()
     ? path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'functions', fileName) // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
     : path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
 const getPathToFunction = (root: string, funcName: string): string => path.join(root, 'amplify', 'backend', 'function', funcName);

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -6,6 +6,7 @@ import { config } from 'dotenv';
 import execa from 'execa';
 import { v4 as uuid } from 'uuid';
 import { getLayerDirectoryName, LayerDirectoryType } from '..';
+import { isWindowsPlatform } from '@aws-amplify/amplify-cli-core';
 
 export * from './add-circleci-tags';
 export * from './api';
@@ -176,8 +177,8 @@ export const getFunctionSrcNode = (root: string, functionName: string, fileName 
 };
 
 const getTestFileNamePath = (fileName: string): string =>
-  process.env.CODEBUILD_SRC_DIR
-    ? path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'functions', fileName)
+  process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()
+    ? path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'functions', fileName) // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
     : path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
 const getPathToFunction = (root: string, funcName: string): string => path.join(root, 'amplify', 'backend', 'function', funcName);
 const getPathToLayer = (root: string, layerProjectName: LayerDirectoryType): string =>

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -175,10 +175,10 @@ export const getFunctionSrcNode = (root: string, functionName: string, fileName 
   return fs.readFileSync(indexPath).toString();
 };
 
-const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
+// const isWindowsPlatform = (): boolean => !!process?.platform?.startsWith('win');
 
 const getTestFileNamePath = (fileName: string): string =>
-  process.env.CODEBUILD_SRC_DIR && isWindowsPlatform()
+  process.env.CODEBUILD_SRC_DIR // && isWindowsPlatform()
     ? path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'functions', fileName) // This condition is to account for a difference in the use of __dirname and paths in CodeBuild Windows jobs
     : path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
 const getPathToFunction = (root: string, funcName: string): string => path.join(root, 'amplify', 'backend', 'function', funcName);

--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -176,7 +176,9 @@ export const getFunctionSrcNode = (root: string, functionName: string, fileName 
 };
 
 const getTestFileNamePath = (fileName: string): string =>
-  path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
+  process.env.CODEBUILD_SRC_DIR
+    ? path.join(process.env.CODEBUILD_SRC_DIR, 'packages', 'amplify-e2e-tests', 'functions', fileName)
+    : path.join(__dirname, '..', '..', '..', 'amplify-e2e-tests', 'functions', fileName);
 const getPathToFunction = (root: string, funcName: string): string => path.join(root, 'amplify', 'backend', 'function', funcName);
 const getPathToLayer = (root: string, layerProjectName: LayerDirectoryType): string =>
   path.join(root, 'amplify', 'backend', 'function', getLayerDirectoryName(layerProjectName));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
There is a difference in the way that paths are resolved in CircleCI vs CodeBuild. This was causing many Windows tests to fail because the paths to schemas would not resolve correctly.

This PR also enables artifacts for Windows tests.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
