### PR TITLE
ci: update env names to match cleanup regex

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom-resource-with-storage.test.ts
@@ -23,7 +23,7 @@ import { v4 as uuid } from 'uuid';
 describe('adding custom resources test', () => {
   const projectName = 'cusres';
   let projRoot: string;
-  const envName = 'dev';
+  const envName = 'devtest';
   beforeEach(async () => {
     projRoot = await createNewProjectDir(projectName);
     await initJSProjectWithProfile(projRoot, { envName, disableAmplifyAppCreation: false });

--- a/packages/amplify-e2e-tests/src/__tests__/import_s3_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_s3_3.test.ts
@@ -23,7 +23,7 @@ const profileName = 'amplify-integ-test-user';
 
 describe('headless s3 import', () => {
   const projectPrefix = 'sssheadimp';
-  const bucketPrefix = 'sss-headless-import-';
+  const bucketPrefix = 'sss-headless-import-test';
 
   const projectSettings = {
     name: projectPrefix,

--- a/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init-special-case.test.ts
@@ -39,7 +39,7 @@ describe('amplify init', () => {
   });
 
   it('test init on a git pulled project', async () => {
-    const envName = 'dev';
+    const envName = 'devtest';
     const resourceName = 'authConsoleTest';
     await initJSProjectWithProfile(projectRoot, { disableAmplifyAppCreation: false, name: resourceName, envName });
     await addAuthWithDefault(projectRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/layer-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer-1.test.ts
@@ -175,7 +175,7 @@ describe('amplify add lambda layer', () => {
       projName,
     };
 
-    const noLayerEnv = 'nolayerenv';
+    const noLayerEnv = 'nolayertest';
 
     await addEnvironment(projRoot, { envName: noLayerEnv });
     await checkoutEnvironment(projRoot, { envName });

--- a/packages/amplify-e2e-tests/src/__tests__/parameter-store-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/parameter-store-2.test.ts
@@ -19,7 +19,7 @@ import {
 
 describe('parameters in Parameter Store', () => {
   let projRoot: string;
-  const envName = 'enva';
+  const envName = 'devtest';
 
   beforeEach(async () => {
     projRoot = await createNewProjectDir('multi-env');

--- a/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
@@ -36,7 +36,7 @@ describe('generated tags test', () => {
 
   it('should compare the nested stack tags key with the tags.json file and return true', async () => {
     const projName = 'tagsTest';
-    const envName = 'devtag';
+    const envName = 'devtagtest';
     await initJSProjectWithProfile(projRoot, { name: projName, envName });
     await addPRODHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);

--- a/packages/amplify-e2e-tests/src/__tests__/with-babel-config.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/with-babel-config.test.ts
@@ -15,7 +15,7 @@ describe('project with babel config', () => {
   let packageJsonPath: string;
   let babelConfigPath: string;
   const projName = 'withBabelConfig';
-  const envName = 'dev';
+  const envName = 'devtest';
 
   beforeAll(async () => {
     projectRoot = await createNewProjectDir(projName);

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -139,8 +139,7 @@ type AWSAccountInfo = {
 
 const PINPOINT_TEST_REGEX = /integtest/;
 const APPSYNC_TEST_REGEX = /integtest/;
-const BUCKET_TEST_REGEX =
-  /test|cusres.*-dev|-enva|sss-headless-import|devtag|nolayerenv|amplify-specialinit|withbabelconfig|amplify-hooks.*-deployment/;
+const BUCKET_TEST_REGEX = /test/;
 const IAM_TEST_REGEX = /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-/;
 const USER_POOL_TEST_REGEX = /integtest|amplify_backend_manager/;
 const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -139,7 +139,8 @@ type AWSAccountInfo = {
 
 const PINPOINT_TEST_REGEX = /integtest/;
 const APPSYNC_TEST_REGEX = /integtest/;
-const BUCKET_TEST_REGEX = /test/;
+const BUCKET_TEST_REGEX =
+  /test|cusres.*-dev|-enva|sss-headless-import|devtag|nolayerenv|amplify-specialinit|withbabelconfig|amplify-hooks.*-deployment/;
 const IAM_TEST_REGEX = /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-/;
 const USER_POOL_TEST_REGEX = /integtest|amplify_backend_manager/;
 const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Some bucket names were not being generated with a 'test' substring to match the cleanup regex.
This will allow those tests to produce buckets which can be cleaned up by the cleanup script.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
