### PR TITLE
chore: bump data deps

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@aws-amplify/amplify-app": "5.0.13",
     "@aws-amplify/amplify-category-analytics": "5.0.15",
-    "@aws-amplify/amplify-category-api": "^5.5.0",
+    "@aws-amplify/amplify-category-api": "^5.5.2",
     "@aws-amplify/amplify-category-auth": "3.4.3",
     "@aws-amplify/amplify-category-custom": "3.1.3",
     "@aws-amplify/amplify-category-function": "5.4.3",
@@ -66,7 +66,7 @@
     "@aws-amplify/amplify-util-mock": "5.4.3",
     "@aws-amplify/amplify-util-uibuilder": "1.9.3",
     "@aws-cdk/cloudformation-diff": "~2.68.0",
-    "amplify-codegen": "^4.1.4",
+    "amplify-codegen": "^4.1.8",
     "amplify-dotnet-function-runtime-provider": "2.0.8",
     "amplify-go-function-runtime-provider": "2.3.26",
     "amplify-java-function-runtime-provider": "2.3.26",

--- a/packages/amplify-container-hosting/package.json
+++ b/packages/amplify-container-hosting/package.json
@@ -26,7 +26,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.5.0",
+    "@aws-amplify/amplify-category-api": "^5.5.2",
     "@aws-amplify/amplify-cli-core": "4.2.3",
     "@aws-amplify/amplify-environment-parameters": "1.7.3",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -37,7 +37,7 @@
     "@aws-amplify/cli-extensibility-helper": "3.0.13",
     "@aws-amplify/graphql-transformer-core": "^1.4.0",
     "@aws-amplify/graphql-transformer-interfaces": "^2.3.0",
-    "amplify-codegen": "^4.1.4",
+    "amplify-codegen": "^4.1.8",
     "archiver": "^5.3.0",
     "aws-cdk-lib": "~2.80.0",
     "aws-sdk": "^2.1405.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -39,7 +39,7 @@
     "@aws-amplify/amplify-prompts": "2.8.0",
     "@aws-amplify/amplify-provider-awscloudformation": "8.3.3",
     "@hapi/topo": "^5.0.0",
-    "amplify-codegen": "^4.1.4",
+    "amplify-codegen": "^4.1.8",
     "amplify-dynamodb-simulator": "2.8.3",
     "amplify-storage-simulator": "1.10.0",
     "chokidar": "^3.5.3",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,12 +14,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.5.0",
+    "@aws-amplify/amplify-category-api": "^5.5.2",
     "@aws-amplify/amplify-cli-core": "4.2.3",
     "@aws-amplify/amplify-prompts": "2.8.0",
     "@aws-amplify/codegen-ui": "2.14.2",
     "@aws-amplify/codegen-ui-react": "2.14.2",
-    "amplify-codegen": "^4.1.4",
+    "amplify-codegen": "^4.1.8",
     "aws-sdk": "^2.1405.0",
     "fs-extra": "^8.1.0",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,9 +143,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-amplify/amplify-category-api@npm:^5.5.0":
-  version: 5.5.0
-  resolution: "@aws-amplify/amplify-category-api@npm:5.5.0"
+"@aws-amplify/amplify-category-api@npm:^5.5.2":
+  version: 5.5.2
+  resolution: "@aws-amplify/amplify-category-api@npm:5.5.2"
   dependencies:
     "@aws-amplify/graphql-auth-transformer": 2.1.13
     "@aws-amplify/graphql-schema-generator": 0.3.0
@@ -193,7 +193,7 @@ __metadata:
     amplify-util-headless-input: ^1.9.12
     aws-cdk-lib: ^2.80.0
     constructs: ^10.0.5
-  checksum: 0da5325ee0580cdf3d1ad69bc29ca9baac08af7e60f49ca64ca42d5d5c20635f138c4f5965b66906867d3bcf2760f5e3a51d5e692b2c55c3875a7a6907b07741
+  checksum: c637cd7a70b858559bf5dd4f3437e71574d6405e6134470bbd6404c233f0a6cad5b1f8e15a890f59d3461884207cea2f3c82b0d14f557f37ec80f444754b860d
   languageName: node
   linkType: hard
 
@@ -492,7 +492,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-container-hosting@workspace:packages/amplify-container-hosting"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.5.0
+    "@aws-amplify/amplify-category-api": ^5.5.2
     "@aws-amplify/amplify-cli-core": 4.2.3
     "@aws-amplify/amplify-environment-parameters": 1.7.3
     fs-extra: ^8.1.0
@@ -797,7 +797,7 @@ __metadata:
     "@types/lodash.throttle": ^4.1.6
     "@types/node": ^12.12.6
     "@types/uuid": ^8.0.0
-    amplify-codegen: ^4.1.4
+    amplify-codegen: ^4.1.8
     archiver: ^5.3.0
     aws-cdk-lib: ~2.80.0
     aws-sdk: ^2.1405.0
@@ -885,7 +885,7 @@ __metadata:
     "@types/node": ^12.12.6
     "@types/semver": ^7.1.0
     "@types/which": ^1.3.2
-    amplify-codegen: ^4.1.4
+    amplify-codegen: ^4.1.8
     amplify-dynamodb-simulator: 2.8.3
     amplify-nodejs-function-runtime-provider: 2.5.3
     amplify-storage-simulator: 1.10.0
@@ -924,7 +924,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-util-uibuilder@workspace:packages/amplify-util-uibuilder"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.5.0
+    "@aws-amplify/amplify-category-api": ^5.5.2
     "@aws-amplify/amplify-cli-core": 4.2.3
     "@aws-amplify/amplify-prompts": 2.8.0
     "@aws-amplify/appsync-modelgen-plugin": ^2.4.4
@@ -934,7 +934,7 @@ __metadata:
     "@types/jest": ^29.5.1
     "@types/semver": ^7.1.0
     "@types/tiny-async-pool": ^2.0.0
-    amplify-codegen: ^4.1.4
+    amplify-codegen: ^4.1.8
     aws-sdk: ^2.1405.0
     fs-extra: ^8.1.0
     node-fetch: ^2.6.7
@@ -997,9 +997,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/appsync-modelgen-plugin@npm:2.5.1, @aws-amplify/appsync-modelgen-plugin@npm:^2.4.4":
-  version: 2.5.1
-  resolution: "@aws-amplify/appsync-modelgen-plugin@npm:2.5.1"
+"@aws-amplify/appsync-modelgen-plugin@npm:2.5.3, @aws-amplify/appsync-modelgen-plugin@npm:^2.4.4":
+  version: 2.5.3
+  resolution: "@aws-amplify/appsync-modelgen-plugin@npm:2.5.3"
   dependencies:
     "@graphql-codegen/plugin-helpers": ^1.18.8
     "@graphql-codegen/visitor-plugin-common": ^1.22.0
@@ -1014,7 +1014,7 @@ __metadata:
     ts-dedent: ^1.1.0
   peerDependencies:
     graphql: ^15.5.0
-  checksum: 07fb5825ad89d95650f832a52cef82bc54a1cae3a421e3b0ccca29a75b7c859df8624c68c50aa66d30217f73a731e9d1651be403039bac8c5ddda01fe395d142
+  checksum: a5ca3c82b5583bde43374f693034066aaf18b01323ba219ced0c4ef60b7a2810e47f1993d6c94c6eca09852b4e26952258eaf655c4cc78ed30e99ff0ec3d63f4
   languageName: node
   linkType: hard
 
@@ -1055,7 +1055,7 @@ __metadata:
   dependencies:
     "@aws-amplify/amplify-app": 5.0.13
     "@aws-amplify/amplify-category-analytics": 5.0.15
-    "@aws-amplify/amplify-category-api": ^5.5.0
+    "@aws-amplify/amplify-category-api": ^5.5.2
     "@aws-amplify/amplify-category-auth": 3.4.3
     "@aws-amplify/amplify-category-custom": 3.1.3
     "@aws-amplify/amplify-category-function": 5.4.3
@@ -1099,7 +1099,7 @@ __metadata:
     "@types/tar-fs": ^2.0.0
     "@types/treeify": ^1.0.0
     "@types/update-notifier": ^5.1.0
-    amplify-codegen: ^4.1.4
+    amplify-codegen: ^4.1.8
     amplify-dotnet-function-runtime-provider: 2.0.8
     amplify-go-function-runtime-provider: 2.3.26
     amplify-java-function-runtime-provider: 2.3.26
@@ -1266,16 +1266,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/graphql-docs-generator@npm:4.0.3":
-  version: 4.0.3
-  resolution: "@aws-amplify/graphql-docs-generator@npm:4.0.3"
+"@aws-amplify/graphql-docs-generator@npm:4.0.5":
+  version: 4.0.5
+  resolution: "@aws-amplify/graphql-docs-generator@npm:4.0.5"
   dependencies:
     graphql: ^15.5.0
     handlebars: 4.7.7
     yargs: ^15.1.0
   bin:
     graphql-docs-generator: bin/cli
-  checksum: 5486426ecc726b69820ecc610c36a61a8ee37477c05e2ef073264431ecb783e4ac63714fda000ae2c3e8568f0e3e00534b317c05698b31430c13d709f1cd8e09
+  checksum: c7cf1b35b4bed6d0081ae9e67b76a0e91a961493ab2281c734e4dbd67c6d804b8484189b2d4371bbfc050fc5936a5c0cdf98f5d7c80e060031c66bda9275df44
   languageName: node
   linkType: hard
 
@@ -1500,9 +1500,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/graphql-types-generator@npm:3.0.3":
-  version: 3.0.3
-  resolution: "@aws-amplify/graphql-types-generator@npm:3.0.3"
+"@aws-amplify/graphql-types-generator@npm:3.0.5":
+  version: 3.0.5
+  resolution: "@aws-amplify/graphql-types-generator@npm:3.0.5"
   dependencies:
     "@babel/generator": 7.0.0-beta.4
     "@babel/types": 7.0.0-beta.4
@@ -1525,7 +1525,7 @@ __metadata:
     yargs: ^15.1.0
   bin:
     graphql-types-generator: lib/cli.js
-  checksum: 513e648bf98e27803bc0b1a9807cdf8db98b5c81f9b3ee8f822aaa02f8320fe043ee43b5de2a2a1f9a6bf91a2fbb211b0f0efb7dd1942288ef360139654d9936
+  checksum: eb09daca42212dc7c063a1f2455b5898e4d72cfa0691221169e2529437aef1bbd99c0b18974d76eb318a3e651e5ec9be974f15a066c0496c45c303fce9053230
   languageName: node
   linkType: hard
 
@@ -12983,13 +12983,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"amplify-codegen@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "amplify-codegen@npm:4.1.4"
+"amplify-codegen@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "amplify-codegen@npm:4.1.8"
   dependencies:
-    "@aws-amplify/appsync-modelgen-plugin": 2.5.1
-    "@aws-amplify/graphql-docs-generator": 4.0.3
-    "@aws-amplify/graphql-types-generator": 3.0.3
+    "@aws-amplify/appsync-modelgen-plugin": 2.5.3
+    "@aws-amplify/graphql-docs-generator": 4.0.5
+    "@aws-amplify/graphql-types-generator": 3.0.5
     "@graphql-codegen/core": 2.6.6
     chalk: ^3.0.0
     fs-extra: ^8.1.0
@@ -13006,7 +13006,7 @@ __metadata:
   peerDependencies:
     "@aws-amplify/amplify-cli-core": "*"
     graphql-transformer-core: ^8.0.0
-  checksum: 7f47747ae825817401f331f4f135b7c1ea01e9d1e2f2fed68436ce0292b9d990af29711fd4ff87ce70d20ab66c49b7b10e3c73419907408e0708bcb2a54091f3
+  checksum: 98db11d5840564035cc71c599657a974065da6c6277e5d7f90e91a12b49db7ea464c608e80826bb16d94f303e01054d7e0b4e808a63285fa3c87c700082ddeb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes
Bump data demps, this materially clears the require cache on `override` changes in REST/GraphQL APIs.

#### Issue #, if available
N/A

#### Description of how you validated changes
Manually tested override changes, unit + e2e tests otherwise.

[E2E Test Run](https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/22456/workflows/5a492835-c661-424f-befe-d0968ab7997d)

#### Checklist
- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
