### PR TITLE
fix: add check for codebuild when updating url

### DIFF
--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -72,7 +72,7 @@ const getCompressedBinaryUrl = (): string => {
   const compressedBinaryName = getPlatformCompressedBinaryName();
   let url = `${BINARY_LOCATION}/${version}/${compressedBinaryName}`;
 
-  if (process.env.IS_AMPLIFY_CI) {
+  if (process.env.IS_AMPLIFY_CI && process.env.CODEBUILD_SRC_DIR) {
     // use cloudfront distribution for e2e
     url = `https://${process.env.PKG_CLI_CLOUDFRONT_URL}/${version}/${compressedBinaryName}`;
     url = url.replace('.tgz', `-${getCommitHash()}.tgz`);

--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -75,6 +75,7 @@ const getCompressedBinaryUrl = (): string => {
   if (process.env.IS_AMPLIFY_CI && process.env.CODEBUILD_SRC_DIR) {
     // use cloudfront distribution for e2e
     url = `https://${process.env.PKG_CLI_CLOUDFRONT_URL}/${version}/${compressedBinaryName}`;
+  } else if (process.env.IS_AMPLIFY_CI) {
     url = url.replace('.tgz', `-${getCommitHash()}.tgz`);
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
PKG_CLI_CLOUDFRONT_URL is not set in CircleCI. So initially that value was resolving to undefined. Now it will fall into the "else if" and the url will be determined by the hash alone.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
