### PR TITLE
fix(amplify-frontend-javascript): use CommonJS exports to support Node env

### DIFF
--- a/packages/amplify-frontend-javascript/lib/aws-exports.empty.js
+++ b/packages/amplify-frontend-javascript/lib/aws-exports.empty.js
@@ -3,4 +3,4 @@
 
 const awsmobile = {};
 
-export default awsmobile;
+module.exports = awsmobile;

--- a/packages/amplify-frontend-javascript/lib/aws_exports.js.ejs
+++ b/packages/amplify-frontend-javascript/lib/aws_exports.js.ejs
@@ -4,4 +4,4 @@
 const awsmobile = <%- JSON.stringify(props.configOutput, null, 4) %>;
 
 
-export default awsmobile;
+module.exports = awsmobile;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Changed the template of `aws-exports.js` file for `amplify-front-javascript` package to use CommonJS exports. This allows to import and use `aws-exports.js` in a Node environment without transpiling ES modules.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

* `yarn setup-dev` and regenerated `aws-exports.js` file and run sample app locally

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
