### PR TITLE
ci: account for merge in rc script

### DIFF
--- a/scripts/release-rc-codebuild.sh
+++ b/scripts/release-rc-codebuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-repo_name="sobolk/amplify-cli"
+repo_name="aws-amplify/amplify-cli"
 
 git remote update
 

--- a/scripts/release-rc-codebuild.sh
+++ b/scripts/release-rc-codebuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-repo_name="aws-amplify/amplify-cli"
+repo_name="sobolk/amplify-cli"
 
 git remote update
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The RC branch creation script attempts to merge main. Sometimes that merge results in extra commit added to RC branch. When that happens the RC branch name does not match RC version that we publish. This then makes RC promotion fail as scripts are looking for wrong sha. 

We used to mitigate this by hand by creating missing branch (i.e. renaming).

This PR adds an action to rc script to rename branch to match HEAD commit if needed.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested by changing upstream to fork and executing script.

**No merge commit scenario**

```
bcd0740fa72c:amplify-cli sobkamil$ ./scripts/release-rc-codebuild.sh 68a4d18fdfdd93568702e2ec96c6dde5f94da6a6
Fetching origin
Fetching upstream
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Creating release_rc/68a4d18fdfdd935 branch
Switched to and reset branch 'release_rc/68a4d18fdfdd935'
From github.com:sobolk/amplify-cli
 * branch                  main       -> FETCH_HEAD
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Already up to date.
Pushing release_rc/68a4d18fdfdd935 to origin
Running pre-push hook
Running yarn build-tests-changed
lerna notice cli v6.6.1
lerna info versioning independent
lerna notice filter changed since "dev"
lerna info Looking for changed packages since dev
lerna success run No packages found with the lifecycle script 'build-tests'
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote:
remote: Create a pull request for 'release_rc/68a4d18fdfdd935' on GitHub by visiting:
remote:      https://github.com/sobolk/amplify-cli/pull/new/release_rc/68a4d18fdfdd935
remote:
To github.com:sobolk/amplify-cli.git
 * [new branch]            release_rc/68a4d18fdfdd935 -> release_rc/68a4d18fdfdd935
```

**After mocking merge commit by adding extra commit to main**

```
bcd0740fa72c:amplify-cli sobkamil$ ./scripts/release-rc-codebuild.sh 68a4d18fdfdd93568702e2ec96c6dde5f94da6a6
Merge remote-tracking branch 'origin/main' into release_rc/68a4d18fdfdd935
Fetching origin
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 6 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), 4.42 KiB | 565.00 KiB/s, done.
From github.com:sobolk/amplify-cli
   303b9ce374..9990f4fb38  main       -> origin/main
Fetching upstream
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Creating release_rc/68a4d18fdfdd935 branch
Switched to and reset branch 'release_rc/68a4d18fdfdd935'
From github.com:sobolk/amplify-cli
 * branch                  main       -> FETCH_HEAD
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Running commit-msg hook
Running npx --no -- commitlint --edit .git/MERGE_MSG
Merge made by the 'ort' strategy.
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

 packages/amplify-graphiql-explorer/src/index.tsx | 1 +
 1 file changed, 1 insertion(+)
New commit was added to RC branch during merge, renaming branch to release_rc/d4ac8bb9ce2aa0e
Switched to a new branch 'release_rc/d4ac8bb9ce2aa0e'
Pushing release_rc/d4ac8bb9ce2aa0e to origin
Running pre-push hook
Running yarn build-tests-changed
lerna notice cli v6.6.1
lerna info versioning independent
lerna notice filter changed since "dev"
lerna info Looking for changed packages since dev

   ✔    6/6 dependent project tasks succeeded [5 read from cache]

   Hint: you can run the command with --verbose to see the full dependent project outputs

 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————


> @aws-amplify/amplify-appsync-simulator:build


> @aws-amplify/amplify-appsync-simulator:build-tests


 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  Lerna (powered by Nx)   Successfully ran target build-tests for project @aws-amplify/amplify-appsync-simulator and 7 tasks it depends on (22s)

   Nx read the output from the cache instead of running the command for 5 out of 8 tasks.

Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 10 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 389 bytes | 129.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote:
remote: Create a pull request for 'release_rc/d4ac8bb9ce2aa0e' on GitHub by visiting:
remote:      https://github.com/sobolk/amplify-cli/pull/new/release_rc/d4ac8bb9ce2aa0e
remote:
To github.com:sobolk/amplify-cli.git
 * [new branch]            release_rc/d4ac8bb9ce2aa0e -> release_rc/d4ac8bb9ce2aa0e
```

See screenshot where top commit matches rc branch name after merge
![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/12d1b8be-faaa-4dc0-8058-6077d244c62c)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
