### PR TITLE
fix: top level comment not replacing existing ones

### DIFF
--- a/packages/amplify-category-function/src/constants.ts
+++ b/packages/amplify-category-function/src/constants.ts
@@ -3,7 +3,7 @@ export const categoryName = 'function';
 export const envVarPrintoutPrefix =
   '\nYou can access the following resource attributes as environment variables from your Lambda function\n\t';
 const topLevelCommentBlockTitle = 'Amplify Params - DO NOT EDIT';
-export const topLevelCommentPrefix = `/* ${topLevelCommentBlockTitle}\n\t`;
+export const topLevelCommentPrefix = `/* ${topLevelCommentBlockTitle}\n`;
 export const topLevelCommentSuffix = `\n${topLevelCommentBlockTitle} */`;
 
 export enum CRUDOperation {

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/updateTopLevelComment.ts
@@ -17,7 +17,7 @@ export const tryUpdateTopLevelComment = (resourceDirPath: string, envVars: strin
   updateTopLevelComment(sourceFilePath, newComment);
 };
 
-const createTopLevelComment = (envVars: string[]) => `${topLevelCommentPrefix}${envVars.sort().join(`${EOL}\t`)}${topLevelCommentSuffix}`;
+const createTopLevelComment = (envVars: string[]) => `${topLevelCommentPrefix}\t${envVars.sort().join(`${EOL}\t`)}${topLevelCommentSuffix}`;
 
 const updateTopLevelComment = (filePath, newComment) => {
   const commentRegex = new RegExp(`${_.escapeRegExp(topLevelCommentPrefix)}[a-zA-Z0-9\\-\\s._=]+${_.escapeRegExp(topLevelCommentSuffix)}`);


### PR DESCRIPTION
Fixes the issue where top level comments are not replaced after an update to the function.

#### Description of changes

This fixes the issue where the regex for the function top level comments are not working, resulting in duplicates of the Amplify params that is generated after an update to a function (especially resources).

`js
/* Amplify Params - DO NOT EDIT
	<YOUR PARAM HERE>
Amplify Params - DO NOT EDIT */
/* Amplify Params - DO NOT EDIT
	<YOUR PARAM HERE>
	<NEW PARAM HERE>
Amplify Params - DO NOT EDIT */
<YOUR CODES HERE>
`

#### Issue #, if available

NA

#### Description of how you validated changes

Updated a function in my local environment and the top level comments are correctly replaced. 

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
