### PR TITLE
feat(amplify-util-uibuilder): amplify js backwards compatibility

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -142,7 +142,7 @@ function verifyPkgCli {
     verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((750 * 1024 * 1024))
     verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((750 * 1024 * 1024))
     verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((750 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((600 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((660 * 1024 * 1024))
 }
 
 function unsetNpmRegistryUrl {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "resolutions": {
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "cross-fetch": "^2.2.6",
     "glob-parent": "^6.0.2",
     "got": "^11.8.5",

--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/schema": "^8.3.1",
     "@graphql-tools/utils": "^8.5.1",
     "amplify-velocity-template": "1.4.12",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "cors": "^2.8.5",
     "dataloader": "^2.0.0",

--- a/packages/amplify-category-auth/package.json
+++ b/packages/amplify-category-auth/package.json
@@ -37,7 +37,7 @@
     "amplify-headless-interface": "1.17.4",
     "amplify-util-headless-input": "1.9.15",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "axios": "^0.26.0",
     "chalk": "^4.1.1",
     "change-case": "^4.1.1",

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -31,7 +31,7 @@
     "@aws-amplify/amplify-function-plugin-interface": "1.11.0",
     "@aws-amplify/amplify-prompts": "2.8.4",
     "archiver": "^5.3.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "cloudform-types": "^4.2.0",
     "enquirer": "^2.3.6",

--- a/packages/amplify-category-geo/package.json
+++ b/packages/amplify-category-geo/package.json
@@ -32,7 +32,7 @@
     "amplify-headless-interface": "1.17.4",
     "amplify-util-headless-input": "1.9.15",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "constructs": "^10.0.5",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.21",

--- a/packages/amplify-category-notifications/package.json
+++ b/packages/amplify-category-notifications/package.json
@@ -30,7 +30,7 @@
     "@aws-amplify/amplify-environment-parameters": "1.8.2",
     "@aws-amplify/amplify-prompts": "2.8.4",
     "@aws-amplify/amplify-provider-awscloudformation": "8.6.1",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.21",

--- a/packages/amplify-category-predictions/package.json
+++ b/packages/amplify-category-predictions/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.2.7",
     "@aws-amplify/amplify-prompts": "2.8.4",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "fs-extra": "^8.1.0",
     "uuid": "^8.3.2"

--- a/packages/amplify-category-storage/package.json
+++ b/packages/amplify-category-storage/package.json
@@ -35,7 +35,7 @@
     "amplify-headless-interface": "1.17.4",
     "amplify-util-headless-input": "1.9.15",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "constructs": "^10.0.5",
     "enquirer": "^2.3.6",

--- a/packages/amplify-cli-npm/index.ts
+++ b/packages/amplify-cli-npm/index.ts
@@ -16,4 +16,4 @@ export const install = async (): Promise<void> => {
   return binary.install();
 };
 
-// force version bump to 12.5.0
+// force version bump to 12.5.1

--- a/packages/amplify-cli-npm/index.ts
+++ b/packages/amplify-cli-npm/index.ts
@@ -16,4 +16,4 @@ export const install = async (): Promise<void> => {
   return binary.install();
 };
 
-// force version bump to 12.5.1
+// force version bump to 12.6.0

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -74,7 +74,7 @@
     "amplify-nodejs-function-runtime-provider": "2.5.7",
     "amplify-python-function-runtime-provider": "2.4.30",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "ci-info": "^3.8.0",
     "cli-table3": "^0.6.0",

--- a/packages/amplify-console-integration-tests/package.json
+++ b/packages/amplify-console-integration-tests/package.json
@@ -24,7 +24,7 @@
     "@aws-amplify/amplify-cli-core": "4.2.7",
     "@aws-amplify/amplify-e2e-core": "5.3.2",
     "@types/ini": "^1.3.30",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "dotenv": "^8.2.0",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-dynamodb-simulator/package.json
+++ b/packages/amplify-dynamodb-simulator/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.2.7",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "detect-port": "^1.3.0",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -28,7 +28,7 @@
     "amplify-headless-interface": "1.17.4",
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",
     "dotenv": "^8.2.0",
     "execa": "^5.1.1",

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -42,7 +42,7 @@
     "aws-amplify": "^4.2.8",
     "aws-appsync": "^4.1.1",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "axios": "^0.26.0",
     "constructs": "^10.0.5",
     "dotenv": "^8.2.0",

--- a/packages/amplify-environment-parameters/package.json
+++ b/packages/amplify-environment-parameters/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "mkdirp": "^1.0.4",
     "ts-json-schema-generator": "~1.1.2"
   },

--- a/packages/amplify-opensearch-simulator/package.json
+++ b/packages/amplify-opensearch-simulator/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.2.7",
     "@aws-amplify/amplify-prompts": "2.8.4",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "detect-port": "^1.3.0",
     "execa": "^5.1.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -40,7 +40,7 @@
     "amplify-codegen": "^4.6.2",
     "archiver": "^5.3.0",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "bottleneck": "2.19.5",
     "chalk": "^4.1.1",
     "cloudform-types": "^4.2.0",

--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -78,7 +78,7 @@
     "amplify-nodejs-function-runtime-provider": "2.5.7",
     "aws-appsync": "^4.1.4",
     "aws-cdk-lib": "~2.80.0",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "aws-sdk-mock": "^5.8.0",
     "axios": "^0.26.0",
     "constructs": "^10.0.5",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -20,7 +20,7 @@
     "@aws-amplify/codegen-ui": "2.14.2",
     "@aws-amplify/codegen-ui-react": "2.14.2",
     "amplify-codegen": "^4.6.2",
-    "aws-sdk": "^2.1426.0",
+    "aws-sdk": "^2.1464.0",
     "fs-extra": "^8.1.0",
     "node-fetch": "^2.6.7",
     "ora": "^4.0.3",

--- a/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
@@ -316,7 +316,7 @@ describe('can generate components', () => {
       });
     });
 
-    it('should inclue dependencies', async () => {
+    it('should include dependencies', async () => {
       isDataStoreEnabledMocked.mockResolvedValue(false);
       getMetadataPromise.mockReturnValue({
         features: {

--- a/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
+++ b/packages/amplify-util-uibuilder/src/__tests__/generateComponents.test.ts
@@ -1,9 +1,9 @@
 import aws from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+import { getCodegenConfig } from 'amplify-codegen';
+import { isDataStoreEnabled } from '@aws-amplify/amplify-category-api';
 import * as utils from '../commands/utils';
 import { run } from '../commands/generateComponents';
-import { isDataStoreEnabled } from '@aws-amplify/amplify-category-api';
 import { getTransformerVersion } from '../commands/utils/featureFlags';
-import { getCodegenConfig } from 'amplify-codegen';
 import { getUiBuilderComponentsPath } from '../commands/utils/getUiBuilderComponentsPath';
 
 jest.mock('../commands/utils');
@@ -40,6 +40,10 @@ utilsMock.extractUIComponents = jest.fn().mockReturnValue(undefined);
 utilsMock.waitForSucceededJob = jest
   .fn()
   .mockReturnValue({ asset: { downloadUrl: 'amazon.com' }, statusMessage: `{\"codegenErrors\": [{\"schemaName\": \"BlogUpdateForm\"}]}` });
+utilsMock.parsePackageJsonFile = jest.fn().mockReturnValue({ dependencies: {} });
+utilsMock.getStartCodegenJobDependencies = jest
+  .fn()
+  .mockReturnValue({ '@aws-amplify/ui-react': '4.6.0', 'aws-amplify': '^5.0.2', '@aws-amplify/ui-react-storage': '^1.2.0' });
 
 jest.mock('../commands/utils/featureFlags', () => ({
   getTransformerVersion: jest.fn().mockReturnValue(2),
@@ -306,6 +310,28 @@ describe('can generate components', () => {
                   typesFilePath: '',
                 },
               },
+            }),
+          },
+        }),
+      });
+    });
+
+    it('should inclue dependencies', async () => {
+      isDataStoreEnabledMocked.mockResolvedValue(false);
+      getMetadataPromise.mockReturnValue({
+        features: {
+          ...defaultStudioFeatureFlags,
+          isGraphQLEnabled: 'true',
+        },
+      });
+      await run(context, 'PostPull');
+      expect(mockStartCodegenJob).toHaveBeenCalledWith({
+        appId: 'testAppId',
+        environmentName: 'testEnvName',
+        codegenJobToCreate: expect.objectContaining({
+          renderConfig: {
+            react: expect.objectContaining({
+              dependencies: { '@aws-amplify/ui-react': '4.6.0', 'aws-amplify': '^5.0.2', '@aws-amplify/ui-react-storage': '^1.2.0' },
             }),
           },
         }),

--- a/packages/amplify-util-uibuilder/src/commands/utils/notifyMissingPackages.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/notifyMissingPackages.ts
@@ -3,44 +3,82 @@ import { printer } from '@aws-amplify/amplify-prompts';
 import fs from 'fs-extra';
 import path from 'path';
 import rangeSubset from 'semver/ranges/subset';
-import { RequiredDependency } from '@aws-amplify/codegen-ui';
-import { ReactRequiredDependencyProvider } from '@aws-amplify/codegen-ui-react';
 import { extractArgs } from './extractArgs';
+import { CodegenDependencies } from 'aws-sdk/clients/amplifyuibuilder';
 
-const getRequiredDependencies = (hasStorageManagerField?: boolean): RequiredDependency[] =>
-  new ReactRequiredDependencyProvider().getRequiredDependencies(hasStorageManagerField);
+type PackageJson = { dependencies: { [key: string]: string } };
+
+/**
+ * Returns a parsed package.json file
+ * @param context cli context object
+ * @returns A JSON object representing the package.json file in the local project
+ */
+export const parsePackageJsonFile = (context: $TSContext): PackageJson | undefined => {
+  const args = extractArgs(context);
+  const localEnvFilePath = args.localEnvFilePath ?? pathManager.getLocalEnvFilePath();
+  if (!fs.existsSync(localEnvFilePath)) {
+    printer.debug('localEnvFilePath could not be determined - skipping parsing file.');
+    return undefined;
+  }
+  const localEnvJson = JSONUtilities.readJson(localEnvFilePath);
+  const packageJsonPath = path.join((localEnvJson as $TSAny).projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    printer.debug('package.json file not found');
+    return undefined;
+  }
+  const packageJson = JSONUtilities.readJson(packageJsonPath) as PackageJson;
+  return packageJson;
+};
+
+/**
+ * Get the versions of the codegen dependencies from the package.json file
+ * @param packageJsonFile
+ * @returns codegen dependencies and versions
+ */
+export const getStartCodegenJobDependencies = (packageJsonFile: PackageJson) => {
+  const codegenDependencies: { [key: string]: string } = {};
+  ['aws-amplify', '@aws-amplify/ui-react-storage', '@aws-amplify/ui-react'].forEach((dep) => {
+    if (packageJsonFile.dependencies[dep]) {
+      codegenDependencies[dep] = packageJsonFile.dependencies[dep];
+    } else {
+      // use the latest available if there aren't any current dependencies in the project
+      codegenDependencies[dep] = 'latest';
+    }
+  });
+  return codegenDependencies;
+};
 
 /**
  * Displays a warning to the user if they have npm dependencies
  * they need to install in their application for UIBuilder components to work properly
  */
-export const notifyMissingPackages = (context: $TSContext, hasStorageManagerField?: boolean): void => {
-  const args = extractArgs(context);
-  const localEnvFilePath = args.localEnvFilePath ?? pathManager.getLocalEnvFilePath();
-  if (!fs.existsSync(localEnvFilePath)) {
-    printer.debug('localEnvFilePath could not be determined - skipping dependency notification.');
+export const notifyMissingPackages = (
+  context: $TSContext,
+  hasStorageManagerField?: boolean,
+  dependencies?: CodegenDependencies | undefined,
+): void => {
+  const packageJson = parsePackageJsonFile(context);
+  if (!packageJson) {
+    printer.debug('skipping dependency notification.');
     return;
   }
-  const localEnvJson = JSONUtilities.readJson(localEnvFilePath);
-  const packageJsonPath = path.join((localEnvJson as $TSAny).projectPath, 'package.json');
-  if (!fs.existsSync(packageJsonPath)) {
-    printer.debug('package.json file not found - skipping dependency notification.');
-    return;
-  }
-  const packageJson = JSONUtilities.readJson(packageJsonPath) as { dependencies: { [key: string]: string } };
-  getRequiredDependencies(hasStorageManagerField).forEach((dependency: $TSAny) => {
-    const packageIsInstalled = Object.keys(packageJson.dependencies).includes(dependency.dependencyName);
+
+  // don't warn about the storage dependency if the project doesn't need it
+  const dependenciesToCheck = hasStorageManagerField
+    ? dependencies
+    : dependencies?.filter((dependency) => dependency.name !== '@aws-amplify/ui-react-storage');
+
+  dependenciesToCheck?.forEach((dependency) => {
+    const packageIsInstalled = Object.keys(packageJson.dependencies).includes(`${dependency.name}`);
     if (!packageIsInstalled) {
       printer.warn(
-        `UIBuilder components require "${dependency.dependencyName}" that is not in your package.json. Run \`npm install "${dependency.dependencyName}@${dependency.supportedSemVerPattern}"\`. ${dependency.reason}`,
+        `UIBuilder components require "${dependency.name}" that is not in your package.json. Run \`npm install "${dependency.name}@${dependency.supportedVersion}"\`. ${dependency.reason}`,
       );
-    } else if (!rangeSubset(packageJson.dependencies[dependency.dependencyName], dependency.supportedSemVerPattern)) {
+    } else if (!rangeSubset(packageJson.dependencies[`${dependency.name}`], dependency.supportedVersion ?? '')) {
       printer.warn(
-        `UIBuilder components require version "${dependency.supportedSemVerPattern}" of "${
-          dependency.dependencyName
-        }". You currently are on version "${packageJson.dependencies[dependency.dependencyName]}". Run \`npm install "${
-          dependency.dependencyName
-        }@${dependency.supportedSemVerPattern}"\`. ${dependency.reason}`,
+        `UIBuilder components require version "${dependency.supportedVersion}" of "${dependency.name}". You currently are on version "${
+          packageJson.dependencies[`${dependency.name}`]
+        }". Run \`npm install "${dependency.name}@${dependency.supportedVersion}"\`. ${dependency.reason}`,
       );
     }
   });

--- a/packages/amplify-util-uibuilder/src/commands/utils/notifyMissingPackages.ts
+++ b/packages/amplify-util-uibuilder/src/commands/utils/notifyMissingPackages.ts
@@ -9,9 +9,9 @@ import { CodegenDependencies } from 'aws-sdk/clients/amplifyuibuilder';
 type PackageJson = { dependencies: { [key: string]: string } };
 
 /**
- * Returns a parsed package.json file
+ * Returns a parsed package.json file if present
  * @param context cli context object
- * @returns A JSON object representing the package.json file in the local project
+ * @returns A JSON object representing the package.json file in the local project or undefined if not found
  */
 export const parsePackageJsonFile = (context: $TSContext): PackageJson | undefined => {
   const args = extractArgs(context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,7 +114,7 @@ __metadata:
     "@types/node": ^12.12.6
     "@types/ws": ^8.2.2
     amplify-velocity-template: 1.4.12
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     cors: ^2.8.5
     dataloader: ^2.0.0
@@ -222,7 +222,7 @@ __metadata:
     amplify-headless-interface: 1.17.4
     amplify-util-headless-input: 1.9.15
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     axios: ^0.26.0
     chalk: ^4.1.1
     change-case: ^4.1.1
@@ -269,7 +269,7 @@ __metadata:
     "@aws-amplify/amplify-prompts": 2.8.4
     "@types/folder-hash": ^4.0.1
     archiver: ^5.3.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     cloudform-types: ^4.2.0
     enquirer: ^2.3.6
@@ -298,7 +298,7 @@ __metadata:
     amplify-headless-interface: 1.17.4
     amplify-util-headless-input: 1.9.15
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     constructs: ^10.0.5
     fs-extra: ^8.1.0
     lodash: ^4.17.21
@@ -342,7 +342,7 @@ __metadata:
     "@aws-amplify/amplify-environment-parameters": 1.8.2
     "@aws-amplify/amplify-prompts": 2.8.4
     "@aws-amplify/amplify-provider-awscloudformation": 8.6.1
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     fs-extra: ^8.1.0
     lodash: ^4.17.21
@@ -359,7 +359,7 @@ __metadata:
     "@aws-amplify/amplify-cli-core": 4.2.7
     "@aws-amplify/amplify-prompts": 2.8.4
     "@aws-sdk/client-rekognition": ^3.303.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     fs-extra: ^8.1.0
     uuid: ^8.3.2
@@ -378,7 +378,7 @@ __metadata:
     amplify-headless-interface: 1.17.4
     amplify-util-headless-input: 1.9.15
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     cloudform-types: ^4.2.0
     constructs: ^10.0.5
@@ -485,7 +485,7 @@ __metadata:
     "@aws-amplify/amplify-cli-core": 4.2.7
     "@aws-amplify/amplify-e2e-core": 5.3.2
     "@types/ini": ^1.3.30
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     dotenv: ^8.2.0
     execa: ^5.1.1
     fs-extra: ^8.1.0
@@ -536,7 +536,7 @@ __metadata:
     amplify-headless-interface: 1.17.4
     aws-amplify: ^4.2.8
     aws-appsync: ^4.1.1
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     dotenv: ^8.2.0
     execa: ^5.1.1
@@ -563,7 +563,7 @@ __metadata:
   dependencies:
     "@aws-amplify/amplify-cli-core": 4.2.7
     ajv: ^6.12.6
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     lodash: ^4.17.21
     mkdirp: ^1.0.4
     ts-json-schema-generator: ~1.1.2
@@ -766,7 +766,7 @@ __metadata:
     "@aws-amplify/amplify-prompts": 2.8.4
     "@types/node": ^12.12.6
     "@types/openpgp": ^4.4.19
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     detect-port: ^1.3.0
     execa: ^5.1.1
     fs-extra: ^8.1.0
@@ -814,7 +814,7 @@ __metadata:
     amplify-codegen: ^4.6.2
     archiver: ^5.3.0
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     bottleneck: 2.19.5
     chalk: ^4.1.1
     cloudform-types: ^4.2.0
@@ -906,7 +906,7 @@ __metadata:
     amplify-storage-simulator: 1.11.0
     aws-appsync: ^4.1.4
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     aws-sdk-mock: ^5.8.0
     axios: ^0.26.0
     chokidar: ^3.5.3
@@ -952,7 +952,7 @@ __metadata:
     "@types/semver": ^7.1.0
     "@types/tiny-async-pool": ^2.0.0
     amplify-codegen: ^4.6.2
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     fs-extra: ^8.1.0
     node-fetch: ^2.6.7
     ora: ^4.0.3
@@ -1123,7 +1123,7 @@ __metadata:
     amplify-nodejs-function-runtime-provider: 2.5.7
     amplify-python-function-runtime-provider: 2.4.30
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     chalk: ^4.1.1
     ci-info: ^3.8.0
     cli-table3: ^0.6.0
@@ -13973,7 +13973,7 @@ __metadata:
   resolution: "amplify-dynamodb-simulator@workspace:packages/amplify-dynamodb-simulator"
   dependencies:
     "@aws-amplify/amplify-cli-core": 4.2.7
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     detect-port: ^1.3.0
     execa: ^5.1.1
     fs-extra: ^8.1.0
@@ -14016,7 +14016,7 @@ __metadata:
     aws-amplify: ^4.2.8
     aws-appsync: ^4.1.1
     aws-cdk-lib: ~2.80.0
-    aws-sdk: ^2.1426.0
+    aws-sdk: ^2.1464.0
     axios: ^0.26.0
     constructs: ^10.0.5
     dotenv: ^8.2.0
@@ -14922,9 +14922,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1426.0":
-  version: 2.1426.0
-  resolution: "aws-sdk@npm:2.1426.0"
+"aws-sdk@npm:^2.1464.0":
+  version: 2.1464.0
+  resolution: "aws-sdk@npm:2.1464.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -14936,7 +14936,7 @@ __metadata:
     util: ^0.12.4
     uuid: 8.0.0
     xml2js: 0.5.0
-  checksum: 4d79be6a7ea7436989d8dc183f4a5a881a8935e8ab93270b6c1d5caac7f93e640b979c48a0af2569a9b063175ec3137427ba8a6545cada1f858b938d3cbab46b
+  checksum: 042485e757a035fb0486a7010897073a2919e561e1f54da68dc2cc5d81fe710bf9c57a4914bbece554a42efc4170acbdc52f9308d5d845ae09b4b6e64b31455a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes

Update the StartCodegenJob operation to be backwards compatible for amplify js. StartCodegenJob is now passed the relevant local project dependencies for codegen to know which version of amplify js to codegen.

E.g. If the local project has a dependecy of `aws-amplify ^5.0.2`, then codegen will generate v5 compatible code. If there are no dependencies yet, codegen will generate the latest code available and recommend to install the dependencies.

Linux threshold increase:

The new aws-sdk version is needed to finish the feature. It also triggered the linux arm compressed threshold to be crossed. This increases the limit so it can pass.

#### Issue #, if available

NA

#### Description of how you validated changes

Unit test
Testing against a personal app
Currently running e2e tests, I'll update when they complete here.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
