### PR TITLE
ci: fail fast in pr and e2e scripts

### DIFF
--- a/scripts/cloud-e2e.sh
+++ b/scripts/cloud-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 source ./scripts/cloud-cli-utils.sh
 export CURR_BRANCH=$(git branch --show-current)

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -7,7 +7,7 @@ printf 'What is your PR number ? '
 read PR_NUMBER
 
 mwinit --aea
-ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=Admin --provider=isengard --once
+ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=CodeBuildE2E --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
 --profile=cb-ci-account \
 --region us-east-1 \

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 source $scriptDir/.env set


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR is to address cases when one of commands fails in the middle of `cloud-e2e` and `cloud-pr` scripts.
Before change script was proceeding and gave confusing output like this:

```
./scripts/cloud-pr.sh: line 10: ada: command not found

The config profile (cb-ci-account) could not be found
https://us-east-1.console.aws.amazon.com/codesuite/codebuild//projects/AmplifyCLI-PR-Testing/batch/?region=us-east-1
```

I.e. absence of `ada` tool resulted in cascade of failures instead of stopping just there.

Additionally switching to less privilidged `CodeBuildE2E` role.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. Running `yarn cloud-pr` to validate this PR.
1. Tested negative case by injecting error.

```
bcd0740fa72c:amplify-cli sobkamil$ yarn cloud-pr
What is your PR number ? 23456
PIN for sobkamil:
Press the button on your U2F token...
Successfully authenticated using u2f, session cookie saved in /Users/sobkamil/.midway/cookie
Successfully signed SSH public key /Users/sobkamil/.ssh/id_ecdsa.pub. The SSH certificate was saved in /Users/sobkamil/.ssh/id_ecdsa-cert.pub
./scripts/cloud-pr.sh: line 10: adaaa: command not found
bcd0740fa72c:amplify-cli sobkamil$
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
