### PR TITLE
chore: move authentication before branch creation in cloud-e2e script

### DIFF
--- a/scripts/cloud-e2e.sh
+++ b/scripts/cloud-e2e.sh
@@ -43,7 +43,7 @@ function cloudE2E {
     export CLOUD_E2E_PROFILE=AmplifyCLIE2E
     export CLOUD_E2E_ACCOUNT=$E2E_ACCOUNT_PROD
     export TARGET_BRANCH=run-cb-e2e/$USER/$CURR_BRANCH
-    git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$TARGET_BRANCH --no-verify --force-with-lease
     authenticate
+    git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$TARGET_BRANCH --no-verify --force-with-lease
     triggerBuild
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently when running `yarn cloud-e2e` it creates a branch in this repo before authenticating. If authentication fails, the branch is left behind. This PR switches the order of these two steps.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes
Ran `yarn cloud-e2e`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
