### PR TITLE
fix: s3 upload index.html at last

### DIFF
--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -91,15 +91,6 @@ describe('cloudfront-manager', () => {
 
   beforeEach(() => {});
 
-  test('index.html files should be sorted to the end of the list', () => {
-    const sortedFiiles1 = fileUploader.exportForTesting.sortUploadFiles(['index.html', 'assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js']);
-    const sortedFiiles2 = fileUploader.exportForTesting.sortUploadFiles(['assets/index-87aefcd1.js', 'index.html', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'logo.png']);
-    const sortedFiiles3 = fileUploader.exportForTesting.sortUploadFiles(['assets/index-87aefcd1.js', 'index.html', 'assets/index-d41dc7ea.css', 'assets/index.html', 'logo.png']);
-    expect(sortedFiiles1).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'index.html']);
-    expect(sortedFiiles2).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'logo.png', 'index.html']);
-    expect(sortedFiiles3).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'logo.png', 'index.html', 'assets/index.html']);
-  });
-
   test('run', async () => {
     await fileUploader.run(mockContext, 'mockDistributionFolder');
     expect(fileScanner.scan).toBeCalled();

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -6,7 +6,9 @@ jest.mock('../../../../lib/S3AndCloudFront/helpers/file-scanner', () => {
     }),
   };
 });
-jest.mock('../../../../lib/S3AndCloudFront/helpers/upload-file', () => {return {uploadFile: jest.fn()}});
+jest.mock('../../../../lib/S3AndCloudFront/helpers/upload-file', () => {
+  return { uploadFile: jest.fn() };
+});
 
 const fs = require('fs-extra');
 const mime = require('mime-types');
@@ -98,11 +100,11 @@ describe('cloudfront-manager', () => {
     expect(fileScanner.scan).toBeCalled();
   });
 
-  test('uploadFileCalls should have the index.html at the end', () => { 
+  test('uploadFileCalls should have the index.html at the end', () => {
     expect(uploadFile).toHaveBeenCalled();
     const uploadFileCalls = uploadFile.mock.calls;
 
     expect(uploadFileCalls.length).toBe(5);
     expect(uploadFileCalls[4][3]).toBe('index.html');
-  })
+  });
 });

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -91,6 +91,15 @@ describe('cloudfront-manager', () => {
 
   beforeEach(() => {});
 
+  test('index.html files should be sorted to the end of the list', () => {
+    const sortedFiiles1 = fileUploader.exportForTesting.sortUploadFiles(['index.html', 'assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js']);
+    const sortedFiiles2 = fileUploader.exportForTesting.sortUploadFiles(['assets/index-87aefcd1.js', 'index.html', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'logo.png']);
+    const sortedFiiles3 = fileUploader.exportForTesting.sortUploadFiles(['assets/index-87aefcd1.js', 'index.html', 'assets/index-d41dc7ea.css', 'assets/index.html', 'logo.png']);
+    expect(sortedFiiles1).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'index.html']);
+    expect(sortedFiiles2).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'assets/mapbox-gl-0f4a37a4.js', 'logo.png', 'index.html']);
+    expect(sortedFiiles3).toEqual(['assets/index-87aefcd1.js', 'assets/index-d41dc7ea.css', 'logo.png', 'index.html', 'assets/index.html']);
+  });
+
   test('run', async () => {
     await fileUploader.run(mockContext, 'mockDistributionFolder');
     expect(fileScanner.scan).toBeCalled();

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -84,7 +84,7 @@ describe('cloudfront-manager', () => {
     },
   };
 
-  beforeAll(async () => {
+  beforeAll(() => {
     fs.createReadStream = jest.fn(() => {
       return {};
     });

--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/file-uploader.test.js
@@ -91,16 +91,19 @@ describe('cloudfront-manager', () => {
     mime.lookup = jest.fn(() => {
       return 'text/plain';
     });
-    await fileUploader.run(mockContext, 'mockDistributionFolder');
   });
 
-  beforeEach(() => {});
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   test('file scanner should be called', async () => {
+    await fileUploader.run(mockContext, 'mockDistributionFolder');
     expect(fileScanner.scan).toBeCalled();
   });
 
-  test('uploadFileCalls should have the index.html at the end', () => {
+  test('uploadFileCalls should have the index.html at the end', async () => {
+    await fileUploader.run(mockContext, 'mockDistributionFolder');
     expect(uploadFile).toHaveBeenCalled();
     const uploadFileCalls = uploadFile.mock.calls;
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -19,13 +19,14 @@ async function run(context, distributionDirPath) {
 
   const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution;
 
+  const filesToUploadFirst = fileList.filter(filePath => !filePath.includes('index.html'));
+  const filesToUploadLast = fileList.filter(filePath => filePath.includes('index.html'));
 
-  await Promise.all(fileList.map(async filePath => {
-    if(!filePath.includes('index.html')) {
-      return await uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
-  }}));
+  await Promise.all(filesToUploadFirst.map(async filePath => {
+      return uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
+  }));
 
-  fileList.filter(filePath => filePath.includes('index.html')).forEach(filePath => {
+  filesToUploadLast.forEach(filePath => {
     uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
   });
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -50,5 +50,5 @@ function getHostingBucketName(context) {
 }
 
 module.exports = {
-  run
+  run,
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -76,4 +76,7 @@ async function uploadFile(s3Client, hostingBucketName, distributionDirPath, file
 
 module.exports = {
   run,
+  exportForTesting: {
+    sortUploadFiles,
+  }
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -18,7 +18,7 @@ async function run(context, distributionDirPath) {
 
   const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution;
 
-  uploadFileTasks = sortUploadFiles(fileList)
+  const uploadFileTasks = sortUploadFiles(fileList)
       .map(filePath => () => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
 
   const spinner = new Ora('Uploading files.');
@@ -75,8 +75,5 @@ async function uploadFile(s3Client, hostingBucketName, distributionDirPath, file
 }
 
 module.exports = {
-  run,
-  exportForTesting: {
-    sortUploadFiles,
-  }
+  run
 };

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -19,7 +19,13 @@ async function run(context, distributionDirPath) {
 
   const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution;
 
-  fileList.forEach(filePath => {
+
+  await Promise.all(fileList.map(async filePath => {
+    if(!filePath.includes('index.html')) {
+      return await uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
+  }}));
+
+  fileList.filter(filePath => filePath.includes('index.html')).forEach(filePath => {
     uploadFileTasks.push(() => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
   });
 

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/file-uploader.js
@@ -18,14 +18,8 @@ async function run(context, distributionDirPath) {
 
   const hasCloudFront = !!context?.exeInfo?.template?.Resources?.CloudFrontDistribution;
 
-  const filesToUploadLast = "index.html";
-  const sortFiles = (fileA, fileB) => 
-        fileA.includes(filesToUploadLast) ? 1 : fileB.includes(filesToUploadLast) ? -1 : 0;
-
-  fileList.sort(sortFiles);
-
-  uploadFileTasks = fileList.map(filePath => () => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront))
-
+  uploadFileTasks = sortUploadFiles(fileList)
+      .map(filePath => () => uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront));
 
   const spinner = new Ora('Uploading files.');
   try {
@@ -36,6 +30,13 @@ async function run(context, distributionDirPath) {
     spinner.fail('Error has occurred during file upload.');
     throw e;
   }
+}
+
+function sortUploadFiles(fileList) {
+  const filesToUploadLast = "index.html";
+  const sortFiles = (fileA, fileB) => fileA.includes(filesToUploadLast) ? 1 : fileB.includes(filesToUploadLast) ? -1 : 0;
+
+  return fileList.sort(sortFiles);
 }
 
 async function getS3Client(context, action) {

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/upload-file.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/upload-file.js
@@ -1,0 +1,31 @@
+const fs = require('fs-extra');
+const path = require('path');
+const mime = require('mime-types');
+
+
+async function uploadFile(s3Client, hostingBucketName, distributionDirPath, filePath, hasCloudFront) {
+  let relativeFilePath = path.relative(distributionDirPath, filePath);
+  // make Windows-style relative paths compatible to S3
+  relativeFilePath = relativeFilePath.replace(/\\/g, '/');
+  const fileStream = fs.createReadStream(filePath);
+  const contentType = mime.lookup(relativeFilePath);
+  const uploadParams = {
+    Bucket: hostingBucketName,
+    Key: relativeFilePath,
+    Body: fileStream,
+    ContentType: contentType || 'text/plain',
+  };
+
+  if (!hasCloudFront) {
+    uploadParams.ACL = 'public-read';
+  }
+
+  const data = await s3Client.upload(uploadParams).promise();
+
+  return data;
+}
+
+module.exports = {
+  uploadFile
+};
+


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR is to mitigate https://github.com/aws-amplify/amplify-cli/issues/2087 as proposed by @timoteialbu .

**Issue**: since `index.html` is not always uploaded to S3 at last, it sometimes causes file not found issue if a dependent file is uploaded after index.html

**Fix**: `await Promise.all` all other files except `index.html`, then upload `index.html` at the end.

**Note**: 
1. This PR is just a mitigation. To fundamentally resolve the issue, users need to enable some sort of cache or versionize.
2. I've checked some popular build tools and they all use `index.html`. The build tools I checked are: angular-cli@16,  react@18.2.0 + cra@5.0.1, react + next@13.4.7, react + vite@4.3.9, vue@3.3.4, vue + nuxt@3.5.2, vue + vite@4.3.9

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/2087

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
