### PR TITLE
fix: remove error STRING_VALUE cannot be converted to an Integer (#12…

### DIFF
--- a/packages/amplify-category-auth/resources/adminAuth/admin-auth-cognitoActions.js
+++ b/packages/amplify-category-auth/resources/adminAuth/admin-auth-cognitoActions.js
@@ -145,6 +145,8 @@ async function getUser(username) {
 }
 
 async function listUsers(Limit, PaginationToken) {
+  Limit = parseInt(Limit);
+
   const params = {
     UserPoolId: userPoolId,
     ...(Limit && { Limit }),
@@ -168,6 +170,8 @@ async function listUsers(Limit, PaginationToken) {
 }
 
 async function listGroups(Limit, PaginationToken) {
+  Limit = parseInt(Limit);
+
   const params = {
     UserPoolId: userPoolId,
     ...(Limit && { Limit }),
@@ -191,6 +195,8 @@ async function listGroups(Limit, PaginationToken) {
 }
 
 async function listGroupsForUser(username, Limit, NextToken) {
+  Limit = parseInt(Limit);
+
   const params = {
     UserPoolId: userPoolId,
     Username: username,
@@ -218,6 +224,8 @@ async function listGroupsForUser(username, Limit, NextToken) {
 }
 
 async function listUsersInGroup(groupname, Limit, NextToken) {
+  Limit = parseInt(Limit);
+
   const params = {
     GroupName: groupname,
     UserPoolId: userPoolId,


### PR DESCRIPTION
#### Description of changes

#### Issue:

When calling the AdminQueries lambda function with the limit parameter, it returns a 500 error because the limit parameter cannot be converted to an integer.

#### Fix:

Update the code used to generate the AdminQueries lambda function by parsing the limit parameter to return an integer.

#### Change in this PR:

Added `parseInt` to `packages/amplify-category-auth/resources/adminAuth/admin-auth-cognitoActions.js` when using the Limit parameter.

#### Issue #, if available

#### Description of how you validated changes

I created a sample app and tested the following paths on the AdminQueries lambda function using the limit parameter:

* listUsers
* listGroups
* listGroupsForUser
* listUsersInGroup

They work as expected after applying my fix return the correct response with http code 200.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
