### PR TITLE
test: enforce no-unused-vars rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,7 +113,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-inferrable-types': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': 'error',
         'consistent-return': 'error',
         'import/no-extraneous-dependencies': 'error',
         'no-constant-condition': 'off',

--- a/packages/amplify-appsync-simulator/src/__tests__/index.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/index.test.ts
@@ -4,10 +4,8 @@ import { VelocityTemplate } from '../velocity';
 
 import {
   AmplifyAppSyncSimulatorAuthenticationType,
-  AppSyncSimulatorDataSourceNoneConfig,
   AmplifyAppSyncSimulatorConfig,
   AppSyncMockFile,
-  AppSyncSimulatorBaseResolverConfig,
   RESOLVER_KIND,
   AppSyncSimulatorUnitResolverConfig,
 } from '../type-definition';

--- a/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/resolvers/pipeline-resolver.test.ts
@@ -63,14 +63,14 @@ describe('Pipeline Resolvers', () => {
     beforeEach(() => {
       fnImpl = {
         fn1: {
-          resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context, info) => ({
+          resolve: jest.fn().mockImplementation((source, args, stash) => ({
             result: 'FN1-RESULT',
             args,
             stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn1'] },
           })),
         },
         fn2: {
-          resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context, info) => ({
+          resolve: jest.fn().mockImplementation((source, args, stash) => ({
             args,
             result: 'FN2-RESULT',
             stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn2'] },
@@ -171,12 +171,12 @@ describe('Pipeline Resolvers', () => {
         appsyncErrors: [],
       };
       const info = {};
-      fnImpl.fn1.resolve.mockImplementation((source, args, stash, prevResult, context, info) => ({
+      fnImpl.fn1.resolve.mockImplementation((source, args, stash) => ({
         result: 'FN1-RESULT',
         args: { ...args, fn1Arg: 'FN1-ARG1' },
         stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn1'] },
       }));
-      fnImpl.fn2.resolve.mockImplementation((source, args, stash, prevResult, context, info) => ({
+      fnImpl.fn2.resolve.mockImplementation((source, args, stash) => ({
         result: 'FN2-RESULT',
         args: { ...args, fn2Arg: 'FN2-ARG1' },
         stash: { ...stash, exeSeq: [...(stash.exeSeq || []), 'fn2'] },
@@ -245,7 +245,7 @@ describe('Pipeline Resolvers', () => {
     it('bails out early on terminal error', async () => {
       resolver = new AppSyncPipelineResolver(baseConfig, simulatorContext);
       fnImpl.fn1 = {
-        resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context, info) => {
+        resolve: jest.fn().mockImplementation((source, args, stash, prevResult, context) => {
           const err = new Error('fn1-ERROR');
           context.appsyncErrors = [...context.appsyncErrors, err];
           return {

--- a/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSIPAddress.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/scalars/AWSIPAddress.test.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import { scalars } from '../../schema/appsync-scalars';
 describe('AWSIPAddress parse', () => {
   it('should parse valid ip address', () => {

--- a/packages/amplify-appsync-simulator/src/__tests__/server/subscription/websocket-server/server.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/server/subscription/websocket-server/server.test.ts
@@ -103,7 +103,7 @@ describe('WebsocketSubscriptionServer', () => {
 
     it('should accept connection when the protocol is graphql-ws', async () => {
       const client = new WS(`ws://localhost:${serverPort}${REALTIME_SUBSCRIPTION_PATH}`, 'graphql-ws');
-      const messagePromise = new Promise((resolve, _) => {
+      const messagePromise = new Promise((resolve) => {
         client.addEventListener('close', (event) => {
           expect(event.wasClean).toBeTruthy();
           resolve(undefined);
@@ -133,7 +133,7 @@ describe('WebsocketSubscriptionServer', () => {
     it('should fail connection when onConnectionHandler throw and error', async () => {
       onConnectHandler.mockRejectedValue('error');
       const client = new WS(`ws://localhost:${serverPort}${REALTIME_SUBSCRIPTION_PATH}`, 'graphql-ws');
-      const messagePromise = new Promise((resolve, _) => {
+      const messagePromise = new Promise((resolve) => {
         client.addEventListener('close', (event) => {
           expect(event.code).toEqual(1002);
           resolve(undefined);
@@ -164,7 +164,7 @@ describe('WebsocketSubscriptionServer', () => {
         type: MESSAGE_TYPES.GQL_CONNECTION_INIT,
         payload: {},
       };
-      const messagePromise = new Promise((resolve, _) => {
+      const messagePromise = new Promise((resolve) => {
         client.onmessage = (message: WS.MessageEvent) => {
           const data = JSON.parse(message.data as string);
           expect(data.type).toEqual(MESSAGE_TYPES.GQL_CONNECTION_ACK);
@@ -183,7 +183,7 @@ describe('WebsocketSubscriptionServer', () => {
         type: 'invalid',
         payload: {},
       };
-      const messagePromise = new Promise((resolve, _) => {
+      const messagePromise = new Promise((resolve) => {
         client.onmessage = (message: WS.MessageEvent) => {
           const data = JSON.parse(message.data as string);
           expect(data.type).toEqual(MESSAGE_TYPES.GQL_ERROR);

--- a/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
+++ b/packages/amplify-appsync-simulator/src/__tests__/utils/graphql-runner/query-and-mutation.test.ts
@@ -156,7 +156,6 @@ describe('runQueryAndMutation', () => {
   });
 
   it('should have error object populated when error occurs in the resolver (e.g. Lambda DataSource)', async () => {
-    const name = 'John Doe';
     const doc = parse(/* GraphQL */ `
       query getName {
         getName

--- a/packages/amplify-category-auth/src/__tests__/commands/override.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/commands/override.test.ts
@@ -1,6 +1,5 @@
 import { run } from '../../commands/auth/override';
 import { $TSContext, generateOverrideSkeleton } from '@aws-amplify/amplify-cli-core';
-import { AuthInputState } from '../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state';
 import { checkAuthResourceMigration } from '../../provider-utils/awscloudformation/utils/check-for-auth-migration';
 
 jest.mock('../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state');

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/auth-defaults-appliers.test.ts
@@ -23,7 +23,7 @@ jest.mock('@aws-amplify/amplify-cli-core', () => {
   return {
     ...(jest.requireActual('@aws-amplify/amplify-cli-core') as {}),
     FeatureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+      getBoolean: jest.fn().mockImplementation((name) => {
         return name === 'auth.enableCaseInsensitivity';
       }),
       getNumber: jest.fn(),

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/check-for-auth-migration.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/check-for-auth-migration.test.ts
@@ -1,6 +1,6 @@
 import { migrateResourceToSupportOverride } from '../../../../provider-utils/awscloudformation/utils/migrate-override-resource';
 import { generateAuthStackTemplate } from '../../../../provider-utils/awscloudformation/utils/generate-auth-stack-template';
-import { $TSContext, generateOverrideSkeleton } from '@aws-amplify/amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { AuthInputState } from '../../../../provider-utils/awscloudformation/auth-inputs-manager/auth-input-state';
 import { checkAuthResourceMigration } from '../../../../provider-utils/awscloudformation/utils/check-for-auth-migration';
 

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/generate-cognito-app-client-secret.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/generate-cognito-app-client-secret.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, stateManager, pathManager, AmplifyFault } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, stateManager, pathManager } from '@aws-amplify/amplify-cli-core';
 import { updateAppClientWithGeneratedSecret } from '../../../../provider-utils/awscloudformation/utils/generate-cognito-app-client-secret';
 import { projectHasAuth } from '../../../../provider-utils/awscloudformation/utils/project-has-auth';
 import { getAuthResourceName } from '../../../../utils/getAuthResourceName';
@@ -11,7 +11,6 @@ jest.mock('../../../../provider-utils/awscloudformation/utils/get-app-client-sec
 
 const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
 const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;
-const AmplifyFaultMock = AmplifyFault as jest.MockedClass<typeof AmplifyFault>;
 const projectHasAuthMock = projectHasAuth as jest.MockedFunction<typeof projectHasAuth>;
 const getAuthResourceNameMock = getAuthResourceName as jest.MockedFunction<typeof getAuthResourceName>;
 const getAppClientSecretMock = getAppClientSecret as jest.MockedFunction<typeof getAppClientSecret>;

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/synthesize-resources.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/synthesize-resources.test.ts
@@ -2,7 +2,6 @@ import { $TSAny, $TSContext, AmplifyCategories, JSONUtilities, pathManager } fro
 import { UserPoolGroupMetadata } from '../../../../provider-utils/awscloudformation/auth-stack-builder';
 import { updateUserPoolGroups } from '../../../../provider-utils/awscloudformation/utils/synthesize-resources';
 import { createAdminAuthFunction } from '../../../../provider-utils/awscloudformation/utils/synthesize-resources';
-import * as path from 'path';
 
 jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('fs-extra');

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
@@ -1,9 +1,7 @@
 jest.mock('@aws-amplify/amplify-cli-core', () => {
   return {
     FeatureFlags: {
-      getBoolean: jest.fn().mockImplementation(() => {
-        return true;
-      }),
+      getBoolean: jest.fn().mockReturnValue(true),
     },
   };
 });

--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/utils/trigger-flow-auth-helper.test.js
@@ -1,7 +1,7 @@
 jest.mock('@aws-amplify/amplify-cli-core', () => {
   return {
     FeatureFlags: {
-      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+      getBoolean: jest.fn().mockImplementation(() => {
         return true;
       }),
     },

--- a/packages/amplify-category-custom/src/__tests__/utils/build-custom-resources.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/utils/build-custom-resources.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext, AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import execa from 'execa';
 import { buildCustomResources } from '../../utils/build-custom-resources';
 

--- a/packages/amplify-category-custom/src/__tests__/utils/dependency-management-utils.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/utils/dependency-management-utils.test.ts
@@ -26,29 +26,8 @@ pathManager.getBackendDirPath = jest.fn().mockReturnValue('mockTargetDir');
 pathManager.getResourceDirectoryPath = jest.fn().mockReturnValue('mockResourceDir');
 
 describe('getResourceCfnOutputAttributes() scenarios', () => {
-  let mockContext: $TSContext;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContext = {
-      amplify: {
-        openEditor: jest.fn(),
-        updateamplifyMetaAfterResourceAdd: jest.fn(),
-        copyBatch: jest.fn(),
-        getResourceStatus: jest.fn().mockResolvedValue({
-          allResources: [
-            {
-              resourceName: 'mockresource1',
-              service: 'customCDK',
-            },
-            {
-              resourceName: 'mockresource2',
-              service: 'customCDK',
-            },
-          ],
-        }),
-      },
-    } as unknown as $TSContext;
   });
 
   it('get resource attr for resources with build folder with one cfn file', async () => {
@@ -109,29 +88,8 @@ describe('getResourceCfnOutputAttributes() scenarios', () => {
 });
 
 describe('getAllResources() scenarios', () => {
-  let mockContext: $TSContext;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContext = {
-      amplify: {
-        openEditor: jest.fn(),
-        updateamplifyMetaAfterResourceAdd: jest.fn(),
-        copyBatch: jest.fn(),
-        getResourceStatus: jest.fn().mockResolvedValue({
-          allResources: [
-            {
-              resourceName: 'mockresource1',
-              service: 'customCDK',
-            },
-            {
-              resourceName: 'mockresource2',
-              service: 'customCDK',
-            },
-          ],
-        }),
-      },
-    } as unknown as $TSContext;
   });
 
   it('get all resource types', async () => {
@@ -161,29 +119,8 @@ describe('getAllResources() scenarios', () => {
 });
 
 describe('addCDKResourceDependency() scenarios', () => {
-  let mockContext: $TSContext;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockContext = {
-      amplify: {
-        openEditor: jest.fn(),
-        updateamplifyMetaAfterResourceAdd: jest.fn(),
-        copyBatch: jest.fn(),
-        getResourceStatus: jest.fn().mockResolvedValue({
-          allResources: [
-            {
-              resourceName: 'mockresource1',
-              service: 'customCDK',
-            },
-            {
-              resourceName: 'mockresource2',
-              service: 'customCDK',
-            },
-          ],
-        }),
-      },
-    } as unknown as $TSContext;
   });
 
   it('get depenencies for a custom CDK stack', async () => {

--- a/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
+++ b/packages/amplify-category-function/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/addLayerToFunctionWalkthrough.test.ts
@@ -172,7 +172,7 @@ describe('add layer to function walkthrough', () => {
   });
 
   it('asks to reorder the selected layers', async () => {
-    const result = await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub);
+    await addLayersToFunctionWalkthrough(getContextStubWith(confirmPromptTrue_mock), runtimeStub);
 
     expect(askLayerOrderQuestion_mock.mock.calls.length).toBe(1);
   });

--- a/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/commands/geo/remove.test.ts
@@ -5,7 +5,7 @@ import { run } from '../../../commands/geo/remove';
 
 const mockRemoveResource = removeResource as jest.MockedFunction<typeof removeResource>;
 const mockResource = 'resource12345';
-mockRemoveResource.mockImplementation((context: $TSContext, service: string): Promise<string> => {
+mockRemoveResource.mockImplementation((): Promise<string> => {
   return new Promise<string>((resolve) => {
     resolve(mockResource);
   });

--- a/packages/amplify-category-geo/src/__tests__/index.test.ts
+++ b/packages/amplify-category-geo/src/__tests__/index.test.ts
@@ -4,7 +4,6 @@ import { getPermissionPolicies } from '../index';
 jest.mock('@aws-amplify/amplify-cli-core');
 
 describe('only grant permission policies as requested', () => {
-  const provider = 'awscloudformation';
   let mockContext: $TSContext;
   // construct mock amplify meta
   const mockAmplifyMeta: $TSObject = {

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -165,7 +165,7 @@ export class S3MockDataBuilder {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(__startCliInputState: S3UserInputs | undefined) {
+  constructor() {
     /* noop */
   }
 

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/service-walkthroughs/s3-walkthrough.test.ts
@@ -51,8 +51,8 @@ describe('add s3 walkthrough tests', () => {
         getResourceStatus: async () => {
           return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
         },
-        copyBatch: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
-        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+        copyBatch: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
+        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
         pathManager: {
           getBackendDirPath: jest.fn().mockReturnValue('mockTargetDir'),
         },
@@ -70,7 +70,7 @@ describe('add s3 walkthrough tests', () => {
     });
     jest.spyOn(AmplifyS3ResourceStackTransform.prototype, 'transform').mockImplementation(() => Promise.resolve());
     jest.spyOn(s3AuthAPI, 'migrateAuthDependencyResource').mockReturnValue(
-      new Promise((resolve, _reject) => {
+      new Promise((resolve) => {
         process.nextTick(() => resolve(true));
       }),
     );
@@ -241,8 +241,8 @@ describe('update s3 permission walkthrough tests', () => {
         getResourceStatus: () => {
           return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
         }, //eslint-disable-line
-        copyBatch: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
-        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+        copyBatch: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
+        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
         pathManager: {
           getBackendDirPath: jest.fn().mockReturnValue('mockTargetDir'),
         },
@@ -445,8 +445,8 @@ describe('update s3 lambda-trigger walkthrough tests', () => {
         getResourceStatus: () => {
           return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
         }, //eslint-disable-line
-        copyBatch: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
-        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+        copyBatch: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
+        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
         pathManager: {
           getBackendDirPath: jest.fn().mockReturnValue('mockTargetDir'),
         },
@@ -710,8 +710,8 @@ describe('migrate s3 and update s3 permission walkthrough tests', () => {
         getResourceStatus: async () => {
           return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
         },
-        copyBatch: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
-        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve, reject) => resolve(true))),
+        copyBatch: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
+        updateamplifyMetaAfterResourceAdd: jest.fn().mockReturnValue(new Promise((resolve) => resolve(true))),
         pathManager: {
           getBackendDirPath: jest.fn().mockReturnValue('mockTargetDir'),
         },

--- a/packages/amplify-cli-core/src/__tests__/cliContextEnvironmentProvider.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/cliContextEnvironmentProvider.test.ts
@@ -3,7 +3,7 @@ import { CLIEnvironmentProvider, CLIContextEnvironmentProvider } from '..';
 describe('ContextCLIEnvironmentProvider tests', () => {
   test('returns env name from initialized context', () => {
     const context: any = {
-      getEnvInfo: (_: boolean): any => {
+      getEnvInfo: (): any => {
         return {
           envName: 'testenv',
         };
@@ -17,7 +17,7 @@ describe('ContextCLIEnvironmentProvider tests', () => {
 
   test('returns empty env name from when envInfo is undefined in context', () => {
     const context: any = {
-      getEnvInfo: (_: boolean): any => {
+      getEnvInfo: (): any => {
         return undefined;
       },
     };
@@ -29,7 +29,7 @@ describe('ContextCLIEnvironmentProvider tests', () => {
 
   test('returns empty env name from when envInfo.envName is undefined in context', () => {
     const context: any = {
-      getEnvInfo: (_: boolean): any => {
+      getEnvInfo: (): any => {
         return {
           envName: undefined,
         };
@@ -43,7 +43,7 @@ describe('ContextCLIEnvironmentProvider tests', () => {
 
   test('returns empty env name from when getEnvInfo throws', () => {
     const context: any = {
-      getEnvInfo: (_: boolean): any => {
+      getEnvInfo: (): any => {
         throw new Error();
       },
     };
@@ -55,7 +55,7 @@ describe('ContextCLIEnvironmentProvider tests', () => {
 
   test('throws when undefined context passed in', () => {
     expect(() => {
-      const _: CLIEnvironmentProvider = new CLIContextEnvironmentProvider(undefined as any);
+      new CLIContextEnvironmentProvider(undefined as any);
     }).toThrowError('CLIContextEnvironmentProvider expects a context instance');
   });
 });

--- a/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/featureFlags.test.ts
@@ -148,7 +148,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider successfully', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -191,7 +191,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail with json error', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -211,7 +211,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider successfully - overrides 1', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -237,7 +237,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider successfully - overrides 2', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -263,7 +263,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider successfully - overrides 3', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -289,7 +289,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider successfully - overrides 4', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -315,7 +315,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail with env error - section', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -333,7 +333,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail with env error - value', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -351,7 +351,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail with env error - bool', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -369,7 +369,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail with env error - number', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -387,7 +387,7 @@ describe('feature flags', () => {
 
     test('initialize feature flag provider fail unknown flags unless false', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -415,7 +415,7 @@ The following feature flags have validation errors:
 
     test('initialize feature flag provider with unknown false flag', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -555,7 +555,7 @@ The following feature flags have validation errors:
   describe('file provider tests', () => {
     test('missing projectPath argument', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -573,7 +573,7 @@ The following feature flags have validation errors:
 
     test('reads features when both files exists', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -603,7 +603,7 @@ The following feature flags have validation errors:
 
     test('reads features when no environment file exist', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -627,7 +627,7 @@ The following feature flags have validation errors:
 
     test('reads features when no files exist', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -647,7 +647,7 @@ The following feature flags have validation errors:
 
     test('reads features when only environment file exists', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => ({
+        getEnvInfo: (): any => ({
           envName: 'dev',
         }),
       };
@@ -673,7 +673,7 @@ The following feature flags have validation errors:
 
     test('reads features when no files exists and env is unavailable', async () => {
       const context: any = {
-        getEnvInfo: (__: boolean): any => undefined,
+        getEnvInfo: (): any => undefined,
       };
 
       const envProvider: CLIEnvironmentProvider = new CLIContextEnvironmentProvider(context);

--- a/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/hooks/hooksExecutor.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as execa from 'execa';
-import * as fs from 'fs-extra';
-import { executeHooks, HooksMeta, skipHooksFilePath } from '../../hooks';
+import { executeHooks, HooksMeta } from '../../hooks';
 import * as skipHooksModule from '../../hooks/skipHooks';
 import { pathManager, stateManager } from '../../state-manager';
 import { CommandLineInput } from '../../types';

--- a/packages/amplify-cli-core/src/__tests__/jsonUtilities.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/jsonUtilities.test.ts
@@ -160,7 +160,7 @@ describe('JSONUtilities tests', () => {
 
   test('JSON parse throws error when jsonString is undefined', () => {
     expect(() => {
-      const _ = JSONUtilities.parse(undefined as unknown as string);
+      JSONUtilities.parse(undefined as unknown as string);
     }).toThrowError(`'jsonString' argument missing or empty`);
   });
 

--- a/packages/amplify-cli-logger/src/__tests__/TestFilePath.test.ts
+++ b/packages/amplify-cli-logger/src/__tests__/TestFilePath.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import path from 'path';
 import { constants } from '../constants';
 

--- a/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
+++ b/packages/amplify-cli/src/__tests__/amplify-exception-handler.test.ts
@@ -8,7 +8,7 @@ const printerMock = printer as any;
 
 const reportErrorMock = reportError as jest.MockedFunction<typeof reportError>;
 jest.mock('../commands/diagnose', () => ({
-  reportError: jest.fn(async (__context: Context, __error: Error | undefined): Promise<void> => {
+  reportError: jest.fn(async (): Promise<void> => {
     /* no-op */
   }),
 }));
@@ -30,7 +30,7 @@ describe('test exception handler', () => {
   } as unknown as Context;
   beforeEach(() => {
     jest.resetAllMocks();
-    processExit = jest.spyOn(process, 'exit').mockImplementation((__code?: number) => undefined as never);
+    processExit = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     init(contextMock);
   });
   it('error handler should call usageData emitError', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/status.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/status.test.ts
@@ -4,7 +4,7 @@ import { showApiAuthAcm } from '@aws-amplify/amplify-category-api';
 jest.mock('@aws-amplify/amplify-category-hosting');
 jest.mock('@aws-amplify/amplify-cli-core');
 jest.mock('@aws-amplify/amplify-category-api', () => ({
-  showApiAuthAcm: jest.fn(async (_: any, __: string) => ''),
+  showApiAuthAcm: jest.fn(async () => ''),
 }));
 
 const pathManagerMock = pathManager as jest.Mocked<typeof pathManager>;

--- a/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/upgrade.pkg.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs-extra';
 import fetch, { Response } from 'node-fetch';
 import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import * as core from '@aws-amplify/amplify-cli-core';
-import * as path from 'path';
 import execa from 'execa';
 import { run } from '../../commands/upgrade';
 import { windowsPathSerializer } from '../testUtils/snapshot-serializer';

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/execute-provider-utils.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/execute-provider-utils.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../../extensions/amplify-helpers/get-provider-plugins.ts', () => (
 jest.mock('../../../../__mocks__/faked-plugin', () => ({
   providerUtils: {
     compileSchema: jest.fn().mockReturnValue(Promise.resolve({})),
-    zipFiles: jest.fn((context, [srcDir, dstZipFilePath]) => {
+    zipFiles: jest.fn(() => {
       return Promise.resolve({});
     }),
   },

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/remove-resource.test.ts
@@ -1,6 +1,5 @@
 import { stateManager, exitOnNextTick, ResourceDoesNotExistError } from '@aws-amplify/amplify-cli-core';
 import { printer, prompter } from '@aws-amplify/amplify-prompts';
-import * as inquirer from 'inquirer';
 import * as path from 'path';
 import { removeResourceParameters } from '../../../extensions/amplify-helpers/envResourceParams';
 import { removeResource, forceRemoveResource } from '../../../extensions/amplify-helpers/remove-resource';
@@ -31,7 +30,6 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
 }));
 
 const stateManagerMock = stateManager as jest.Mocked<typeof stateManager>;
-const inquirerMock = inquirer as jest.Mocked<typeof inquirer>;
 
 jest.mock('@aws-amplify/amplify-prompts');
 const prompterMock = prompter as jest.Mocked<typeof prompter>;

--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/resource-status-diff.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/resource-status-diff.test.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs-extra';
 import { stateManager, pathManager } from '@aws-amplify/amplify-cli-core';
 import { CLOUD_INITIALIZED } from '../../../extensions/amplify-helpers/get-cloud-init-status';
 import { capitalize, globCFNFilePath, ResourceDiff, stackMutationType } from '../../../extensions/amplify-helpers/resource-status-diff';
-import { cronJobSetting } from '../../../../../amplify-category-function/lib/provider-utils/awscloudformation/utils/constants';
 
 // Mock Glob to fetch test cloudformation
 jest.mock('glob');

--- a/packages/amplify-cli/src/__tests__/flow-report.test.ts
+++ b/packages/amplify-cli/src/__tests__/flow-report.test.ts
@@ -215,8 +215,6 @@ const getGeoHeadlessTestInput = () => {
   return headlessPayload;
 };
 
-const getAPIHeadlessTestInput = () => {};
-
 const getGraphQLHeadlessTestInput = () => {
   const headlessPayload: AddApiRequest = {
     version: 1,

--- a/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
+++ b/packages/amplify-console-integration-tests/__tests__/pullAndInit.test.ts
@@ -246,7 +246,7 @@ describe('amplify app console tests', () => {
     expect(authTeamInfo).not.toHaveProperty('hostedUIProviderCreds');
 
     // with frontend
-    const frontendConfig = deleteAmplifyDir(projRoot);
+    deleteAmplifyDir(projRoot);
     await headlessPull(
       projRoot,
       { envName, appId },

--- a/packages/amplify-e2e-core/src/utils/nexpect.ts
+++ b/packages/amplify-e2e-core/src/utils/nexpect.ts
@@ -160,7 +160,7 @@ function chain(context: Context): ExecutionContext {
 
     wait(
       expectation: string | RegExp,
-      callback = (data: string) => {
+      callback: (data: string) => void = () => {
         // empty
       },
     ): ExecutionContext {

--- a/packages/amplify-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-e2e-core/src/utils/pinpoint.ts
@@ -1,5 +1,4 @@
 import { Pinpoint } from 'aws-sdk';
-import _ from 'lodash';
 import { EOL } from 'os';
 import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions, addCircleCITags, KEY_DOWN_ARROW } from '..';
 

--- a/packages/amplify-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-e2e-core/src/utils/sdk-calls.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable no-return-await */
 import {
-  config,
   DynamoDB,
   S3,
   CognitoIdentity,

--- a/packages/amplify-e2e-tests/src/__tests__/api_2b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_2b.test.ts
@@ -15,7 +15,6 @@ import {
 } from '@aws-amplify/amplify-e2e-core';
 import { existsSync } from 'fs';
 import { TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
-import _ from 'lodash';
 import * as path from 'path';
 
 const providerName = 'awscloudformation';

--- a/packages/amplify-e2e-tests/src/__tests__/api_9b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_9b.test.ts
@@ -4,23 +4,19 @@ import {
   initJSProjectWithProfile,
   addApiWithoutSchema,
   updateApiSchema,
-  updateApiWithMultiAuth,
   createNewProjectDir,
   deleteProjectDir,
   getAppSyncApi,
   getProjectMeta,
-  getTransformConfig,
   getDDBTable,
   addFunction,
   getBackendAmplifyMeta,
   amplifyPushUpdateForDependentModel,
   amplifyPushForce,
-  createRandomName,
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
 import path from 'path';
 import { existsSync } from 'fs';
-import { TRANSFORM_CURRENT_VERSION } from 'graphql-transformer-core';
 
 describe('amplify add api (GraphQL)', () => {
   let projRoot: string;

--- a/packages/amplify-e2e-tests/src/__tests__/auth_3a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_3a.test.ts
@@ -8,7 +8,6 @@ import {
   createNewProjectDir,
   deleteProjectDir,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 const defaultsSettings = {
   name: 'authTest',

--- a/packages/amplify-e2e-tests/src/__tests__/auth_3b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_3b.test.ts
@@ -2,19 +2,12 @@ import {
   initJSProjectWithProfile,
   deleteProject,
   amplifyPushAuth,
-  addAuthWithDefault,
-  removeAuthWithDefault,
-  addAuthWithMaxOptions,
   addAuthUserPoolOnly,
-  getBackendAmplifyMeta,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
   getUserPool,
-  getUserPoolClients,
-  getLambdaFunction,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 const defaultsSettings = {
   name: 'authTest',

--- a/packages/amplify-e2e-tests/src/__tests__/auth_3c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_3c.test.ts
@@ -2,11 +2,7 @@ import {
   initJSProjectWithProfile,
   deleteProject,
   amplifyPushAuth,
-  addAuthWithDefault,
-  removeAuthWithDefault,
   addAuthWithMaxOptions,
-  addAuthUserPoolOnly,
-  getBackendAmplifyMeta,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
@@ -14,7 +10,6 @@ import {
   getUserPoolClients,
   getLambdaFunction,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 const defaultsSettings = {
   name: 'authTest',

--- a/packages/amplify-e2e-tests/src/__tests__/auth_4a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_4a.test.ts
@@ -2,27 +2,19 @@ import * as fs from 'fs-extra';
 import {
   initJSProjectWithProfile,
   initAndroidProjectWithProfile,
-  initIosProjectWithProfile,
   deleteProject,
   amplifyPushAuth,
-  addFeatureFlag,
-  addAuthWithRecaptchaTrigger,
   addAuthWithCustomTrigger,
   addAuthWithSignInSignOutUrl,
   updateAuthWithoutCustomTrigger,
-  updateAuthRemoveRecaptchaTrigger,
   updateAuthSignInSignOutUrl,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
-  getAwsAndroidConfig,
-  getAwsIOSConfig,
   getUserPool,
   getUserPoolClients,
   getLambdaFunction,
-  getFunction,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 const defaultsSettings = {
   name: 'authTest',

--- a/packages/amplify-e2e-tests/src/__tests__/auth_4b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_4b.test.ts
@@ -2,27 +2,18 @@ import * as fs from 'fs-extra';
 import {
   initJSProjectWithProfile,
   initAndroidProjectWithProfile,
-  initIosProjectWithProfile,
   deleteProject,
   amplifyPushAuth,
   addFeatureFlag,
   addAuthWithRecaptchaTrigger,
   addAuthWithCustomTrigger,
-  addAuthWithSignInSignOutUrl,
-  updateAuthWithoutCustomTrigger,
   updateAuthRemoveRecaptchaTrigger,
-  updateAuthSignInSignOutUrl,
   createNewProjectDir,
   deleteProjectDir,
   getProjectMeta,
   getAwsAndroidConfig,
-  getAwsIOSConfig,
-  getUserPool,
-  getUserPoolClients,
-  getLambdaFunction,
   getFunction,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 const defaultsSettings = {
   name: 'authTest',

--- a/packages/amplify-e2e-tests/src/__tests__/auth_9.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_9.test.ts
@@ -46,7 +46,7 @@ describe('amplify auth with trigger', () => {
     expect(userPool.UserPool.LambdaConfig.DefineAuthChallenge).toBeDefined();
     expect(userPool.UserPool.LambdaConfig.VerifyAuthChallengeResponse).toBeDefined();
 
-    await updateAuthChangeToUserPoolOnlyAndSetCodeMessages(projRoot, {});
+    await updateAuthChangeToUserPoolOnlyAndSetCodeMessages(projRoot);
 
     await amplifyPushAuth(projRoot);
 
@@ -64,7 +64,7 @@ describe('amplify auth with trigger', () => {
     expect(userPool.UserPool.LambdaConfig.VerifyAuthChallengeResponse).toBeDefined();
   });
 
-  const updateAuthChangeToUserPoolOnlyAndSetCodeMessages = async (cwd: string, settings: any): Promise<void> => {
+  const updateAuthChangeToUserPoolOnlyAndSetCodeMessages = async (cwd: string): Promise<void> => {
     return new Promise((resolve, reject) => {
       const chain = spawn(getCLIPath(), ['update', 'auth'], { cwd, stripColors: true });
 

--- a/packages/amplify-e2e-tests/src/__tests__/custom_policies_container.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/custom_policies_container.test.ts
@@ -10,7 +10,6 @@ import {
   createNewProjectDir,
   deleteProjectDir,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 import { JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import AWS from 'aws-sdk';
 import path from 'path';

--- a/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/delete.test.ts
@@ -25,7 +25,6 @@ import {
   pushToCloud,
 } from '@aws-amplify/amplify-e2e-core';
 import * as fs from 'fs-extra';
-import _ from 'lodash';
 import { addEnvironment, checkoutEnvironment, removeEnvironment } from '../environment/env';
 import { addCodegen } from '../codegen/add';
 import { getAWSExportsPath } from '../aws-exports/awsExports';
@@ -174,7 +173,7 @@ async function appExists(appId: string, region: string) {
 }
 
 async function timeout(timeout: number) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(resolve, timeout);
   });
 }

--- a/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_1.test.ts
@@ -23,8 +23,6 @@ import {
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
 
-import _ from 'lodash';
-
 describe('nodejs', () => {
   describe('amplify add function', () => {
     let projRoot: string;

--- a/packages/amplify-e2e-tests/src/__tests__/function_2a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2a.test.ts
@@ -17,7 +17,6 @@ import {
   loadFunctionTestFile,
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 describe('nodejs', () => {
   describe('amplify add function with additional permissions', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/function_2b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2b.test.ts
@@ -17,7 +17,6 @@ import {
   createRandomName,
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 describe('nodejs', () => {
   describe('amplify add function with additional permissions', () => {
@@ -68,11 +67,7 @@ describe('nodejs', () => {
       await amplifyPush(projRoot);
       const meta = getProjectMeta(projRoot);
       const { GraphQLAPIIdOutput: appsyncId } = Object.keys(meta.api).map((key) => meta.api[key])[0].output;
-      const {
-        Arn: functionArn,
-        Name: functionName,
-        Region: region,
-      } = Object.keys(meta.function).map((key) => meta.function[key])[0].output;
+      const { Name: functionName, Region: region } = Object.keys(meta.function).map((key) => meta.function[key])[0].output;
       expect(appsyncId).toBeDefined();
       expect(functionName).toBeDefined();
       expect(region).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/function_2c.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_2c.test.ts
@@ -9,7 +9,6 @@ import {
   initJSProjectWithProfile,
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 
 describe('nodejs', () => {
   describe('amplify add function with additional permissions', () => {

--- a/packages/amplify-e2e-tests/src/__tests__/function_6.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_6.test.ts
@@ -15,7 +15,6 @@ import {
   amplifyPushForce,
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
-import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { addEnvironmentYes } from '../environment/env';
 

--- a/packages/amplify-e2e-tests/src/__tests__/function_8.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_8.test.ts
@@ -1,9 +1,6 @@
 import {
   addFunction,
-  addLayer,
-  addOptData,
   amplifyPushAuth,
-  amplifyPushLayer,
   createNewProjectDir,
   deleteProject,
   deleteProjectDir,

--- a/packages/amplify-e2e-tests/src/__tests__/function_9b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_9b.test.ts
@@ -20,7 +20,6 @@ import {
   generateRandomShortId,
 } from '@aws-amplify/amplify-e2e-core';
 import path from 'path';
-import _ from 'lodash';
 
 const GraphQLTransformerLatestVersion = 2;
 

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_1.test.ts
@@ -126,7 +126,6 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
 
     const url = GraphQLAPIEndpointOutput as string;
-    const apiKey = GraphQLAPIKeyOutput as string;
 
     const appSyncClient = new AWSAppSyncClient({
       url,

--- a/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
@@ -83,7 +83,6 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
     expect(graphqlApi.apiId).toEqual(GraphQLAPIIdOutput);
 
     const url = GraphQLAPIEndpointOutput as string;
-    const apiKey = GraphQLAPIKeyOutput as string;
 
     const appSyncClient = new AWSAppSyncClient({
       url,
@@ -108,7 +107,7 @@ describe('amplify add api (GraphQL) - Lambda Authorizer', () => {
         note: 'initial note',
       },
     };
-    const createResult: any = await appSyncClient.mutate({
+    await appSyncClient.mutate({
       mutation: gql(createMutation),
       fetchPolicy: 'no-cache',
       variables: createInput,

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2a.test.ts
@@ -48,7 +48,6 @@ describe('auth import identity pool and userpool', () => {
 
   // We need an extra OG project to make sure that autocomplete prompt hits in
   let dummyOGProjectRoot: string;
-  let dummyOGShortId: string;
   let dummyOGSettings: AddAuthIdentityPoolAndUserPoolWithOAuthSettings;
 
   let projectRoot: string;
@@ -66,7 +65,6 @@ describe('auth import identity pool and userpool', () => {
     ogProjectDetails = getOGAuthProjectDetails(ogProjectRoot);
 
     dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
-    dummyOGShortId = getShortId();
     dummyOGSettings = createIDPAndUserPoolWithOAuthSettings(dummyOGProjectSettings.name, ogShortId);
 
     await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_2b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_2b.test.ts
@@ -11,13 +11,11 @@ import {
   addS3StorageWithSettings,
 } from '@aws-amplify/amplify-e2e-core';
 import {
-  AuthProjectDetails,
   createIDPAndUserPoolWithOAuthSettings,
   expectAuthLocalAndOGMetaFilesOutputMatching,
   expectLocalAndCloudMetaFilesMatching,
   expectLocalAndPulledBackendConfigMatching,
   getAuthProjectDetails,
-  getOGAuthProjectDetails,
   getShortId,
   headlessPull,
   importIdentityPoolAndUserPool,
@@ -45,11 +43,9 @@ describe('auth import identity pool and userpool', () => {
   let ogProjectRoot: string;
   let ogShortId: string;
   let ogSettings: AddAuthIdentityPoolAndUserPoolWithOAuthSettings;
-  let ogProjectDetails: AuthProjectDetails;
 
   // We need an extra OG project to make sure that autocomplete prompt hits in
   let dummyOGProjectRoot: string;
-  let dummyOGShortId: string;
   let dummyOGSettings: AddAuthIdentityPoolAndUserPoolWithOAuthSettings;
 
   let projectRoot: string;
@@ -64,10 +60,7 @@ describe('auth import identity pool and userpool', () => {
     await addAuthIdentityPoolAndUserPoolWithOAuth(ogProjectRoot, ogSettings);
     await amplifyPushAuth(ogProjectRoot);
 
-    ogProjectDetails = getOGAuthProjectDetails(ogProjectRoot);
-
     dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
-    dummyOGShortId = getShortId();
     dummyOGSettings = createIDPAndUserPoolWithOAuthSettings(dummyOGProjectSettings.name, ogShortId);
 
     await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);

--- a/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_auth_3.test.ts
@@ -59,7 +59,6 @@ describe('auth import userpool only', () => {
 
   // We need an extra OG project to make sure that autocomplete prompt hits in
   let dummyOGProjectRoot: string;
-  let dummyOGShortId: string;
   let dummyOGSettings: AddAuthUserPoolOnlyWithOAuthSettings;
 
   let projectRoot: string;
@@ -77,7 +76,6 @@ describe('auth import userpool only', () => {
     ogProjectDetails = getOGAuthProjectDetails(ogProjectRoot);
 
     dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
-    dummyOGShortId = getShortId();
     dummyOGSettings = createUserPoolOnlyWithOAuthSettings(dummyOGProjectSettings.name, ogShortId);
 
     await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);

--- a/packages/amplify-e2e-tests/src/__tests__/import_s3_1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_s3_1.test.ts
@@ -34,8 +34,6 @@ import {
   expectS3LocalAndOGMetaFilesOutputMatching,
 } from '../import-helpers';
 
-const profileName = 'amplify-integ-test-user';
-
 describe('s3 import', () => {
   const projectPrefix = 'sssimp';
   const ogProjectPrefix = 'ogsssimp';
@@ -60,7 +58,6 @@ describe('s3 import', () => {
 
   // We need an extra OG project to make sure that autocomplete prompt hits in
   let dummyOGProjectRoot: string;
-  let dummyOGShortId: string;
   let dummyOGSettings: AddStorageSettings;
 
   let projectRoot: string;
@@ -79,7 +76,6 @@ describe('s3 import', () => {
     ogProjectDetails = getOGStorageProjectDetails(ogProjectRoot);
 
     dummyOGProjectRoot = await createNewProjectDir(dummyOGProjectSettings.name);
-    dummyOGShortId = getShortId();
     dummyOGSettings = createStorageSettings(dummyOGProjectSettings.name, ogShortId);
 
     await initJSProjectWithProfile(dummyOGProjectRoot, dummyOGProjectSettings);

--- a/packages/amplify-e2e-tests/src/__tests__/pr-previews-multi-env-1.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/pr-previews-multi-env-1.test.ts
@@ -7,7 +7,6 @@ import {
   getAmplifyInitConfig,
   getAwsProviderConfig,
   getProjectConfig,
-  getProjectMeta,
   gitCleanFdX,
   gitCommitAll,
   gitInit,
@@ -17,17 +16,12 @@ import {
 
 describe('environment commands with functions secrets handling', () => {
   let projRoot: string;
-  let appId: string;
-  let region: string;
 
   beforeAll(async () => {
     projRoot = await createNewProjectDir('env-test');
     await initJSProjectWithProfile(projRoot, { disableAmplifyAppCreation: false, envName: 'dev' });
     await addManualHosting(projRoot);
     await amplifyPushAuth(projRoot);
-    const meta = getProjectMeta(projRoot);
-    appId = meta.providers.awscloudformation.AmplifyAppId;
-    region = meta.providers.awscloudformation.Region;
   });
 
   afterAll(async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/resolvers.test.ts
@@ -15,7 +15,6 @@ import {
 } from '@aws-amplify/amplify-e2e-core';
 import { join } from 'path';
 import * as fs from 'fs-extra';
-import _ from 'lodash';
 
 describe('user created resolvers', () => {
   let projectDir: string;

--- a/packages/amplify-e2e-tests/src/__tests__/storage-simulator/S3server.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/storage-simulator/S3server.test.ts
@@ -6,7 +6,6 @@ const port = 20005; // for testing
 const route = '/mock-testing';
 const bucket = 'mock-testing';
 const localDirS3 = __dirname + '/test-data/';
-const actual_file = __dirname + '/test-data/2.png';
 
 let s3client;
 let simulator;
@@ -56,7 +55,6 @@ describe('test server running', () => {
 });
 
 describe('Test get api', () => {
-  const actual_file = __dirname + '/test-data/2.png';
   test('get image work ', async () => {
     const data = await s3client.getObject({ Bucket: bucket, Key: '2.png' }).promise();
     expect(data).toBeDefined();
@@ -124,7 +122,7 @@ describe('Test delete api', () => {
     fs.copySync(__dirname + '/test-data/normal/', dirPathOne + '/');
   });
   test('test one delete ', async () => {
-    const data = await s3client.deleteObject({ Bucket: bucket, Key: 'deleteOne/2.png' }).promise();
+    await s3client.deleteObject({ Bucket: bucket, Key: 'deleteOne/2.png' }).promise();
     expect(fs.rmdirSync(dirPathOne)).toBeUndefined;
   });
 });

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
@@ -21,8 +21,6 @@ import {
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
 import gql from 'graphql-tag';
-import moment from 'moment';
-import { IAM } from 'aws-sdk';
 
 (global as any).fetch = require('node-fetch');
 
@@ -30,12 +28,9 @@ describe('transformer @auth migration test', () => {
   let projRoot: string;
   let projectName: string;
 
-  const BUILD_TIMESTAMP = moment().format('YYYYMMDDHHmmss');
   const GROUPNAME = 'Admin';
   const PASSWORD = 'user1Password';
-  const NEW_PASSWORD = 'user1Password!!!**@@@';
   const EMAIL = 'username@amazon.com';
-  const UNAUTH_ROLE_NAME = `unauthRole${BUILD_TIMESTAMP}`;
 
   const modelSchemaV1 = 'transformer_migration/auth-model-v1.graphql';
   const modelSchemaV2 = 'transformer_migration/auth-model-v2.graphql';
@@ -58,7 +53,6 @@ describe('transformer @auth migration test', () => {
   });
 
   it('migration of queries with different auth methods should succeed', async () => {
-    const iamHelper = new IAM({ region: 'us-east-2' });
     const awsconfig = configureAmplify(projRoot);
     const userPoolId = getUserPoolId(projRoot);
 

--- a/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
+++ b/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace jest {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface Matchers<R> {
     toBeIAMRoleWithArn(roleName: string, arn?: string): R;
     toBeAS3Bucket(bucketName: string): R;

--- a/packages/amplify-prompts/src/__tests__/prompter.test.ts
+++ b/packages/amplify-prompts/src/__tests__/prompter.test.ts
@@ -95,7 +95,7 @@ describe('input', () => {
     const promptResponse = 'this is the result';
     const transformedValue = 'transformed value';
     promptMock.mockResolvedValueOnce({ result: promptResponse });
-    expect(await prompter.input('test message', { transform: (_) => transformedValue })).toEqual(transformedValue);
+    expect(await prompter.input('test message', { transform: () => transformedValue })).toEqual(transformedValue);
   });
 
   it('transforms each input part separately when "many" specified', async () => {

--- a/packages/amplify-prompts/src/__tests__/stopwatch.test.ts
+++ b/packages/amplify-prompts/src/__tests__/stopwatch.test.ts
@@ -4,14 +4,14 @@ describe('stopwatch test', () => {
   it('test stopwatch start and pause', async () => {
     const stopwatch = new Stopwatch();
     stopwatch.start();
-    await new Promise((resolve, __reject) => {
+    await new Promise((resolve) => {
       setTimeout(resolve, 300);
     });
     stopwatch.pause();
     expect(stopwatch.getElapsedMilliseconds()).toBeGreaterThanOrEqual(295);
     expect(stopwatch.getElapsedMilliseconds()).toBeLessThan(350);
     stopwatch.start();
-    await new Promise((resolve, __reject) => {
+    await new Promise((resolve) => {
       setTimeout(resolve, 300);
     });
     stopwatch.pause();

--- a/packages/amplify-prompts/src/__tests__/validators.test.ts
+++ b/packages/amplify-prompts/src/__tests__/validators.test.ts
@@ -66,45 +66,41 @@ describe('minLength', () => {
 
 describe('and', () => {
   it('returns true if all validators return true', async () => {
-    expect(await and([(input) => true, (input) => true])('anything')).toBe(true);
+    expect(await and([() => true, () => true])('anything')).toBe(true);
   });
 
   it('returns first error message', async () => {
-    expect(await and([(input) => true, (input) => 'first error', (input) => 'second error'])('anything')).toMatchInlineSnapshot(
-      `"first error"`,
-    );
+    expect(await and([() => true, () => 'first error', () => 'second error'])('anything')).toMatchInlineSnapshot(`"first error"`);
   });
 
   it('returns override message if any validators return error message', async () => {
-    expect(
-      await and([(input) => true, (input) => 'first error', (input) => 'second error'], 'custom error message')('anything'),
-    ).toMatchInlineSnapshot(`"custom error message"`);
+    expect(await and([() => true, () => 'first error', () => 'second error'], 'custom error message')('anything')).toMatchInlineSnapshot(
+      `"custom error message"`,
+    );
   });
 });
 
 describe('or', () => {
   it('returns true if one validator returns true', async () => {
-    expect(await or([(input) => 'first error', (input) => true])('anything')).toBe(true);
+    expect(await or([() => 'first error', () => true])('anything')).toBe(true);
   });
 
   it('returns last error message if all validators return error', async () => {
-    expect(await or([(input) => 'first error', (input) => 'second error'])('anything')).toMatchInlineSnapshot(`"second error"`);
+    expect(await or([() => 'first error', () => 'second error'])('anything')).toMatchInlineSnapshot(`"second error"`);
   });
 
   it('returns override error mmessage if all validators return error', async () => {
-    expect(await or([(input) => 'first error', (input) => 'second error'], 'custom message')('anything')).toMatchInlineSnapshot(
-      `"custom message"`,
-    );
+    expect(await or([() => 'first error', () => 'second error'], 'custom message')('anything')).toMatchInlineSnapshot(`"custom message"`);
   });
 });
 
 describe('not', () => {
   it('returns error message if validator returns true', async () => {
-    expect(await not((input) => true, 'custom error message')('anything')).toMatchInlineSnapshot(`"custom error message"`);
+    expect(await not(() => true, 'custom error message')('anything')).toMatchInlineSnapshot(`"custom error message"`);
   });
 
   it('returns true when validator returns error message', async () => {
-    expect(await not((input) => 'error message', 'other message')('anything')).toBe(true);
+    expect(await not(() => 'error message', 'other message')('anything')).toBe(true);
   });
 });
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/aws-cfn.test.js
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/aws-cfn.test.js
@@ -3,7 +3,6 @@
 jest.mock('columnify');
 
 const columnify = require('columnify');
-const { times } = require('lodash');
 const { initializeProgressBars } = require('../../aws-utils/aws-cfn-progress-formatter');
 const CloudFormation = require('../../aws-utils/aws-cfn');
 

--- a/packages/amplify-provider-awscloudformation/src/__tests__/display-helpful-urls.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/display-helpful-urls.test.ts
@@ -41,7 +41,6 @@ describe('showSMSSandBoxWarning', () => {
     isInSandboxMode: jest.fn(),
   };
 
-  let mockedSNSClass;
   const context = {
     print: {
       warning: jest.fn(),
@@ -50,7 +49,7 @@ describe('showSMSSandBoxWarning', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockedSNSClass = jest.spyOn(SNS, 'getInstance').mockResolvedValue(mockedSNSClientInstance as unknown as SNS);
+    jest.spyOn(SNS, 'getInstance').mockResolvedValue(mockedSNSClientInstance as unknown as SNS);
   });
 
   describe('when API is missing in SDK', () => {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/iterative-deployment/deployment-state-manager.test.ts
@@ -41,18 +41,18 @@ describe('deployment state manager', () => {
     const getInstanceSpy = jest.spyOn(S3, 'getInstance');
 
     getInstanceSpy.mockReturnValue(
-      new Promise((resolve, __) => {
+      new Promise((resolve) => {
         resolve({
           // eslint-disable-next-line
           uploadFile: async (s3Params: any, showSpinner: boolean): Promise<string> =>
-            new Promise((resolve, _) => {
+            new Promise((resolve) => {
               s3Files[s3Params.Key] = s3Params.Body;
 
               resolve('');
             }),
           // eslint-disable-next-line
           getStringObjectFromBucket: async (bucketName: string, objectKey: string): Promise<string> =>
-            new Promise((resolve, _) => {
+            new Promise((resolve) => {
               resolve(s3Files[objectKey]);
             }),
         } as unknown as S3);

--- a/packages/amplify-provider-awscloudformation/src/__tests__/push-resources.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/push-resources.test.ts
@@ -30,7 +30,7 @@ glob_mock.sync.mockImplementation((pattern) => {
 });
 
 const fs_mock = jest.mocked(fs);
-fs_mock.lstatSync.mockImplementation((_path, _options) => {
+fs_mock.lstatSync.mockImplementation(() => {
   return {
     isDirectory: jest.fn().mockReturnValue(true),
   } as unknown as fs.Stats;

--- a/packages/amplify-provider-awscloudformation/src/__tests__/resource-package/resource-export.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/resource-package/resource-export.test.ts
@@ -36,7 +36,7 @@ pathManager_mock.findProjectRoot = jest.fn().mockReturnValue('projectpath');
 pathManager_mock.getBackendDirPath = jest.fn().mockReturnValue('backend');
 
 const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
-JSONUtilitiesMock.stringify.mockImplementation((data, __) => JSON.stringify(data, null, 2));
+JSONUtilitiesMock.stringify.mockImplementation((data) => JSON.stringify(data, null, 2));
 JSONUtilitiesMock.parse.mockImplementation((data) => JSON.parse(data));
 JSONUtilitiesMock.readJson.mockImplementation((pathToJson: string) => {
   if (pathToJson.includes('function') && pathToJson.includes('amplifyexportestlayer5f16d693')) {
@@ -76,12 +76,12 @@ readCFNTemplate_mock.mockImplementation((path) => {
 });
 const buildOverrideDir_mock = buildOverrideDir as jest.MockedFunction<typeof buildOverrideDir>;
 
-buildOverrideDir_mock.mockImplementation(async (cwd: string, dest: string) => false);
+buildOverrideDir_mock.mockImplementation(async () => false);
 
 jest.mock('fs-extra');
 const fs_mock = fs as jest.Mocked<typeof fs>;
 fs_mock.existsSync.mockReturnValue(true);
-fs_mock.lstatSync.mockImplementation((_path, _options) => {
+fs_mock.lstatSync.mockImplementation(() => {
   return {
     isDirectory: jest.fn().mockReturnValue(true),
   } as unknown as fs.Stats;
@@ -244,7 +244,7 @@ const lambdaTemplate = {
   },
 };
 
-const invokePluginMethod = jest.fn((_context, _category, _service, functionName, _others) => {
+const invokePluginMethod = jest.fn((_context, _category, _service, functionName) => {
   if (functionName === 'buildResource') {
     return 'mockbuildTimeStamp';
   }

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/root-stack-transform.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/root-stack-transform.test.ts
@@ -4,7 +4,7 @@ import { AmplifyRootStackTransform } from '../../root-stack-builder/root-stack-t
 jest.mock('@aws-amplify/amplify-cli-core');
 const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
 
-JSONUtilitiesMock.stringify.mockImplementation((data, __) => JSON.stringify(data, null, 2));
+JSONUtilitiesMock.stringify.mockImplementation((data) => JSON.stringify(data, null, 2));
 JSONUtilitiesMock.parse.mockImplementation((data) => JSON.parse(data));
 
 describe('Root stack template tests', () => {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/utils/amplify-resource-state-utils.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/utils/amplify-resource-state-utils.test.ts
@@ -2,7 +2,7 @@ import { getTableNames, getPreviousDeploymentRecord } from '../../utils/amplify-
 import { CloudFormation } from 'aws-sdk';
 
 const cfnClientStub = {
-  describeStackResources: ({ StackName }) => ({
+  describeStackResources: () => ({
     promise: () =>
       Promise.resolve({
         StackResources: [
@@ -13,7 +13,7 @@ const cfnClientStub = {
         ],
       }),
   }),
-  describeStacks: ({ StackName }) => ({
+  describeStacks: () => ({
     promise: () =>
       Promise.resolve({
         Stacks: [

--- a/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
+++ b/packages/amplify-util-headless-input/src/__tests__/geo/update/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { validateAddGeoRequest, validateUpdateGeoRequest } from '../../../index';
+import { validateUpdateGeoRequest } from '../../../index';
 
 const assetRoot = path.resolve(path.join(__dirname, '..', '..', 'assets'));
 

--- a/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/connections-with-auth-tests.e2e.test.ts
@@ -128,8 +128,6 @@ type Stage @model @auth(rules: [{ allow: groups, groups: ["Admin"]}]) {
     GRAPHQL_ENDPOINT = server.url + '/graphql';
     logDebug(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
 
-    const apiKey = result.config.appSync.apiKey;
-
     // Verify we have all the details
     expect(GRAPHQL_ENDPOINT).toBeTruthy();
 

--- a/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/key-with-auth.e2e.test.ts
@@ -209,40 +209,6 @@ async function createOrder(client: GraphQLClient, customerEmail: string, orderId
   return result;
 }
 
-async function updateOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
-  const result = await client.query(
-    `mutation UpdateOrder($input: UpdateOrderInput!) {
-        updateOrder(input: $input) {
-            customerEmail
-            orderId
-            createdAt
-        }
-    }`,
-    {
-      input: { customerEmail, orderId },
-    },
-  );
-  logDebug(JSON.stringify(result, null, 4));
-  return result;
-}
-
-async function deleteOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
-  const result = await client.query(
-    `mutation DeleteOrder($input: DeleteOrderInput!) {
-        deleteOrder(input: $input) {
-            customerEmail
-            orderId
-            createdAt
-        }
-    }`,
-    {
-      input: { customerEmail, orderId },
-    },
-  );
-  logDebug(JSON.stringify(result, null, 4));
-  return result;
-}
-
 async function getOrder(client: GraphQLClient, customerEmail: string, orderId: string) {
   const result = await client.query(
     `query GetOrder($customerEmail: String!, $orderId: String!) {

--- a/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-auth-transformer.e2e.test.ts
@@ -157,8 +157,6 @@ beforeAll(async () => {
     GRAPHQL_ENDPOINT = server.url + '/graphql';
     logDebug(`Using graphql url: ${GRAPHQL_ENDPOINT}`);
 
-    const apiKey = result.config.appSync.apiKey;
-
     const idToken = signUpAddToGroupAndGetJwtToken(USER_POOL_ID, USERNAME1, USERNAME1, [
       ADMIN_GROUP_NAME,
       PARTICIPANT_GROUP_NAME,
@@ -540,7 +538,7 @@ test('Test listPosts query when authorized', async () => {
   expect(firstPost.data.createPost.createdAt).toBeDefined();
   expect(firstPost.data.createPost.updatedAt).toBeDefined();
   expect(firstPost.data.createPost.owner).toEqual(USERNAME1);
-  const secondPost = await GRAPHQL_CLIENT_2.query(
+  await GRAPHQL_CLIENT_2.query(
     `mutation {
         createPost(input: { title: "testing list" }) {
             id

--- a/packages/amplify-util-mock/src/__e2e__/model-connection-transformer.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/model-connection-transformer.e2e.test.ts
@@ -143,7 +143,6 @@ test('Test queryPost query', async () => {
 const title = 'Test Query with Sort Field';
 const comment1 = 'a comment and a date! - 1';
 const comment2 = 'a comment and a date! - 2';
-const whenpast = '2017-10-01T00:00:00.000Z';
 const when1 = '2018-10-01T00:00:00.000Z';
 const whenmid = '2018-12-01T00:00:00.000Z';
 const when2 = '2019-10-01T00:00:01.000Z';

--- a/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
+++ b/packages/amplify-util-mock/src/__e2e__/subscriptions-with-auth.e2e.test.ts
@@ -34,11 +34,9 @@ const AWS_REGION = 'my-local-2';
 
 let APPSYNC_CLIENT_1: AWSAppSyncClient<any> = undefined;
 let APPSYNC_CLIENT_2: AWSAppSyncClient<any> = undefined;
-let APPSYNC_CLIENT_3: AWSAppSyncClient<any> = undefined;
 
 let GRAPHQL_CLIENT_1: GraphQLClient = undefined;
 let GRAPHQL_CLIENT_2: GraphQLClient = undefined;
-let GRAPHQL_CLIENT_3: GraphQLClient = undefined;
 
 const USER_POOL_ID = 'fake_user_pool';
 
@@ -181,7 +179,7 @@ beforeAll(async () => {
       Authorization: idToken2,
     });
     const idToken3 = signUpAddToGroupAndGetJwtToken(USER_POOL_ID, USERNAME3, USERNAME3, []);
-    APPSYNC_CLIENT_3 = new AWSAppSyncClient({
+    new AWSAppSyncClient({
       url: GRAPHQL_ENDPOINT,
       region: AWS_REGION,
       disableOffline: true,
@@ -193,7 +191,7 @@ beforeAll(async () => {
         jwtToken: idToken3,
       },
     });
-    GRAPHQL_CLIENT_3 = new GraphQLClient(GRAPHQL_ENDPOINT, {
+    new GraphQLClient(GRAPHQL_ENDPOINT, {
       Authorization: idToken3,
     });
 
@@ -237,7 +235,7 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
     `,
   });
 
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const subscription = observer.subscribe((event: any) => {
       const student = event.data.onCreateStudent;
       subscription.unsubscribe();
@@ -261,7 +259,7 @@ test('Test that only authorized members are allowed to view subscriptions', asyn
 
 test('Test a subscription on update', async () => {
   // susbcribe to update students as user 2
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_2.subscribe({
       query: gql`
         subscription OnUpdateStudent {
@@ -309,7 +307,7 @@ test('Test a subscription on update', async () => {
 
 test('Test a subscription on delete', async () => {
   // subscribe to onDelete as user 2
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_2.subscribe({
       query: gql`
         subscription OnDeleteStudent {
@@ -359,7 +357,7 @@ test('test that group is only allowed to listen to subscriptions and listen to o
   expect(result.errors[0].message === 'Unauthorized');
 
   // though they should see when a new member is created
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_2.subscribe({
       query: gql`
         subscription OnCreateMember {
@@ -393,7 +391,7 @@ test('authorized group is allowed to listen to onUpdate', async () => {
   const memberID = '001';
   const memberName = 'newUsername';
 
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_2.subscribe({
       query: gql`
         subscription OnUpdateMember {
@@ -427,7 +425,7 @@ test('authoirzed group is allowed to listen to onDelete', async () => {
   const memberID = '001';
   const memberName = 'newUsername';
 
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_2.subscribe({
       query: gql`
         subscription OnDeleteMember {
@@ -459,7 +457,7 @@ test('authoirzed group is allowed to listen to onDelete', async () => {
 
 // ownerField Tests
 test('Test subscription onCreatePost with ownerField', async () => {
-  const subscriptionPromise = new Promise((resolve, _) => {
+  const subscriptionPromise = new Promise((resolve) => {
     const observer = APPSYNC_CLIENT_1.subscribe({
       query: gql`
       subscription OnCreatePost {

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/intrinsic-functions.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/intrinsic-functions.test.ts
@@ -149,7 +149,7 @@ describe('intrinsic-functions', () => {
 
     it('should call parseValue if the ref is not a string', () => {
       const node = [{ 'Fn::Join': ['-', ['foo', 'bar']] }];
-      const parseValue = jest.fn((val) => 'fromParam');
+      const parseValue = jest.fn(() => 'fromParam');
       expect(cfnRef(node, cfnContext, parseValue)).toEqual('foo');
     });
 

--- a/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/CFNParser/resource-processors/appsync.test.ts
@@ -46,12 +46,6 @@ describe('dynamoDBResourceHandler', () => {
         ],
       },
     };
-    const cfnContext: CloudFormationParseContext = {
-      params: {},
-      conditions: {},
-      resources: {},
-      exports: {},
-    };
     const processedResource = dynamoDBResourceHandler(resource.Properties.TableName, resource);
     expect(processedResource.Properties.AttributeDefinitions).toEqual(resource.Properties.AttributeDefinitions);
     expect(processedResource.Properties.KeySchema).toEqual(resource.Properties.KeySchema);

--- a/packages/amplify-util-mock/src/__tests__/api/api.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/api.test.ts
@@ -27,12 +27,6 @@ jest.mock('amplify-dynamodb-simulator', () => jest.fn());
 jest.mock('fs-extra');
 
 const mockProjectRoot = 'mock-app';
-const mockContext = {
-  amplify: {
-    getEnvInfo: jest.fn().mockReturnValue({ projectPath: mockProjectRoot }),
-    loadRuntimePlugin: jest.fn().mockReturnValue({}),
-  },
-} as unknown as $TSContext;
 
 describe('Test Mock API methods', () => {
   beforeEach(() => {

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
@@ -53,7 +53,7 @@ describe('Invoke local lambda function', () => {
     expect(printer.info).toBeCalledWith(JSON.stringify(echoInput, undefined, 2));
     expect(printer.error).toBeCalledTimes(0);
     expect(printer.info).toBeCalledWith('Finished execution.');
-    expect(isBuilt).toBeTruthy();
+    expect(isBuilt).toBe(true);
   });
 
   it('invoke the local lambda using trigger config with given data', async () => {

--- a/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/api/lambda-invoke.test.ts
@@ -53,6 +53,7 @@ describe('Invoke local lambda function', () => {
     expect(printer.info).toBeCalledWith(JSON.stringify(echoInput, undefined, 2));
     expect(printer.error).toBeCalledTimes(0);
     expect(printer.info).toBeCalledWith('Finished execution.');
+    expect(isBuilt).toBeTruthy();
   });
 
   it('invoke the local lambda using trigger config with given data', async () => {
@@ -69,11 +70,7 @@ describe('Invoke local lambda function', () => {
       }),
     } as $TSAny;
 
-    let isBuilt = false;
     getInvokerMock.mockResolvedValueOnce(() => new Promise((resolve) => setTimeout(() => resolve('lambda value'), 11000)));
-    getBuilderMock.mockReturnValueOnce(async () => {
-      isBuilt = true;
-    });
     const echoInput = { key: 'value' };
     timeConstrainedInvokerMock.mockResolvedValue(echoInput);
     const mockTriggerConfig = {

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
@@ -1,7 +1,7 @@
 import * as ddbUtils from '../../../utils/dynamo-db/utils';
 import * as AWSMock from 'aws-sdk-mock';
 import * as AWS from 'aws-sdk';
-import { DescribeTableOutput, CreateTableInput, UpdateTableInput, UpdateTableOutput, TableDescription } from 'aws-sdk/clients/dynamodb';
+import { DescribeTableOutput, CreateTableInput, UpdateTableInput, TableDescription } from 'aws-sdk/clients/dynamodb';
 import { waitTillTableStateIsActive } from '../../../utils/dynamo-db/helpers';
 import { DynamoDB } from 'aws-sdk';
 

--- a/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/velocity/model-auth.test.ts
@@ -724,7 +724,6 @@ describe('@model field auth', () => {
 });
 
 describe('@model @primaryIndex @index auth', () => {
-  let vtlTemplate: VelocityTemplateSimulator;
   let transformer: GraphQLTransform;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -746,8 +745,8 @@ describe('@model @primaryIndex @index auth', () => {
       authConfig,
       transformers: [new ModelTransformer(), new PrimaryKeyTransformer(), new IndexTransformer(), new AuthTransformer()],
     });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    vtlTemplate = new VelocityTemplateSimulator({ authConfig });
+
+    new VelocityTemplateSimulator({ authConfig });
   });
 
   test('listX operations', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

**This PR:**
1. enables `@typescript-eslint/no-unused-vars` rule in tests
2. eliminates all unused symbols.

**Out of scope.**
This PR does not attempt to fix tests that does not have much sense. Just enable the rule for better future.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Running full E2E suite. Will merge if passes.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
