### PR TITLE
ci: remove skip ci flag

### DIFF
--- a/.circleci/cb-publish-step-1-set-versions.sh
+++ b/.circleci/cb-publish-step-1-set-versions.sh
@@ -14,7 +14,7 @@ if [[ "$PROJECT_NAME" == "TaggedReleaseWithoutE2E" ]]; then
     exit 1
   fi
 
-  npx lerna version --exact --preid=$NPM_TAG --conventional-commits --conventional-prerelease --yes --no-push --include-merged-tags --message "chore(release): Publish tagged release $NPM_TAG [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
+  npx lerna version --exact --preid=$NPM_TAG --conventional-commits --conventional-prerelease --yes --no-push --include-merged-tags --message "chore(release): Publish tagged release $NPM_TAG" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
 
 # @latest release
 elif [[ "$PROJECT_NAME" == "Release" ]]; then
@@ -25,10 +25,10 @@ elif [[ "$PROJECT_NAME" == "Release" ]]; then
   fi
 
   # create release commit and release tags
-  npx lerna version --exact --conventional-commits --conventional-graduate --yes --no-push --include-merged-tags --message "chore(release): Publish latest [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
+  npx lerna version --exact --conventional-commits --conventional-graduate --yes --no-push --include-merged-tags --message "chore(release): Publish latest" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
 
 # release candidate or local publish for testing / building binary
 else
   # create release commit and release tags
-  npx lerna version --preid=rc.$(git rev-parse --short=15 HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc [ci skip]" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
+  npx lerna version --preid=rc.$(git rev-parse --short=15 HEAD) --exact --conventional-prerelease --conventional-commits --yes --no-push --include-merged-tags --message "chore(release): Publish rc" --no-commit-hooks --force-publish '@aws-amplify/cli-internal'
 fi


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The `[ci skip]` flag was used by CircleCI to not run workflow after pushing release commit.
In CodeBuild we no longer trigger releases from push events, so this flag is no longer useful.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
