### PR TITLE
test: fix pull-2 when multiple userpools present

### DIFF
--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -144,6 +144,17 @@ export const getUserPool = async (userpoolId, region) => {
   return res;
 };
 
+export const listUserPools = async (region, maxResults = 5) => {
+  config.update({ region });
+  let res;
+  try {
+    res = await new CognitoIdentityServiceProvider().listUserPools({ MaxResults: maxResults }).promise();
+  } catch (e) {
+    console.log(e);
+  }
+  return res?.UserPools ?? [];
+};
+
 export const getMFAConfiguration = async (
   userPoolId: string,
   region: string,

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_1b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_1b.test.ts
@@ -108,9 +108,7 @@ describe('auth import userpool only', () => {
     await importUserPoolOnly(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
     // Imported auth resources cannot be used together with \'storage\' category\'s authenticated and unauthenticated access.
-    await expect(addS3WithAuthConfigurationMismatchErrorExit(projectRoot, {})).rejects.toThrowError(
-      'Process exited with non zero exit code 1',
-    );
+    await expect(addS3WithAuthConfigurationMismatchErrorExit(projectRoot)).rejects.toThrowError('Process exited with non zero exit code 1');
   });
 
   it('imported user pool only should allow iam auth in graphql api', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/pull-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pull-2.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable spellcheck/spell-checker */
 import {
   addAuthIdentityPoolAndUserPoolWithOAuth,
   amplifyPushAuth,
@@ -6,6 +5,7 @@ import {
   deleteProject,
   deleteProjectDir,
   getAppId,
+  getProjectMeta,
   initJSProjectWithProfile,
   pullProject,
 } from '@aws-amplify/amplify-e2e-core';
@@ -47,7 +47,11 @@ describe('amplify pull', () => {
       name: 'import',
       envName: 'integtest',
     });
-    await importSingleIdentityPoolAndUserPool(importRoot, settings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
+
+    const meta = getProjectMeta(importRoot);
+    const region = meta.providers.awscloudformation.Region;
+
+    await importSingleIdentityPoolAndUserPool(importRoot, settings.userPoolName, region, { native: '_app_client ', web: '_app_clientWeb' });
     await amplifyPushAuth(importRoot);
 
     const appId = getAppId(importRoot);

--- a/packages/amplify-e2e-tests/src/import-helpers/walkthroughs.ts
+++ b/packages/amplify-e2e-tests/src/import-helpers/walkthroughs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { getCLIPath, nspawn as spawn } from '@aws-amplify/amplify-e2e-core';
 
 export const importUserPoolOnly = (cwd: string, autoCompletePrefix: string, clientNames?: { web?: string; native?: string }) => {
@@ -126,7 +125,7 @@ export const removeImportedAuthHeadless = async (cwd: string, authResourceName: 
   await chain.runAsync();
 };
 
-export const addS3WithAuthConfigurationMismatchErrorExit = (cwd: string, settings: any) => {
+export const addS3WithAuthConfigurationMismatchErrorExit = (cwd: string) => {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['add', 'storage'], { cwd, stripColors: true })
       .wait('Select from one of the below mentioned services')
@@ -155,11 +154,11 @@ export const addS3WithAuthConfigurationMismatchErrorExit = (cwd: string, setting
 
 export const headlessPullExpectError = (
   projectRoot: string,
-  amplifyParameters: Object,
-  providersParameter: Object,
+  amplifyParameters: Record<string, unknown>,
+  providersParameter: Record<string, unknown>,
   errorMessage: string,
-  categoriesParameter?: Object,
-  frontendParameter?: Object,
+  categoriesParameter?: Record<string, unknown>,
+  frontendParameter?: Record<string, unknown>,
 ): Promise<void> => {
   const pullCommand: string[] = [
     'pull',
@@ -194,10 +193,10 @@ export const headlessPullExpectError = (
 
 export const headlessPull = (
   projectRoot: string,
-  amplifyParameters: Object,
-  providersParameter: Object,
-  categoriesParameter?: Object,
-  frontendParameter?: Object,
+  amplifyParameters: Record<string, unknown>,
+  providersParameter: Record<string, unknown>,
+  categoriesParameter?: Record<string, unknown>,
+  frontendParameter?: Record<string, unknown>,
 ): Promise<void> => {
   const pullCommand: string[] = [
     'pull',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Make SDK call to check number of user pools for test so we know if we need to filter userpools or not in prompt
- Refactor some eslint disable comments away

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
