### PR TITLE
chore: auto format wait_for_ids.json after splitting tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "smoketest@latest": "CLI_VERSION=latest lerna run smoketest --output-style=stream-without-prefixes",
     "smoketest@rc": "CLI_VERSION=rc lerna run smoketest --output-style=stream-without-prefixes",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
-    "split-e2e-tests-codebuild": "yarn ts-node ./scripts/split-e2e-tests-codebuild.ts && prettier --write ./codebuild_specs/wait_for_ids.json",
+    "split-e2e-tests-codebuild": "yarn ts-node ./scripts/split-e2e-tests-codebuild.ts",
     "split-e2e-tests-codebuild-single": "yarn ts-node ./scripts/generate_single_test_buildspec_codebuild.ts",
     "test-changed": "lerna run test --since dev",
     "test-ci": "lerna run test --concurrency 4 -- --ci -i",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "smoketest@latest": "CLI_VERSION=latest lerna run smoketest --output-style=stream-without-prefixes",
     "smoketest@rc": "CLI_VERSION=rc lerna run smoketest --output-style=stream-without-prefixes",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml",
-    "split-e2e-tests-codebuild": "yarn ts-node ./scripts/split-e2e-tests-codebuild.ts",
+    "split-e2e-tests-codebuild": "yarn ts-node ./scripts/split-e2e-tests-codebuild.ts && prettier --write ./codebuild_specs/wait_for_ids.json",
     "split-e2e-tests-codebuild-single": "yarn ts-node ./scripts/generate_single_test_buildspec_codebuild.ts",
     "test-changed": "lerna run test --since dev",
     "test-ci": "lerna run test --concurrency 4 -- --ci -i",

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -314,7 +314,7 @@ function main(): void {
   );
   let allBuilds = [...splitE2ETests, ...splitMigrationV8Tests, ...splitMigrationV10Tests];
   const dependeeIdentifiers: string[] = allBuilds.map((buildObject) => buildObject.identifier).sort();
-  const dependeeIdentifiersFileContents = JSON.stringify(dependeeIdentifiers, null, 4);
+  const dependeeIdentifiersFileContents = `${JSON.stringify(dependeeIdentifiers, null, 2)}\n`;
   const waitForIdsFilePath = './codebuild_specs/wait_for_ids.json';
   fs.writeFileSync(waitForIdsFilePath, dependeeIdentifiersFileContents);
   const reportsAggregator = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
The way that wait_for_ids.json is generated always fails the linter. This change makes sure that prettier is run on the file directly after it is generated. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
