### PR TITLE
fix: do not store windows specific package manager extension

### DIFF
--- a/packages/amplify-cli-core/src/utils/packageManager.ts
+++ b/packages/amplify-cli-core/src/utils/packageManager.ts
@@ -40,14 +40,14 @@ class NpmPackageManager implements PackageManager {
 class YarnPackageManager implements PackageManager {
   readonly packageManager: PackageManagerType = 'yarn';
   readonly displayValue = 'Yarn';
-  readonly executable = isWindows ? 'yarn.cmd' : 'yarn';
+  readonly executable = 'yarn'; // Windows does not require `.cmd` extension to invoke yarn
   readonly lockFile = 'yarn.lock';
   version?: SemVer;
 
   getRunScriptArgs = (scriptName: string) => [scriptName];
   getInstallArgs = (buildType = BuildType.PROD) => {
     const useYarnModern = this.version?.major && this.version?.major > 1;
-    return useYarnModern ? ['install'] : ['--no-bin-links'].concat(buildType === 'PROD' ? ['--production'] : []);
+    return (useYarnModern ? ['install'] : ['--no-bin-links']).concat(buildType === 'PROD' ? ['--production'] : []);
   };
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Remove the `.cmd` extension from `yarn` for Windows since it's not needed and causes issues with teams working across multiple OS's

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
https://us-east-1.console.aws.amazon.com/codesuite/codebuild/671107461633/projects/AmplifyCLI-E2E-Testing/batch/AmplifyCLI-E2E-Testing:1306a0c1-9604-4ed5-906c-96f456d5bf3a?region=us-east-1#

I'm relying on this [test](https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-e2e-tests/src/__tests__/function_14.test.ts) for verification.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
