### PR TITLE
Revert "test: remove extra hash"

### DIFF
--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -26,8 +26,9 @@ function startLocalRegistry {
 # Codebuild only
 function uploadPkgCliForE2E {
     cd out/
+    export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
-    aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64.tgz
+    aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
     cd ..
 }
 function uploadPkgCli {
@@ -35,9 +36,14 @@ function uploadPkgCli {
     aws configure --profile=s3-uploader set aws_secret_access_key $S3_SECRET_ACCESS_KEY
     aws configure --profile=s3-uploader set aws_session_token $S3_AWS_SESSION_TOKEN
     cd out/
+    export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
 
     if [[ "$CIRCLE_BRANCH" == "release" ]] || [[ "$CIRCLE_BRANCH" =~ ^run-e2e-with-rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^release_rc\/.* ]] || [[ "$CIRCLE_BRANCH" =~ ^tagged-release ]]; then
+        aws --profile=s3-uploader s3 cp amplify-pkg-win-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-win-x64-$(echo $hash).tgz
+        aws --profile=s3-uploader s3 cp amplify-pkg-macos-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-macos-x64-$(echo $hash).tgz
+        aws --profile=s3-uploader s3 cp amplify-pkg-linux-arm64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-arm64-$(echo $hash).tgz
+        aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
 
         ALREADY_EXISTING_FILES="$(set -o pipefail && aws --profile=s3-uploader s3 ls s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64 | ( egrep -v "amplify-pkg-linux-x64-.*" || true ) | wc -l | xargs)"
         INCORRECT_PERMISSIONS=$?
@@ -58,7 +64,7 @@ function uploadPkgCli {
         aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64.tgz
 
     else
-        aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64.tgz
+        aws --profile=s3-uploader s3 cp amplify-pkg-linux-x64.tgz s3://aws-amplify-cli-do-not-delete/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
     fi
 
     cd ..

--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -25,9 +25,14 @@ function startLocalRegistry {
 
 function uploadPkgCliCodeBuild {
     cd out/
+    export hash=$(git rev-parse HEAD | cut -c 1-12)
     export version=$(./amplify-pkg-linux-x64 --version)
 
     if [[ "$BRANCH_NAME" == "release" ]] || [[ "$BRANCH_NAME" =~ ^run-e2e-with-rc\/.* ]] || [[ "$BRANCH_NAME" =~ ^release_rc\/.* ]] || [[ "$BRANCH_NAME" =~ ^tagged-release ]]; then
+        aws s3 cp amplify-pkg-win-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-win-x64-$(echo $hash).tgz
+        aws s3 cp amplify-pkg-macos-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-macos-x64-$(echo $hash).tgz
+        aws s3 cp amplify-pkg-linux-arm64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-arm64-$(echo $hash).tgz
+        aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
 
         ALREADY_EXISTING_FILES="$(set -o pipefail && aws s3 ls s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64 | ( egrep -v "amplify-pkg-linux-x64-.*" || true ) | wc -l | xargs)"
         INCORRECT_PERMISSIONS=$?
@@ -48,7 +53,7 @@ function uploadPkgCliCodeBuild {
         aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64.tgz
 
     else
-        aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64.tgz
+        aws s3 cp amplify-pkg-linux-x64.tgz s3://$PKG_CLI_BUCKET_NAME/$(echo $version)/amplify-pkg-linux-x64-$(echo $hash).tgz
     fi
 
     cd ..

--- a/packages/amplify-cli-npm/binary.ts
+++ b/packages/amplify-cli-npm/binary.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { spawnSync } from 'child_process';
+import { spawnSync, execSync } from 'child_process';
 import util from 'util';
 import tar from 'tar-stream';
 import { createGunzip } from 'zlib';
@@ -75,9 +75,25 @@ const getCompressedBinaryUrl = (): string => {
   if (process.env.IS_AMPLIFY_CI && process.env.CODEBUILD_SRC_DIR) {
     // use cloudfront distribution for e2e
     url = `https://${process.env.PKG_CLI_CLOUDFRONT_URL}/${version}/${compressedBinaryName}`;
+    url = url.replace('.tgz', `-${getCommitHash()}.tgz`);
+  } else if (process.env.IS_AMPLIFY_CI) {
+    url = url.replace('.tgz', `-${getCommitHash()}.tgz`);
   }
 
   return url;
+};
+
+/**
+ * CI-only, used for testing hash-based binaries
+ *
+ * @returns string
+ */
+const getCommitHash = (): string => {
+  if (process.env.hash) {
+    return process.env.hash;
+  }
+  const hash = execSync('(git rev-parse HEAD | cut -c 1-12) || false').toString();
+  return hash.substr(0, 12);
 };
 
 /**


### PR DESCRIPTION
Reverts aws-amplify/amplify-cli#13071, uploading pkg binaries step is now failing when there is a version conflict; see failure here https://tiny.amazon.com/s9vu3e41/IsenLink