### PR TITLE
fix: add retained secrets to syncSecretDeltas

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
       "@yarn/plugin-typescript"
     ]
   },
-  "packageManager": "yarn@3.6.4",
+  "packageManager": "yarn@3.5.0",
   "resolutions": {
     "aws-sdk": "^2.1464.0",
     "cross-fetch": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
       "@yarn/plugin-typescript"
     ]
   },
-  "packageManager": "yarn@3.6.3",
+  "packageManager": "yarn@3.6.4",
   "resolutions": {
     "aws-sdk": "^2.1464.0",
     "cross-fetch": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
       "@yarn/plugin-typescript"
     ]
   },
-  "packageManager": "yarn@3.5.0",
+  "packageManager": "yarn@3.6.3",
   "resolutions": {
     "aws-sdk": "^2.1464.0",
     "cross-fetch": "^2.2.6",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Intentionally add secrets already in the cloud with `operation: 'retain'` when syncing secret deltas, this will ensure local secrets do not get removed and the removal pushed to the cloud.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manual validation:
1. `amplify-dev init -y`
2. `amplify-dev add function` - Add function with 1 secret
3. `amplify-dev push`
4. `amplify-dev env add devtwo` - Add another env
5. `amplify-dev push` - Push function with 1 secret to new env
6. `amplify-dev function configure` - Add new secret
7. `amplify-dev push` - Push new secret to env devtwo
8. `amplify-dev env checkout dev` - Switch to dev env, function locally still has 2 secrets
9. `amplify-dev push` - Push new secret, observe old secret still exists

Add and run new e2e test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
