### PR TITLE
fix: don't render spinner in non-TTY terminal

### DIFF
--- a/packages/amplify-prompts/src/__tests__/spinner.test.ts
+++ b/packages/amplify-prompts/src/__tests__/spinner.test.ts
@@ -1,0 +1,66 @@
+import { AmplifySpinner } from '../progressbars/spinner';
+import { AmplifyTerminal } from '../progressbars/terminal';
+
+jest.mock('../progressbars/terminal');
+const amplifyTerminalMocked = jest.mocked(AmplifyTerminal);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('in non-TTY terminal', () => {
+  beforeEach(() => {
+    jest.spyOn(AmplifyTerminal.prototype, 'isTTY').mockReturnValue(false);
+  });
+
+  it('is noop', () => {
+    const spinner = new AmplifySpinner();
+
+    spinner.start('initial message');
+    spinner.resetMessage('other message');
+    spinner.stop('last message');
+
+    expect(amplifyTerminalMocked.mock.instances.length).toEqual(1);
+    expect(AmplifyTerminal).toHaveBeenCalledTimes(1);
+    expect(amplifyTerminalMocked.mock.instances[0].writeLines).toHaveBeenCalledTimes(0);
+    expect(amplifyTerminalMocked.mock.instances[0].cursor).toHaveBeenCalledTimes(0);
+    expect(amplifyTerminalMocked.mock.instances[0].getLastHeight).toHaveBeenCalledTimes(0);
+    expect(amplifyTerminalMocked.mock.instances[0].newLine).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('in TTY terminal', () => {
+  let spinner: AmplifySpinner;
+  beforeEach(() => {
+    jest.spyOn(AmplifyTerminal.prototype, 'isTTY').mockReturnValue(true);
+    spinner = new AmplifySpinner();
+  });
+
+  afterEach(() => {
+    // always stop the spinner to clear internal timer.
+    spinner.stop();
+  });
+
+  it('starts spinner renders initial message, and stops spinner', async () => {
+    const initialMessage = 'initial message';
+    const intermediateMessage = 'intermediate message';
+    const lastMessage = 'last message';
+    spinner.start(initialMessage);
+    spinner.resetMessage(intermediateMessage);
+    // wait for default rate of 50ms plus small delta to let spinner render new message.
+    await new Promise((resolve) => setTimeout(resolve, 50 + 10));
+    spinner.stop(lastMessage);
+    expect(amplifyTerminalMocked.mock.instances.length).toEqual(1);
+    expect(AmplifyTerminal).toHaveBeenCalledTimes(1);
+    expect(amplifyTerminalMocked.mock.instances[0].writeLines).toHaveBeenCalledTimes(3);
+    expect(amplifyTerminalMocked.mock.instances[0].writeLines).toHaveBeenCalledWith([{ color: '', renderString: `⠋ ${initialMessage}` }]);
+    expect(amplifyTerminalMocked.mock.instances[0].writeLines).toHaveBeenCalledWith([
+      { color: '', renderString: `⠙ ${intermediateMessage}` },
+    ]);
+    expect(amplifyTerminalMocked.mock.instances[0].writeLines).toHaveBeenCalledWith([{ color: 'green', renderString: lastMessage }]);
+    expect(amplifyTerminalMocked.mock.instances[0].cursor).toHaveBeenCalledTimes(2);
+    expect(amplifyTerminalMocked.mock.instances[0].cursor).toHaveBeenCalledWith(false);
+    expect(amplifyTerminalMocked.mock.instances[0].getLastHeight).toHaveBeenCalledTimes(0);
+    expect(amplifyTerminalMocked.mock.instances[0].newLine).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/amplify-prompts/src/progressbars/spinner.ts
+++ b/packages/amplify-prompts/src/progressbars/spinner.ts
@@ -28,7 +28,7 @@ export class AmplifySpinner {
    * Render function
    */
   private render(): void {
-    if (!this.terminal) {
+    if (!this.terminal || !this.terminal.isTTY()) {
       return;
     }
     if (this.timer) {
@@ -52,6 +52,9 @@ export class AmplifySpinner {
     if (!this.terminal) {
       this.terminal = new AmplifyTerminal();
     }
+    if (!this.terminal.isTTY()) {
+      return;
+    }
     this.prefixText = text ? text.replace('\n', '') : this.prefixText;
     this.terminal.cursor(false);
     this.render();
@@ -61,7 +64,7 @@ export class AmplifySpinner {
    * Reset spinner message
    */
   resetMessage(text: string | null): void {
-    if (!this.terminal) {
+    if (!this.terminal || !this.terminal.isTTY()) {
       this.start(text);
       return;
     }
@@ -75,16 +78,18 @@ export class AmplifySpinner {
     if (!this.terminal) {
       return;
     }
-    const lines: TerminalLine[] = [
-      {
-        renderString: text || '',
-        color: success ? 'green' : 'red',
-      },
-    ];
+    if (this.terminal.isTTY()) {
+      const lines: TerminalLine[] = [
+        {
+          renderString: text || '',
+          color: success ? 'green' : 'red',
+        },
+      ];
 
-    clearTimeout(this.timer);
-    this.terminal.writeLines(lines);
-    this.terminal.cursor(true);
+      clearTimeout(this.timer);
+      this.terminal.writeLines(lines);
+      this.terminal.cursor(true);
+    }
     this.terminal = null;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR makes Spinner noop in non-TTY terminals.

Customers who spawn CLI process as child process or stream logs to files observe control characters and transitions in output. These are not needed in these scenarios and only obscure output.


<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. Added unit tests
2. Ran full e2e suite.
3. Manual checks
    1. Stream to logs withouth fix
    2. Stream to logs with fix
    3. push in TTY terminal to validate spinner is rendering

**Before change - log to file**
![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/b0b10b49-6b30-4263-8bc1-40ee92414424)

**After change - log to file**
![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/0be0c3b1-4bf1-4898-b71e-b333ece86694)


**TTY**
(see spinner next to "This will take few minutes", the other is harder to catch as it uploads faster).
![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/8bf7526c-f793-457f-af8e-43440c5a1c8b)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
