### PR TITLE
ci: disable release workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,6 @@ workflows:
           filters:
             branches:
               only:
-                - dev
                 - /run-e2e\/.*/
                 - /pull\/.*
   nightly_console_integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,13 @@ workflows:
   setup:
     when: << pipeline.parameters.setup >>
     jobs:
-      - setup
+      - setup:
+          filters:
+            branches:
+              only:
+                - dev
+                - /run-e2e\/.*/
+                - /pull\/.*
   nightly_console_integration_tests:
     when: << pipeline.parameters.nightly_console_integration_tests >>
     jobs:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Setup job is required to run release/release_rc/tagged-release.*, so we can disable those workflows by locking down the setup job so it only runs during PR/E2E workflows.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
