### PR TITLE
chore: remove disallowed secret pattern match

### DIFF
--- a/packages/amplify-nodejs-function-template-provider/resources/lambda/lambda-auth/event.json
+++ b/packages/amplify-nodejs-function-template-provider/resources/lambda/lambda-auth/event.json
@@ -2,7 +2,7 @@
   "authorizationToken": "ExampleAUTHtoken123123123",
   "requestContext": {
     "apiId": "aaaaaa123123123example123",
-    "accountId": "111122223333",
+    "accountId": "123456789012",
     "requestId": "f4081827-1111-4444-5555-5cf4695f339f",
     "queryString": "mutation CreateEvent {...}\n\nquery MyQuery {...}\n",
     "operationName": "MyQuery",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
https://github.com/aws-amplify/amplify-cli/pull/11428 introduced a fake account id that is disallowed by our secret scanning. This PR switches the fake account id to an allowed value.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
