### PR TITLE
fix: populate custom resources CDK stacks with region and account (#12575)

### DIFF
--- a/packages/amplify-category-custom/src/__tests__/utils/generate-cfn-from-cdk.test.ts
+++ b/packages/amplify-category-custom/src/__tests__/utils/generate-cfn-from-cdk.test.ts
@@ -1,0 +1,26 @@
+import { getCDKProps } from '../../utils/generate-cfn-from-cdk';
+
+describe('generate-cfn-from-cdk', () => {
+  describe('getCDKProps', () => {
+    beforeEach(() => {
+      process.env = {};
+    });
+
+    test('should return undefined if CDK env vars are not set', () => {
+      const actual = getCDKProps();
+      expect(actual).toBeUndefined();
+    });
+
+    test('should return cdk props with env set', () => {
+      process.env = {
+        CDK_DEFAULT_ACCOUNT: 'some_account_id',
+        CDK_DEFAULT_REGION: 'us-east-1',
+      };
+
+      const actual = getCDKProps();
+
+      expect(actual.env?.account).toEqual('some_account_id');
+      expect(actual.env?.region).toEqual('us-east-1');
+    });
+  });
+});

--- a/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
+++ b/packages/amplify-category-custom/src/utils/generate-cfn-from-cdk.ts
@@ -2,11 +2,24 @@ import * as cdk from 'aws-cdk-lib';
 import { JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
 import * as path from 'path';
 import { categoryName } from './constants';
+import { StackProps } from '@aws-cdk/core';
 
 export type AmplifyResourceProps = {
   category: string;
   resourceName: string;
 };
+
+export function getCDKProps(): StackProps {
+  if (process.env.CDK_DEFAULT_ACCOUNT || process.env.CDK_DEFAULT_REGION) {
+    return {
+      env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+      },
+    };
+  }
+  return {};
+}
 
 export async function generateCloudFormationFromCDK(resourceName: string) {
   const targetDir = pathManager.getResourceDirectoryPath(undefined, categoryName, resourceName);
@@ -14,7 +27,7 @@ export async function generateCloudFormationFromCDK(resourceName: string) {
 
   const amplifyResourceProps: AmplifyResourceProps = { category: categoryName, resourceName };
 
-  const customStack: cdk.Stack = new cdkStack(undefined, undefined, undefined, amplifyResourceProps);
+  const customStack: cdk.Stack = new cdkStack(undefined, undefined, getCDKProps(), amplifyResourceProps);
 
   // @ts-ignore
   JSONUtilities.writeJson(path.join(targetDir, 'build', `${resourceName}-cloudformation-template.json`), customStack._toCloudFormation());

--- a/packages/amplify-e2e-tests/custom-resources/barebone-cdk-stack.ts
+++ b/packages/amplify-e2e-tests/custom-resources/barebone-cdk-stack.ts
@@ -1,0 +1,35 @@
+import * as cdk from 'aws-cdk-lib';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Construct } from 'constructs';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
+export class cdkStack extends cdk.Stack {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(scope: Construct, id: string, props?: cdk.StackProps, amplifyResourceProps?: AmplifyHelpers.AmplifyResourceProps) {
+    super(scope, id, props);
+    /* Do not remove - Amplify CLI automatically injects the current deployment environment in this input parameter */
+    new cdk.CfnParameter(this, 'env', {
+      type: 'String',
+      description: 'Current Amplify CLI env name',
+    });
+    /* AWS CDK code goes here - learn more: https://docs.aws.amazon.com/cdk/latest/guide/home.html */
+
+    ec2.Vpc.fromLookup(this, 'VPC', {
+      isDefault: true,
+    });
+
+    const queue = new sqs.Queue(this, 'sqs-queue');
+    // 👇 create sns topic
+    const topic = new sns.Topic(this, 'sns-topic');
+
+    // 👇 subscribe queue to topic
+    topic.addSubscription(new subs.SqsSubscription(queue));
+
+    // creation of resources inside the VPC
+  }
+}


### PR DESCRIPTION
#### Description of changes
Custom resource should populate with region and account from CDK default variables.

https://docs.aws.amazon.com/cdk/v2/guide/environments.html

#### Issue #, if available
[#12575](https://github.com/aws-amplify/amplify-cli/issues/12575)

#### Description of how you validated changes
Manual testing, unit test & e2e tests added

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
