### PR TITLE
test: enable more linter rules in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,7 +118,7 @@ module.exports = {
         'import/no-extraneous-dependencies': 'off',
         'no-constant-condition': 'off',
         'no-restricted-syntax': 'off',
-        'no-useless-catch': 'off',
+        'no-useless-catch': 'error',
         'no-useless-escape': 'off',
         'no-var': 'error',
         'prefer-const': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ module.exports = {
         'no-useless-catch': 'error',
         'no-useless-escape': 'off',
         'no-var': 'error',
-        'prefer-const': 'off',
+        'prefer-const': 'error',
         'spellcheck/spell-checker': 'off',
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,7 @@ module.exports = {
         'no-restricted-syntax': 'off',
         'no-useless-catch': 'off',
         'no-useless-escape': 'off',
-        'no-var': 'off',
+        'no-var': 'error',
         'prefer-const': 'off',
         'spellcheck/spell-checker': 'off',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
         '@typescript-eslint/no-inferrable-types': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
-        'consistent-return': 'off',
+        'consistent-return': 'error',
         'import/no-extraneous-dependencies': 'off',
         'no-constant-condition': 'off',
         'no-restricted-syntax': 'off',

--- a/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/__helpers__/appsync-client.ts
@@ -94,7 +94,7 @@ export async function appSyncClient<ResponseDataType = unknown, VarsType = Recor
             if (body.errors?.length) {
               return reject(new Error(`GraphQL request error(s): ${JSON.stringify(body.errors)}`));
             }
-            resolve(body.data);
+            return resolve(body.data);
           })
           .once('error', (err) => reject(err));
       },

--- a/packages/amplify-appsync-simulator/src/__tests__/server/websocket-subscription.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/server/websocket-subscription.test.ts
@@ -119,7 +119,7 @@ describe('websocket subscription', () => {
 
   describe('onSubscribe', () => {
     let subsServer: AppSyncSimulatorSubscriptionServer;
-    let asyncIterator = new PubSub().asyncIterator('onMessage');
+    const asyncIterator = new PubSub().asyncIterator('onMessage');
     const tokenString = 'token-here';
     const jwt = { iss: 'some issuer' };
     const doc = parse(/* GraphQL */ `

--- a/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/subscription.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/subscription.test.ts
@@ -18,8 +18,8 @@ describe('runSubscription', () => {
   `);
   let schema: GraphQLSchema;
 
-  let subscriptionResolver = jest.fn();
-  let subscriptionSubscribe = jest.fn();
+  const subscriptionResolver = jest.fn();
+  const subscriptionSubscribe = jest.fn();
 
   const executionContext: AppSyncGraphQLExecutionContext = {
     headers: { 'x-api-key': 'da-fake-key' },

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/list-utils.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/list-utils.test.ts
@@ -7,7 +7,7 @@ import { AmplifyAppSyncSimulatorAuthenticationType } from '../../../type-definit
 
 const stubInfo = {} as unknown;
 export const mockInfo = stubInfo as GraphQLResolveInfo;
-var util;
+let util;
 
 beforeEach(() => {
   const executionContext: AppSyncGraphQLExecutionContext = {

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/math.test.ts
@@ -5,7 +5,7 @@ import { AmplifyAppSyncSimulatorAuthenticationType } from '../../../type-definit
 
 const stubInfo = {} as unknown;
 export const mockInfo = stubInfo as GraphQLResolveInfo;
-var util;
+let util;
 
 beforeEach(() => {
   const executionContext: AppSyncGraphQLExecutionContext = {

--- a/packages/amplify-appsync-simulator/src/__tests__/velocity/util/str.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/velocity/util/str.test.ts
@@ -5,7 +5,7 @@ import { AppSyncGraphQLExecutionContext } from '../../../utils/graphql-runner';
 
 const stubInfo = {} as unknown;
 export const mockInfo = stubInfo as GraphQLResolveInfo;
-var util;
+let util;
 
 beforeEach(() => {
   const executionContext: AppSyncGraphQLExecutionContext = {

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
@@ -29,7 +29,7 @@ const pluginInstance = {
 const getOAuthObjectFromCognitoMock = getOAuthObjectFromCognito as jest.MockedFunction<typeof getOAuthObjectFromCognito>;
 
 // mock context
-let mockContext = {
+const mockContext = {
   amplify: {
     getProjectConfig: jest.fn().mockReturnValue({
       projectName: 'authHeadless',

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
@@ -24,9 +24,7 @@ jest.mock('@aws-amplify/amplify-cli-core', () => {
     ...(jest.requireActual('@aws-amplify/amplify-cli-core') as {}),
     FeatureFlags: {
       getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
-        if (name === 'auth.enableCaseInsensitivity') {
-          return true;
-        }
+        return name === 'auth.enableCaseInsensitivity';
       }),
       getNumber: jest.fn(),
       getObject: jest.fn(),

--- a/packages/amplify-category-custom/src/__tests__/commands/update.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/commands/update.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../walkthroughs/cloudformation-walkthrough');
 jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('@aws-amplify/amplify-prompts');
 
-let mockAmplifyMeta = {
+const mockAmplifyMeta = {
   custom: {
     mockcdkresourcename: {
       service: CDK_SERVICE_NAME,

--- a/packages/amplify-category-custom/src/__tests__/walkthroughts/cdk-walkthrough.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/walkthroughts/cdk-walkthrough.test.ts
@@ -22,7 +22,7 @@ pathManager.getBackendDirPath = jest.fn().mockReturnValue('mockTargetDir');
 (JSONUtilities.writeJson = jest.fn()), (JSONUtilities.readJson = jest.fn());
 
 const buildCustomResources_mock = buildCustomResources as jest.MockedFunction<typeof buildCustomResources>;
-let customResourceNameQuestion_mock = customResourceNameQuestion as jest.MockedFunction<typeof customResourceNameQuestion>;
+const customResourceNameQuestion_mock = customResourceNameQuestion as jest.MockedFunction<typeof customResourceNameQuestion>;
 customResourceNameQuestion_mock.mockResolvedValue('customresoourcename');
 
 describe('addCDKWalkthrough scenarios', () => {

--- a/packages/amplify-category-custom/src/__tests__/walkthroughts/cloudformation-walkthrough.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/walkthroughts/cloudformation-walkthrough.test.ts
@@ -19,7 +19,7 @@ jest.mock('fs-extra', () => ({
 
 pathManager.getBackendDirPath = jest.fn().mockReturnValue('mockTargetDir');
 
-let customResourceNameQuestion_mock = customResourceNameQuestion as jest.MockedFunction<typeof customResourceNameQuestion>;
+const customResourceNameQuestion_mock = customResourceNameQuestion as jest.MockedFunction<typeof customResourceNameQuestion>;
 customResourceNameQuestion_mock.mockResolvedValue('customresoourcename');
 
 describe('addCFNWalkthrough scenarios', () => {

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/utils/lambda-layer-cloud-formation-template.test.ts
@@ -114,7 +114,7 @@ describe('test layer CFN generation functions', () => {
   });
 
   it('should generate the expected CFN for an existing LL version and new version with complex permissions', () => {
-    let permissions: LayerPermission[] = [
+    const permissions: LayerPermission[] = [
       { type: PermissionEnum.Private },
       { type: PermissionEnum.AwsAccounts, accounts: ['123456789012', '098765432112'] },
       { type: PermissionEnum.AwsOrg, orgs: ['o-123456789012', 'o-098765432112'] },
@@ -129,7 +129,7 @@ describe('test layer CFN generation functions', () => {
 
   it('should generate the expected CFN for an existing LL version and new version with public permission', () => {
     // Public should override other permissions
-    let permissions: LayerPermission[] = [
+    const permissions: LayerPermission[] = [
       { type: PermissionEnum.Private },
       { type: PermissionEnum.AwsAccounts, accounts: ['123456789012', '098765432112'] },
       { type: PermissionEnum.AwsOrg, orgs: ['o-123456789012', 'o-098765432112'] },

--- a/packages/amplify-category-hosting/__tests__/index.test.js
+++ b/packages/amplify-category-hosting/__tests__/index.test.js
@@ -32,8 +32,8 @@ describe('index', () => {
   const ANOTHERSERVICE = 'AnotherHostingService';
 
   const mockAvailableServices = [];
-  let mockDisabledServices = [];
-  let mockEnabledServices = [];
+  const mockDisabledServices = [];
+  const mockEnabledServices = [];
 
   const mockAnswers = {
     selectedServices: [],

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/dynamoDb-walkthrough.test.ts
@@ -141,7 +141,7 @@ describe('update ddb walkthrough tests', () => {
   });
 
   it('updateWalkthrough() test to add gsi', async () => {
-    let mockAmplifyMeta = {
+    const mockAmplifyMeta = {
       storage: {
         mockresourcename: {
           service: 'DynamoDB',

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.test.ts
@@ -94,7 +94,7 @@ describe('add s3 walkthrough tests', () => {
 
     stateManager.getMeta = jest.fn().mockReturnValue(S3MockDataBuilder.mockAmplifyMeta);
 
-    let options = {};
+    const options = {};
     const returnedResourcename = await addWalkthrough(mockContext, S3MockDataBuilder.mockFilePath, mockContext, options);
 
     expect(returnedResourcename).toEqual(S3MockDataBuilder.mockResourceName);
@@ -126,7 +126,7 @@ describe('add s3 walkthrough tests', () => {
 
     stateManager.getMeta = jest.fn().mockReturnValue(S3MockDataBuilder.mockAmplifyMeta);
 
-    let options = {};
+    const options = {};
     const returnedResourcename = await addWalkthrough(mockContext, S3MockDataBuilder.mockFilePath, mockContext, options);
 
     expect(returnedResourcename).toEqual(S3MockDataBuilder.mockResourceName);
@@ -160,7 +160,7 @@ describe('add s3 walkthrough tests', () => {
 
     stateManager.getMeta = jest.fn().mockReturnValue(S3MockDataBuilder.mockAmplifyMeta);
 
-    let options = {};
+    const options = {};
     const returnedResourcename = await addWalkthrough(mockContext, S3MockDataBuilder.mockFilePath, mockContext, options);
 
     expect(returnedResourcename).toEqual(S3MockDataBuilder.mockResourceName);
@@ -202,7 +202,7 @@ describe('add s3 walkthrough tests', () => {
 
     stateManager.getMeta = jest.fn().mockReturnValue(S3MockDataBuilder.mockAmplifyMeta);
 
-    let options = {};
+    const options = {};
     const returnedResourcename = await addWalkthrough(mockContext, S3MockDataBuilder.mockFilePath, mockContext, options);
 
     expect(returnedResourcename).toEqual(S3MockDataBuilder.mockResourceName);

--- a/packages/amplify-cli-core/src/__tests__/help.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/help.test.ts
@@ -148,42 +148,42 @@ describe('amplify help functions: ', () => {
   ];
 
   it('lookup valid command (init) and expect not null', () => {
-    let initCommandInfo = lookUpCommand(mockCommandsInfo, 'init');
+    const initCommandInfo = lookUpCommand(mockCommandsInfo, 'init');
     expect(initCommandInfo).not.toBeUndefined();
   });
 
   it('lookup invalid command and expect null', () => {
-    let invalidCommandInfo = lookUpCommand(mockCommandsInfo, 'invalidcommand');
+    const invalidCommandInfo = lookUpCommand(mockCommandsInfo, 'invalidcommand');
     expect(invalidCommandInfo).toBeUndefined();
   });
 
   it('lookup valid command (init) and expect correct command name', () => {
-    let initCommandInfo = lookUpCommand(mockCommandsInfo, 'init');
+    const initCommandInfo = lookUpCommand(mockCommandsInfo, 'init');
     expect(initCommandInfo!.command).toBe('init');
   });
 
   it('lookup valid command (configure) and expect correct command name', () => {
-    let initCommandInfo = lookUpCommand(mockCommandsInfo, 'configure');
+    const initCommandInfo = lookUpCommand(mockCommandsInfo, 'configure');
     expect(initCommandInfo!.command).toBe('configure');
   });
 
   it('lookup valid subcommand (configure project) and expect not null', () => {
-    let configureProjectSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'project');
+    const configureProjectSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'project');
     expect(configureProjectSubCommandInfo).not.toBeUndefined();
   });
 
   it('lookup invalid subcommand and expect null', () => {
-    let invalidSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'invalidcommand', 'invalidsubcommand');
+    const invalidSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'invalidcommand', 'invalidsubcommand');
     expect(invalidSubCommandInfo).toBeUndefined();
   });
 
   it('lookup valid subcommand (configure project) and expect correct subcommand name', () => {
-    let configureProjectSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'project');
+    const configureProjectSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'project');
     expect(configureProjectSubCommandInfo!.subCommand).toBe('project');
   });
 
   it('lookup valid subcommand (configure hosting) correct subcommand name', () => {
-    let configureHostingSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'hosting');
+    const configureHostingSubCommandInfo = lookUpSubcommand(mockCommandsInfo, 'configure', 'hosting');
     expect(configureHostingSubCommandInfo!.subCommand).toBe('hosting');
   });
 
@@ -195,7 +195,7 @@ describe('amplify help functions: ', () => {
       plugin: 'core',
       subCommands: ['configure'],
     };
-    let specifiedCommands = parseHelpCommands(configureInput, mockCommandsInfo);
+    const specifiedCommands = parseHelpCommands(configureInput, mockCommandsInfo);
     expect(specifiedCommands.command).toBe('configure');
     expect(specifiedCommands.subCommand).toBe('');
   });
@@ -208,14 +208,13 @@ describe('amplify help functions: ', () => {
       options: { help: true, yes: false },
       subCommands: ['mock', 'function'],
     };
-    let specifiedCommands = parseHelpCommands(mockFunctionInput, mockCommandsInfo);
+    const specifiedCommands = parseHelpCommands(mockFunctionInput, mockCommandsInfo);
     expect(specifiedCommands.command).toBe('mock');
     expect(specifiedCommands.subCommand).toBe('function');
   });
 
   it('run help invalid command', () => {
-    let mockContext: $TSContext;
-    mockContext = {
+    const mockContext = {
       input: {
         argv: ['node', 'amplify', 'invalid', 'command', '-h'],
         command: 'help',
@@ -230,9 +229,7 @@ describe('amplify help functions: ', () => {
   });
 
   it('run help command (mock)', () => {
-    let mockContext: $TSContext;
-
-    mockContext = {
+    const mockContext = {
       print: {
         info: jest.fn(),
       },
@@ -249,9 +246,7 @@ describe('amplify help functions: ', () => {
   });
 
   it('run help subcommand (mock function)', () => {
-    let mockContext: $TSContext;
-
-    mockContext = {
+    const mockContext = {
       print: {
         info: jest.fn(),
       },

--- a/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
@@ -43,6 +43,7 @@ jest.mock('which', () => ({
     if (runtimeName === 'python3') return pathToPython3Runtime;
     if (runtimeName === 'python') return pathToPythonRuntime;
     if (runtimeName === 'node') return pathToNodeRuntime;
+    throw new Error('unknown runtime');
   }),
 }));
 jest.mock('fs-extra', () => {

--- a/packages/amplify-cli/src/__tests__/commands/uninstall.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/uninstall.pkg.test.ts
@@ -13,7 +13,7 @@ execa_mock.command.mockResolvedValue({} as any);
 jest.mock('fs-extra');
 const fs_mock = fs as jest.Mocked<typeof fs>;
 
-let userConfirmation = true;
+const userConfirmation = true;
 const context_stub = {
   amplify: {
     confirmPrompt: async () => userConfirmation,

--- a/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/consoleHosting.test.ts
@@ -42,18 +42,14 @@ describe('amplify console add hosting', () => {
 
   // Manual tests
   it('add / publish / configure/ serve /remove hosting for manual deployment should succeed', async () => {
-    try {
-      await addManualHosting(projRoot);
-      expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'hosting', 'amplifyhosting'))).toBe(true);
-      const type = loadTypeFromTeamProviderInfo(projRoot, ORIGINAL_ENV);
-      expect(type).toBe(TYPE_MANUAL);
-      npmInstall(projRoot);
-      await amplifyPublish(projRoot);
-      await removeHosting(projRoot);
-      await amplifyPush(projRoot);
-    } catch (err) {
-      throw err;
-    }
+    await addManualHosting(projRoot);
+    expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'hosting', 'amplifyhosting'))).toBe(true);
+    const type = loadTypeFromTeamProviderInfo(projRoot, ORIGINAL_ENV);
+    expect(type).toBe(TYPE_MANUAL);
+    npmInstall(projRoot);
+    await amplifyPublish(projRoot);
+    await removeHosting(projRoot);
+    await amplifyPush(projRoot);
   });
 
   it('when hosting is enabled, add new env should be able to deploy frontend successfully', async () => {

--- a/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
@@ -134,7 +134,7 @@ describe('amplify console build', () => {
     const originalProjectDirPath = await util.createNewProjectDir('console-original');
     await headlessInit(originalProjectDirPath, amplifyParam, providersParam, codegenParam);
     expect(checkAmplifyFolderStructure(originalProjectDirPath)).toBeTruthy();
-    let originalTeamProviderInfo = getTeamProviderInfo(originalProjectDirPath);
+    const originalTeamProviderInfo = getTeamProviderInfo(originalProjectDirPath);
     expect(originalTeamProviderInfo).toBeDefined();
     expect(originalTeamProviderInfo['devteama']).toBeDefined();
 
@@ -153,7 +153,7 @@ describe('amplify console build', () => {
     };
     await headlessInit(clonedProjectDirPath, amplifyParam, providersParam, codegenParam);
     expect(checkAmplifyFolderStructure(clonedProjectDirPath)).toBeTruthy();
-    let clonedTeamProviderInfo = getTeamProviderInfo(clonedProjectDirPath);
+    const clonedTeamProviderInfo = getTeamProviderInfo(clonedProjectDirPath);
     expect(clonedTeamProviderInfo).toBeDefined();
     expect(clonedTeamProviderInfo['devteamb']).toBeDefined();
 

--- a/packages/amplify-e2e-core/failed-test-reporter.js
+++ b/packages/amplify-e2e-core/failed-test-reporter.js
@@ -20,7 +20,7 @@ class FailedTestNameReporter {
   getFailedTestRegEx(results) {
     let failedTestNames = [];
     if (results.testResults) {
-      for (let result of results.testResults) {
+      for (const result of results.testResults) {
         failedTestNames = [...failedTestNames, ...this.getFailedTestRegEx(result)];
       }
     } else if (results.status === 'failed') {

--- a/packages/amplify-e2e-core/src/nexpect-reporter.js
+++ b/packages/amplify-e2e-core/src/nexpect-reporter.js
@@ -96,8 +96,8 @@ class AmplifyCLIExecutionReporter {
                 }),
               );
             }
-            let sanitizedSections = [];
-            for (let section of commandAndParams) {
+            const sanitizedSections = [];
+            for (const section of commandAndParams) {
               // this ensures only alphanumeric values are in the file name
               sanitizedSections.push(section.replace(/[^a-z0-9]/gi, '_').toLowerCase());
             }

--- a/packages/amplify-e2e-tests/functions/s3-list-objects.js
+++ b/packages/amplify-e2e-tests/functions/s3-list-objects.js
@@ -3,7 +3,7 @@ const awsS3Client = new AWS.S3();
 const bucketEnvVar = '{{bucketEnvVar}}'; // This value is replaced from test
 
 exports.handler = async () => {
-  let listObjects = await awsS3Client
+  const listObjects = await awsS3Client
     .listObjectsV2({
       Bucket: process.env[bucketEnvVar],
     })

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2a.test.ts
@@ -105,7 +105,7 @@ describe('auth import identity pool and userpool', () => {
     await initJSProjectWithProfile(projectRoot, projectSettings);
     await importIdentityPoolAndUserPool(projectRoot, ogSettings.userPoolName, { native: '_app_client ', web: '_app_clientWeb' });
 
-    let projectDetails = getAuthProjectDetails(projectRoot);
+    const projectDetails = getAuthProjectDetails(projectRoot);
 
     expectAuthProjectDetailsMatch(projectDetails, ogProjectDetails);
 

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2b.test.ts
@@ -112,7 +112,7 @@ describe('auth import identity pool and userpool', () => {
 
     await amplifyPushAuth(projectRoot);
 
-    let projectDetails = getAuthProjectDetails(projectRoot);
+    const projectDetails = getAuthProjectDetails(projectRoot);
 
     const appId = getAppId(projectRoot);
     expect(appId).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/schema-iterative-update-locking.test.ts
@@ -52,9 +52,7 @@ describe('Schema iterative update - locking', () => {
     const appId = getAppId(projectRoot);
     expect(appId).toBeDefined();
 
-    let projectRootPull;
-
-    projectRootPull = await createNewProjectDir('iterlock-pull');
+    const projectRootPull = await createNewProjectDir('iterlock-pull');
 
     await amplifyPull(projectRootPull, { override: false, emptyDir: true, appId });
 

--- a/packages/amplify-e2e-tests/src/__tests__/storage-1a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-1a.test.ts
@@ -22,6 +22,7 @@ function getServiceMeta(projectRoot: string, category: string, service: string):
       return meta.storage[storageResourceName];
     }
   }
+  return undefined;
 }
 
 describe('amplify add/update storage(S3)', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/storage-1b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-1b.test.ts
@@ -21,6 +21,7 @@ function getServiceMeta(projectRoot: string, category: string, service: string):
       return meta.storage[storageResourceName];
     }
   }
+  return undefined;
 }
 
 describe('amplify add/update storage(S3)', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-5.test.ts
@@ -31,6 +31,7 @@ function getServiceMeta(projectRoot: string, category: string, service: string):
       return meta.storage[storageResourceName];
     }
   }
+  return undefined;
 }
 
 describe('s3 override tests', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/storage-simulator/S3server.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-simulator/S3server.test.ts
@@ -2,10 +2,10 @@ import { AmplifyStorageSimulator } from 'amplify-storage-simulator';
 import * as AWS from 'aws-sdk';
 import * as fs from 'fs-extra';
 
-let port = 20005; // for testing
-let route = '/mock-testing';
-let bucket = 'mock-testing';
-let localDirS3 = __dirname + '/test-data/';
+const port = 20005; // for testing
+const route = '/mock-testing';
+const bucket = 'mock-testing';
+const localDirS3 = __dirname + '/test-data/';
 const actual_file = __dirname + '/test-data/2.png';
 
 let s3client;
@@ -20,7 +20,7 @@ beforeAll(async () => {
     region: 'eu-west-2',
   });
 
-  let ep = new AWS.Endpoint('http://localhost:20005');
+  const ep = new AWS.Endpoint('http://localhost:20005');
   s3client = new AWS.S3({
     apiVersion: '2006-03-01',
     endpoint: ep.href,
@@ -90,7 +90,7 @@ describe('Test list api', () => {
   });
 
   test('list object pagination', async () => {
-    let maxKeys = 2;
+    const maxKeys = 2;
     let total = 7;
     let response = await s3client
       .listObjects({

--- a/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/tags.test.ts
@@ -58,7 +58,7 @@ describe('generated tags test', () => {
 function checkEquality(localTags: {}[], generatedTags: {}[]) {
   localTags.forEach((tagObj) => {
     const rootTag = generatedTags.find((obj) => obj['Key'] === tagObj['Key']);
-    if (tagObj['Key'] !== rootTag['Key']) return false;
+    return tagObj['Key'] === rootTag['Key'];
   });
 
   return true;

--- a/packages/amplify-provider-awscloudformation/src/__tests__/display-helpful-urls.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/display-helpful-urls.test.ts
@@ -99,6 +99,7 @@ describe('showSMSSandBoxWarning', () => {
           case 'COGNITO_SMS_SANDBOX_UPDATE_WARNING':
             return 'enabled';
         }
+        return undefined;
       });
 
       await showSMSSandboxWarning(context);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/resource-package/resource-export.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/resource-package/resource-export.test.ts
@@ -52,6 +52,7 @@ JSONUtilitiesMock.readJson.mockImplementation((pathToJson: string) => {
       Parameters: {},
     } as unknown as Template;
   }
+  return undefined;
 });
 const readCFNTemplate_mock = readCFNTemplate as jest.MockedFunction<typeof readCFNTemplate>;
 readCFNTemplate_mock.mockImplementation((path) => {
@@ -259,6 +260,7 @@ const invokePluginMethod = jest.fn((_context, _category, _service, functionName,
       exposedContainer: 'mockExposedContainer',
     };
   }
+  return undefined;
 });
 jest.mock('../../resourceParams', () => ({
   loadResourceParameters: jest.fn().mockReturnValue({}),

--- a/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
@@ -26,7 +26,7 @@ let GRAPHQL_CLIENT_2 = undefined;
  */
 let GRAPHQL_CLIENT_3 = undefined;
 
-let USER_POOL_ID = 'y9CqgkEJe';
+const USER_POOL_ID = 'y9CqgkEJe';
 
 const USERNAME1 = 'user1@test.com';
 const USERNAME2 = 'user2@test.com';

--- a/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
@@ -28,7 +28,7 @@ let GRAPHQL_CLIENT_2 = undefined;
  */
 let GRAPHQL_CLIENT_3 = undefined;
 
-let USER_POOL_ID = 'fake_user_pool';
+const USER_POOL_ID = 'fake_user_pool';
 
 const USERNAME1 = 'user1@test.com';
 const USERNAME2 = 'user2@test.com';

--- a/packages/amplify-util-mock/src/__e2e__/multi-auth-model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/multi-auth-model-auth-transformer.e2e.test.ts
@@ -19,7 +19,7 @@ let GRAPHQL_ENDPOINT = undefined;
 let APIKEY_GRAPHQL_CLIENT = undefined;
 let USER_POOL_AUTH_CLIENT = undefined;
 
-let USER_POOL_ID = 'fake_user_pool';
+const USER_POOL_ID = 'fake_user_pool';
 
 const USERNAME1 = 'user1@test.com';
 

--- a/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
@@ -238,7 +238,7 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
   });
 
   const subscriptionPromise = new Promise((resolve, _) => {
-    let subscription = observer.subscribe((event: any) => {
+    const subscription = observer.subscribe((event: any) => {
       const student = event.data.onCreateStudent;
       subscription.unsubscribe();
       expect(student.name).toEqual('student1');
@@ -275,7 +275,7 @@ test('Test a subscription on update', async () => {
         }
       `,
     });
-    let subscription = observer.subscribe((event: any) => {
+    const subscription = observer.subscribe((event: any) => {
       const student = event.data.onUpdateStudent;
       subscription.unsubscribe();
       expect(student.id).toEqual(student3ID);
@@ -323,7 +323,7 @@ test('Test a subscription on delete', async () => {
         }
       `,
     });
-    let subscription = observer.subscribe((event: any) => {
+    const subscription = observer.subscribe((event: any) => {
       const student = event.data.onDeleteStudent;
       subscription.unsubscribe();
       expect(student.id).toEqual(student4ID);
@@ -470,7 +470,7 @@ test('Test subscription onCreatePost with ownerField', async () => {
           }
       }`,
     });
-    let subscription = observer.subscribe((event: any) => {
+    const subscription = observer.subscribe((event: any) => {
       const post = event.data.onCreatePost;
       subscription.unsubscribe();
       expect(post.title).toEqual('someTitle');

--- a/packages/amplify-util-mock/src/__e2e__/utils/index.ts
+++ b/packages/amplify-util-mock/src/__e2e__/utils/index.ts
@@ -85,7 +85,7 @@ async function configureLambdaDataSource(config) {
     .forEach((d) => {
       const arn = d.LambdaFunctionArn;
       const arnParts = arn.split(':');
-      let functionName = arnParts[arnParts.length - 1];
+      const functionName = arnParts[arnParts.length - 1];
       const lambdaConfig = getFunctionDetails(functionName);
       d.invoke = (payload) => {
         logDebug('Invoking lambda with config', lambdaConfig);

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
@@ -219,6 +219,7 @@ describe('DynamoDB Utils', () => {
         };
         if (typeof callback === 'function') {
           callback(null, response);
+          return undefined;
         } else {
           return {
             promise: jest.fn().mockResolvedValue(response),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
- enables batch of linter rules, see changes in `.eslintrc.js` for the list.
- fixes violations in test codebase

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
