### PR TITLE
Remove extra space after "Build Command:"

### DIFF
--- a/packages/amplify-frontend-javascript/lib/configuration-manager.js
+++ b/packages/amplify-frontend-javascript/lib/configuration-manager.js
@@ -123,7 +123,7 @@ async function confirmFrameworkConfiguration(context) {
       {
         type: 'input',
         name: 'BuildCommand',
-        message: 'Build Command: ',
+        message: 'Build Command:',
         default: config.BuildCommand,
       },
       {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
