### PR TITLE
Revert "fix(amplify-frontend-ios): pass paths to command options as s…

### DIFF
--- a/packages/amplify-frontend-ios/lib/amplify-xcode.js
+++ b/packages/amplify-frontend-ios/lib/amplify-xcode.js
@@ -33,7 +33,7 @@ const amplifyXcodePath = () => path.join(pathManager.getAmplifyPackageLibDirPath
 async function importConfig(params) {
   let command = `${amplifyXcodePath()} import-config`;
   if (params['path']) {
-    command += ` --path="${params['path']}"`;
+    command += ` --path=${params['path']}`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -46,7 +46,7 @@ async function importConfig(params) {
 async function importModels(params) {
   let command = `${amplifyXcodePath()} import-models`;
   if (params['path']) {
-    command += ` --path="${params['path']}"`;
+    command += ` --path=${params['path']}`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }
@@ -59,7 +59,7 @@ async function importModels(params) {
 async function generateSchema(params) {
   let command = `${amplifyXcodePath()} generate-schema`;
   if (params['output-path']) {
-    command += ` --output-path="${params['output-path']}"`;
+    command += ` --output-path=${params['output-path']}`;
   }
   await execa.command(command, { stdout: 'inherit' });
 }


### PR DESCRIPTION
…trings (#12596)"

This reverts commit 43f73ab268c2c08ed31faf16989fff12ef84c46e.

https://github.com/aws-amplify/amplify-cli/issues/13104

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
