### PR TITLE
'amplify init' ignores specified profile

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -95,9 +95,8 @@ export const getProfiledAwsConfig = async (
       // need to force AWS_SDK_LOAD_CONFIG to a truthy value to force ProcessCredentials to prefer the credential process in ~/.aws/config instead of ~/.aws/credentials
       const sdkLoadConfigOriginal = process.env.AWS_SDK_LOAD_CONFIG;
       process.env.AWS_SDK_LOAD_CONFIG = '1';
-      const chain = new CredentialProviderChain();
       const processProvider = () => new ProcessCredentials({ profile: profileName });
-      chain.providers.push(processProvider);
+      const chain = new CredentialProviderChain([processProvider]);
 
       const credentials = await chain.resolvePromise();
       awsConfigInfo = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Following code seems wrong.

https://github.com/aws-amplify/amplify-cli/blob/989ec35be4dfd2bea19ea82bbe317f212729950f/packages/amplify-provider-awscloudformation/src/system-config-manager.ts#L98-L100

This specifies credential provider to load credential of named profile.
But `providers.push` **appends** provider to [defaultProviders](https://docs.aws.amazon.com/ja_jp/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property).
consequently, specified provider runs after defaultProviders processed.

It causes use of unexpected credential (in my case, default profile is used to create stack instead of specified profile).

#### Issue #3, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
