### PR TITLE
fix: build lambda functions build concurrency

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/function_15.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_15.test.ts
@@ -1,0 +1,42 @@
+import {
+  addFunction,
+  amplifyPushAuth,
+  createNewProjectDir,
+  deleteProject,
+  deleteProjectDir,
+  generateRandomShortId,
+  initJSProjectWithProfile,
+  loadFunctionTestFile,
+  overrideFunctionSrcNode,
+} from '@aws-amplify/amplify-e2e-core';
+import { v4 as uuid } from 'uuid';
+
+describe('amplify push function cases:', () => {
+  let projRoot: string;
+
+  beforeEach(async () => {
+    projRoot = await createNewProjectDir('multiple-function-push');
+  });
+
+  afterEach(async () => {
+    await deleteProject(projRoot);
+    deleteProjectDir(projRoot);
+  });
+
+  it('should be able to push multiple functions at the same time', async () => {
+    const projName = `multilambda${generateRandomShortId()}`;
+    await initJSProjectWithProfile(projRoot, { name: projName });
+
+    const [shortId] = uuid().split('-');
+    const functionName = `nodetestfunction${shortId}`;
+
+    await addFunction(projRoot, { functionTemplate: 'Hello World', name: functionName }, 'nodejs');
+    await amplifyPushAuth(projRoot);
+
+    const functionCode = loadFunctionTestFile('case-function.js').replace('{{testString}}', 'Hello from Lambda!');
+    overrideFunctionSrcNode(projRoot, functionName, functionCode);
+    await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'python');
+
+    await amplifyPushAuth(projRoot);
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/push-resources.ts
+++ b/packages/amplify-provider-awscloudformation/src/push-resources.ts
@@ -564,7 +564,10 @@ export const updateStackForAPIMigration = async (context: $TSContext, category: 
 
 const prepareBuildableResources = async (context: $TSContext, resources: $TSAny[]): Promise<void> => {
   // Only build and package resources which are required
-  await Promise.all(resources.filter((resource) => resource.build).map((resource) => prepareResource(context, resource)));
+  const resourcesToBuild = resources.filter((resource) => resource.build);
+  for (const resource of resourcesToBuild) {
+    await prepareResource(context, resource);
+  }
 };
 
 const prepareResource = async (context: $TSContext, resource: $TSAny) => {


### PR DESCRIPTION
#### Description of changes
- converted from `Promise.all` to `for-of await` to fix the lambda function build concurrency issue


#### Issue #12793 
#### Description of how you validated changes
- manual test
- e2e test added

Steps to reproduce:
```
1. amplify init --yes
2. amplify add function (nodejs default values)
3. amplify push
4. edit the index.js from nodejs function to get into the update status
5. amplify add function (python or go)
6. amplify push
```

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
