### PR TITLE
fix: build lambda functions build concurrency

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -564,7 +564,10 @@ export const updateStackForAPIMigration = async (context: $TSContext, category: 
 
 const prepareBuildableResources = async (context: $TSContext, resources: $TSAny[]): Promise<void> => {
   // Only build and package resources which are required
-  await Promise.all(resources.filter((resource) => resource.build).map((resource) => prepareResource(context, resource)));
+  const resourcesToBuild = resources.filter((resource) => resource.build);
+  for (const resource of resourcesToBuild) {
+    await prepareResource(context, resource);
+  }
 };
 
 const prepareResource = async (context: $TSContext, resource: $TSAny) => {


### PR DESCRIPTION
#### Description of changes
- converted from `Promise.all` to `for-of await` to fix the lambda function build concurrency issue


#### Issue #12793 
#### Description of how you validated changes
- manual test, follow-up PR for e2e test to be added

Steps to reproduce:
```
1. amplify init --yes
2. amplify add function (nodejs default values)
3. amplify push
4. edit the index.js from nodejs function to get into the update status
5. amplify add function (python or go)
6. amplify push
```

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
