### PR TITLE
Renamed map and mapper properties to __map and __mapper, to avoid conflicts with graphql schemas containing those properties

### DIFF
--- a/packages/amplify-appsync-simulator/src/velocity/value-mapper/map.ts
+++ b/packages/amplify-appsync-simulator/src/velocity/value-mapper/map.ts
@@ -3,67 +3,67 @@ import { JavaInteger } from './integer';
 import { toJSON } from './to-json';
 
 export class JavaMap {
-  private map: Map<string, any>;
+  private __map: Map<string, any>;
   // eslint-disable-next-line @typescript-eslint/ban-types
-  private mapper: Function;
+  private __mapper: Function;
   constructor(obj, mapper) {
-    this.mapper = mapper;
-    this.map = new Map();
+    this.__mapper = mapper;
+    this.__map = new Map();
     Object.entries(obj).forEach(([key, value]) => {
-      this.map.set(key, value);
+      this.__map.set(key, value);
     });
   }
 
   clear() {
-    this.map.clear();
+    this.__map.clear();
   }
 
   containsKey(key) {
-    return this.map.has(key);
+    return this.__map.has(key);
   }
 
   containsValue(value) {
-    return Array.from(this.map.values()).indexOf(value) !== -1;
+    return Array.from(this.__map.values()).indexOf(value) !== -1;
   }
 
   entrySet() {
-    const entries = Array.from(this.map.entries()).map(([key, value]) =>
+    const entries = Array.from(this.__map.entries()).map(([key, value]) =>
       createMapProxy(
         new JavaMap(
           {
             key,
             value,
           },
-          this.mapper,
+          this.__mapper,
         ),
       ),
     );
 
-    return new JavaArray(entries, this.mapper);
+    return new JavaArray(entries, this.__mapper);
   }
 
   equals(value) {
-    return Array.from(this.map.entries()).every(([key, v]) => value.get(key) === v);
+    return Array.from(this.__map.entries()).every(([key, v]) => value.get(key) === v);
   }
 
   get(key) {
-    if (this.map.has(key.toString())) {
-      return this.map.get(key.toString());
+    if (this.__map.has(key.toString())) {
+      return this.__map.get(key.toString());
     }
     return null;
   }
 
   isEmpty() {
-    return this.map.size === 0;
+    return this.__map.size === 0;
   }
 
   keySet() {
-    return new JavaArray(Array.from(this.map.keys()).map(this.mapper as any), this.mapper);
+    return new JavaArray(Array.from(this.__map.keys()).map(this.__mapper as any), this.__mapper);
   }
 
   put(key, value) {
-    const saveValue = this.mapper(value);
-    this.map.set(key, saveValue);
+    const saveValue = this.__mapper(value);
+    this.__map.set(key, saveValue);
     return saveValue;
   }
 
@@ -75,24 +75,24 @@ export class JavaMap {
   }
 
   remove(key) {
-    if (!this.map.has(key)) {
+    if (!this.__map.has(key)) {
       return null;
     }
-    const value = this.map.get(key);
-    this.map.delete(key);
+    const value = this.__map.get(key);
+    this.__map.delete(key);
     return value;
   }
 
   size() {
-    return new JavaInteger(this.map.size);
+    return new JavaInteger(this.__map.size);
   }
 
   values() {
-    return new JavaArray(Array.from(this.map.values()), this.mapper);
+    return new JavaArray(Array.from(this.__map.values()), this.__mapper);
   }
 
   toJSON() {
-    return Array.from(this.map.entries()).reduce(
+    return Array.from(this.__map.entries()).reduce(
       (sum, [key, value]) => ({
         ...sum,
         [key]: toJSON(value),
@@ -105,14 +105,14 @@ export class JavaMap {
 export function createMapProxy(map) {
   return new Proxy(map, {
     get(obj, prop) {
-      if (map.map.has(prop)) {
+      if (map.__map.has(prop)) {
         return map.get(prop);
       }
       return map[prop];
     },
     set(obj, prop, val) {
       if (typeof val !== 'function') {
-        map.map.set(prop, val);
+        map.__map.set(prop, val);
       }
       return true;
     },


### PR DESCRIPTION
#### Description of changes

This PR addresses the issue reported in https://github.com/aws-amplify/amplify-category-api/issues/1676, where any valid Graphql schema containing a property called either `map` or `mapper` will crash without error in the appsync simulator.

#### Issue #, if available

https://github.com/aws-amplify/amplify-category-api/issues/1676

#### Description of how you validated changes

The problem is that the velocity implementation stores the graphql data in an object that also has private objects called generic names. The fix is to name them with a double-underscore to indicate they are not part of userland payloads. 

#### Testing

I have run the current test suite, but have not written a new test for this change.

I have also been using this locally on a production schema for a few months and it's working as intended. In fact, I rely upon it :-) 

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [X] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
