### PR TITLE
Revert "test: make test teardown resilient to failures"

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
@@ -13,7 +13,7 @@ import {
   enableAdminUI,
   amplifyStudioHeadlessPull,
 } from '@aws-amplify/amplify-e2e-core';
-import { spawnSync, spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { spawnSync, spawn } from 'child_process';
 import { AmplifyUIBuilder } from 'aws-sdk';
 import fs from 'fs-extra';
 import path from 'path';
@@ -110,28 +110,16 @@ describe('amplify pull with uibuilder', () => {
       fs.readFileSync(path.join(__dirname, '..', 'cypress', 'uibuilder', 'uibuilder-spec.js')),
     );
 
-    let npmStartProcess: ChildProcessWithoutNullStreams;
-    let res: execa.ExecaSyncReturnValue<string>;
-    describe('cypress tests', () => {
-      beforeAll(async () => {
-        npmStartProcess = spawn(getNpmPath(), ['start'], { cwd: reactDir, timeout: 300000 });
-        // Give react server time to start
-        await new Promise((resolve) => setTimeout(resolve, 60000));
-      });
-
-      afterAll(async () => {
-        // kill the react server process
-        spawnSync('kill', [`${npmStartProcess.pid}`], { encoding: 'utf8' });
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        // Seriously, kill the react server process
-        // react-scripts somehow resurrects the process automatically after the first kill.
-        spawnSync('pkill', ['-f', 'react'], { encoding: 'utf8' });
-      });
-
-      it('...return exit code 0', () => {
-        res = execa.sync(getNpxPath(), ['cypress', 'run'], { cwd: reactDir, encoding: 'utf8' });
-        expect(res.exitCode).toBe(0);
-      });
-    });
+    const npmStartProcess = spawn(getNpmPath(), ['start'], { cwd: reactDir, timeout: 300000 });
+    // Give react server time to start
+    await new Promise((resolve) => setTimeout(resolve, 60000));
+    const res = execa.sync(getNpxPath(), ['cypress', 'run'], { cwd: reactDir, encoding: 'utf8' });
+    // kill the react server process
+    spawnSync('kill', [`${npmStartProcess.pid}`], { encoding: 'utf8' });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // Seriously, kill the react server process
+    // react-scripts somehow resurrects the process automatically after the first kill.
+    spawnSync('pkill', ['-f', 'react'], { encoding: 'utf8' });
+    expect(res.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#12799

Causes test to fail: https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/21317/workflows/76b43c76-cd33-4a1f-9fb4-721e848a3e56/jobs/1002553