### PR TITLE
chore: fix unallowed characters in single test split script

### DIFF
--- a/scripts/generate_single_test_buildspec_codebuild.ts
+++ b/scripts/generate_single_test_buildspec_codebuild.ts
@@ -54,10 +54,11 @@ const main = () => {
   const jobBuildSpec: jobBuildSpecType = {
     identifier: `${os}_${filePath
       .replace(/src\/__tests__\//g, '')
-      .replace(/.test/g, '')
-      .replace(/.ts/g, '')
+      .replace(/\.test/g, '')
+      .replace(/\.ts/g, '')
       .replace(/\./g, '_')
-      .replace(/-/g, '_')}`,
+      .replace(/-/g, '_')
+      .replace(/\//g, '_')}`,
     buildspec: os === 'l' ? 'codebuild_specs/run_e2e_tests_linux.yml' : 'codebuild_specs/run_e2e_tests_windows.yml',
     env: {
       variables: {

--- a/scripts/generate_single_test_buildspec_codebuild.ts
+++ b/scripts/generate_single_test_buildspec_codebuild.ts
@@ -52,7 +52,12 @@ const main = () => {
   ];
 
   const jobBuildSpec: jobBuildSpecType = {
-    identifier: `${os}_${filePath.replace('src/__tests__/', '').replace('.test', '').replace('.ts', '')}`,
+    identifier: `${os}_${filePath
+      .replace(/src\/__tests__\//g, '')
+      .replace(/.test/g, '')
+      .replace(/.ts/g, '')
+      .replace(/\./g, '_')
+      .replace(/-/g, '_')}`,
     buildspec: os === 'l' ? 'codebuild_specs/run_e2e_tests_linux.yml' : 'codebuild_specs/run_e2e_tests_windows.yml',
     env: {
       variables: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
