### PR TITLE
fix: exclude tests from npm publish

### DIFF
--- a/packages/amplify-cli-logger/.npmignore
+++ b/packages/amplify-cli-logger/.npmignore
@@ -1,6 +1,4 @@
-**/__mocks__/**
 **/__tests__/**
-**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-environment-parameters/.npmignore
+++ b/packages/amplify-environment-parameters/.npmignore
@@ -1,6 +1,4 @@
-**/__mocks__/**
 **/__tests__/**
-**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-frontend-flutter/.npmignore
+++ b/packages/amplify-frontend-flutter/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-frontend-javascript/.npmignore
+++ b/packages/amplify-frontend-javascript/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-prompts/.npmignore
+++ b/packages/amplify-prompts/.npmignore
@@ -1,6 +1,4 @@
-**/__mocks__/**
 **/__tests__/**
-**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-util-mock/.npmignore
+++ b/packages/amplify-util-mock/.npmignore
@@ -1,6 +1,7 @@
 **/__mocks__/**
 **/__tests__/**
 **/__e2e__/**
+**/__e2e_v2__/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/amplify-util-uibuilder/.npmignore
+++ b/packages/amplify-util-uibuilder/.npmignore
@@ -1,6 +1,4 @@
-**/__mocks__/**
 **/__tests__/**
-**/tests/**
 src
 tsconfig.json
 tsconfig.tsbuildinfo


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

I've noticed that we ship unnecessary files to npm.
Repro:
- create any npm project `npm init`
- add latest `@aws-amplify/cli-internal` as dependency
- `npm install`
- search for `describe` (or some other test keyword) in node_modules.

![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/9ef66e54-e6f4-450c-a7c7-a007e5276e25)


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

E2E tests https://us-east-1.console.aws.amazon.com/codebuild/home?region=us-east-1#/builds/build-batch/AmplifyCLI-E2E-Testing:d4b76a83-a078-4741-b0bb-0743f81cae3b/view/new

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
