### PR TITLE
chore: remove redundant app id error

### DIFF
--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import sequential from 'promise-sequential';
 import { CLIContextEnvironmentProvider, FeatureFlags, pathManager, stateManager, $TSContext, $TSAny } from '@aws-amplify/amplify-cli-core';
 import _ from 'lodash';
-import { printer, prompter } from '@aws-amplify/amplify-prompts';
+import { prompter } from '@aws-amplify/amplify-prompts';
 import { getFrontendPlugins } from '../extensions/amplify-helpers/get-frontend-plugins';
 import { getProviderPlugins } from '../extensions/amplify-helpers/get-provider-plugins';
 import { insertAmplifyIgnore } from '../extensions/amplify-helpers/git-manager';

--- a/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
+++ b/packages/amplify-cli/src/init-steps/s9-onSuccess.ts
@@ -88,15 +88,6 @@ export const onSuccess = async (context: $TSContext): Promise<void> => {
   if (!context.parameters.options?.app) {
     printWelcomeMessage(context);
   }
-
-  const appId = currentAmplifyMeta?.providers?.awscloudformation?.AmplifyAppId;
-
-  if (!appId) {
-    printer.warn('The maximum number of apps that you can create with Amplify in this region has likely been reached:');
-    printer.info('For more information on Amplify Service Quotas, see:');
-    printer.info('https://docs.aws.amazon.com/general/latest/gr/amplify.html#service-quotas-amplify');
-    printer.blankLine();
-  }
 };
 
 const generateLocalRuntimeFiles = (context: $TSContext): void => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This warning is redundant as of this PR: https://github.com/aws-amplify/amplify-cli/pull/10839/files
Whenever the app id can't be resolved, customers would see a warning that they had reached the app limit even when they had not. Removing this warning will alleviate some confusion. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
