### PR TITLE
chore: bump api category to 5.7.7

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@aws-amplify/amplify-app": "5.0.22",
     "@aws-amplify/amplify-category-analytics": "5.0.22",
-    "@aws-amplify/amplify-category-api": "^5.7.6",
+    "@aws-amplify/amplify-category-api": "^5.7.7",
     "@aws-amplify/amplify-category-auth": "3.7.1",
     "@aws-amplify/amplify-category-custom": "3.1.10",
     "@aws-amplify/amplify-category-function": "5.6.1",

--- a/packages/amplify-container-hosting/package.json
+++ b/packages/amplify-container-hosting/package.json
@@ -26,7 +26,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.7.6",
+    "@aws-amplify/amplify-category-api": "^5.7.7",
     "@aws-amplify/amplify-cli-core": "4.2.10",
     "@aws-amplify/amplify-environment-parameters": "1.9.1",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.7.6",
+    "@aws-amplify/amplify-category-api": "^5.7.7",
     "@aws-amplify/amplify-cli-core": "4.2.10",
     "@aws-amplify/amplify-prompts": "2.8.4",
     "@aws-amplify/codegen-ui": "2.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,9 +152,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-amplify/amplify-category-api@npm:^5.7.6":
-  version: 5.7.6
-  resolution: "@aws-amplify/amplify-category-api@npm:5.7.6"
+"@aws-amplify/amplify-category-api@npm:^5.7.7":
+  version: 5.7.7
+  resolution: "@aws-amplify/amplify-category-api@npm:5.7.7"
   dependencies:
     "@aws-amplify/graphql-auth-transformer": 3.1.9
     "@aws-amplify/graphql-schema-generator": 0.4.8
@@ -202,7 +202,7 @@ __metadata:
     amplify-util-headless-input: ^1.9.15
     aws-cdk-lib: ^2.80.0
     constructs: ^10.0.5
-  checksum: 5afaa811602ad18dbc44512ab56901f0d202676a92acf736e672ca72f72a3fc77f80e7f51fef27cc9cb410d3874ba00d647df035b6684acbf99853ca4d8428b2
+  checksum: 8bf174ae4ddbe769bcbe16d0efffff9f86b91514255aea8f8cd1b2544eba086f8e9c297e88668640a7d775d8ad7f5d2387f93c99b40992d8ae45f8f0574df16e
   languageName: node
   linkType: hard
 
@@ -502,7 +502,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-container-hosting@workspace:packages/amplify-container-hosting"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.7.6
+    "@aws-amplify/amplify-category-api": ^5.7.7
     "@aws-amplify/amplify-cli-core": 4.2.10
     "@aws-amplify/amplify-environment-parameters": 1.9.1
     fs-extra: ^8.1.0
@@ -941,7 +941,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-util-uibuilder@workspace:packages/amplify-util-uibuilder"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.7.6
+    "@aws-amplify/amplify-category-api": ^5.7.7
     "@aws-amplify/amplify-cli-core": 4.2.10
     "@aws-amplify/amplify-prompts": 2.8.4
     "@aws-amplify/appsync-modelgen-plugin": ^2.6.0
@@ -1072,7 +1072,7 @@ __metadata:
   dependencies:
     "@aws-amplify/amplify-app": 5.0.22
     "@aws-amplify/amplify-category-analytics": 5.0.22
-    "@aws-amplify/amplify-category-api": ^5.7.6
+    "@aws-amplify/amplify-category-api": ^5.7.7
     "@aws-amplify/amplify-category-auth": 3.7.1
     "@aws-amplify/amplify-category-custom": 3.1.10
     "@aws-amplify/amplify-category-function": 5.6.1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Added region support for HKG
Full changelog: https://github.com/aws-amplify/amplify-category-api/releases/tag/%40aws-amplify%2Famplify-category-api%405.7.7
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
