### PR TITLE
chore: require amplify cli admin to approve pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,7 @@
-# Amplify CLI Team owns the full repo by default.
-
-* @aws-amplify/amplify-cli
+# Require at least one Amplify CLI Admin to approve changes.
+# Non-admin reviewers participate in pull request review quorum by having write access to repository.
+* @aws-amplify/amplify-cli-admins
 
 # Add Data team folks focused on GQL transform/codegen to ownership for packages which will be migrated, in addition to the existing cli team.
-
-/packages/amplify-graphiql-explorer @aws-amplify/amplify-cli @aws-amplify/amplify-data-buildtime
-/packages/amplify-velocity-template @aws-amplify/amplify-cli @aws-amplify/amplify-data-buildtime
-
-# Add folks focused on reviewing changes to CI/CD scripts/buildspecs
-
-/.circleci/ @aws-amplify/amplify-cli-admins
-/.github/ @aws-amplify/amplify-cli-admins
-/scripts/ @aws-amplify/amplify-cli-admins
-/shared-scripts.sh @aws-amplify/amplify-cli-admins
-/codebuild_specs/ @aws-amplify/amplify-cli-admins
+/packages/amplify-graphiql-explorer @aws-amplify/amplify-cli-admins @aws-amplify/amplify-data-buildtime
+/packages/amplify-velocity-template @aws-amplify/amplify-cli-admins @aws-amplify/amplify-data-buildtime


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR changes `CODEOWNERS` file to require a member of `amplify-cli-admins` group to approve the change.

Github evaluates branch protection rules (in a form we have them) in such a way that:
1. It requires quorum (min number of reviewers) this can be anybody with write access to repo.
2. It requires a code owners to approve changes under certain paths. At least one code owner approval fulfills this requirement.

Therefore combination of rules above serves effectively as two tier approval process.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
