### PR TITLE
ci: make region a parameter to batch script

### DIFF
--- a/scripts/cloud-cli-utils.sh
+++ b/scripts/cloud-cli-utils.sh
@@ -6,6 +6,8 @@ set -e
 set -o allexport
 source ./scripts/.env set
 
+REGION=us-east-1
+
 function authenticate {
     account_number=$1
     role_name=$2
@@ -14,7 +16,7 @@ function authenticate {
     mwinit --aea
     echo Loading account credentials for Account $account_number with Role: $role_name...
     ada cred update --profile="${profile_name}" --account="${account_number}" --role=${role_name} --provider=isengard --once
-    aws configure set region us-east-1 --profile $profile_name
+    aws configure set region $REGION --profile $profile_name
 }
 function triggerProjectBatch {
     account_number=$1
@@ -26,8 +28,8 @@ function triggerProjectBatch {
     echo AWS Account: $account_number
     echo Project: $project_name 
     echo Target Branch: $target_branch
-    RESULT=$(aws codebuild start-build-batch --profile="${profile_name}" --project-name $project_name --source-version=$target_branch \
+    RESULT=$(aws codebuild start-build-batch --region=$REGION --profile="${profile_name}" --project-name $project_name --source-version=$target_branch \
      --environment-variables-override name=BRANCH_NAME,value=$target_branch,type=PLAINTEXT \
      --query 'buildBatch.id' --output text)
-    echo "https://us-east-1.console.aws.amazon.com/codesuite/codebuild/$account_number/projects/$project_name/batch/$RESULT?region=us-east-1"
+    echo "https://$REGION.console.aws.amazon.com/codesuite/codebuild/$account_number/projects/$project_name/batch/$RESULT?region=$REGION"
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This will ensure that region is us-east-1 when requesting a codebuild job so that people who have set a different region locally don't get an error.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
