### PR TITLE
fix: usage data should not throw errors

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -120,6 +120,7 @@
     "@types/treeify": "^1.0.0",
     "@types/update-notifier": "^5.1.0",
     "cloudform-types": "^4.2.0",
+    "jest": "^29.5.0",
     "nock": "^12.0.3",
     "typescript": "^4.9.5"
   },

--- a/packages/amplify-cli/src/__tests__/usage-data.test.ts
+++ b/packages/amplify-cli/src/__tests__/usage-data.test.ts
@@ -21,7 +21,7 @@ describe('test usageData', () => {
   const printerMock = printer as jest.Mocked<typeof printer>;
 
   beforeEach(() => {
-    printerMock.warn = jest.fn();
+    printerMock.debug = jest.fn();
   });
 
   beforeAll(() => {

--- a/packages/amplify-cli/src/__tests__/usage-data.test.ts
+++ b/packages/amplify-cli/src/__tests__/usage-data.test.ts
@@ -186,7 +186,7 @@ describe('test usageData', () => {
     const usageData = UsageData.Instance;
     usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES);
     expect(() => usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES)).not.toThrowError();
-    expect(printerMock.warn).toBeCalledWith(`${ManuallyTimedCodePath.INIT_ENV_CATEGORIES} already has a running timer`);
+    expect(printerMock.debug).toBeCalledWith(`${ManuallyTimedCodePath.INIT_ENV_CATEGORIES} already has a running timer`);
   });
 
   it('does nothing when stopping a timer that is not running', () => {

--- a/packages/amplify-cli/src/__tests__/usage-data.test.ts
+++ b/packages/amplify-cli/src/__tests__/usage-data.test.ts
@@ -1,21 +1,29 @@
-import url from 'url';
 import nock from 'nock';
+import url from 'url';
 import * as uuid from 'uuid';
 
-import { UsageData } from '../domain/amplify-usageData/UsageData';
-import { getUrl } from '../domain/amplify-usageData/getUsageDataUrl';
-import { AmplifyError } from '@aws-amplify/amplify-cli-core';
-import { CLIInput as CommandLineInput } from '../domain/command-input';
-import { ManuallyTimedCodePath } from '@aws-amplify/amplify-cli-core';
-import { UsageDataPayload } from '../domain/amplify-usageData/UsageDataPayload';
-import { SerializableError } from '../domain/amplify-usageData/SerializableError';
+import { AmplifyError, ManuallyTimedCodePath } from '@aws-amplify/amplify-cli-core';
 import { ProjectSettings } from '@aws-amplify/amplify-cli-core/src/types';
+import { printer } from '@aws-amplify/amplify-prompts';
+import { SerializableError } from '../domain/amplify-usageData/SerializableError';
+import { UsageData } from '../domain/amplify-usageData/UsageData';
+import { UsageDataPayload } from '../domain/amplify-usageData/UsageDataPayload';
+import { getUrl } from '../domain/amplify-usageData/getUsageDataUrl';
+import { CLIInput as CommandLineInput } from '../domain/command-input';
 
 const baseOriginalUrl = 'https://cli.amplify';
 const pathToUrl = '/metrics';
 const originalUrl = `${baseOriginalUrl}${pathToUrl}`;
 
+jest.mock('@aws-amplify/amplify-prompts');
+
 describe('test usageData', () => {
+  const printerMock = printer as jest.Mocked<typeof printer>;
+
+  beforeEach(() => {
+    printerMock.warn = jest.fn();
+  });
+
   beforeAll(() => {
     process.env = Object.assign(process.env, { AMPLIFY_CLI_BETA_USAGE_TRACKING_URL: originalUrl });
   });
@@ -174,12 +182,11 @@ describe('test usageData', () => {
     expect((UsageData.Instance as unknown as any).pushNormalizationFactor).toEqual(3);
   });
 
-  it('errors if starting a duplicate timer', () => {
+  it('should not error if starting a duplicate timer', () => {
     const usageData = UsageData.Instance;
     usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES);
-    expect(() => usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES)).toThrowErrorMatchingInlineSnapshot(
-      '"initEnvCategories already has a running timer"',
-    );
+    expect(() => usageData.startCodePathTimer(ManuallyTimedCodePath.INIT_ENV_CATEGORIES)).not.toThrowError();
+    expect(printerMock.warn).toBeCalledWith(`${ManuallyTimedCodePath.INIT_ENV_CATEGORIES} already has a running timer`);
   });
 
   it('does nothing when stopping a timer that is not running', () => {

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import { ICommandInput, IFlowReport } from '@aws-amplify/amplify-cli-shared-interfaces';
-import { prompter } from '@aws-amplify/amplify-prompts';
+import { prompter, printer } from '@aws-amplify/amplify-prompts';
 import https from 'https';
 import { pick } from 'lodash';
 import { UrlWithStringQuery } from 'url';
@@ -117,9 +117,10 @@ export class UsageData implements IUsageData {
    */
   startCodePathTimer(codePath: StartableTimedCodePath): void {
     if (this.codePathTimers.has(codePath)) {
-      throw new Error(`${codePath} already has a running timer`);
+      printer.warn(`${codePath} already has a running timer`);
+    } else {
+      this.codePathTimers.set(codePath, Timer.start());
     }
-    this.codePathTimers.set(codePath, Timer.start());
   }
 
   /**

--- a/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
+++ b/packages/amplify-cli/src/domain/amplify-usageData/UsageData.ts
@@ -117,7 +117,7 @@ export class UsageData implements IUsageData {
    */
   startCodePathTimer(codePath: StartableTimedCodePath): void {
     if (this.codePathTimers.has(codePath)) {
-      printer.warn(`${codePath} already has a running timer`);
+      printer.debug(`${codePath} already has a running timer`);
     } else {
       this.codePathTimers.set(codePath, Timer.start());
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,6 +1117,7 @@ __metadata:
     hidefile: ^3.0.0
     ini: ^1.3.5
     inquirer: ^7.3.3
+    jest: ^29.5.0
     lodash: ^4.17.21
     nock: ^12.0.3
     node-fetch: ^2.6.7


### PR DESCRIPTION
#### Description of changes
- removed throw statement from usage data

#### Issue #12734
#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
