### PR TITLE
chore: lint tests, fix misused promises in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,22 +102,26 @@ module.exports = {
     },
     {
       // edit rules here to modify test linting
-      files: ['__tests__/**', '*.test.ts', '**/amplify-e2e-tests/**'],
-      plugins: ['jest'],
-      extends: ['plugin:jest/recommended'],
-      rules: {
-        '@typescript-eslint/unbound-method': 'off',
-        'jest/unbound-method': 'error',
-        '@typescript-eslint/no-explicit-any': 'off',
-        'spellcheck/spell-checker': 'off',
+      files: ['**/__tests__/**', '**/__test__/**', '*.test.ts', '**/amplify-e2e-*/**', '**/test/**', '**/tests/**', '**/__e2e__/**'],
+      parserOptions: {
+        project: ['tsconfig.tests.json'],
       },
-    },
-    {
-      // disable spell checker in tests
-      files: ['**/__tests__/**', '**/__test__/**', '*.test.ts', 'packages/amplify-e2e-*/**', '**/test/**', '**/tests/**'],
-      plugins: ['jest'],
-      extends: ['plugin:jest/recommended'],
       rules: {
+        '@typescript-eslint/ban-ts-comment': 'off',
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-inferrable-types': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        'consistent-return': 'off',
+        'import/no-extraneous-dependencies': 'off',
+        'no-constant-condition': 'off',
+        'no-restricted-syntax': 'off',
+        'no-useless-catch': 'off',
+        'no-useless-escape': 'off',
+        'no-var': 'off',
+        'prefer-const': 'off',
         'spellcheck/spell-checker': 'off',
       },
     },
@@ -132,8 +136,6 @@ module.exports = {
   // Files / paths / globs that shouldn't be linted at all
   // (note that only .js, .jsx, .ts, and .tsx files are linted in the first place)
   ignorePatterns: [
-    '**/__tests__/**',
-    '**.test.**',
     '.eslintrc.js',
     'scripts/',
     'node_modules',
@@ -142,7 +144,6 @@ module.exports = {
     '__mocks__',
     'coverage',
     'packages/**/lib',
-    '**/__e2e__/**',
 
     // Forked package
     'amplify-velocity-template',
@@ -207,6 +208,7 @@ module.exports = {
     '/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts',
     '/packages/amplify-environment-parameters/lib',
     '/packages/amplify-opensearch-simulator/lib',
+    '/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/handlerWithSyntaxError.js',
 
     // Ignore CHANGELOG.md files
     '/packages/*/CHANGELOG.md',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "link-dev": "mkdir -p .bin/ && cd packages/amplify-cli && ln -s \"$(pwd)/bin/amplify\" ../../.bin/amplify-dev && cd ../../",
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
     "lint-check-package-json": "yarn eslint --no-eslintrc --config .eslint.package.json.js '**/package.json'",
-    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=835",
+    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=773",
     "lint-fix-package-json": "yarn lint-check-package-json --fix",
     "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "mergewords": "yarn ts-node ./scripts/handle-dict-conflicts.ts",

--- a/packages/amplify-appsync-simulator/src/__tests__/server/subscription/websocket-server/server.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/server/subscription/websocket-server/server.test.ts
@@ -78,8 +78,8 @@ describe('WebsocketSubscriptionServer', () => {
     server.start();
   });
 
-  afterEach(() => {
-    server?.stop();
+  afterEach(async () => {
+    await server?.stop();
     httpServer?.close();
   });
 
@@ -390,7 +390,7 @@ describe('WebsocketSubscriptionServer', () => {
       const data = {
         onMessage: 'hello from iterator',
       };
-      pubsub.publish('onMessage', data);
+      void pubsub.publish('onMessage', data);
       const msg = await waitForMessage(client, MESSAGE_TYPES.GQL_DATA);
       expect(msg).toEqual({
         type: MESSAGE_TYPES.GQL_DATA,

--- a/packages/amplify-appsync-simulator/src/__tests__/server/websocket-subscription.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/server/websocket-subscription.test.ts
@@ -73,10 +73,10 @@ describe('websocket subscription', () => {
     expect(startSpy).toHaveBeenCalled();
   });
 
-  it('should call websocket servers stop method when stop is called', () => {
+  it('should call websocket servers stop method when stop is called', async () => {
     const stopSpy = jest.spyOn(WebsocketSubscriptionServer.prototype, 'stop');
     const subs = new AppSyncSimulatorSubscriptionServer(simulatorContext, server, subscriptionPath);
-    subs.stop();
+    await subs.stop();
     expect(stopSpy).toHaveBeenCalled();
   });
 

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-inputs-manager/auth-input-state.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-inputs-manager/auth-input-state.test.ts
@@ -120,5 +120,5 @@ test('Auth Input State -> validate cli payload manual payload', async () => {
 test('Auth Input State -> validate cli payload manual payload to throw error', async () => {
   const resourceName = 'mockResource';
   const authState = new AuthInputState(mockContext, resourceName);
-  expect(authState.isCLIInputsValid()).rejects.toThrowError();
+  await expect(authState.isCLIInputsValid()).rejects.toThrowError();
 });

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.test.ts
@@ -70,24 +70,24 @@ describe('generateCognitoStackResources', () => {
     authProviders: [],
   };
 
-  it('adds correct preSignUp  lambda config and permissions', () => {
+  it('adds correct preSignUp  lambda config and permissions', async () => {
     const testApp = new cdk.App();
     const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoPreSignUpTriggerTest', { synthesizer: new AuthStackSynthesizer() });
-    cognitoStack.generateCognitoStackResources(props);
+    await cognitoStack.generateCognitoStackResources(props);
     expect(cognitoStack.userPool?.lambdaConfig).toHaveProperty('preSignUp');
     expect(cognitoStack.lambdaConfigPermissions).toHaveProperty('UserPoolPreSignupLambdaInvokePermission');
   });
 
-  it('disables updateAttributeSetting when autoVerified attributes not present', () => {
+  it('disables updateAttributeSetting when autoVerified attributes not present', async () => {
     const testApp = new cdk.App();
     const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoPreSignUpTriggerTest', { synthesizer: new AuthStackSynthesizer() });
     const updatedProps = { ...props };
     delete updatedProps.autoVerifiedAttributes;
-    cognitoStack.generateCognitoStackResources(updatedProps);
+    await cognitoStack.generateCognitoStackResources(updatedProps);
     expect(cognitoStack.userPool?.userAttributeUpdateSettings).toBeUndefined();
   });
 
-  it('correctly adds updateAttributeSetting when autoVerifiedAttributes attributes is TOTP', () => {
+  it('correctly adds updateAttributeSetting when autoVerifiedAttributes attributes is TOTP', async () => {
     const testApp = new cdk.App();
     // eslint-disable-next-line spellcheck/spell-checker
     const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoUpdateAttributesettingTest', {
@@ -97,7 +97,7 @@ describe('generateCognitoStackResources', () => {
       ...props,
       userAutoVerifiedAttributeUpdateSettings: [AttributeType.PHONE_NUMBER],
     };
-    cognitoStack.generateCognitoStackResources(updatedProps);
+    await cognitoStack.generateCognitoStackResources(updatedProps);
     expect(cognitoStack.userPool?.userAttributeUpdateSettings).toMatchInlineSnapshot(`
 {
   "attributesRequireVerificationBeforeUpdate": [
@@ -107,7 +107,7 @@ describe('generateCognitoStackResources', () => {
 `);
   });
 
-  it('correctly adds updateAttributeSetting when autoVerifiedAttributes attributes is email', () => {
+  it('correctly adds updateAttributeSetting when autoVerifiedAttributes attributes is email', async () => {
     const testApp = new cdk.App();
     // eslint-disable-next-line spellcheck/spell-checker
     const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoUpdateAttributesettingTesting1', {
@@ -117,7 +117,7 @@ describe('generateCognitoStackResources', () => {
       ...props,
       userAutoVerifiedAttributeUpdateSettings: [AttributeType.EMAIL],
     };
-    cognitoStack.generateCognitoStackResources(updatedProps);
+    await cognitoStack.generateCognitoStackResources(updatedProps);
     expect(cognitoStack.userPool?.userAttributeUpdateSettings).toMatchInlineSnapshot(`
 {
   "attributesRequireVerificationBeforeUpdate": [
@@ -131,7 +131,7 @@ describe('generateCognitoStackResources', () => {
     expect(cognitoStack.lambdaConfigPermissions).toHaveProperty('UserPoolPreSignupLambdaInvokePermission');
   });
 
-  it('correctly adds oauth properties on userpool client when oauthMetaData is defined', () => {
+  it('correctly adds oauth properties on userpool client when oauthMetaData is defined', async () => {
     const testApp = new cdk.App();
     // eslint-disable-next-line spellcheck/spell-checker
     const cognitoStack = new AmplifyAuthCognitoStack(testApp, 'CognitoUpdateAttributesettingTesting1', {
@@ -142,7 +142,7 @@ describe('generateCognitoStackResources', () => {
       oAuthMetadata:
         '{"AllowedOAuthFlows":["code"],"AllowedOAuthScopes":["phone","email","openid","profile","aws.cognito.signin.user.admin"],"CallbackURLs":["https://localhost:3000/"]}',
     };
-    cognitoStack.generateCognitoStackResources(updatedProps);
+    await cognitoStack.generateCognitoStackResources(updatedProps);
     expect(cognitoStack.userPoolClientWeb).toHaveProperty('allowedOAuthFlows');
     expect(cognitoStack.userPoolClientWeb).toHaveProperty('allowedOAuthScopes');
     expect(cognitoStack.userPoolClientWeb).toHaveProperty('callbackUrLs');

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
@@ -67,7 +67,7 @@ let mockContext = {
 
 describe('import checks', () => {
   test('throws amplify error when auth headless params are missing during pull', async () => {
-    expect(() => updateConfigOnEnvInit(mockContext, 'auth', 'Cognito')).rejects.toThrowErrorMatchingInlineSnapshot(
+    await expect(() => updateConfigOnEnvInit(mockContext, 'auth', 'Cognito')).rejects.toThrowErrorMatchingInlineSnapshot(
       `"auth headless is missing the following inputParameters facebookAppIdUserPool, facebookAppSecretUserPool, loginwithamazonAppIdUserPool, loginwithamazonAppSecretUserPool, googleAppIdUserPool, googleAppSecretUserPool"`,
     );
   });
@@ -77,7 +77,7 @@ describe('update config when amplify pull headless command', () => {
   test('throws amplify error when auth headless params are missing during pull', async () => {
     mockContext.input.command = 'pull';
     getOAuthObjectFromCognitoMock.mockResolvedValue(undefined);
-    expect(() => updateConfigOnEnvInit(mockContext, 'auth', 'Cognito')).rejects.toThrowErrorMatchingInlineSnapshot(
+    await expect(() => updateConfigOnEnvInit(mockContext, 'auth', 'Cognito')).rejects.toThrowErrorMatchingInlineSnapshot(
       `"auth headless is missing the following inputParameters facebookAppIdUserPool, facebookAppSecretUserPool, loginwithamazonAppIdUserPool, loginwithamazonAppSecretUserPool, googleAppIdUserPool, googleAppSecretUserPool"`,
     );
   });

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/migrate-override-resource.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/migrate-override-resource.test.ts
@@ -83,7 +83,7 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
 }));
 test('migrate resource', async () => {
   const resourceName = 'mockResource';
-  migrateResourceToSupportOverride(resourceName);
+  await migrateResourceToSupportOverride(resourceName);
   const expectedPath = path.join('mockProjectPath', 'cli-inputs.json');
   const expectedPayload = {
     version: '1',

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/index.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/index.test.ts
@@ -33,7 +33,7 @@ const buildFunction_mock = buildFunction as jest.MockedFunction<typeof buildFunc
 
 describe('awscloudformation function provider', () => {
   beforeEach(() => jest.clearAllMocks());
-  it('opens the correct service console', () => {
+  it('opens the correct service console', async () => {
     const contextStub = {
       amplify: {
         getProjectMeta: () => ({
@@ -45,14 +45,14 @@ describe('awscloudformation function provider', () => {
         }),
       },
     } as $TSContext;
-    openConsole(contextStub, ServiceName.LambdaFunction);
+    await openConsole(contextStub, ServiceName.LambdaFunction);
     const openMock = open as any;
     expect(openMock.mock.calls.length).toBe(1);
     expect(openMock.mock.calls[0][0]).toMatchSnapshot();
 
     openMock.mockClear();
 
-    openConsole(contextStub, ServiceName.LambdaLayer);
+    await openConsole(contextStub, ServiceName.LambdaLayer);
     expect(openMock.mock.calls.length).toBe(1);
     expect(openMock.mock.calls[0][0]).toMatchSnapshot();
   });

--- a/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/service-utils/resourceUtils.test.ts
@@ -185,17 +185,17 @@ describe('Test reading the resource meta information', () => {
   it('fails reading the meta information for non-existing resource', async () => {
     const nonExistingMap = 'map12345';
     const errorMessage = (resourceName: string): string => `Error reading Meta Parameters for ${resourceName}`;
-    expect(async () => await readResourceMetaParameters(ServiceName.Map, nonExistingMap)).rejects.toThrowError(
+    await expect(async () => await readResourceMetaParameters(ServiceName.Map, nonExistingMap)).rejects.toThrowError(
       errorMessage(nonExistingMap),
     );
 
     const nonExistingPlaceIndex = 'placeIndex12345';
-    expect(async () => await readResourceMetaParameters(ServiceName.PlaceIndex, nonExistingPlaceIndex)).rejects.toThrowError(
+    await expect(async () => await readResourceMetaParameters(ServiceName.PlaceIndex, nonExistingPlaceIndex)).rejects.toThrowError(
       errorMessage(nonExistingPlaceIndex),
     );
 
     const nonExistingGeofenceCollection = 'geofenceCollection12345';
-    expect(
+    await expect(
       async () => await readResourceMetaParameters(ServiceName.GeofenceCollection, nonExistingGeofenceCollection),
     ).rejects.toThrowError(errorMessage(nonExistingGeofenceCollection));
   });

--- a/packages/amplify-category-notifications/src/__tests__/channel-apns.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-apns.test.ts
@@ -153,7 +153,6 @@ describe('channel-APNS', () => {
     expect(enableData).toEqual(mockAPNSChannelResponseData(true, ChannelAction.ENABLE, mockPinpointResponseData.APNSChannelResponse));
   });
 
-  // eslint-disable-next-line jest/no-focused-tests
   test('enable unsuccessful', async () => {
     prompterMock.pick.mockResolvedValueOnce('Certificate');
 

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -116,7 +116,6 @@ describe('Test S3 transform generates correct CFN template', () => {
   });
 });
 
-// eslint-disable-next-line jest/no-export
 export class S3MockDataBuilder {
   static mockBucketName = 'mock-stack-builder-bucket-name-99'; // s3 bucket naming rules allows alphanumeric and hyphens
   static mockResourceName = 'mockResourceName';

--- a/packages/amplify-cli-core/src/__tests__/amplify-lockfile-dependency-detector/amplify-nodejs-detector.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/amplify-lockfile-dependency-detector/amplify-nodejs-detector.test.ts
@@ -13,7 +13,7 @@ describe('no package Manager cases', () => {
   it('error thrown when no package manager found', async () => {
     (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockReturnValue(new Promise((resolve) => resolve(null)));
     const projectRoot = path.join(__dirname, 'resources');
-    expect(
+    await expect(
       async () =>
         await AmplifyNodePkgDetector.getInstance({
           projectRoot,
@@ -31,7 +31,7 @@ describe('parsing yarn lock files', () => {
 
     (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockResolvedValue(yarnPackageManager);
     const projectRoot = path.join(__dirname, 'resources');
-    expect(
+    await expect(
       async () =>
         await AmplifyNodePkgDetector.getInstance({
           projectRoot,
@@ -46,7 +46,7 @@ describe('parsing yarn lock files', () => {
     const amplifyDetectorProps: AmplifyNodePkgDetectorProps = {
       projectRoot,
     };
-    expect(async () =>
+    await expect(async () =>
       (await AmplifyNodePkgDetector.getInstance(amplifyDetectorProps)).detectAffectedDirectDependencies('@aws-cdk/core'),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`"yarn.lock parsing failed with an error: Invalid value type 1:16 in lockfile"`);
   });
@@ -201,7 +201,7 @@ describe('parsing package lock files', () => {
     (npmPackageManager as $TSAny).lockFile = 'package-lock-not-found.json';
     (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockResolvedValue(npmPackageManager);
     const projectRoot = path.join(__dirname, 'resources');
-    expect(
+    await expect(
       async () =>
         await AmplifyNodePkgDetector.getInstance({
           projectRoot,
@@ -216,7 +216,7 @@ describe('parsing package lock files', () => {
     const amplifyDetectorProps: AmplifyNodePkgDetectorProps = {
       projectRoot,
     };
-    expect(async () =>
+    await expect(async () =>
       (await AmplifyNodePkgDetector.getInstance(amplifyDetectorProps)).detectAffectedDirectDependencies('@aws-cdk/core'),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"package-lock.json parsing failed with an error: 'jsonString' argument missing or empty"`,
@@ -395,7 +395,7 @@ describe('parsing yarn2 lock files', () => {
     const amplifyDetectorProps: AmplifyNodePkgDetectorProps = {
       projectRoot,
     };
-    expect(async () =>
+    await expect(async () =>
       (await AmplifyNodePkgDetector.getInstance(amplifyDetectorProps)).detectAffectedDirectDependencies('@aws-cdk/core'),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"yarn.lock parsing failed with an error: Unknown token: { line: 3, col: 2, type: 'INVALID', value: undefined } 3:2 in lockfile"`,

--- a/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
@@ -464,12 +464,12 @@ The following feature flags have validation errors:
       process.env = { ...realProcessEnv };
     });
 
-    test('initialization does not fail when process.env is not available', () => {
+    test('initialization does not fail when process.env is not available', async () => {
       process.env = {};
 
       expect(process.env).toEqual({});
 
-      provider.load();
+      await provider.load();
     });
 
     test('successfully parse every form of variables', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/uninstall.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/uninstall.pkg.test.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs-extra';
 import { hideSync } from 'hidefile';
 import { setRegPendingDelete } from '../../utils/win-utils';
 import { windowsPathSerializer } from '../testUtils/snapshot-serializer';
-import * as path from 'path';
 
 jest.mock('execa');
 const execa_mock = execa as jest.Mocked<typeof execa>;
@@ -72,7 +71,7 @@ describe('uninstall packaged CLI on mac / linux', () => {
   });
 
   it('throws if it cannot remove the .amplify dir', async () => {
-    fs_mock.remove.mockImplementationOnce(async () => {
+    fs_mock.remove.mockImplementationOnce(() => {
       throw new Error('fs remove did not work!');
     });
 

--- a/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-interpolation-in-snapshots */
 import * as fs from 'fs-extra';
 import fetch, { Response } from 'node-fetch';
 import { $TSContext } from '@aws-amplify/amplify-cli-core';
@@ -156,10 +155,10 @@ describe('run upgrade using packaged CLI', () => {
 
     let movedBinToTemp = false;
     fsMock.move
-      .mockImplementationOnce(async () => {
+      .mockImplementationOnce(() => {
         movedBinToTemp = true;
       })
-      .mockImplementationOnce(async () => {
+      .mockImplementationOnce(() => {
         if (!movedBinToTemp) throw new Error('fs.move was not called before copying extracted file to bin location');
       });
 

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/resource-status.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/resource-status.test.ts
@@ -485,9 +485,11 @@ describe('resource-status', () => {
       const fsMock = fs as jest.Mocked<typeof fs>;
       fsMock.existsSync.mockReturnValue(true);
       const hashElementMock = hashElement as jest.MockedFunction<typeof hashElement>;
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       hashElementMock.mockImplementation(async () => ({
         hash: sampleHash1,
       }));
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       hashElementMock.mockImplementationOnce(async () => ({
         hash: sampleHash2,
       }));
@@ -740,7 +742,6 @@ describe('resource-status', () => {
 
     it('throws an error when non amplify project', async () => {
       (getCloudInitStatus as jest.MockedFunction<typeof getCloudInitStatus>).mockReturnValue(NON_AMPLIFY_PROJECT);
-      // eslint-disable-next-line jest/valid-expect
       await expect(getResourceStatus()).rejects.toThrow('No Amplify backend project files detected within this folder.');
     });
   });
@@ -816,9 +817,11 @@ describe('resource-status', () => {
       const fsMock = fs as jest.Mocked<typeof fs>;
       fsMock.existsSync.mockReturnValue(true);
       const hashElementMock = hashElement as jest.MockedFunction<typeof hashElement>;
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       hashElementMock.mockImplementation(async () => ({
         hash: sampleHash1,
       }));
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       hashElementMock.mockImplementationOnce(async () => ({
         hash: sampleHash2,
       }));

--- a/packages/amplify-cli/src/__tests__/plugin-helpers/verify-plugin.test.ts
+++ b/packages/amplify-cli/src/__tests__/plugin-helpers/verify-plugin.test.ts
@@ -48,12 +48,14 @@ describe('verify-plugin', () => {
     });
 
     it('returns PluginDirPathNotExist error when specify not exist path', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementation(() => Promise.resolve(false));
       const result = await verifyPlugin(path.join('path', 'to', 'plugin'));
       expect(result).toEqual(new PluginVerificationResult(false, PluginVerificationError.PluginDirPathNotExist));
     });
 
     it('returns PluginDirPathNotExist error when specify non directory path', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementation(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(false),
@@ -64,6 +66,7 @@ describe('verify-plugin', () => {
     });
 
     it('returns InvalidNodePackage error when specify package.json not exists directory path', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementation(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -83,6 +86,7 @@ describe('verify-plugin', () => {
 
     it('returns MissingManifest error when amplify-plugin.json is not exists.', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -95,6 +99,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(false));
 
       const result = await verifyPlugin(path.join('path', 'to', 'plugin'));
@@ -104,6 +109,7 @@ describe('verify-plugin', () => {
 
     it('returns MissingManifest error when amplify-plugin.json is not file.', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -116,6 +122,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(false),
@@ -129,6 +136,7 @@ describe('verify-plugin', () => {
 
     it('returns InvalidManifest error when amplify-plugin.json is not json file.', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -141,6 +149,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(true),
@@ -160,6 +169,7 @@ describe('verify-plugin', () => {
 
     it('returns InvalidManifest error when plugin name is invalid', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -172,6 +182,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(true),
@@ -199,6 +210,7 @@ describe('verify-plugin', () => {
 
     it('returns MissingHandleAmplifyEventMethod error when plugin has invalid handle methods', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -211,6 +223,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(true),
@@ -242,6 +255,7 @@ describe('verify-plugin', () => {
 
     it('returns that verified is true when plugin pass all verifications', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -254,6 +268,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(true),
@@ -279,6 +294,7 @@ describe('verify-plugin', () => {
 
     it('returns that verified is true when plugin has no event handlers', async () => {
       // stat package.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const stat = {
         isDirectory: jest.fn().mockReturnValue(true),
@@ -291,6 +307,7 @@ describe('verify-plugin', () => {
       readJsonMock.mockReturnValueOnce(packageJson);
 
       // stat amplify-plugin.json
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       fsMock.pathExists.mockImplementationOnce(() => Promise.resolve(true));
       const statManifest = {
         isFile: jest.fn().mockReturnValue(true),

--- a/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
@@ -50,7 +50,7 @@ describe('amplify add api (GraphQL)', () => {
 
     transformConfig.Version = TRANSFORM_BASE_VERSION;
     const apiRoot = path.join(projRoot, 'amplify', 'backend', 'api', name);
-    writeTransformerConfiguration(apiRoot, transformConfig);
+    await writeTransformerConfiguration(apiRoot, transformConfig);
 
     await amplifyPush(projRoot);
 

--- a/packages/amplify-e2e-tests/src/__tests__/api_5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_5.test.ts
@@ -39,14 +39,14 @@ describe('amplify add api (REST)', () => {
     expect(service).toBe('DynamoDB');
     expect(lastPushTimeStamp).toBeDefined();
     expect(lastPushDirHash).toBeDefined();
-    validateRestApiMeta(projRoot, meta);
+    await validateRestApiMeta(projRoot, meta);
   });
 
   it('init a project, then add a serverless rest api', async () => {
     await initJSProjectWithProfile(projRoot, {});
     await addRestApi(projRoot, { isCrud: false });
     await amplifyPushUpdate(projRoot);
-    validateRestApiMeta(projRoot);
+    await validateRestApiMeta(projRoot);
   });
 
   it('init a project, create lambda and attach it to an api', async () => {
@@ -54,7 +54,7 @@ describe('amplify add api (REST)', () => {
     await addFunction(projRoot, { functionTemplate: 'Hello World' }, 'nodejs');
     await addRestApi(projRoot, { existingLambda: true });
     await amplifyPushUpdate(projRoot);
-    validateRestApiMeta(projRoot);
+    await validateRestApiMeta(projRoot);
   });
 
   it('init a project, create lambda and attach multiple rest apis', async () => {
@@ -113,6 +113,6 @@ describe('amplify add api (REST)', () => {
       expect(PolicyName).toMatch(/PolicyAPIGWUnauth\d/);
     }
 
-    validateRestApiMeta(projRoot, amplifyMeta);
+    await validateRestApiMeta(projRoot, amplifyMeta);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_6a.test.ts
@@ -46,8 +46,12 @@ describe('amplify rebuild api', () => {
     expect(region).toBeDefined();
 
     const modelNames = ['Todo', 'Task', 'Worker'];
-    modelNames.forEach(async (modelName) => await testTableBeforeRebuildApi(apiId, region, modelName));
+    for (const modelName of modelNames) {
+      await testTableBeforeRebuildApi(apiId, region, modelName);
+    }
     await rebuildApi(projRoot, projName);
-    modelNames.forEach(async (modelName) => await testTableAfterRebuildApi(apiId, region, modelName));
+    for (const modelName of modelNames) {
+      await testTableAfterRebuildApi(apiId, region, modelName);
+    }
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/api_8.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_8.test.ts
@@ -34,7 +34,7 @@ describe('amplify add api (REST and GRAPHQL)', () => {
     await addRestApi(projRoot, { existingLambda: true });
     await addRestApi(projRoot, { isFirstRestApi: false, existingLambda: true, path: '/newpath' });
     await amplifyPushUpdate(projRoot);
-    validateRestApiMeta(projRoot);
+    await validateRestApiMeta(projRoot);
 
     const apisDirectory = path.join(projRoot, 'amplify', 'backend', 'api');
     const apis = readdirSync(apisDirectory);
@@ -69,6 +69,6 @@ describe('amplify add api (REST and GRAPHQL)', () => {
 
     expect(graphqlApi).toBeDefined();
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
-    validateRestApiMeta(projRoot, meta);
+    await validateRestApiMeta(projRoot, meta);
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/diagnose.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/diagnose.test.ts
@@ -97,7 +97,7 @@ describe('amplify diagnose --send-report', () => {
     // delete the file and send report again
     const backendFConfigFilePath: string = path.join(projectRoot, 'amplify', 'backend', 'backend-config.json');
     fs.unlinkSync(backendFConfigFilePath);
-    diagnoseSendReport_ZipFailed(projectRoot);
+    await diagnoseSendReport_ZipFailed(projectRoot);
   });
 });
 const unzipAndReturnFiles = async (zipPath: string, unzippedDir: string): Promise<string[]> => {

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-a.test.ts
@@ -72,7 +72,7 @@ describe('amplify export pull a', () => {
     const meta = getBackendAmplifyMeta(projRoot);
     const stackName = _.get(meta, ['providers', 'awscloudformation', 'StackName']);
     const pathToExportGeneratedConfig = path.join(projRoot, 'exportSrc');
-    fs.ensureDir(pathToExportGeneratedConfig);
+    await fs.ensureDir(pathToExportGeneratedConfig);
     await exportPullBackend(projRoot, {
       exportPath: pathToExportGeneratedConfig,
       frontend,

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-b.test.ts
@@ -76,7 +76,7 @@ describe('amplify export pull b', () => {
     const meta = getBackendAmplifyMeta(projRoot);
     const stackName = _.get(meta, ['providers', 'awscloudformation', 'StackName']);
     const pathToExportGeneratedConfig = path.join(projRoot, 'exportSrc');
-    fs.ensureDir(pathToExportGeneratedConfig);
+    await fs.ensureDir(pathToExportGeneratedConfig);
     await exportPullBackend(projRoot, {
       exportPath: pathToExportGeneratedConfig,
       frontend,

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-c.test.ts
@@ -76,7 +76,7 @@ describe('amplify export pull c', () => {
     const meta = getBackendAmplifyMeta(projRoot);
     const stackName = _.get(meta, ['providers', 'awscloudformation', 'StackName']);
     const pathToExportGeneratedConfig = path.join(projRoot, 'exportSrc');
-    fs.ensureDir(pathToExportGeneratedConfig);
+    await fs.ensureDir(pathToExportGeneratedConfig);
     await exportPullBackend(projRoot, {
       exportPath: pathToExportGeneratedConfig,
       frontend,

--- a/packages/amplify-e2e-tests/src/__tests__/export-pull-d.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/export-pull-d.test.ts
@@ -71,7 +71,7 @@ describe('amplify export pull d', () => {
     const meta = getBackendAmplifyMeta(projRoot);
     const stackName = _.get(meta, ['providers', 'awscloudformation', 'StackName']);
     const pathToExportGeneratedConfig = path.join(projRoot, 'exportSrc');
-    fs.ensureDir(pathToExportGeneratedConfig);
+    await fs.ensureDir(pathToExportGeneratedConfig);
     await exportPullBackend(projRoot, {
       exportPath: pathToExportGeneratedConfig,
       frontend,

--- a/packages/amplify-e2e-tests/src/__tests__/git-clone-attach.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/git-clone-attach.test.ts
@@ -91,7 +91,7 @@ describe('attach amplify to git-cloned project', () => {
     const preCleanTpi = getTeamProviderInfo(projRoot);
     const importBucketRegion = (Object.values(preCleanTpi[envName].categories.storage)[0] as any).region;
     const appId = preCleanTpi[envName].awscloudformation.AmplifyAppId;
-    gitCleanFdx(projRoot);
+    await gitCleanFdx(projRoot);
 
     const socialProviders = getSocialProviders();
     const categoriesConfig = {

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
@@ -259,7 +259,7 @@ describe('auth import userpool only', () => {
     } finally {
       // delete the app client
       if (appClientId) {
-        deleteAppClient(profileName, ogProjectRoot, appClientId);
+        await deleteAppClient(profileName, ogProjectRoot, appClientId);
       }
     }
   });
@@ -295,7 +295,7 @@ describe('auth import userpool only', () => {
     } finally {
       // delete the app client
       if (appClientId) {
-        deleteAppClient(profileName, ogProjectRoot, appClientId);
+        await deleteAppClient(profileName, ogProjectRoot, appClientId);
       }
     }
   });

--- a/packages/amplify-e2e-tests/src/__tests__/layer-3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer-3.test.ts
@@ -68,7 +68,7 @@ describe('test amplify remove function', () => {
     });
     arns.push(getCurrentLayerArnFromMeta(projRoot, settings));
     arns.splice(0, 3);
-    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
+    await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
   });
 
   it('init a project, add layer, push 2 layer versions, add 2 dependent functions, check that removal is blocked', async () => {
@@ -135,13 +135,13 @@ describe('test amplify remove function', () => {
     );
 
     await removeLayerVersion(projRoot, { removeNoLayerVersions: true, multipleResources: true }, [1, 2], [1, 2]);
-    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
+    await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns);
 
     await removeFunction(projRoot, fnName1);
     await removeFunction(projRoot, fnName2);
 
     await removeLayerVersion(projRoot, {}, [1], [1, 2]);
     await amplifyPushAuth(projRoot);
-    validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns.splice(1));
+    await validateLayerMetadata(projRoot, settings, getProjectMeta(projRoot), envName, arns.splice(1));
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
@@ -78,7 +78,9 @@ describe('emulator operations', () => {
 
   it('should fail to launch on windows OS', async () => {
     jest.spyOn(cliCore, 'isWindowsPlatform').mockReturnValueOnce(true);
-    await expect(() => openSearchEmulator.launch(mockSearchableResourcePath)).rejects.toThrow('Cannot launch OpenSearch simulator on windows OS');
+    await expect(() => openSearchEmulator.launch(mockSearchableResourcePath)).rejects.toThrow(
+      'Cannot launch OpenSearch simulator on windows OS',
+    );
   });
   it('correctly resolves the path to local opensearch binary', async () => {
     const relativePathFromMockSearchableResourceDir = await openSearchEmulator.getPathToOpenSearchBinary();

--- a/packages/amplify-e2e-tests/src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
@@ -78,7 +78,7 @@ describe('emulator operations', () => {
 
   it('should fail to launch on windows OS', async () => {
     jest.spyOn(cliCore, 'isWindowsPlatform').mockReturnValueOnce(true);
-    expect(() => openSearchEmulator.launch(mockSearchableResourcePath)).rejects.toThrow('Cannot launch OpenSearch simulator on windows OS');
+    await expect(() => openSearchEmulator.launch(mockSearchableResourcePath)).rejects.toThrow('Cannot launch OpenSearch simulator on windows OS');
   });
   it('correctly resolves the path to local opensearch binary', async () => {
     const relativePathFromMockSearchableResourceDir = await openSearchEmulator.getPathToOpenSearchBinary();

--- a/packages/amplify-e2e-tests/src/cypress/uibuilder/uibuilder-spec.js
+++ b/packages/amplify-e2e-tests/src/cypress/uibuilder/uibuilder-spec.js
@@ -1,5 +1,4 @@
 describe('Assert page loads properly', () => {
-  /* eslint-disable-next-line jest/expect-expect */
   it('Visits the page', () => {
     cy.visit('http://localhost:3000');
     cy.get('.amplify-input').first().type('fake@email.com').should('have.value', 'fake@email.com');

--- a/packages/amplify-environment-parameters/src/__tests__/backend-config-parameters-controller.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/backend-config-parameters-controller.test.ts
@@ -29,7 +29,7 @@ describe('BackendConfigParameterMapController', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.isolateModules(async () => {
+    jest.isolateModules(() => {
       // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
       const { getParametersControllerInstance } = require('../backend-config-parameters-controller');
       backendParamsController = getParametersControllerInstance();
@@ -136,7 +136,7 @@ describe('BackendConfigParameterMapController', () => {
 
   describe('save', () => {
     it('writes current parameter state to backend config', async () => {
-      backendParamsController.save();
+      await backendParamsController.save();
       expect(stateManagerMock.setBackendConfig.mock.calls[0][1]).toMatchInlineSnapshot(`
 {
   "parameters": {

--- a/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
+++ b/packages/amplify-environment-parameters/src/__tests__/environment-parameter-manager.test.ts
@@ -31,6 +31,7 @@ let ensureEnvParamManager: () => Promise<{ instance: IEnvironmentParameterManage
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   jest.isolateModules(async () => {
     ({ ensureEnvParamManager } = await import('../environment-parameter-manager'));
   });

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-basic.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-basic.migration.test.ts
@@ -37,7 +37,7 @@ describe('api REST migration tests', () => {
     await amplifyPushUpdateLegacy(projRoot);
 
     const meta = getProjectMeta(projRoot);
-    validateRestApiMeta(projRoot, meta);
+    await validateRestApiMeta(projRoot, meta);
 
     // pull down with vlatest
     const appId = getAppId(projRoot);
@@ -53,7 +53,7 @@ describe('api REST migration tests', () => {
 
       // validate metadata
       const meta2 = getProjectMeta(projRoot2);
-      validateRestApiMeta(projRoot2, meta2);
+      await validateRestApiMeta(projRoot2, meta2);
     } finally {
       deleteProjectDir(projRoot2);
     }

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-lambda.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-lambda.migration.test.ts
@@ -67,7 +67,7 @@ describe('api lambda migration tests', () => {
 
     // make sure current project meta is valid
     const meta = getProjectMeta(projRoot);
-    validateRestApiMeta(projRoot, meta);
+    await validateRestApiMeta(projRoot, meta);
 
     // pull down with vlatest
     const appId = getAppId(projRoot);
@@ -84,7 +84,7 @@ describe('api lambda migration tests', () => {
 
       // validate metadata for pulled down project
       const meta2 = getProjectMeta(projRoot2);
-      validateRestApiMeta(projRoot2, meta2);
+      await validateRestApiMeta(projRoot2, meta2);
 
       // validate role policies
       const cfnMeta = meta2.providers.awscloudformation;

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-serverless.migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v10/api-rest-serverless.migration.test.ts
@@ -32,7 +32,7 @@ describe('api serverless migration tests', () => {
     await amplifyPushUpdateLegacy(projRoot);
 
     const meta = getProjectMeta(projRoot);
-    validateRestApiMeta(projRoot, meta);
+    await validateRestApiMeta(projRoot, meta);
 
     // pull down with vlatest
     const appId = getAppId(projRoot);
@@ -48,7 +48,7 @@ describe('api serverless migration tests', () => {
 
       // validate metadata
       const meta2 = getProjectMeta(projRoot2);
-      validateRestApiMeta(projRoot2, meta2);
+      await validateRestApiMeta(projRoot2, meta2);
     } finally {
       deleteProjectDir(projRoot2);
     }

--- a/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/handlerWithSyntaxError.js
+++ b/packages/amplify-nodejs-function-runtime-provider/src/__tests__/utils/handlerWithSyntaxError.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 module.exports.syntaxError = async () => {
   if (false) {
 

--- a/packages/amplify-prompts/src/__tests__/multibar.test.ts
+++ b/packages/amplify-prompts/src/__tests__/multibar.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-conditional-expect */
-
 import { MultiProgressBar as MultiBar } from '../progressbars/multibar';
 import { BarOptions, ItemPayload, ProgressPayload } from '../progressbars/progressbar';
 

--- a/packages/amplify-prompts/src/__tests__/progressbar.test.ts
+++ b/packages/amplify-prompts/src/__tests__/progressbar.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-conditional-expect */
-
 import { ProgressBar as Bar, BarOptions } from '../progressbars/progressbar';
 
 const options: BarOptions = {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/initialize-env.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/initialize-env.test.ts
@@ -20,8 +20,8 @@ describe('initialize environment', () => {
   it('throws AmplifyError if the deployment bucket does not exist', async () => {
     downloadZipMock.mockRejectedValueOnce({ code: 'NoSuchBucket' });
     const actual = await expect(run(contextStub, {})).rejects;
-    actual.toBeInstanceOf(AmplifyException);
-    actual.toMatchInlineSnapshot(
+    await actual.toBeInstanceOf(AmplifyException);
+    await actual.toMatchInlineSnapshot(
       `[EnvironmentNotInitializedError: Could not find a deployment bucket for the specified backend environment. This environment may have been deleted.]`,
     );
   });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/helper.test.ts
@@ -75,56 +75,56 @@ describe('deployment helpers', () => {
       deployFn = jest.fn();
     });
     describe('deploy', () => {
-      it('should extract deploy section when the deploying', () => {
+      it('should extract deploy section when the deploying', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.getDeploymentOperationHandler(deployFn)(context);
+        await helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).toHaveBeenCalledWith(context.stacks[0].deployment);
       });
-      it('should be an no-op if the current index is greater than the number of stacks', () => {
+      it('should be an no-op if the current index is greater than the number of stacks', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.getDeploymentOperationHandler(deployFn)(context);
+        await helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
 
-      it('should be an no-op if the current index is less than 0', () => {
+      it('should be an no-op if the current index is less than 0', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.getDeploymentOperationHandler(deployFn)(context);
+        await helper.getDeploymentOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
     });
     describe('rollback', () => {
-      it('should extract deploy section when the deploying', () => {
+      it('should extract deploy section when the deploying', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: 0,
         };
-        helper.getRollbackOperationHandler(deployFn)(context);
+        await helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).toHaveBeenCalledWith(context.stacks[0].rollback);
       });
-      it('should be an no-op if the current index is greater than the number of stacks', () => {
+      it('should be an no-op if the current index is greater than the number of stacks', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: 2,
         };
-        helper.getRollbackOperationHandler(deployFn)(context);
+        await helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
 
-      it('should be an no-op if the current index is less than 0', () => {
+      it('should be an no-op if the current index is less than 0', async () => {
         const context: DeployMachineContext = {
           ...deploymentContext,
           currentIndex: -1,
         };
-        helper.getRollbackOperationHandler(deployFn)(context);
+        await helper.getRollbackOperationHandler(deployFn)(context);
         expect(deployFn).not.toHaveBeenCalled();
       });
     });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/stack-event-monitor.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/stack-event-monitor.test.ts
@@ -39,8 +39,8 @@ describe('StackEventMonitor', () => {
     });
   });
 
-  test('stop StackEventMonitor', () => {
-    monitor.stop();
+  test('stop StackEventMonitor', async () => {
+    await monitor.stop();
 
     expect(stackProgressPrinterStub.printerFn).toBeCalled();
     expect(clearTimeout).toBeCalledTimes(1);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/cfn-pre-processor.test.ts
@@ -58,28 +58,28 @@ describe('preProcessCFNTemplate', () => {
     expect(newPath).toMatchInlineSnapshot(`"/project/amplify/backend/awscloudformation/build/cfn-template-name.json"`);
   });
 
-  it('test writeCustonPolicies with Lambda function', () => {
-    writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'Lambda', '../dummypath', 'function');
+  it('test writeCustonPolicies with Lambda function', async () => {
+    await writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'Lambda', '../dummypath', 'function');
     expect(pathManager_mock.getResourceDirectoryPath).toBeCalledWith(undefined, 'function', 'testLambdaResourceName');
     expect(readCFNTemplate_mock).toBeCalled();
   });
 
-  it('test writeCustonPolicies with LambdaLayer function', () => {
-    writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'LambdaLayer', '../dummypath', 'function');
+  it('test writeCustonPolicies with LambdaLayer function', async () => {
+    await writeCustomPoliciesToCFNTemplate('testLambdaResourceName', 'LambdaLayer', '../dummypath', 'function');
     expect(pathManager_mock.getResourceDirectoryPath).not.toBeCalled();
     expect(readCFNTemplate_mock).not.toBeCalled();
   });
 
-  it('test writeCustonPolicies with Containers Api', () => {
-    writeCustomPoliciesToCFNTemplate('testApiResourceName', 'ElasticContainer', '../dummypath', 'api');
+  it('test writeCustonPolicies with Containers Api', async () => {
+    await writeCustomPoliciesToCFNTemplate('testApiResourceName', 'ElasticContainer', '../dummypath', 'api');
     expect(pathManager_mock.getResourceDirectoryPath).toBeCalledWith(undefined, 'api', 'testApiResourceName');
     expect(readCFNTemplate_mock).toBeCalled();
   });
 
-  it('test writeCustonPolicies with Appsync', () => {
+  it('test writeCustonPolicies with Appsync', async () => {
     pathManager_mock.getResourceDirectoryPath.mockClear();
     readCFNTemplate_mock.mockClear();
-    writeCustomPoliciesToCFNTemplate('testApiResourceName', 'AppSync', '../dummypath', 'api');
+    await writeCustomPoliciesToCFNTemplate('testApiResourceName', 'AppSync', '../dummypath', 'api');
     expect(pathManager_mock.getResourceDirectoryPath).not.toBeCalled();
     expect(readCFNTemplate_mock).not.toBeCalled();
   });

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/admin-login-server.test.ts
@@ -18,10 +18,8 @@ describe('AdminLoginServer', () => {
   test('run server with 0.0.0.0', async () => {
     const adminLoginServer = new AdminLoginServer('appId', 'http://example.com', printer);
 
-    await new Promise<void>((resolve) => {
-      adminLoginServer.startServer(() => {});
-      resolve();
-    });
+    await adminLoginServer.startServer(() => {});
+
     expect(useMock).toBeCalled();
     expect(postMock).toBeCalled();
     expect(getMock).toBeCalled();
@@ -32,10 +30,7 @@ describe('AdminLoginServer', () => {
     const adminLoginServer = new AdminLoginServer('appId', 'http://example.com', printer);
     listenMock.mockReturnValue({ close: serverCloseMock });
 
-    await new Promise<void>((resolve) => {
-      adminLoginServer.startServer(() => {});
-      resolve();
-    });
+    await adminLoginServer.startServer(() => {});
     adminLoginServer.shutdown();
     expect(serverCloseMock).toBeCalled();
   });

--- a/packages/amplify-util-headless-input/src/__tests__/auth/import/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/auth/import/index.test.ts
@@ -16,7 +16,7 @@ describe('validates import auth headless request', () => {
 
   it('with a rejected promise when an invalid payload is supplied', async () => {
     const resultPromise = validateImportAuthRequest('garbage');
-    expect(resultPromise).rejects.toBeTruthy();
+    await expect(resultPromise).rejects.toBeTruthy();
   });
 
   test.each([

--- a/packages/amplify-util-headless-input/src/__tests__/geo/add/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/add/index.test.ts
@@ -13,6 +13,6 @@ describe('validate add geo request', () => {
 
   it('rejects promise when invalid payload', async () => {
     const resultPromise = validateAddGeoRequest('garbage');
-    expect(resultPromise).rejects.toBeTruthy();
+    await expect(resultPromise).rejects.toBeTruthy();
   });
 });

--- a/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
@@ -13,6 +13,6 @@ describe('validate update geo request', () => {
 
   it('rejects promise when invalid payload', async () => {
     const resultPromise = validateUpdateGeoRequest('garbage');
-    expect(resultPromise).rejects.toBeTruthy();
+    await expect(resultPromise).rejects.toBeTruthy();
   });
 });

--- a/packages/amplify-util-headless-input/src/__tests__/storage/import/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/storage/import/index.test.ts
@@ -20,7 +20,7 @@ describe('validates import storage headless request', () => {
 
   it('non-json content rejects', async () => {
     const resultPromise = validateImportStorageRequest('garbage');
-    expect(resultPromise).rejects.toBeTruthy();
+    await expect(resultPromise).rejects.toBeTruthy();
   });
 
   test.each([

--- a/packages/amplify-util-mock/src/__e2e__/model-with-maps-to.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-with-maps-to.e2e.test.ts
@@ -53,7 +53,6 @@ afterAll(async () => {
     await terminateDDB(ddbEmulator, dbPath);
   } catch (e) {
     console.error(e);
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(true).toEqual(false);
   }
 });

--- a/packages/amplify-util-mock/src/__e2e__/utils/index.ts
+++ b/packages/amplify-util-mock/src/__e2e__/utils/index.ts
@@ -74,7 +74,7 @@ export async function reDeploy(
     await createAndUpdateTable(client, config);
     config = configureDDBDataSource(config, client.config);
   }
-  configureLambdaDataSource(config);
+  await configureLambdaDataSource(config);
   simulator?.reload(config);
   return { simulator, config };
 }

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-arn-to-config.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-arn-to-config.test.ts
@@ -66,15 +66,15 @@ describe('lambda arn to config', () => {
   });
 
   it('throws on malformed arn refs', async () => {
-    expect(lambdaArnToConfig(context_stub, { 'Fn::Sub': { key: 'cant interpret this' } })).rejects.toThrowError();
+    await expect(lambdaArnToConfig(context_stub, { 'Fn::Sub': { key: 'cant interpret this' } })).rejects.toThrowError();
   });
 
   it('throws on unknown arn formats', async () => {
-    expect(lambdaArnToConfig(context_stub, ['dont know', 'what this is'])).rejects.toThrowError();
+    await expect(lambdaArnToConfig(context_stub, ['dont know', 'what this is'])).rejects.toThrowError();
   });
 
   it('throws when arn is valid but no matching lambda found in the project', async () => {
-    expect(lambdaArnToConfig(context_stub, 'validformat::but::no::matchinglambda')).rejects.toThrowError(
+    await expect(lambdaArnToConfig(context_stub, 'validformat::but::no::matchinglambda')).rejects.toThrowError(
       new AmplifyError('MockProcessError', {
         message: `Did not find a Lambda matching ARN [\"validformat::but::no::matchinglambda\"] in the project. Local mocking only supports Lambdas that are configured in the project.`,
         resolution: `Use 'amplify add function' in the root of your app directory to create a new Lambda Function. To connect an AWS Lambda resolver to the GraphQL API, add the @function directive to a field in your schema.`,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "./src",
+    "strict": false,
+    "lib": ["ESNext", "dom"]
+  },
+  "exclude": []
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

**State before**
Before these changes all test sources were excluded from linter in `ignorePatterns` section of `.eslintrc.js` file.

**Goals**
1. Include test files in linting process.
2. Catch and fix all misused promises in tests.

**Out of scope**
In order to bring linter coverage from `zero` to `something that matters` the `overrides` section relevant to test has been redefined to disable rules that gave plethora of errors or warnings (they were not run before anyway!).
These rules should be addressed in separate PRs if ever (volunteers are welcome).

**Details**
Please look at comments I made in relevant source files.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

https://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=run-e2e%2Fsobkamil%2Flint-tests-too 

It seems to have quite a success rate.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
