### PR TITLE
test: use test profile name

### DIFF
--- a/packages/amplify-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-e2e-core/src/init/amplifyPull.ts
@@ -166,8 +166,7 @@ export const amplifyStudioHeadlessPull = (
     awscloudformation: {
       configLevel: 'project',
       useProfile: true,
-      // eslint-disable-next-line spellcheck/spell-checker
-      profileName: profileName ?? 'amplify-integ-test-user',
+      profileName: profileName ?? TEST_PROFILE_NAME,
     },
   };
   const args = ['pull', '--amplify', JSON.stringify({ appId, envName }), '--providers', JSON.stringify(providersConfig), '--yes'];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Modify `amplifyStudioHeadlessPull` to use `TEST_PROFILE_NAME` so that it works with `default` profile locally.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

running test locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
