### PR TITLE
ci: fix wait for script, update PR workflow to match

### DIFF
--- a/codebuild_specs/aggregate_e2e_reports.yml
+++ b/codebuild_specs/aggregate_e2e_reports.yml
@@ -7,7 +7,7 @@ phases:
       - cd ./scripts
       - npm install -g ts-node
       - npm install aws-sdk
-      - ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION ../$WAIT_FOR_IDS_FILE_PATH $CODEBUILD_PROJECT_NAME
+      - ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION ../$WAIT_FOR_IDS_FILE_PATH $PROJECT_NAME
       - cd ..
       - source ./shared-scripts.sh && _downloadReportsFromS3 $CODEBUILD_SOURCE_VERSION
 reports:

--- a/codebuild_specs/aggregate_e2e_reports.yml
+++ b/codebuild_specs/aggregate_e2e_reports.yml
@@ -7,7 +7,7 @@ phases:
       - cd ./scripts
       - npm install -g ts-node
       - npm install aws-sdk
-      - ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION ../$WAIT_FOR_IDS_FILE_PATH AmplifyCLI-E2E-Testing
+      - ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION ../$WAIT_FOR_IDS_FILE_PATH $CODEBUILD_PROJECT_NAME
       - cd ..
       - source ./shared-scripts.sh && _downloadReportsFromS3 $CODEBUILD_SOURCE_VERSION
 reports:

--- a/codebuild_specs/pr_workflow.yml
+++ b/codebuild_specs/pr_workflow.yml
@@ -22,59 +22,37 @@ batch:
       buildspec: codebuild_specs/test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - build_linux
     - identifier: mock_e2e_tests
       buildspec: codebuild_specs/mock_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - build_linux
     - identifier: validate_cdk_version
       buildspec: codebuild_specs/validate_cdk_version.yml
-      depend-on:
-        - build_linux
     - identifier: verify_api_extract
       buildspec: codebuild_specs/verify_api_extract.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - build_linux
     - identifier: verify_yarn_lock
       buildspec: codebuild_specs/verify_yarn_lock.yml
-      depend-on:
-        - build_linux
     - identifier: publish_to_local_registry
       buildspec: codebuild_specs/publish_to_local_registry.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - build_linux
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-      depend-on:
-        - publish_to_local_registry
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
-      depend-on:
-        - publish_to_local_registry

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -536,6 +536,6 @@ function _waitForJobs {
     cd ./scripts
     npm install -g ts-node
     npm install aws-sdk
-    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $CODEBUILD_PROJECT_NAME
+    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME
     cd ..
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -536,6 +536,6 @@ function _waitForJobs {
     cd ./scripts
     npm install -g ts-node
     npm install aws-sdk
-    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path AmplifyCLI-E2E-Testing
+    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $CODEBUILD_PROJECT_NAME
     cd ..
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
PR workflows were failing due to the wait script attempting to query the e2e project for batch build details. It should be querying the PR project batches instead. This updates the code to rely on PROJECT_NAME to determine which batches it should query. Also, the PR workflow still had dependsOn relationships which aren't needed anymore, as of https://github.com/aws-amplify/amplify-cli/pull/12882.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
