### PR TITLE
chore: simplify manual pr script

### DIFF
--- a/.circleci/codebuild-checkout.sh
+++ b/.circleci/codebuild-checkout.sh
@@ -14,7 +14,7 @@ if [[ "$CODEBUILD_SOURCE_VERSION" != "" ]]; then
 fi
 
 # Codebuild doesn't checkout the branch by default
-if [[ "$CODEBUILD_WEBHOOK_TRIGGER" =~ ^pr/ || "$CODEBUILD_SOURCE_VERSION" =~ ^pr/ || "$CODEBUILD_SOURCE_VERSION_REF" =~ refs/pull/[0-9]+/head$ ]]; then
+if [[ "$AMPLIFY_CI_MANUAL_PR_BUILD" == "true" || "$CODEBUILD_WEBHOOK_TRIGGER" =~ ^pr/ || "$CODEBUILD_SOURCE_VERSION" =~ ^pr/ || "$CODEBUILD_SOURCE_VERSION_REF" =~ refs/pull/[0-9]+/head$ ]]; then
   # If we're in PR workflow create temporary local branch.
   # We detect if we're in PR by looking for pr/<number> pattern in code build env variables
   # or by checking if commit is matching refs/pull/<number>/head.

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -6,16 +6,6 @@ source $scriptDir/.env set
 printf 'What is your PR number ? '
 read PR_NUMBER
 
-printf 'Did you submit PR from fork (y/n)? '
-read FROM_FORK
-
-if [ "$FROM_FORK" == "${FROM_FORK#[Yy]}" ] ;then
-  # if not
-  printf 'What is your branch name in main repo ? '
-  read BRANCH_NAME
-  BRANCH_OVERRIDE="--environment-variables-override name=BRANCH_NAME,value=$BRANCH_NAME,type=PLAINTEXT"
-fi
-
 mwinit --aea
 ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=Admin --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
@@ -25,7 +15,8 @@ RESULT=$(aws codebuild start-build-batch \
 --build-timeout-in-minutes-override 180 \
 --source-version "pr/$PR_NUMBER" \
 --debug-session-enabled \
---git-clone-depth-override=1000 $BRANCH_OVERRIDE \
+--git-clone-depth-override=1000 \
+--environment-variables-override name=AMPLIFY_CI_MANUAL_PR_BUILD,value=true,type=PLAINTEXT \
 --query 'buildBatch.id' --output text)
 
 echo "https://us-east-1.console.aws.amazon.com/codesuite/codebuild/$E2E_ACCOUNT_PROD/projects/AmplifyCLI-PR-Testing/batch/$RESULT?region=us-east-1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I keep running into weird corner cases with manual PR build like:
- if submitted from branch from main repo, branch ref is passed to CB
- if submitted from fork, current inference works well
- if submitted from fork but also pushed to e2e branch before,  somehow ref to e2e branch lands in CB

In order to simplify this, and because we have control over submitting manual build. I define an env var that I pass from manual script that is then used in CB to infer that we're in PR workflow.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
