### PR TITLE
chore: update ci-info to use new CI detection logic

### DIFF
--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -35,7 +35,7 @@
     "ajv": "^6.12.6",
     "aws-cdk-lib": "~2.68.0",
     "chalk": "^4.1.1",
-    "ci-info": "^2.0.0",
+    "ci-info": "^3.8.0",
     "cli-table3": "^0.6.0",
     "cloudform-types": "^4.2.0",
     "colors": "1.4.0",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -76,7 +76,7 @@
     "aws-cdk-lib": "~2.68.0",
     "aws-sdk": "^2.1354.0",
     "chalk": "^4.1.1",
-    "ci-info": "^2.0.0",
+    "ci-info": "^3.8.0",
     "cli-table3": "^0.6.0",
     "cloudform-types": "^4.2.0",
     "colors": "1.4.0",
@@ -107,7 +107,6 @@
   "devDependencies": {
     "@aws-amplify/amplify-function-plugin-interface": "1.10.3",
     "@types/archiver": "^5.3.1",
-    "@types/ci-info": "^2.0.0",
     "@types/columnify": "^1.5.1",
     "@types/folder-hash": "^4.0.1",
     "@types/fs-extra": "^8.0.1",

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -771,14 +771,9 @@ export function nspawn(command: string | string[], params: string[] = [], option
     };
 
     // Undo ci-info detection, required for some tests
+    // see https://github.com/watson/ci-info/blob/master/index.js#L57
     if (options.disableCIDetection === true) {
-      delete childEnv.CI;
-      delete childEnv.CONTINUOUS_INTEGRATION;
-      delete childEnv.BUILD_NUMBER;
-      delete childEnv.TRAVIS;
-      delete childEnv.GITHUB_ACTIONS;
-      delete childEnv.CIRCLECI;
-      delete childEnv.CIRCLE_PULL_REQUEST;
+      childEnv.CI = false;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,7 @@ __metadata:
     ajv: ^6.12.6
     aws-cdk-lib: ~2.68.0
     chalk: ^4.1.1
-    ci-info: ^2.0.0
+    ci-info: ^3.8.0
     cli-table3: ^0.6.0
     cloudform-types: ^4.2.0
     colors: 1.4.0
@@ -1079,7 +1079,6 @@ __metadata:
     "@aws-amplify/amplify-util-uibuilder": 1.8.4
     "@aws-cdk/cloudformation-diff": ~2.68.0
     "@types/archiver": ^5.3.1
-    "@types/ci-info": ^2.0.0
     "@types/columnify": ^1.5.1
     "@types/folder-hash": ^4.0.1
     "@types/fs-extra": ^8.0.1
@@ -1102,7 +1101,7 @@ __metadata:
     aws-cdk-lib: ~2.68.0
     aws-sdk: ^2.1354.0
     chalk: ^4.1.1
-    ci-info: ^2.0.0
+    ci-info: ^3.8.0
     cli-table3: ^0.6.0
     cloudform-types: ^4.2.0
     colors: 1.4.0
@@ -9753,13 +9752,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ci-info@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@types/ci-info@npm:2.0.0"
-  checksum: 5c717136b706de46527bffb73ca897b1c32de519b4ccc32ff9000cbb2993ea2cfe2f79d0bdf840a80deefef21169981d42af5c08446f749775f00c4bf49fbcd2
-  languageName: node
-  linkType: hard
-
 "@types/columnify@npm:^1.5.0, @types/columnify@npm:^1.5.1":
   version: 1.5.1
   resolution: "@types/columnify@npm:1.5.1"
@@ -13635,10 +13627,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "ci-info@npm:3.3.0"
-  checksum: f23ec1b3c4717abb5fb9934fe0ab6db621cf767abd3832f07af2803e4809d21908d8b87321de4b79861dfe8105c08dba1803a9fb6346d5586b0c57db2bfbce3b
+"ci-info@npm:^3.2.0, ci-info@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "ci-info@npm:3.8.0"
+  checksum: 0d3052193b58356372b34ab40d2668c3e62f1006d5ca33726d1d3c423853b19a85508eadde7f5908496fb41448f465263bf61c1ee58b7832cb6a924537e3863a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Update the `ci-info` package to make the CI check disabling logic work for any CI provider

Fixes the failing node.function.test.ts in CodeBuild due to this [line](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-tests/src/__tests__/migration/node.function.test.ts#L91).

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
