### PR TITLE
chore: migrate to husky@8

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -7,5 +7,5 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No color
 
 echo "${GREEN}Running commit-msg hook${NC}"
-echo "${CYAN}Running yarn commitlint -E HUSKY_GIT_PARAMS${NC}"
+echo "${CYAN}Running npx --no -- commitlint --edit $1${NC}"
 npx --no -- commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Define color variables
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No color
+
+echo "${GREEN}Running commit-msg hook${NC}"
+echo "${CYAN}Running yarn commitlint -E HUSKY_GIT_PARAMS${NC}"
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Define color variables
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No color
+
+echo "${GREEN}Running pre-commit hook${NC}"
+echo "${CYAN}Running yarn prettier staged files${NC}"
+git diff --name-only --cached --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | xargs yarn prettier --write
+echo "${CYAN}Running yarn stage prettified files${NC}"
+git diff --name-only --cached --diff-filter=ACM | xargs git add
+echo "${CYAN}Running yarn lint-fix${NC}"
+yarn lint-fix
+echo "${CYAN}Running ./scripts/package-json-check.sh${NC}"
+./scripts/package-json-check.sh
+echo "${CYAN}Running yarn verify-commit${NC}"
+yarn verify-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,6 +9,8 @@ NC='\033[0m' # No color
 echo "${GREEN}Running pre-commit hook${NC}"
 echo "${CYAN}Running yarn prettier staged files${NC}"
 git diff --name-only --cached --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | xargs yarn prettier --write
+echo "${CYAN}Running yarn lint-staged${NC}"
+yarn lint-fix
 echo "${CYAN}Running yarn stage prettified files${NC}"
 git diff --name-only --cached --diff-filter=ACM | xargs git add
 echo "${CYAN}Running yarn lint-fix${NC}"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Define color variables
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No color
+
+echo "${GREEN}Running pre-push hook${NC}"
+echo "${CYAN}Running yarn build-tests-changed && yarn split-e2e-tests${NC}"
+yarn build-tests-changed && yarn split-e2e-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,17 +170,7 @@ Valid commit types are as follows:
 
 ### Git Hooks
 
-You will notice the extra actions carried out when you run the `git commit` or `git push` commands on this monorepo, that's because the following git hooks are configured using [husky](https://github.com/typicode/husky/tree/main) (you can see them in the root [package.json](https://github.com/aws-amplify/amplify-cli/blob/f2ac2b27b6b0dbf0c52edbc696c35b71f539c944/package.json#L61) file):
-
-```json
-"husky": {
-    "hooks": {
-        "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-        "pre-push": "yarn verify-api-extract && yarn build-tests-changed && yarn split-e2e-tests",
-        "pre-commit": "yarn verify-commit"
-    }
-}
-```
+You will notice the extra actions carried out when you run the `git commit` or `git push` commands on this monorepo, that's because the following git hooks are configured using [husky](https://github.com/typicode/husky/tree/main) (you can see them in [.husky](.husky) file):
 
 > NOTE: To ensure those git hooks properly execute, run `yarn` or `npm install` at the root of this monorepo to install the necessary dev dependency packages.
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pkg-all-local": "yarn verdaccio-clean && yarn verdaccio-start && yarn verdaccio-connect && yarn publish-to-verdaccio && yarn pkg-all && yarn verdaccio-disconnect",
     "pkg-all": "bash -c 'source .circleci/local_publish_helpers.sh && generatePkgCli'",
     "pkg-clean": "rimraf build out pkg/node_modules pkg/yarn.lock",
+    "postinstall": "husky install",
     "prettier-changes": "git diff --name-only --diff-filter MRA dev | xargs yarn prettier --write",
     "prettier-check": "yarn prettier --check .",
     "prettier-write": "yarn prettier --write .",
@@ -69,8 +70,7 @@
     "verify-api-extract": "yarn extract-api && ./scripts/verify-extract-api.sh",
     "verify-commit": "yarn ts-node ./scripts/verify-commit.ts",
     "verify-yarn-lock": "./scripts/verify-yarn-lock.sh",
-    "workflow-results": "yarn ts-node ./scripts/cci-workflow-results.ts",
-    "postinstall": "husky install"
+    "workflow-results": "yarn ts-node ./scripts/cci-workflow-results.ts"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-cli/issues"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "verify-api-extract": "yarn extract-api && ./scripts/verify-extract-api.sh",
     "verify-commit": "yarn ts-node ./scripts/verify-commit.ts",
     "verify-yarn-lock": "./scripts/verify-yarn-lock.sh",
-    "workflow-results": "yarn ts-node ./scripts/cci-workflow-results.ts"
+    "workflow-results": "yarn ts-node ./scripts/cci-workflow-results.ts",
+    "postinstall": "husky install"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-cli/issues"
@@ -80,13 +81,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-cli.git"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "yarn build-tests-changed && yarn split-e2e-tests",
-      "pre-commit": "yarn prettier-changes && yarn lint-fix && ./scripts/package-json-check.sh && yarn verify-commit"
-    }
   },
   "author": "Amazon Web Services",
   "license": "Apache-2.0",

--- a/scripts/package-json-check.sh
+++ b/scripts/package-json-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ ! -z "git diff --diff-filter=MRA --name-only | grep package.json" ]; then
   yarn lint-fix-package-json
-  echo "Changes made to package.json files. Please stage these changes before pushing."
+  git diff --diff-filter=MRA --name-only | grep package.json | xargs git add
 fi


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

After https://github.com/aws-amplify/amplify-cli/pull/12869, it has some issues:
1. error message in exist local folder
> Can't find Husky, skipping post-commit hook
> You can reinstall it using 'npm install husky --save-dev' or delete this hook

2. if clone a new repo, the hook would not work

**Reason**: Husky doesn't use config in package.json after version 7 ([ref](https://stackoverflow.com/a/68761163/12610324))
**Fix**: This PR is to migrate the setup to make husky@8 works. [Migration Guide](https://typicode.github.io/husky/getting-started.html)

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

<img width="718" alt="image" src="https://github.com/aws-amplify/amplify-cli/assets/11983489/0e832e30-de41-49a9-98db-74d259fd13d0">

<img width="544" alt="image" src="https://github.com/aws-amplify/amplify-cli/assets/11983489/68273ca4-da88-4861-969c-a9cf1f368fa1">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
