### PR TITLE
fix(amplify-graphiql-explorer): amplify mock with Cognito User Pool

### DIFF
--- a/packages/amplify-graphiql-explorer/package.json
+++ b/packages/amplify-graphiql-explorer/package.json
@@ -37,7 +37,7 @@
     "jest": "^29.0.0",
     "jest-resolve": "^26.0.2",
     "jest-watch-typeahead": "^1.0.0",
-    "jsonwebtoken": "^9.0.0",
+    "jsrsasign": "^10.8.6",
     "mini-css-extract-plugin": "^2.4.5",
     "postcss": "^8.4.4",
     "postcss-flexbugs-fixes": "^5.0.2",
@@ -73,6 +73,7 @@
   "devDependencies": {
     "@semantic-ui-react/css-patch": "^1.0.0",
     "@types/jest": "^29.5.1",
+    "@types/jsrsasign": "^10",
     "@types/node": "^12.12.6",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11"

--- a/packages/amplify-graphiql-explorer/src/utils/jwt.ts
+++ b/packages/amplify-graphiql-explorer/src/utils/jwt.ts
@@ -1,12 +1,16 @@
-import { decode, sign, verify } from 'jsonwebtoken';
+import { KJUR, b64utoutf8 } from 'jsrsasign';
 
 export function generateToken(decodedToken: string | object): string {
   try {
     if (typeof decodedToken === 'string') {
       decodedToken = JSON.parse(decodedToken);
     }
-    const token = sign(decodedToken, 'open-secrete');
-    verify(token, 'open-secrete');
+    const header = { alg: 'HS256', typ: 'JWT' };
+    const token = KJUR.jws.JWS.sign('HS256', JSON.stringify(header), decodedToken, 'open-secrete');
+    const isValid = KJUR.jws.JWS.verify(token, 'open-secrete');
+    if (!isValid) {
+      throw new Error('Invalid token.');
+    }
     return token;
   } catch (e) {
     const err = new Error('Error when generating OIDC token: ' + e.message);
@@ -15,7 +19,7 @@ export function generateToken(decodedToken: string | object): string {
 }
 
 export function parse(token): object {
-  const decodedToken = decode(token);
+  const decodedToken = KJUR.jws.JWS.readSafeJSONString(b64utoutf8(token.split('.')[1]));
   return decodedToken as object;
 }
 

--- a/packages/amplify-graphiql-explorer/src/utils/jwt.ts
+++ b/packages/amplify-graphiql-explorer/src/utils/jwt.ts
@@ -19,6 +19,9 @@ export function generateToken(decodedToken: string | object): string {
 }
 
 export function parse(token): object {
+  if (!token) {
+    return {};
+  }
   const decodedToken = KJUR.jws.JWS.readSafeJSONString(b64utoutf8(token.split('.')[1]));
   return decodedToken as object;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,6 +631,7 @@ __metadata:
     "@testing-library/react": ^11.1.0
     "@testing-library/user-event": ^12.1.10
     "@types/jest": ^29.5.1
+    "@types/jsrsasign": ^10
     "@types/node": ^12.12.6
     "@types/react": ^17.0.39
     "@types/react-dom": ^17.0.11
@@ -662,7 +663,7 @@ __metadata:
     jest: ^29.0.0
     jest-resolve: ^26.0.2
     jest-watch-typeahead: ^1.0.0
-    jsonwebtoken: ^9.0.0
+    jsrsasign: ^10.8.6
     mini-css-extract-plugin: ^2.4.5
     postcss: ^8.4.4
     postcss-flexbugs-fixes: ^5.0.2
@@ -10070,6 +10071,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/jsrsasign@npm:^10":
+  version: 10.5.8
+  resolution: "@types/jsrsasign@npm:10.5.8"
+  checksum: 50fae7b760ad56c6e51ed859b0d89fa877398266efe9e343229a02c8a5027eaf96a3568546ff5f639ffc53cda8be3fa5031855def9e800ca5d6d245dd12dc8d1
   languageName: node
   linkType: hard
 
@@ -21175,6 +21183,13 @@ __metadata:
     json-schema: 0.4.0
     verror: 1.10.0
   checksum: 5e4bca99e90727c2040eb4c2190d0ef1fe51798ed5714e87b841d304526190d960f9772acc7108fa1416b61e1122bcd60e4460c91793dce0835df5852aab55af
+  languageName: node
+  linkType: hard
+
+"jsrsasign@npm:^10.8.6":
+  version: 10.8.6
+  resolution: "jsrsasign@npm:10.8.6"
+  checksum: 60f574594fdcd203a9204de9f1e6581e1b880f71358500a7ef62b995acc656e6dcd7f7ad055983b1cbb560ede6afc7b511e5afc88b821eea28661476067fa78e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This bug is caused by jsonwebtoken's verify method.
The issue is here. https://github.com/auth0/node-jsonwebtoken/issues/863
There is no choice but to use an alternative library.

I've replaced jsonwebtoken to jsrsasign.
I chose jsrsasign for the following reasons:
1.  jsrsasign is featured on jwt.io which is a trustworthy website. https://jwt.io/libraries?language=JavaScript
2. Since jose requested async/await, jsrsasign is less affected by the fix. There is not much difference in functionality.


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

aws-amplify/amplify-category-api#1646 12905

#### Description of how you validated changes

I've confirmed `amplify mock` with Cognito User Pool works.
The GraphiQL page is shown propery. The queries work.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
