### PR TITLE
fix: overriden mock resource outputs are respected in amplifyconfiguration

### DIFF
--- a/packages/amplify-frontend-android/lib/amplify-config-helper.js
+++ b/packages/amplify-frontend-android/lib/amplify-config-helper.js
@@ -1,4 +1,4 @@
-function generateConfig(context, newAWSConfig) {
+function generateConfig(context, newAWSConfig, amplifyResources) {
   const metadata = context.amplify.getProjectMeta();
   const amplifyConfig = {
     UserAgent: 'aws-amplify-cli/2.0',
@@ -6,7 +6,7 @@ function generateConfig(context, newAWSConfig) {
   };
   constructAnalytics(metadata, amplifyConfig);
   constructNotifications(metadata, amplifyConfig);
-  constructApi(metadata, amplifyConfig);
+  constructApi(metadata, amplifyConfig, amplifyResources);
   // Auth plugin with entire awsconfiguration contained required for Native GA release
   constructAuth(metadata, amplifyConfig, newAWSConfig);
   constructPredictions(metadata, amplifyConfig);
@@ -85,7 +85,7 @@ function constructAnalytics(metadata, amplifyConfig) {
   }
 }
 
-function constructApi(metadata, amplifyConfig) {
+function constructApi(metadata, amplifyConfig, amplifyResources) {
   const categoryName = 'api';
   const pluginName = 'awsAPIPlugin';
   const region = metadata.providers.awscloudformation.Region;
@@ -106,10 +106,11 @@ function constructApi(metadata, amplifyConfig) {
           }
           amplifyConfig[categoryName].plugins[pluginName][r] = {
             endpointType: 'GraphQL',
-            endpoint: resourceMeta.output.GraphQLAPIEndpointOutput,
+            endpoint:
+              getAppSyncResourceOutput(amplifyResources, 'GraphQLAPIEndpointOutput') || resourceMeta.output.GraphQLAPIEndpointOutput,
             region,
             authorizationType,
-            apiKey: resourceMeta.output.GraphQLAPIKeyOutput,
+            apiKey: getAppSyncResourceOutput(amplifyResources, 'GraphQLAPIKeyOutput') || resourceMeta.output.GraphQLAPIKeyOutput,
           };
         } else if (resourceMeta.service === 'API Gateway') {
           amplifyConfig[categoryName].plugins[pluginName][r] = {
@@ -279,6 +280,13 @@ function constructGeo(metadata, amplifyConfig) {
   }
   if (placeIndexConfig.items.length > 0) {
     amplifyConfig[categoryName].plugins[pluginName]['searchIndices'] = placeIndexConfig;
+  }
+}
+
+function getAppSyncResourceOutput(amplifyResources, outputName) {
+  const appSyncResourceMapping = amplifyResources?.serviceResourceMapping?.AppSync;
+  if (appSyncResourceMapping && appSyncResourceMapping[0]) {
+    return appSyncResourceMapping[0]?.output?.[outputName];
   }
 }
 

--- a/packages/amplify-frontend-android/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-android/lib/frontend-config-creator.js
@@ -91,7 +91,7 @@ function writeToFile(filePath, fileName, configObject) {
 
 function getAmplifyConfig(context, amplifyResources, cloudAmplifyResources) {
   const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
-  return amplifyConfigHelper.generateConfig(context, newAWSConfig);
+  return amplifyConfigHelper.generateConfig(context, newAWSConfig, amplifyResources);
 }
 
 function getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources) {

--- a/packages/amplify-frontend-android/tests/amplify-config-helper.test.js
+++ b/packages/amplify-frontend-android/tests/amplify-config-helper.test.js
@@ -1,4 +1,4 @@
-const configHelper = require('../../amplify-frontend-android/lib/amplify-config-helper');
+const configHelper = require('../lib/amplify-config-helper');
 jest.mock('@aws-amplify/amplify-cli-core');
 
 const mapServiceName = 'Map';
@@ -123,6 +123,95 @@ describe('customer pinpoint configuration', () => {
         },
       },
     };
+    expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
+  });
+});
+
+describe('AppSync configuration', () => {
+  const mockContext = {
+    amplify: {
+      getProjectMeta: jest.fn(),
+    },
+  };
+  let amplifyMeta = {};
+  const expectedAmplifyConfiguration = {
+    UserAgent: 'aws-amplify-cli/2.0',
+    Version: '1.0',
+    api: {
+      plugins: {
+        awsAPIPlugin: {
+          testapi: {
+            apiKey: 'expectedApiKey',
+            authorizationType: undefined,
+            endpoint: 'expectedEndpoint',
+            endpointType: 'GraphQL',
+            region: 'us-east-1',
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    amplifyMeta = {
+      providers: {
+        awscloudformation: {
+          Region: 'us-east-1',
+        },
+      },
+      api: {
+        testapi: {
+          service: 'AppSync',
+          output: {
+            GraphQLAPIEndpointOutput: 'expectedEndpoint',
+            GraphQLAPIKeyOutput: 'expectedApiKey',
+          },
+        },
+      },
+    };
+  });
+  it('generates correct endpoint and apiKey based on outputs in Amplify meta', () => {
+    mockContext.amplify.getProjectMeta = jest.fn().mockReturnValue(amplifyMeta);
+    const amplifyConfiguration = configHelper.generateConfig(mockContext, {}, {});
+
+    const expectedAmplifyConfiguration = {
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+      api: {
+        plugins: {
+          awsAPIPlugin: {
+            testapi: {
+              apiKey: 'expectedApiKey',
+              authorizationType: undefined,
+              endpoint: 'expectedEndpoint',
+              endpointType: 'GraphQL',
+              region: 'us-east-1',
+            },
+          },
+        },
+      },
+    };
+    expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
+  });
+
+  it('generates correct endpoint and apiKey based on overriden resource outputs', () => {
+    amplifyMeta.api.testapi.output.GraphQLAPIEndpointOutput = 'notExpectedEndpoint';
+    amplifyMeta.api.testapi.output.GraphQLAPIKeyOutput = 'notExpectedEndpoint';
+    mockContext.amplify.getProjectMeta = jest.fn().mockReturnValue(amplifyMeta);
+    const amplifyResources = {
+      serviceResourceMapping: {
+        AppSync: [
+          {
+            output: {
+              GraphQLAPIEndpointOutput: 'expectedEndpoint',
+              GraphQLAPIKeyOutput: 'expectedApiKey',
+            },
+          },
+        ],
+      },
+    };
+    const amplifyConfiguration = configHelper.generateConfig(mockContext, {}, amplifyResources);
     expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
   });
 });

--- a/packages/amplify-frontend-ios/lib/frontend-config-creator.js
+++ b/packages/amplify-frontend-ios/lib/frontend-config-creator.js
@@ -81,7 +81,7 @@ function writeToFile(filePath, fileName, configObject) {
 
 function getAmplifyConfig(context, amplifyResources, cloudAmplifyResources) {
   const newAWSConfig = getNewAWSConfigObject(context, amplifyResources, cloudAmplifyResources);
-  const amplifyConfig = amplifyConfigHelper.generateConfig(context, newAWSConfig);
+  const amplifyConfig = amplifyConfigHelper.generateConfig(context, newAWSConfig, amplifyResources);
   return amplifyConfig;
 }
 

--- a/packages/amplify-frontend-ios/tests/amplify-config-helper.test.js
+++ b/packages/amplify-frontend-ios/tests/amplify-config-helper.test.js
@@ -1,4 +1,4 @@
-const configHelper = require('../../amplify-frontend-android/lib/amplify-config-helper');
+const configHelper = require('../lib/amplify-config-helper');
 jest.mock('@aws-amplify/amplify-cli-core');
 
 const mapServiceName = 'Map';
@@ -89,6 +89,11 @@ describe('generate maps and search configuration', () => {
 describe('customer pinpoint configuration', () => {
   it('generates correct notifications channel pinpoint configuration', () => {
     const amplifyMeta = {
+      providers: {
+        awscloudformation: {
+          Region: 'us-east-1',
+        },
+      },
       notifications: {
         amplifyplayground: {
           service: 'Pinpoint',
@@ -106,8 +111,14 @@ describe('customer pinpoint configuration', () => {
         },
       },
     };
-    const amplifyConfiguration = {};
-    configHelper.constructNotifications(amplifyMeta, amplifyConfiguration);
+
+    const mockContext = {
+      amplify: {
+        getProjectMeta: jest.fn().mockReturnValue(amplifyMeta),
+      },
+    };
+
+    const amplifyConfiguration = configHelper.generateConfig(mockContext, {});
 
     const expectedAmplifyConfiguration = {
       notifications: {
@@ -123,6 +134,95 @@ describe('customer pinpoint configuration', () => {
         },
       },
     };
+    expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
+  });
+});
+
+describe('AppSync configuration', () => {
+  const mockContext = {
+    amplify: {
+      getProjectMeta: jest.fn(),
+    },
+  };
+  let amplifyMeta = {};
+  const expectedAmplifyConfiguration = {
+    UserAgent: 'aws-amplify-cli/2.0',
+    Version: '1.0',
+    api: {
+      plugins: {
+        awsAPIPlugin: {
+          testapi: {
+            apiKey: 'expectedApiKey',
+            authorizationType: undefined,
+            endpoint: 'expectedEndpoint',
+            endpointType: 'GraphQL',
+            region: 'us-east-1',
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    amplifyMeta = {
+      providers: {
+        awscloudformation: {
+          Region: 'us-east-1',
+        },
+      },
+      api: {
+        testapi: {
+          service: 'AppSync',
+          output: {
+            GraphQLAPIEndpointOutput: 'expectedEndpoint',
+            GraphQLAPIKeyOutput: 'expectedApiKey',
+          },
+        },
+      },
+    };
+  });
+  it('generates correct endpoint and apiKey based on outputs in Amplify meta', () => {
+    mockContext.amplify.getProjectMeta = jest.fn().mockReturnValue(amplifyMeta);
+    const amplifyConfiguration = configHelper.generateConfig(mockContext, {}, {});
+
+    const expectedAmplifyConfiguration = {
+      UserAgent: 'aws-amplify-cli/2.0',
+      Version: '1.0',
+      api: {
+        plugins: {
+          awsAPIPlugin: {
+            testapi: {
+              apiKey: 'expectedApiKey',
+              authorizationType: undefined,
+              endpoint: 'expectedEndpoint',
+              endpointType: 'GraphQL',
+              region: 'us-east-1',
+            },
+          },
+        },
+      },
+    };
+    expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
+  });
+
+  it('generates correct endpoint and apiKey based on overriden resource outputs', () => {
+    amplifyMeta.api.testapi.output.GraphQLAPIEndpointOutput = 'notExpectedEndpoint';
+    amplifyMeta.api.testapi.output.GraphQLAPIKeyOutput = 'notExpectedEndpoint';
+    mockContext.amplify.getProjectMeta = jest.fn().mockReturnValue(amplifyMeta);
+    const amplifyResources = {
+      serviceResourceMapping: {
+        AppSync: [
+          {
+            output: {
+              GraphQLAPIEndpointOutput: 'expectedEndpoint',
+              GraphQLAPIKeyOutput: 'expectedApiKey',
+            },
+          },
+        ],
+      },
+    };
+    const amplifyConfiguration = configHelper.generateConfig(mockContext, {}, amplifyResources);
     expect(amplifyConfiguration).toMatchObject(expectedAmplifyConfiguration);
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes an issue with mocking where the local GraphQL endpoint and API key are not reflected in the `amplifyconfiguration.json` file when customer runs `amplify mock api` in iOS/Android projects. Refer to [discord customer report](https://discord.com/channels/705853757799399426/1138901502929420369/1141030405735203020) for more information.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests, check in iOS,Android samples.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
