### PR TITLE
fix: add permissions boundary to IAM Role created for auth trigger

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/generate-auth-trigger-template.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/generate-auth-trigger-template.test.ts
@@ -1,10 +1,11 @@
+import { getPermissionsBoundaryArn } from '@aws-amplify/amplify-cli-core';
 import {
   AuthTriggerConnection,
   AuthTriggerPermissions,
   TriggerType,
 } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/cognito-user-input-types';
 import { createCustomResourceForAuthTrigger } from '../../../../provider-utils/awscloudformation/utils/generate-auth-trigger-template';
-
+jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('uuid');
 describe('generate Auth Trigger Template', () => {
   it('successfully generate IAM policies when permissions are defined', async () => {
@@ -78,6 +79,44 @@ describe('generate Auth Trigger Template', () => {
   "Type": "AWS::IAM::Policy",
 }
 `);
+    // No permissions boundary set if not available
+    expect(cfn.Resources.authTriggerFnServiceRole08093B67.Properties.PermissionsBoundary).toBeUndefined();
+  });
+
+  it('adds permissions boundary to new role if available', async () => {
+    // Setup for a successfully generating custom resource.
+    const mockAuthTriggerConnections: AuthTriggerConnection[] = [
+      {
+        lambdaFunctionName: 'randomFn',
+        triggerType: TriggerType.PostConfirmation,
+        lambdaFunctionArn: 'randomArn',
+      },
+    ];
+    const mockAuthTriggerPermissions: AuthTriggerPermissions[] = [
+      {
+        policyName: 'AddToGroupCognito',
+        trigger: 'PostConfirmation',
+        effect: 'Allow',
+        actions: ['cognito-idp:AdminAddUserToGroup', 'cognito-idp:GetGroup', 'cognito-idp:CreateGroup'],
+        resource: {
+          paramType: '!GetAtt',
+          keys: ['UserPool', 'Arn'],
+        },
+      },
+    ];
+
+    // ensure permissions boundary is set
+    const getPermissionsBoundaryArn_mock = getPermissionsBoundaryArn as jest.MockedFunction<typeof getPermissionsBoundaryArn>;
+    getPermissionsBoundaryArn_mock.mockReturnValue('testPermissionsBoundaryArn');
+
+    // execute the test
+    const cfn = await createCustomResourceForAuthTrigger(mockAuthTriggerConnections, false, mockAuthTriggerPermissions);
+
+    //validate
+    expect(cfn.Resources.authTriggerFnServiceRole08093B67.Properties.PermissionsBoundary).toStrictEqual('testPermissionsBoundaryArn');
+
+    // Restore for other folks
+    getPermissionsBoundaryArn_mock.mockRestore();
   });
 
   it('does not generate iam policies for Auth trigger when permissions are empty', async () => {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/utils/generate-auth-trigger-template.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { $TSAny, AmplifyFault, JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
+import { $TSAny, AmplifyFault, JSONUtilities, pathManager, getPermissionsBoundaryArn } from '@aws-amplify/amplify-cli-core';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cdk from 'aws-cdk-lib';
@@ -165,6 +165,11 @@ const createCustomResource = (
         resources: [userpoolArn.valueAsString],
       }),
     );
+
+    const policyArn = getPermissionsBoundaryArn();
+    if (policyArn) {
+      iam.PermissionsBoundary.of(authTriggerFn).apply(iam.ManagedPolicy.fromManagedPolicyArn(stack, 'PermissionsBoundary', policyArn));
+    }
 
     // reason to add iam::PassRole
     // AccessDeniedException: User: <IAM User> is not authorized to perform: iam:PassRole


### PR DESCRIPTION
#### Description of changes

fix: add permissions boundary for IAM Role created for auth trigger

#### Issue #, if available

N/A

#### Description of how you validated changes

manually executing the use case and unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
