### PR TITLE
ci: configure codeql to ignore e2e branches

### DIFF
--- a/.github/workflows/codeql-tests.yaml
+++ b/.github/workflows/codeql-tests.yaml
@@ -3,9 +3,7 @@ name: 'CodeQL Tests'
 
 on:
   push:
-    branches-ignore:
-      - run-e2e/**
-      - run-cb-e2e/**
+    branches: [dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/codeql-tests.yaml
+++ b/.github/workflows/codeql-tests.yaml
@@ -3,6 +3,9 @@ name: 'CodeQL Tests'
 
 on:
   push:
+    branches-ignore:
+      - run-e2e/**
+      - run-cb-e2e/**
   pull_request:
 
 jobs:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,6 +3,9 @@ name: 'CodeQL'
 
 on:
   push:
+      branches-ignore:
+      - run-e2e/**
+      - run-cb-e2e/**
   pull_request:
 
 jobs:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,9 +3,7 @@ name: 'CodeQL'
 
 on:
   push:
-    branches-ignore:
-      - run-e2e/**
-      - run-cb-e2e/**
+    branches: [dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,7 +3,7 @@ name: 'CodeQL'
 
 on:
   push:
-      branches-ignore:
+    branches-ignore:
       - run-e2e/**
       - run-cb-e2e/**
   pull_request:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Currently, starting e2e tests on a PR cause our CodeQL action to run again. This PR updates the action to ignore e2e branches.

https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#avoiding-unnecessary-scans-of-pull-requests

#### Description of how you validated changes
See checks below. E2e tests were intentionally cancelled.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
