### PR TITLE
feat: add flag to disable gsi limit check in iterative deployments

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/graphql-resource-manager/amplify-graphql-resource-manager.ts
@@ -29,6 +29,8 @@ import { addGSI, getGSIDetails, removeGSI } from './dynamodb-gsi-helpers';
 
 import { loadConfiguration } from '../configuration-manager';
 
+export const DISABLE_GSI_LIMIT_CHECK_OPTION = 'disable-gsi-limit-check';
+
 const ROOT_LEVEL = 'root';
 const RESERVED_ROOT_STACK_TEMPLATE_STATE_KEY_NAME = '_root';
 const CONNECTION_STACK_NAME = 'ConnectionStack';
@@ -43,6 +45,7 @@ export type GQLResourceManagerProps = {
   backendDir: string;
   cloudBackendDir: string;
   rebuildAllTables?: boolean;
+  disableGSILimitCheck?: boolean;
 };
 
 /**
@@ -76,6 +79,7 @@ export class GraphQLResourceManager {
   private backendApiProjectRoot: string;
   private templateState: TemplateState;
   private rebuildAllTables = false; // indicates that all underlying model tables should be rebuilt
+  private readonly disableGSILimitCheck;
 
   public static createInstance = async (
     context: $TSContext,
@@ -89,12 +93,14 @@ export class GraphQLResourceManager {
     const apiStack = await cfn
       .describeStackResources({ StackName: StackId, LogicalResourceId: gqlResource.providerMetadata.logicalId })
       .promise();
+
     return new GraphQLResourceManager({
       cfnClient: cfn,
       resourceMeta: { ...gqlResource, stackId: apiStack.StackResources[0].PhysicalResourceId },
       backendDir: pathManager.getBackendDirPath(),
       cloudBackendDir: pathManager.getCurrentCloudBackendDirPath(),
       rebuildAllTables,
+      disableGSILimitCheck: context?.input?.options?.[DISABLE_GSI_LIMIT_CHECK_OPTION],
     });
   };
 
@@ -113,6 +119,7 @@ export class GraphQLResourceManager {
     this.cloudBackendApiProjectRoot = path.join(props.cloudBackendDir, GraphQLResourceManager.categoryName, this.resourceMeta.resourceName);
     this.templateState = new TemplateState();
     this.rebuildAllTables = props.rebuildAllTables || false;
+    this.disableGSILimitCheck = props.disableGSILimitCheck || false;
   }
 
   run = async (): Promise<DeploymentStep[]> => {
@@ -438,7 +445,7 @@ export class GraphQLResourceManager {
 
   private addGSI = (gsiRecord: GSIRecord, tableName: string, template: Template): void => {
     const table = template.Resources[tableName] as DynamoDB.Table;
-    template.Resources[tableName] = addGSI(gsiRecord, table);
+    template.Resources[tableName] = addGSI(gsiRecord, table, this.disableGSILimitCheck);
   };
 
   private deleteGSI = (indexName: string, tableName: string, template: Template): void => {


### PR DESCRIPTION
#### Description of changes
Adding a new flag to support overriding DynamoDB GSI limits for customers with limit increases in dynamodb. Also fix printing the name since in general it's not a string, but a `Ref` object.

By executing `amplify push --disable-gsi-limit-check` the limit checks will be disabled.

Relevant docs update: https://github.com/aws-amplify/docs/pull/5836

#### Issue #, if available
https://github.com/aws-amplify/amplify-category-api/issues/1812

#### Description of how you validated changes
Unit Tests, and ran w/ a `setup-dev` target, with a stubbed out low value.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
