### PR TITLE
test: fix layer e2e, env name has 10 character limit

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/layer-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer-1.test.ts
@@ -175,7 +175,7 @@ describe('amplify add lambda layer', () => {
       projName,
     };
 
-    const noLayerEnv = 'nolayertest';
+    const noLayerEnv = 'nolyrtest';
 
     await addEnvironment(projRoot, { envName: noLayerEnv });
     await checkoutEnvironment(projRoot, { envName });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This PR fixes the failing `layer-1.test.ts` e2e test due to the environment name being too long

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli/22457/workflows/f59c5276-1241-40b8-a6a5-8cd0f2b85d40/jobs/1038177

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
