### PR TITLE
ci: fix verify-api-extract codebuild

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -125,6 +125,7 @@ function _verifyAPIExtract {
     # download [repo, .cache from s3]
     loadCache repo $CODEBUILD_SRC_DIR
     loadCache .cache $HOME/.cache
+    unset IS_AMPLIFY_CI
     yarn verify-api-extract
 }
 function _verifyYarnLock {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
IS_AMPLIFY_CI is not set during verify-api-extract in CircleCI; this updates it to match in CodeBuild, which sets it globally.
For codebuild to be the same, we need to manually unset IS_AMPLIFY_CI.
If we don't do this, IS_AMPLIFY_CI flag is detected during the install of amplify-cli-npm package during verify-api-extract, which would try to download the pkg cli using the commit hash instead of from production. The download the amplify-cli is caused by a post install script, and is not relevant to the verify-api-extract step.
See for more context: https://github.com/aws-amplify/amplify-cli/pull/13012/files/a34d2ddb08d759b778f092d490d8e3043df432ab#r1276765401

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
