### PR TITLE
fix: parse cognito pools with service role

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
@@ -93,7 +93,7 @@ describe('transformer predictions migration test', () => {
     expect(translateResult.errors).toBeUndefined();
     expect(translateResult.data).toBeDefined();
     expect((translateResult.data as any).translateThis).toMatch(
-      /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b))/i,
+      /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b)|(\bStimmentest\b))/i,
     );
 
     speakResult = await appSyncClient.query({

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/predictions-migration.test.ts
@@ -55,7 +55,7 @@ describe('transformer predictions migration test', () => {
     expect(translateResult.errors).toBeUndefined();
     expect(translateResult.data).toBeDefined();
     expect((translateResult.data as any).translateThis).toMatch(
-      /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b))/i,
+      /((\bDies\b)|(\bdas\b)|(\bder\b)) ist ein ((\bStimmtest\b)|(\Sprachtest\b)|(\bStimmentest\b))/i,
     );
 
     const speakQuery = /* GraphQL */ `

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
@@ -7,6 +7,8 @@ let mockCognitoIdentityRoles = {
   unauthenticated: 'arn:aws:iam::123456789012:role/service-role/my-unauth-role',
 };
 
+const iamRoleNameRegex = /[\w+=,.@-]+/;
+
 jest.mock('aws-sdk', () => {
   return {
     CognitoIdentity: jest.fn(() => {
@@ -37,8 +39,8 @@ describe('IdentityPoolService', () => {
 
     // ensure role names match regex for IAM
     // see: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html
-    expect(identityPoolRoles.authRoleName).toMatch(/[\w+=,.@-]+/);
-    expect(identityPoolRoles.unauthRoleName).toMatch(/[\w+=,.@-]+/);
+    expect(identityPoolRoles.authRoleName).toMatch(iamRoleNameRegex);
+    expect(identityPoolRoles.unauthRoleName).toMatch(iamRoleNameRegex);
 
     expect(identityPoolRoles).toEqual({
       authRoleArn: 'arn:aws:iam::123456789012:role/service-role/my-auth-role',
@@ -59,8 +61,8 @@ describe('IdentityPoolService', () => {
 
     // ensure role names match regex for IAM
     // see: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html
-    expect(identityPoolRoles.authRoleName).toMatch(/[\w+=,.@-]+/);
-    expect(identityPoolRoles.unauthRoleName).toMatch(/[\w+=,.@-]+/);
+    expect(identityPoolRoles.authRoleName).toMatch(iamRoleNameRegex);
+    expect(identityPoolRoles.unauthRoleName).toMatch(iamRoleNameRegex);
 
     expect(identityPoolRoles).toEqual({
       authRoleArn: 'arn:aws:iam::123456789012:role/my-auth-role',

--- a/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/aws-utils/IdentityPoolService.test.ts
@@ -33,11 +33,18 @@ jest.mock('../../configuration-manager', () => {
 describe('IdentityPoolService', () => {
   it('should correctly parse arn if it contains multiple forward slashes', async () => {
     const idpService = await createIdentityPoolService({} as unknown as $TSContext, {});
-    expect(await idpService.getIdentityPoolRoles('mockIdpId')).toEqual({
+    const identityPoolRoles = await idpService.getIdentityPoolRoles('mockIdpId');
+
+    // ensure role names match regex for IAM
+    // see: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html
+    expect(identityPoolRoles.authRoleName).toMatch(/[\w+=,.@-]+/);
+    expect(identityPoolRoles.unauthRoleName).toMatch(/[\w+=,.@-]+/);
+
+    expect(identityPoolRoles).toEqual({
       authRoleArn: 'arn:aws:iam::123456789012:role/service-role/my-auth-role',
-      authRoleName: 'service-role/my-auth-role',
+      authRoleName: 'my-auth-role',
       unauthRoleArn: 'arn:aws:iam::123456789012:role/service-role/my-unauth-role',
-      unauthRoleName: 'service-role/my-unauth-role',
+      unauthRoleName: 'my-unauth-role',
     });
   });
 
@@ -48,7 +55,14 @@ describe('IdentityPoolService', () => {
       unauthenticated: 'arn:aws:iam::123456789012:role/my-unauth-role',
     };
 
-    expect(await idpService.getIdentityPoolRoles('mockIdpId')).toEqual({
+    const identityPoolRoles = await idpService.getIdentityPoolRoles('mockIdpId');
+
+    // ensure role names match regex for IAM
+    // see: https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html
+    expect(identityPoolRoles.authRoleName).toMatch(/[\w+=,.@-]+/);
+    expect(identityPoolRoles.unauthRoleName).toMatch(/[\w+=,.@-]+/);
+
+    expect(identityPoolRoles).toEqual({
       authRoleArn: 'arn:aws:iam::123456789012:role/my-auth-role',
       authRoleName: 'my-auth-role',
       unauthRoleArn: 'arn:aws:iam::123456789012:role/my-unauth-role',

--- a/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
+++ b/packages/amplify-provider-awscloudformation/src/aws-utils/IdentityPoolService.ts
@@ -104,7 +104,7 @@ export class IdentityPoolService implements IIdentityPoolService {
       const fullRoleName = parseArn(arn).resource;
       const parts = fullRoleName.split('/');
       if (parts.length >= 2) {
-        resourceName = parts.slice(1).join('/');
+        resourceName = [...parts].pop();
       }
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Correctly parse Cognito user/identity pools with `service-role` prepended (e.g. `arn:aws:iam::<account-id>:role/service-role/roleName`).

#### Issue #, if available

#13345

#### Description of how you validated changes

Manually with `amplify-dev import auth` and Cognito user/identity pools with `service-role`.
Updated unit tests and added IAM regex validation for roles.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
