### PR TITLE
ci: skip push hooks in releases

### DIFF
--- a/.circleci/cb-publish-step-4-push-to-git.sh
+++ b/.circleci/cb-publish-step-4-push-to-git.sh
@@ -5,7 +5,7 @@ git config --global user.email aws@amazon.com
 
 if [[ "$BRANCH_NAME" =~ ^tagged-release ]] || [[ "$BRANCH_NAME" =~ ^run-e2e-with-rc\/.* ]] || [[ "$BRANCH_NAME" =~ ^release_rc\/.* ]]; then
   # push release commit
-  git push origin "$BRANCH_NAME"
+  git push origin "$BRANCH_NAME" --no-verify
 
   # push release tags
   git tag --points-at HEAD | xargs git push origin
@@ -13,7 +13,7 @@ if [[ "$BRANCH_NAME" =~ ^tagged-release ]] || [[ "$BRANCH_NAME" =~ ^run-e2e-with
 # @latest release
 elif [[ "$BRANCH_NAME" == "release" ]]; then
   # push release commit
-  git push origin "$BRANCH_NAME"
+  git push origin "$BRANCH_NAME" --no-verify
 
   # push release tags
   git tag --points-at HEAD | xargs git push origin
@@ -22,13 +22,13 @@ elif [[ "$BRANCH_NAME" == "release" ]]; then
   git fetch origin main
   git checkout main
   git merge release --ff-only
-  git push origin main
+  git push origin main --no-verify
 
   # fast forward hotfix to release
   git fetch origin hotfix
   git checkout hotfix
   git merge release --ff-only
-  git push origin hotfix
+  git push origin hotfix --no-verify
 else
   echo "branch name" "$BRANCH_NAME" "did not match any branch publish rules."
   exit 1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

There's no point running push hooks in release pipelines. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
