### PR TITLE
fix: parsing arn with multiple slashes when importing auth

### DIFF
--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -8,6 +8,7 @@
 
 import Ajv from 'ajv';
 import { ApiKeyConfig } from '@aws-amplify/graphql-transformer-interfaces';
+import { ARN } from '@aws-sdk/util-arn-parser';
 import { BuildType } from '@aws-amplify/amplify-function-plugin-interface';
 import * as cdk from 'aws-cdk-lib';
 import { ChildProcess } from 'child_process';
@@ -1504,6 +1505,9 @@ export const packageManagers: Record<PackageManagerType, PackageManager>;
 
 // @public (undocumented)
 export type PackageManagerType = 'yarn' | 'npm' | 'pnpm' | 'custom';
+
+// @public (undocumented)
+export const parseArn: (arn: string) => ARN;
 
 // @public (undocumented)
 export function parseHelpCommands(input: $TSAny, commandsInfo: Array<CommandInfo>): {

--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -32,6 +32,7 @@
     "@aws-amplify/amplify-function-plugin-interface": "1.11.0",
     "@aws-amplify/amplify-prompts": "2.8.0",
     "@aws-amplify/graphql-transformer-interfaces": "^2.2.2",
+    "@aws-sdk/util-arn-parser": "^3.310.0",
     "@yarnpkg/lockfile": "^1.1.0",
     "ajv": "^6.12.6",
     "aws-cdk-lib": "~2.68.0",

--- a/packages/amplify-cli-core/src/utils/arn-parser.ts
+++ b/packages/amplify-cli-core/src/utils/arn-parser.ts
@@ -1,0 +1,5 @@
+import { ARN, parse } from '@aws-sdk/util-arn-parser';
+
+export const parseArn = (arn: string): ARN => {
+  return parse(arn);
+};

--- a/packages/amplify-cli-core/src/utils/index.ts
+++ b/packages/amplify-cli-core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './arn-parser';
 export * from './doc-links';
 export * from './fileSize';
 /* eslint-disable import/no-cycle */

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
@@ -1,0 +1,68 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { createIdentityPoolService } from '../../aws-utils/IdentityPoolService';
+import { loadConfiguration } from '../../configuration-manager';
+
+let mockCognitoIdentityRoles = {
+  authenticated: 'arn:aws:iam::123456789012:role/service-role/my-auth-role',
+  unauthenticated: 'arn:aws:iam::123456789012:role/service-role/my-unauth-role',
+};
+
+jest.mock('aws-sdk', () => {
+  return {
+    CognitoIdentity: jest.fn(() => {
+      return {
+        config: {},
+        getIdentityPoolRoles: jest.fn().mockImplementation(() => ({
+          promise: async () => {
+            return {
+              Roles: mockCognitoIdentityRoles,
+            };
+          },
+        })),
+      };
+    }),
+  };
+});
+
+jest.mock('../../configuration-manager', () => {
+  return {
+    loadConfiguration: jest.fn().mockReturnValue({}) as jest.MockedFunction<typeof loadConfiguration>,
+  };
+});
+
+describe('IdentityPoolService', () => {
+  it('should correctly parse arn if it contains multiple forward slashes', async () => {
+    const idpService = await createIdentityPoolService({} as unknown as $TSContext, {});
+    expect(await idpService.getIdentityPoolRoles('mockIdpId')).toEqual({
+      authRoleArn: 'arn:aws:iam::123456789012:role/service-role/my-auth-role',
+      authRoleName: 'service-role/my-auth-role',
+      unauthRoleArn: 'arn:aws:iam::123456789012:role/service-role/my-unauth-role',
+      unauthRoleName: 'service-role/my-unauth-role',
+    });
+  });
+
+  it('should correctly parse arn if it contains a single forward slash', async () => {
+    const idpService = await createIdentityPoolService({} as unknown as $TSContext, {});
+    mockCognitoIdentityRoles = {
+      authenticated: 'arn:aws:iam::123456789012:role/my-auth-role',
+      unauthenticated: 'arn:aws:iam::123456789012:role/my-unauth-role',
+    };
+
+    expect(await idpService.getIdentityPoolRoles('mockIdpId')).toEqual({
+      authRoleArn: 'arn:aws:iam::123456789012:role/my-auth-role',
+      authRoleName: 'my-auth-role',
+      unauthRoleArn: 'arn:aws:iam::123456789012:role/my-unauth-role',
+      unauthRoleName: 'my-unauth-role',
+    });
+  });
+
+  it('should fail to parse arn if it contains no forward slash', async () => {
+    const idpService = await createIdentityPoolService({} as unknown as $TSContext, {});
+    mockCognitoIdentityRoles = {
+      authenticated: 'arn:aws:iam::123456789012:my-auth-role',
+      unauthenticated: 'arn:aws:iam::123456789012:my-unauth-role',
+    };
+
+    await expect(idpService.getIdentityPoolRoles('mockIdpId')).rejects.toBeDefined();
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -1,4 +1,4 @@
-import { $TSAny, $TSContext, AmplifyFault, AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { $TSAny, $TSContext, AmplifyFault, AmplifyError, parseArn } from '@aws-amplify/amplify-cli-core';
 import { IIdentityPoolService } from '@aws-amplify/amplify-util-import';
 import { CognitoIdentity } from 'aws-sdk';
 import { PaginationKey, IdentityPool, IdentityPoolShortDescription, ListIdentityPoolsResponse } from 'aws-sdk/clients/cognitoidentity';
@@ -101,10 +101,10 @@ export class IdentityPoolService implements IIdentityPoolService {
     let resourceName;
 
     if (arn) {
-      const parts = arn.split('/');
-
-      if (parts.length === 2) {
-        resourceName = parts[1];
+      const fullRoleName = parseArn(arn).resource;
+      const parts = fullRoleName.split('/');
+      if (parts.length >= 2) {
+        resourceName = parts.slice(1).join('/');
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,6 +389,7 @@ __metadata:
     "@aws-amplify/amplify-function-plugin-interface": 1.10.3
     "@aws-amplify/amplify-prompts": 2.8.0
     "@aws-amplify/graphql-transformer-interfaces": ^2.2.2
+    "@aws-sdk/util-arn-parser": ^3.310.0
     "@types/ejs": ^3.1.1
     "@types/fs-extra": ^8.0.1
     "@types/hjson": ^2.4.2
@@ -4643,6 +4644,15 @@ __metadata:
   dependencies:
     tslib: ^1.8.0
   checksum: 94a2c489490b336761c1e8268a87b0bc5d390e32cf70d805a0984d3fe0800bad789909c3ca837427354ec5694ca68fa031804fdb5101dd3873460200b520110e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:^3.310.0":
+  version: 3.310.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 7214c1291748751976d2d5125d79d49dcb40a0f2276b6da41403c2fd4ecdeb611a604afe06d35c74f66231af78234367698c472b18b671f6e1685890d2508563
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Allow more than 1 forward slash in role arns for authenticated and unauthenticated roles when importing auth

This PR is nearly a duplicate of #12987, but it targets the hotfix branch.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-cli/issues/12817

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually imported auth (Cognito User Pool and Identity Pool) with multiple slashes in the IAM role names for auth and unauth. Created test web app to confirm account creation and sign-in/sign-out.

These steps fail with 12.2.0 CLI, but succeed with PR changes.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
