### PR TITLE
ci: fix cleanup script - stale stack detection

### DIFF
--- a/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
@@ -501,7 +501,9 @@ const getStacks = async (account: AWSAccountInfo, region: string, cbClient: Code
 const getCIJobDetails = async (build_id: string, cbClient: CodeBuild): Promise<CodeBuild.Build | undefined> => {
   const batchBuilds = await cbClient.batchGetBuilds({ ids: [build_id] }).promise();
   const buildInfo = batchBuilds?.builds?.[0];
-
+  console.log(`getCIJobDetails build_id=${build_id}`);
+  console.log(`getCIJobDetails buildInfo=${JSON.stringify(buildInfo)}`);
+  console.log(`getCIJobDetails batchBuilds?.builds=${JSON.stringify(batchBuilds?.builds)}`);
   return buildInfo;
 };
 
@@ -872,6 +874,8 @@ const deleteResources = async (
   accountIndex: number,
   staleResources: Record<string, ReportEntry>,
 ): Promise<void> => {
+  console.log(`deleteResources accountIndex=${accountIndex}`)
+  console.log(`deleteResources staleResources=${JSON.stringify(staleResources)}`)
   for (const jobId of Object.keys(staleResources)) {
     const resources = staleResources[jobId];
     if (resources.amplifyApps) {
@@ -1051,7 +1055,14 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
  * of account ids since the logs these are written to will be effectively public.
  */
 const cleanup = async (): Promise<void> => {
-  const filterPredicateStaleResources = (job: ReportEntry) => job?.cbInfo?.buildStatus === 'finished' || job.jobId === ORPHAN;
+  const filterPredicateStaleResources = (job: ReportEntry) => {
+    console.log(`filterPredicateStaleResources job?.cbInfo?.buildStatus=${job?.cbInfo?.buildStatus}`)
+    console.log(`filterPredicateStaleResources job.jobId=${job.jobId}`);
+    if(job?.cbInfo?.buildStatus){
+      console.log(`filterPredicateStaleResources job=${JSON.stringify(job)}`);
+    }
+    return job?.cbInfo?.buildStatus === 'finished' || job.jobId === ORPHAN;
+  }
   const accounts = await getAccountsToCleanup();
   for (let i = 0; i < 3; ++i) {
     console.log('CLEANUP ROUND: ', i + 1);

--- a/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
@@ -502,9 +502,7 @@ const getStacks = async (account: AWSAccountInfo, region: string, cbClient: Code
 const getCIJobDetails = async (build_id: string, cbClient: CodeBuild): Promise<CodeBuild.Build | undefined> => {
   const batchBuilds = await cbClient.batchGetBuilds({ ids: [build_id] }).promise();
   const buildInfo = batchBuilds?.builds?.[0];
-  console.log(`getCIJobDetails build_id=${build_id}`);
-  console.log(`getCIJobDetails buildInfo=${JSON.stringify(buildInfo)}`);
-  console.log(`getCIJobDetails batchBuilds?.builds=${JSON.stringify(batchBuilds?.builds)}`);
+
   return buildInfo;
 };
 
@@ -875,8 +873,6 @@ const deleteResources = async (
   accountIndex: number,
   staleResources: Record<string, ReportEntry>,
 ): Promise<void> => {
-  console.log(`deleteResources accountIndex=${accountIndex}`)
-  console.log(`deleteResources staleResources=${JSON.stringify(staleResources)}`)
   for (const jobId of Object.keys(staleResources)) {
     const resources = staleResources[jobId];
     if (resources.amplifyApps) {
@@ -1056,14 +1052,7 @@ const cleanupAccount = async (account: AWSAccountInfo, accountIndex: number, fil
  * of account ids since the logs these are written to will be effectively public.
  */
 const cleanup = async (): Promise<void> => {
-  const filterPredicateStaleResources = (job: ReportEntry) => {
-    console.log(`filterPredicateStaleResources job?.cbInfo?.buildStatus=${job?.cbInfo?.buildStatus}`)
-    console.log(`filterPredicateStaleResources job.jobId=${job.jobId}`);
-    if(job?.cbInfo?.buildStatus){
-      console.log(`filterPredicateStaleResources job=${JSON.stringify(job)}`);
-    }
-    return job?.cbInfo?.buildStatus === 'finished' || job.jobId === ORPHAN;
-  }
+  const filterPredicateStaleResources = (job: ReportEntry) => job?.cbInfo?.buildStatus === 'finished' || job.jobId === ORPHAN;
   const accounts = await getAccountsToCleanup();
   for (let i = 0; i < 3; ++i) {
     console.log('CLEANUP ROUND: ', i + 1);

--- a/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
@@ -19,8 +19,10 @@ const AWS_REGIONS_TO_RUN_TESTS = [
   'us-east-2',
   'us-west-2',
   'eu-west-2',
+  'eu-west-3',
   'eu-central-1',
   'ap-northeast-1',
+  'ap-northeast-2',
   'ap-southeast-1',
   'ap-southeast-2',
 ];

--- a/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-codebuild-resources.ts
@@ -473,10 +473,11 @@ const getStacks = async (account: AWSAccountInfo, region: string, cbClient: Code
   // eventually, we must clean up those child stacks too.
   let rootStacks = stacks.StackSummaries.filter((stack) => {
     const isRoot = !stack.RootId;
-    if (!isStale(stack.CreationTime)) {
+    const isStackStale = isStale(stack.CreationTime);
+    if (!isStackStale) {
       console.log('Skipping stack because created date is:', stack.CreationTime);
     }
-    return isRoot && isStale;
+    return isRoot && isStackStale;
   });
   if (rootStacks.length > DELETE_LIMITS.PER_REGION.CFN_STACK) {
     // we can only delete 100 stacks accross all regions every batch,

--- a/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-e2e-tests/src/cleanup-e2e-resources.ts
@@ -398,10 +398,11 @@ const getStacks = async (account: AWSAccountInfo, region: string): Promise<Stack
   // eventually, we must clean up those child stacks too.
   let rootStacks = stacks.StackSummaries.filter((stack) => {
     const isRoot = !stack.RootId;
-    if (!isStale(stack.CreationTime)) {
+    const isStackStale = isStale(stack.CreationTime);
+    if (!isStackStale) {
       console.log('Skipping stack because created date is:', stack.CreationTime);
     }
-    return isRoot && isStale;
+    return isRoot && isStackStale;
   });
   if (rootStacks.length > DELETE_LIMITS.PER_REGION.CFN_STACK) {
     // we can only delete 100 stacks accross all regions every batch,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This fixes a bug where stacks were classified as stale even if they were younger than 2hrs.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Debugged E2E workflow with https://github.com/aws-amplify/amplify-cli/commit/66c7ee7d0d64a9a2c6f2c72af3209a8c0f929211 .

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
