### PR TITLE
fix: handle profile load in cognito client factory

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cognito-client.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-cognito-client.ts
@@ -9,7 +9,12 @@ export class CognitoUserPoolClientProvider {
 
   static async getInstance(context: $TSContext, options = {}): Promise<CognitoUserPoolClientProvider> {
     if (!CognitoUserPoolClientProvider.instance) {
-      const cred: AwsSecrets = await loadConfiguration(context);
+      let cred: AwsSecrets = {};
+      try {
+        cred = await loadConfiguration(context);
+      } catch (e) {
+        // ignore missing config
+      }
 
       CognitoUserPoolClientProvider.instance = new CognitoUserPoolClientProvider(cred, options);
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Handle profile load gracefully like other aws client factories do. So that they use default cred chain as fallback.

See for reference:
https://github.com/aws-amplify/amplify-cli/blob/5140bb223512c10f675e75fe8cc193e674ce796d/packages/amplify-provider-awscloudformation/src/aws-utils/aws-s3.ts#L52-L57
https://github.com/aws-amplify/amplify-cli/blob/5140bb223512c10f675e75fe8cc193e674ce796d/packages/amplify-provider-awscloudformation/src/aws-utils/aws-ssm.ts#L12-L17

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Existing E2E tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
