### PR TITLE
chore: manual pr build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cloud-e2e-circleci": "CURR_BRANCH=$(git branch | awk '/\\*/{printf \"%s\", $2}') && UPSTREAM_BRANCH=run-e2e/$USER/$CURR_BRANCH && git push $(git remote -v | grep aws-amplify/amplify-cli | head -n1 | awk '{print $1;}') $CURR_BRANCH:$UPSTREAM_BRANCH --no-verify --force-with-lease && echo \"\n\n 🏃 E2E test are running at:\nhttps://app.circleci.com/pipelines/github/aws-amplify/amplify-cli?branch=$UPSTREAM_BRANCH\"",
     "cloud-e2e-local": "bash -c 'source ./scripts/cloud-e2e.sh && cloudE2ELocal'",
     "cloud-e2e": "bash -c 'source ./scripts/cloud-e2e.sh && cloudE2E'",
+    "cloud-pr": "./scripts/cloud-pr.sh",
     "commit": "git-cz",
     "coverage:collect": "ts-node ./scripts/collect-test-coverage.ts",
     "coverage": "codecov || exit 0",

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+source $scriptDir/.env set
+
+printf 'What is your PR number ? '
+read PR_NUMBER
+
+printf 'Did you submit PR from fork (y/n)? '
+read FROM_FORK
+
+if [ "$FROM_FORK" == "${FROM_FORK#[Yy]}" ] ;then
+  # if not
+  printf 'What is your branch name in main repo ? '
+  read BRANCH_NAME
+  BRANCH_OVERRIDE="--environment-variables-override name=BRANCH_NAME,value=$BRANCH_NAME,type=PLAINTEXT"
+fi
+
+mwinit --aea
+ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=Admin --provider=isengard --once
+RESULT=$(aws codebuild start-build-batch \
+--profile=cb-ci-account \
+--region us-east-1 \
+--project-name AmplifyCLI-PR-Testing \
+--build-timeout-in-minutes-override 180 \
+--source-version "pr/$PR_NUMBER" \
+--debug-session-enabled \
+--git-clone-depth-override=1000 $BRANCH_OVERRIDE \
+--query 'buildBatch.id' --output text)
+
+echo "https://us-east-1.console.aws.amazon.com/codesuite/codebuild/$E2E_ACCOUNT_PROD/projects/AmplifyCLI-PR-Testing/batch/$RESULT?region=us-east-1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Ability to kick off PR run manually.

```
yarn cloud-pr
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

```
$ yarn cloud-pr
What is your PR number ? 13070
Did you submit PR from fork (y/n)? y
PIN for sobkamil:
Press the button on your U2F token...
Successfully authenticated using u2f, session cookie saved in /Users/sobkamil/.midway/cookie
Successfully signed SSH public key /Users/sobkamil/.ssh/id_ecdsa.pub. The SSH certificate was saved in /Users/sobkamil/.ssh/id_ecdsa-cert.pub
2023/08/03 13:26:54 This profile appears to be ada managed, so there is no need to explicitly update.
2023/08/03 13:26:54 Your credentials will be pulled automatically, so you may continue on with your workflow.
https://us-east-1.console.aws.amazon.com/codesuite/codebuild/671107461633/projects/AmplifyCLI-PR-Testing/batch/AmplifyCLI-PR-Testing:732a33ba-6411-4937-93f7-2e6c2540b1de?region=us-east-1
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
