### PR TITLE
fix: support paths with whitespaces with xcode

### DIFF
--- a/packages/amplify-frontend-ios/lib/amplify-xcode.js
+++ b/packages/amplify-frontend-ios/lib/amplify-xcode.js
@@ -33,7 +33,7 @@ const amplifyXcodePath = () => path.join(pathManager.getAmplifyPackageLibDirPath
 async function importConfig(params) {
   let command = `${amplifyXcodePath()} import-config`;
   if (params['path']) {
-    command += ` --path=${params['path']}`;
+    command += ` --path="${params['path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -46,7 +46,7 @@ async function importConfig(params) {
 async function importModels(params) {
   let command = `${amplifyXcodePath()} import-models`;
   if (params['path']) {
-    command += ` --path=${params['path']}`;
+    command += ` --path="${params['path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -59,7 +59,7 @@ async function importModels(params) {
 async function generateSchema(params) {
   let command = `${amplifyXcodePath()} generate-schema`;
   if (params['output-path']) {
-    command += ` --output-path=${params['output-path']}`;
+    command += ` --output-path="${params['output-path']}"`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }

--- a/packages/amplify-frontend-ios/native-bindings-codegen/index.js
+++ b/packages/amplify-frontend-ios/native-bindings-codegen/index.js
@@ -49,7 +49,12 @@ const generateCommandParameters = (parameters) => {
     let output;
     switch (kind) {
       case 'option':
-        output = [`if (${funcParamValue}) {`, `    command += \` --${name}=\${${funcParamValue}}\`;`, `  }`];
+        let value = `\${${funcParamValue}}`;
+        // wrap in quotes
+        if (name.includes('path')) {
+          value = `"${value}"`;
+        }
+        output = [`if (${funcParamValue}) {`, `    command += \` --${name}=${value}\`;`, `  }`];
         break;
       case 'flag':
         output = [`if (${funcParamValue}) {`, `    command += \` --${name}\`;`, `  }`];

--- a/packages/amplify-frontend-ios/native-bindings-codegen/index.js
+++ b/packages/amplify-frontend-ios/native-bindings-codegen/index.js
@@ -48,7 +48,7 @@ const generateCommandParameters = (parameters) => {
     const funcParamValue = `params['${name}']`;
     let output;
     switch (kind) {
-      case 'option':
+      case 'option': {
         let value = `\${${funcParamValue}}`;
         // wrap in quotes
         if (name.includes('path')) {
@@ -56,6 +56,7 @@ const generateCommandParameters = (parameters) => {
         }
         output = [`if (${funcParamValue}) {`, `    command += \` --${name}=${value}\`;`, `  }`];
         break;
+      }
       case 'flag':
         output = [`if (${funcParamValue}) {`, `    command += \` --${name}\`;`, `  }`];
         break;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add whitespaces around path arguments for amplify-xcode bindings.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves https://github.com/aws-amplify/amplify-codegen/issues/582

#### Description of how you validated changes

amplify-dev 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
