### PR TITLE
feat: ensure modelgen does not throw an error when running in an uninitialized directory

### DIFF
--- a/packages/amplify-cli/src/__tests__/execution-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/execution-manager.test.ts
@@ -66,6 +66,7 @@ describe('execution manager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockContext.parameters = { options: {} };
   });
 
   it.each([
@@ -92,5 +93,14 @@ describe('execution manager', () => {
     mockContext.input.command = command;
     await executeCommand(mockContext);
     expect(handleAmplifyEventMock).toBeCalledWith(mockContext, args);
+  });
+
+  it('executeCommand skips post models event when target and model-schema parameters are provided', async () => {
+    mockFs.readdirSync.mockReturnValue([]);
+    mockFs.existsSync.mockReturnValue(true);
+    mockContext.input.command = 'models';
+    mockContext.parameters.options = { target: 'javascript', 'model-schema': 'schema.graphql' };
+    await executeCommand(mockContext);
+    expect(handleAmplifyEventMock).not.toBeCalledWith(mockContext, { event: AmplifyEvent.PostCodegenModels, data: {} });
   });
 });

--- a/packages/amplify-cli/src/__tests__/execution-manager.test.ts
+++ b/packages/amplify-cli/src/__tests__/execution-manager.test.ts
@@ -5,6 +5,9 @@ import { CLIInput as CommandLineInput } from '../domain/command-input';
 import { Context } from '../domain/context';
 import { PluginInfo } from '@aws-amplify/amplify-cli-core';
 import { executeCommand } from '../execution-manager';
+import { printer } from '@aws-amplify/amplify-prompts';
+
+jest.mock('@aws-amplify/amplify-prompts');
 
 const handleAmplifyEventMock = jest.fn();
 jest.mock('../../__mocks__/faked-plugin', () => ({
@@ -95,12 +98,16 @@ describe('execution manager', () => {
     expect(handleAmplifyEventMock).toBeCalledWith(mockContext, args);
   });
 
-  it('executeCommand skips post models event when target and model-schema parameters are provided', async () => {
-    mockFs.readdirSync.mockReturnValue([]);
-    mockFs.existsSync.mockReturnValue(true);
-    mockContext.input.command = 'models';
-    mockContext.parameters.options = { target: 'javascript', 'model-schema': 'schema.graphql' };
-    await executeCommand(mockContext);
-    expect(handleAmplifyEventMock).not.toBeCalledWith(mockContext, { event: AmplifyEvent.PostCodegenModels, data: {} });
-  });
+  it.each([[AmplifyEvent.PreCodegenModels], [AmplifyEvent.PostCodegenModels]])(
+    'executeCommand skips %s when target and model-schema parameters are provided',
+    async (event) => {
+      mockFs.readdirSync.mockReturnValue([]);
+      mockFs.existsSync.mockReturnValue(true);
+      mockContext.input.command = 'models';
+      mockContext.parameters.options = { target: 'javascript', 'model-schema': 'schema.graphql' };
+      await executeCommand(mockContext);
+      expect(printer.info).toBeCalledWith(expect.stringContaining(`Skipping ${event}`));
+      expect(handleAmplifyEventMock).not.toBeCalledWith(mockContext, { event, data: {} });
+    },
+  );
 });

--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { prompter } from '@aws-amplify/amplify-prompts';
+import { printer, prompter } from '@aws-amplify/amplify-prompts';
 import { twoStringSetsAreEqual, twoStringSetsAreDisjoint } from './utils/set-ops';
 import { Context } from './domain/context';
 import { scan, getPluginsWithNameAndCommand, getPluginsWithEventHandler } from './plugin-manager';
@@ -269,6 +269,9 @@ const raisePreExportEvent = async (context: Context): Promise<void> => {
 };
 
 const raisePreCodegenModelsEvent = async (context: Context): Promise<void> => {
+  if (shouldSkipCodegenModelsEvents(context, AmplifyEvent.PreCodegenModels)) {
+    return;
+  }
   await raiseEvent(context, { event: AmplifyEvent.PreCodegenModels, data: {} });
 };
 
@@ -309,15 +312,20 @@ const raisePostPullEvent = async (context: Context): Promise<void> => {
   await raiseEvent(context, { event: AmplifyEvent.PostPull, data: {} });
 };
 
-const raisePostCodegenModelsEvent = async (context: Context): Promise<void> => {
+const shouldSkipCodegenModelsEvents = (context: Context, event: AmplifyEvent): boolean => {
   const optionsIndicatingUninitializedModelgen = ['target', 'model-schema'];
   const cliOptions = context?.parameters?.options ? new Set(Object.keys(context.parameters.options)) : new Set();
-  if (optionsIndicatingUninitializedModelgen.every((option) => cliOptions.has(option))) {
-    console.log(
-      `Skipping ${AmplifyEvent.PostCodegenModels} lifecycle event, due to presence of ${JSON.stringify(
-        optionsIndicatingUninitializedModelgen,
-      )} in context options`,
+  const skipEvents = optionsIndicatingUninitializedModelgen.every((option) => cliOptions.has(option));
+  if (skipEvents) {
+    printer.info(
+      `Skipping ${event} lifecycle event, due to presence of ${JSON.stringify(optionsIndicatingUninitializedModelgen)} in context options`,
     );
+  }
+  return skipEvents;
+};
+
+const raisePostCodegenModelsEvent = async (context: Context): Promise<void> => {
+  if (shouldSkipCodegenModelsEvents(context, AmplifyEvent.PostCodegenModels)) {
     return;
   }
   await raiseEvent(context, { event: AmplifyEvent.PostCodegenModels, data: {} });

--- a/packages/amplify-cli/src/execution-manager.ts
+++ b/packages/amplify-cli/src/execution-manager.ts
@@ -310,6 +310,16 @@ const raisePostPullEvent = async (context: Context): Promise<void> => {
 };
 
 const raisePostCodegenModelsEvent = async (context: Context): Promise<void> => {
+  const optionsIndicatingUninitializedModelgen = ['target', 'model-schema'];
+  const cliOptions = context?.parameters?.options ? new Set(Object.keys(context.parameters.options)) : new Set();
+  if (optionsIndicatingUninitializedModelgen.every((option) => cliOptions.has(option))) {
+    console.log(
+      `Skipping ${AmplifyEvent.PostCodegenModels} lifecycle event, due to presence of ${JSON.stringify(
+        optionsIndicatingUninitializedModelgen,
+      )} in context options`,
+    );
+    return;
+  }
   await raiseEvent(context, { event: AmplifyEvent.PostCodegenModels, data: {} });
 };
 


### PR DESCRIPTION
#### Description of changes
We are releasing support for codegen and modelgen without an amplify project being initialized. In order for this to work, the customer will specify a few required cli options, include the modelgen `target` (a superset of amplify frontend), `model-schema` location, and `output-dir`.

However, due to the postModelgenHook, even after a successful execution of modelgen in a non-amplify environment, we see the amplify-frontend-ios package failing due to failure to retrieve backends/paths/etc.

Because we don't generally want lifecycle hooks to fail in this modified runtime environment, I'm disabling them in general if the flags indicating running in an uninitialized state are present, and to log a message indicating this as well.

#### Issue #, if available
N/A

#### Description of how you validated changes
Updated unit tests, and verified w/ `setup-dev`.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
