### PR TITLE
fix: set awscloudformation flag to false in vscode settings after override

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/init_e.test.ts
@@ -40,12 +40,21 @@ describe('amplify init e', () => {
     expect(meta.Region).toBeDefined();
     const { AuthRoleName, UnauthRoleName, UnauthRoleArn, AuthRoleArn, DeploymentBucketName } = meta;
 
+    // test default vscode settings.json for awscloudformation folder
+    const editorSettingsPath = path.join(projRoot, '.vscode', 'settings.json');
+    const editorSettings = fs.readJSONSync(editorSettingsPath);
+    expect(editorSettings['files.exclude']['amplify/backend/awscloudformation']).toEqual(true);
+
     await expect(UnauthRoleName).toBeIAMRoleWithArn(UnauthRoleArn);
     await expect(AuthRoleName).toBeIAMRoleWithArn(AuthRoleArn);
     await expect(DeploymentBucketName).toBeAS3Bucket(DeploymentBucketName);
 
     // override new env
     await amplifyOverrideRoot(projRoot, { testingWithLatestCodebase: false });
+
+    // test awscloudformation folder is not excluded in vscode settings.json after override
+    const editorSettingsAfterOverride = fs.readJSONSync(editorSettingsPath);
+    expect(editorSettingsAfterOverride['files.exclude']['amplify/backend/awscloudformation']).toEqual(false);
 
     // this is where we will write overrides to
     const destOverrideFilePath = path.join(projRoot, 'amplify', 'backend', 'awscloudformation', 'override.ts');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

After running `amplify override`, if the VS Code `settings.json` file exists, set the exclude flag for the awscloudformation folder (where the `override.ts` file is created) to `false` from `true` so users can see the file in VS Code.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manual verification and updated e2e test to assert the flag is properly changed after override.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
