### PR TITLE
fix: skip overrides and custom flag

### DIFF
--- a/packages/amplify-category-custom/src/__tests__/utils/build-custom-resources.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/utils/build-custom-resources.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, AmplifyError } from '@aws-amplify/amplify-cli-core';
 import execa from 'execa';
 import { buildCustomResources } from '../../utils/build-custom-resources';
 
@@ -43,6 +43,7 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
     readJson: jest.fn(),
     stringify: jest.fn(),
   },
+  skipHooks: jest.fn().mockReturnValue(false),
 }));
 
 describe('build custom resources scenarios', () => {

--- a/packages/amplify-category-custom/src/utils/build-custom-resources.ts
+++ b/packages/amplify-category-custom/src/utils/build-custom-resources.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import { categoryName, TYPES_DIR_NAME, AMPLIFY_RESOURCES_TYPE_DEF_FILENAME } from './constants';
 import { getAllResources } from './dependency-management-utils';
 import { generateCloudFormationFromCDK } from './generate-cfn-from-cdk';
+import { skipHooks } from '@aws-amplify/amplify-cli-core';
 
 type ResourceMeta = ResourceTuple & {
   service: string;
@@ -69,7 +70,11 @@ export const generateDependentResourcesType = async (): Promise<void> => {
 
 const buildResource = async (resource: ResourceMeta): Promise<void> => {
   const targetDir = path.resolve(path.join(pathManager.getBackendDirPath(), categoryName, resource.resourceName));
-
+  if (skipHooks()) {
+    throw new AmplifyError('DeploymentError', {
+      message: 'A flag to disable custom resources has been detected, please deploy from a different environment.',
+    }); // should rollback
+  }
   // generate dynamic types for Amplify resources
   await generateDependentResourcesType();
 

--- a/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
@@ -86,21 +86,16 @@ describe('hooksExecutioner tests', () => {
   test('skip Hooks test', async () => {
     mockSkipHooks.mockRestore();
 
-    const orgSkipHooksExist = fs.existsSync(skipHooksFilePath);
-
-    fs.ensureFileSync(skipHooksFilePath);
-    // skip hooks file exists so no execa calls should be made
+    process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES = 'true';
+    // skip hooks flag exists so no execa calls should be made
     await executeHooks(HooksMeta.getInstance({ command: 'push', plugin: 'core' } as CommandLineInput, 'pre'));
     expect(execa).toHaveBeenCalledTimes(0);
 
-    fs.removeSync(skipHooksFilePath);
-    // skip hooks file does not exists so execa calls should be made
+    delete process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES;
+    // skip hooks flag does not exist so execa calls should be made
     await executeHooks(HooksMeta.getInstance({ command: 'push', plugin: 'core' } as CommandLineInput, 'pre'));
     expect(execa).not.toHaveBeenCalledTimes(0);
 
-    // restoring the original state of skip hooks file
-    if (!orgSkipHooksExist) fs.removeSync(skipHooksFilePath);
-    else fs.ensureFileSync(skipHooksFilePath);
     mockSkipHooks = jest.spyOn(skipHooksModule, 'skipHooks');
   });
 

--- a/packages/amplify-cli-core/src/hooks/skipHooks.ts
+++ b/packages/amplify-cli-core/src/hooks/skipHooks.ts
@@ -3,9 +3,9 @@ import { skipHooksFilePath } from './hooksConstants';
 
 export function skipHooks(): boolean {
   // DO NOT CHANGE: used to skip hooks on Admin UI
-  try {
-    return fs.existsSync(skipHooksFilePath);
-  } catch (err) {
+  if (process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES) {
+    return true;
+  } else {
     return false;
   }
 }

--- a/packages/amplify-cli-core/src/hooks/skipHooks.ts
+++ b/packages/amplify-cli-core/src/hooks/skipHooks.ts
@@ -1,6 +1,3 @@
-import * as fs from 'fs-extra';
-import { skipHooksFilePath } from './hooksConstants';
-
 export function skipHooks(): boolean {
   // DO NOT CHANGE: used to skip hooks on Admin UI
   if (process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES) {

--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -2,7 +2,7 @@ import { printer, prompter } from '@aws-amplify/amplify-prompts';
 import execa from 'execa';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { $TSContext, AmplifyError, getPackageManager, pathManager } from '../index';
+import { $TSContext, AmplifyError, getPackageManager, pathManager, skipHooks } from '../index';
 import { JSONUtilities } from '../jsonUtilities';
 
 /**
@@ -46,6 +46,11 @@ export const buildOverrideDir = async (cwd: string, destDirPath: string): Promis
   if (!fs.existsSync(overrideFileName)) {
     // return when no override file found
     return false;
+  }
+  if (skipHooks()) {
+    throw new AmplifyError('DeploymentError', {
+      message: 'A flag to disable overrides has been detected, please deploy from a different environment.',
+    });
   }
   const overrideBackendPackageJson = path.join(pathManager.getBackendDirPath(), 'package.json');
   if (!fs.existsSync(overrideBackendPackageJson)) {

--- a/packages/amplify-cli/src/__tests__/execution-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/execution-manager.test.ts
@@ -74,6 +74,7 @@ describe('execution manager', () => {
     ['pull', { event: AmplifyEvent.PrePull, data: {} }],
     ['models', { event: AmplifyEvent.PreCodegenModels, data: {} }],
   ])('executeCommand raise pre %s event', async (command, args) => {
+    mockFs.readdirSync.mockReturnValue([]);
     mockFs.existsSync.mockReturnValue(true);
     mockContext.input.command = command;
     await executeCommand(mockContext);
@@ -86,6 +87,7 @@ describe('execution manager', () => {
     ['pull', { event: AmplifyEvent.PostPull, data: {} }],
     ['models', { event: AmplifyEvent.PostCodegenModels, data: {} }],
   ])('executeCommand raise post %s event', async (command, args) => {
+    mockFs.readdirSync.mockReturnValue([]);
     mockFs.existsSync.mockReturnValue(true);
     mockContext.input.command = command;
     await executeCommand(mockContext);

--- a/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_6.test.ts
@@ -103,6 +103,12 @@ describe('zero config auth', () => {
     // test happy path
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-auth.ts');
     replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', PROJECT_NAME);
+    // should throw error if AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES is set
+    process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES = 'true';
+    await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
+    // unset
+    delete process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES;
+    // should succeed now
     await amplifyPushOverride(projRoot);
 
     // check overwritten config

--- a/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom_resources.test.ts
@@ -60,8 +60,15 @@ describe('adding custom resources test', () => {
     const ddbName = 'ddb';
     await addSimpleDDB(projRoot, { name: ddbName });
 
-    // happy path test (this custom stack compiles and runs successfully)
+    // should throw error if AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES is set
+    process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES = 'true';
     const srcCustomResourceFilePath = path.join(__dirname, '..', '..', 'custom-resources', 'custom-cdk-stack.ts');
+    fs.copyFileSync(srcRuntimeErrorTest, destCustomResourceFilePath);
+    await expect(amplifyPushAuth(projRoot)).rejects.toThrowError();
+    // unset
+    delete process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES;
+
+    // happy path test (this custom stack compiles and runs successfully)
     fs.copyFileSync(srcCustomResourceFilePath, destCustomResourceFilePath);
 
     await buildCustomResources(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -60,9 +60,15 @@ describe('amplify init e', () => {
     fs.copyFileSync(srcInvalidOverrideRuntimeError, destOverrideFilePath);
     await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
 
-    // test happy path
+    // test with valid file
     const srcOverrideFilePath = path.join(__dirname, '..', '..', 'overrides', 'override-root.ts');
     replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    // should throw error if AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES is set
+    process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES = 'true';
+    await expect(amplifyPushOverride(projRoot)).rejects.toThrowError();
+    // unset
+    delete process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES;
+    // should succeed now
     await amplifyPushOverride(projRoot);
     const newEnvMeta = getProjectMeta(projRoot).providers.awscloudformation;
     expect(newEnvMeta.AuthRoleName).toContain('mockRole');

--- a/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
@@ -208,6 +208,12 @@ describe('ddb override tests', () => {
     );
 
     replaceOverrideFileWithProjectInfo(srcOverrideFilePath, destOverrideFilePath, 'integtest', projectName);
+    // should throw error if AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES is set
+    process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES = 'true';
+    await expect(buildOverrideStorage(projRoot)).rejects.toThrowError();
+    // unset
+    delete process.env.AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES;
+    // should succeed now
     await buildOverrideStorage(projRoot);
     let ddbCFNFileJSON = JSONUtilities.readJson<$TSObject>(cfnFilePath);
     // check if overrides are applied to the cfn file


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This adds support for aborting deployments if skipping overrides and custom resources is optionally set by the flag AMPLIFY_CLI_DISABLE_SCRIPTING_FEATURES.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
