### PR TITLE
ci: use longer rc hashes

### DIFF
--- a/.circleci/cb-publish-step-1-set-versions.sh
+++ b/.circleci/cb-publish-step-1-set-versions.sh
@@ -26,5 +26,5 @@ elif [[ "$BRANCH_NAME" == "release" ]]; then
 # release candidate or local publish for testing / building binary
 else
   # create release commit and release tags
-  npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
+  npx lerna version --preid=rc.$(git rev-parse --short=15 HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
 fi

--- a/.circleci/publish-step-1-set-versions.sh
+++ b/.circleci/publish-step-1-set-versions.sh
@@ -26,5 +26,5 @@ elif [[ "$CIRCLE_BRANCH" == "release" ]]; then
 # release candidate or local publish for testing / building binary
 else
   # create release commit and release tags
-  npx lerna version --preid=rc.$(git rev-parse --short HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
+  npx lerna version --preid=rc.$(git rev-parse --short=15 HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
 fi

--- a/scripts/cloud-release.sh
+++ b/scripts/cloud-release.sh
@@ -13,7 +13,7 @@ function RCLocal {
         echo "Include the release candidate commit ref you wish to release as the first argument"
         exit 1
     fi
-    rc_sha=$(git rev-parse --short "$0")
+    rc_sha=$(git rev-parse --short=15 "$0")
     branch_name="release_rc/$rc_sha"
     git checkout -B "$branch_name" "$rc_sha"
     git push "origin" "$branch_name"
@@ -26,7 +26,7 @@ function RCBeta {
         echo "Include the release candidate commit ref you wish to release as the first argument"
         exit 1
     fi
-    rc_sha=$(git rev-parse --short "$0")
+    rc_sha=$(git rev-parse --short=15 "$0")
     branch_name="release_rc/$rc_sha"
     git checkout -B "$branch_name" "$rc_sha"
     git push "origin" "$branch_name"
@@ -68,7 +68,7 @@ function ReleaseLocal {
         echo "Include the release candidate commit ref you wish to release as the first argument"
         exit 1
     fi
-    rc_sha=$(git rev-parse --short "$0")
+    rc_sha=$(git rev-parse --short=15 "$0")
     rc_branch="release_rc/$rc_sha"
     git checkout "$rc_branch"
     git push "origin" "$rc_branch"~1:refs/heads/release
@@ -82,7 +82,7 @@ function ReleaseBeta {
         echo "Include the release candidate commit ref you wish to release as the first argument"
         exit 1
     fi
-    rc_sha=$(git rev-parse --short "$0")
+    rc_sha=$(git rev-parse --short=15 "$0")
     rc_branch="release_rc/$rc_sha"
     git checkout "$rc_branch"
     git push "origin" "$rc_branch"~1:refs/heads/release

--- a/scripts/finish-release.ts
+++ b/scripts/finish-release.ts
@@ -32,7 +32,7 @@ export class Git {
   }
 
   getShortSha(ref: string = 'HEAD'): string {
-    const command = ['git', 'rev-parse', '--short', ref];
+    const command = ['git', 'rev-parse', '--short=15', ref];
     return execa.sync(command[0], command.slice(1)).stdout.trim();
   }
 

--- a/scripts/promote-rc-codebuild.sh
+++ b/scripts/promote-rc-codebuild.sh
@@ -10,7 +10,7 @@ if [[ -z ${1+x} ]]; then
   exit 1
 fi
 
-rc_sha=$(git rev-parse --short "$1")
+rc_sha=$(git rev-parse --short=15 "$1")
 remote_name=$(git remote -v | grep "$repo_name" | head -n1 | awk '{print $1;}')
 
 if [[ -z ${remote_name+x} ]]; then

--- a/scripts/promote-rc.sh
+++ b/scripts/promote-rc.sh
@@ -21,7 +21,7 @@ if [[ -z ${1+x} ]]; then
   exit 1
 fi
 
-rc_sha=$(git rev-parse --short "$1")
+rc_sha=$(git rev-parse --short=15 "$1")
 remote_name=$(git remote -v | grep "$repo_name" | head -n1 | awk '{print $1;}')
 
 if [[ -z ${remote_name+x} ]]; then

--- a/scripts/release-rc-codebuild.sh
+++ b/scripts/release-rc-codebuild.sh
@@ -11,7 +11,7 @@ if [[ -z ${1+x} ]]; then
   exit 1
 fi
 
-rc_sha=$(git rev-parse --short "$1")
+rc_sha=$(git rev-parse --short=15 "$1")
 remote_name=$(git remote -v | grep "$repo_name" | head -n1 | awk '{print $1;}')
 
 if [[ -z ${remote_name+x} ]]; then

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -20,7 +20,7 @@ if [[ -z ${1+x} ]]; then
   exit 1
 fi
 
-rc_sha=$(git rev-parse --short "$1")
+rc_sha=$(git rev-parse --short=15 "$1")
 remote_name=$(git remote -v | grep "$repo_name" | head -n1 | awk '{print $1;}')
 
 if [[ -z ${remote_name+x} ]]; then

--- a/scripts/tag-rc.sh
+++ b/scripts/tag-rc.sh
@@ -8,7 +8,7 @@ fi
 
 rc_tag="v$(jq -r .version packages/amplify-cli/package.json)"
 commit="$(git rev-parse HEAD~1)"
-short_commit="$(git rev-parse --short HEAD~1)"
+short_commit="$(git rev-parse --short=15 HEAD~1)"
 git tag $rc_tag $commit
 # push the main release tag
 git push origin $rc_tag


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Team members run into a problem of `git rev-parse --short` yielding extra characters locally if they have more remotes connected to repository. This then impacts release scripts which are unable to find relevant RC branches when promoting RCs.

In order to reduce probability of that happening this PR increases minimum short hash size to 15 (from 10 that seems to be picked by default).


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
