### PR TITLE
chore: upgrade aws-amplify from v4 to v6

### DIFF
--- a/packages/amplify-e2e-core/package.json
+++ b/packages/amplify-e2e-core/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-sts": "^3.303.0",
     "@aws-sdk/credential-providers": "^3.303.0",
     "amplify-headless-interface": "1.17.6",
-    "aws-amplify": "^4.2.8",
+    "aws-amplify": "^6.0.4",
     "aws-appsync": "^4.1.1",
     "aws-sdk": "^2.1464.0",
     "chalk": "^4.1.1",

--- a/packages/amplify-e2e-core/src/utils/auth-utils.ts
+++ b/packages/amplify-e2e-core/src/utils/auth-utils.ts
@@ -1,5 +1,6 @@
-import Amplify, { Auth } from 'aws-amplify';
-import AWSAppSyncClient, { AUTH_TYPE } from 'aws-appsync';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/api';
+import { signIn, signOut, resetPassword } from 'aws-amplify/auth';
 import { CognitoIdentityServiceProvider } from 'aws-sdk';
 import fs from 'fs-extra';
 import path from 'path';
@@ -72,65 +73,52 @@ export function getConfiguredCognitoClient(region = process.env.CLI_REGION): Cog
   return cognitoClient;
 }
 
-export function getConfiguredAppsyncClientCognitoAuth(url: string, region: string, user: any) {
-  return new AWSAppSyncClient({
-    url,
-    region,
-    disableOffline: true,
-    auth: {
-      type: AUTH_TYPE.AMAZON_COGNITO_USER_POOLS,
-      jwtToken: user.signInUserSession.idToken.jwtToken,
-    },
-  });
-}
-
-export function getConfiguredAppsyncClientOIDCAuth(url: string, region: string, user: any) {
-  return new AWSAppSyncClient({
-    url,
-    region,
-    disableOffline: true,
-    auth: {
-      type: AUTH_TYPE.OPENID_CONNECT,
-      jwtToken: user.signInUserSession.idToken.jwtToken,
-    },
-  });
-}
-
-export function getConfiguredAppsyncClientAPIKeyAuth(url: string, region: string, apiKey: string): any {
-  return new AWSAppSyncClient({
-    url,
-    region,
-    disableOffline: true,
-    auth: {
-      type: AUTH_TYPE.API_KEY,
-      apiKey,
-    },
-  });
-}
-
-export function getConfiguredAppsyncClientIAMAuth(url: string, region: string) {
-  return new AWSAppSyncClient({
-    url,
-    region,
-    disableOffline: true,
-    auth: {
-      type: AUTH_TYPE.AWS_IAM,
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
+export function getConfiguredAppsyncClientCognitoAuth(config, user) {
+  config.aws_appsync_authenticationType = 'AMAZON_COGNITO_USER_POOLS';
+  Amplify.configure(config, {
+    API: {
+      REST: {
+        headers: async () => {
+          return { Authorization: user.signInUserSession.idToken.jwtToken };
+        },
       },
     },
   });
+  return generateClient();
+}
+
+export function getConfiguredAppsyncClientOIDCAuth(config, user) {
+  config.aws_appsync_authenticationType = 'OPENID_CONNECT';
+  Amplify.configure(config, {
+    API: {
+      REST: {
+        headers: async () => {
+          return { Authorization: user.signInUserSession.idToken.jwtToken };
+        },
+      },
+    },
+  });
+  return generateClient();
+}
+
+export function getConfiguredAppsyncClientAPIKeyAuth(config, apiKey) {
+  config.aws_appsync_authenticationType = 'API_KEY';
+  Amplify.configure({ ...config, aws_appsync_apiKey: apiKey });
+  return generateClient();
+}
+
+export function getConfiguredAppsyncClientIAMAuth(config) {
+  Amplify.configure(config);
+  return generateClient();
 }
 
 export async function signInUser(username: string, password: string) {
-  const user = await Auth.signIn(username, password);
+  const user = await signIn({ username, password });
   return user;
 }
 
 export async function signOutUser(): Promise<void> {
-  await Auth.signOut({ global: true });
+  await signOut({ global: true });
 }
 
 export function configureAmplify(projectDir: string) {
@@ -179,10 +167,9 @@ export function getApiKey(projectDir: string): string {
 }
 
 export async function authenticateUser(username: string, tempPassword: string, password: string) {
-  const signinResult = await Auth.signIn(username, tempPassword);
-  if (signinResult.challengeName === 'NEW_PASSWORD_REQUIRED') {
-    const { requiredAttributes } = signinResult.challengeParam; // the array of required attributes, e.g [‘email’, ‘phone_number’]
-    await Auth.completeNewPassword(signinResult, password, requiredAttributes);
+  const signinResult = await signIn({ username, password: tempPassword });
+  if (signinResult.nextStep.signInStep === 'RESET_PASSWORD') {
+    await resetPassword({ username, options: { password } });
   }
 }
 

--- a/packages/amplify-e2e-tests/package.json
+++ b/packages/amplify-e2e-tests/package.json
@@ -39,7 +39,7 @@
     "amplify-dynamodb-simulator": "2.9.8",
     "amplify-headless-interface": "1.17.6",
     "amplify-storage-simulator": "1.11.3",
-    "aws-amplify": "^4.2.8",
+    "aws-amplify": "^6.0.4",
     "aws-appsync": "^4.1.1",
     "aws-cdk-lib": "~2.80.0",
     "aws-sdk": "^2.1464.0",

--- a/packages/amplify-e2e-tests/src/__tests__/auth/user-groups-s3-access.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth/user-groups-s3-access.test.ts
@@ -15,7 +15,7 @@ import {
   signOutUser,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-import { Auth } from 'aws-amplify';
+import { fetchAuthSession } from 'aws-amplify/auth';
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 
 const defaultsSettings = {
@@ -62,11 +62,11 @@ describe('user group tests', () => {
 
     // Check that user 1 can interact with S3 bucket
     await signInUser(username1, password1);
-    const user1Credentials = await Auth.currentCredentials();
+    const user1Credentials = await fetchAuthSession();
 
     const s3Client1 = new S3Client({
       region,
-      credentials: Auth.essentialCredentials(user1Credentials),
+      credentials: user1Credentials.credentials,
     });
     await s3Client1.send(
       new PutObjectCommand({
@@ -88,10 +88,10 @@ describe('user group tests', () => {
 
     // Check that user 2 does not have permissions to interact with S3 bucket
     await signInUser(username2, password2);
-    const user2Credentials = await Auth.currentCredentials();
+    const user2Credentials = await fetchAuthSession();
     const s3Client2 = new S3Client({
       region,
-      credentials: Auth.essentialCredentials(user2Credentials),
+      credentials: user2Credentials.credentials,
     });
     await expect(
       s3Client2.send(

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
@@ -61,17 +61,9 @@ describe('transformer @auth migration test', () => {
 
     let apiKey = getApiKey(projRoot);
 
-    let appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(
-      awsconfig.aws_appsync_graphqlEndpoint,
-      awsconfig.aws_appsync_region,
-      user,
-    );
-    let appSyncClientViaApiKey = getConfiguredAppsyncClientAPIKeyAuth(
-      awsconfig.aws_appsync_graphqlEndpoint,
-      awsconfig.aws_appsync_region,
-      apiKey,
-    );
-    const appSyncClientViaIAM = getConfiguredAppsyncClientIAMAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region);
+    let appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
+    let appSyncClientViaApiKey = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
+    const appSyncClientViaIAM = getConfiguredAppsyncClientIAMAuth(awsconfig);
 
     let createPostMutation = /* GraphQL */ `
       mutation CreatePost {
@@ -144,7 +136,7 @@ describe('transformer @auth migration test', () => {
     await updateApiSchema(projRoot, projectName, modelSchemaV2);
     await amplifyPushUpdate(projRoot);
 
-    appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+    appSyncClientViaUser = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
     createPostMutation = /* GraphQL */ `
       mutation CreatePost {
@@ -163,11 +155,7 @@ describe('transformer @auth migration test', () => {
     expect(createPostResult.data).toBeDefined();
 
     apiKey = getApiKey(projRoot);
-    appSyncClientViaApiKey = getConfiguredAppsyncClientAPIKeyAuth(
-      awsconfig.aws_appsync_graphqlEndpoint,
-      awsconfig.aws_appsync_region,
-      apiKey,
-    );
+    appSyncClientViaApiKey = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
     createPostPublicMutation = /* GraphQL */ `
       mutation CreatePostPublic {

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/auth-migration.test.ts
@@ -20,7 +20,6 @@ import {
   updateApiWithMultiAuth,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-import gql from 'graphql-tag';
 
 (global as any).fetch = require('node-fetch');
 
@@ -73,12 +72,9 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    let createPostResult = await appSyncClientViaUser.mutate({
-      mutation: gql(createPostMutation),
-      fetchPolicy: 'no-cache',
-    });
+    let createPostResult = (await appSyncClientViaUser.graphql({ query: createPostMutation }, { fetchPolicy: 'no-cache' })) as any;
 
-    expect(createPostResult.errors).toBeUndefined();
+    expect(createPostResult.error).toBeUndefined();
     expect(createPostResult.data).toBeDefined();
 
     let createPostPublicMutation = /* GraphQL */ `
@@ -89,10 +85,10 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    let createPostPublicResult = await appSyncClientViaApiKey.mutate({
-      mutation: gql(createPostPublicMutation),
-      fetchPolicy: 'no-cache',
-    });
+    let createPostPublicResult = (await appSyncClientViaApiKey.graphql(
+      { query: createPostPublicMutation },
+      { fetchPolicy: 'no-cache' },
+    )) as any;
 
     expect(createPostPublicResult.errors).toBeUndefined();
     expect(createPostPublicResult.data).toBeDefined();
@@ -105,10 +101,10 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    const createPostPublicIAMResult = await appSyncClientViaIAM.mutate({
-      mutation: gql(createPostPublicIAMMutation),
-      fetchPolicy: 'no-cache',
-    });
+    const createPostPublicIAMResult = (await appSyncClientViaIAM.graphql(
+      { query: createPostPublicIAMMutation },
+      { fetchPolicy: 'no-cache' },
+    )) as any;
 
     expect(createPostPublicIAMResult.errors).toBeUndefined();
     expect(createPostPublicIAMResult.data).toBeDefined();
@@ -122,10 +118,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    let createSalaryResult = await appSyncClientViaUser.mutate({
-      mutation: gql(createSalaryMutation),
-      fetchPolicy: 'no-cache',
-    });
+    let createSalaryResult = (await appSyncClientViaUser.graphql({ query: createSalaryMutation }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(createSalaryResult.errors).toBeUndefined();
     expect(createSalaryResult.data).toBeDefined();
@@ -146,10 +139,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    createPostResult = await appSyncClientViaUser.mutate({
-      mutation: gql(createPostMutation),
-      fetchPolicy: 'no-cache',
-    });
+    createPostResult = (await appSyncClientViaUser.graphql({ query: createPostMutation }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(createPostResult.errors).toBeUndefined();
     expect(createPostResult.data).toBeDefined();
@@ -165,10 +155,10 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    createPostPublicResult = await appSyncClientViaApiKey.mutate({
-      mutation: gql(createPostPublicMutation),
-      fetchPolicy: 'no-cache',
-    });
+    createPostPublicResult = (await appSyncClientViaApiKey.graphql(
+      { query: createPostPublicMutation },
+      { fetchPolicy: 'no-cache' },
+    )) as any;
 
     expect(createPostPublicResult.errors).toBeUndefined();
     expect(createPostPublicResult.data).toBeDefined();
@@ -182,10 +172,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    createSalaryResult = await appSyncClientViaUser.mutate({
-      mutation: gql(createSalaryMutation),
-      fetchPolicy: 'no-cache',
-    });
+    createSalaryResult = (await appSyncClientViaUser.graphql({ query: createSalaryMutation }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(createSalaryResult.errors).toBeUndefined();
     expect(createSalaryResult.data).toBeDefined();
@@ -201,10 +188,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    let queryResult = await appSyncClientViaUser.query({
-      query: gql(postsQuery),
-      fetchPolicy: 'no-cache',
-    });
+    let queryResult = (await appSyncClientViaUser.graphql({ query: postsQuery }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(queryResult.errors).toBeUndefined();
     expect(queryResult.data).toBeDefined();
@@ -221,10 +205,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    queryResult = await appSyncClientViaApiKey.query({
-      query: gql(postPublicsQuery),
-      fetchPolicy: 'no-cache',
-    });
+    queryResult = (await appSyncClientViaApiKey.graphql({ query: postPublicsQuery }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(queryResult.errors).toBeUndefined();
     expect(queryResult.data).toBeDefined();
@@ -240,10 +221,7 @@ describe('transformer @auth migration test', () => {
       }
     `;
 
-    queryResult = await appSyncClientViaUser.query({
-      query: gql(salaryQuery),
-      fetchPolicy: 'no-cache',
-    });
+    queryResult = (await appSyncClientViaUser.graphql({ query: salaryQuery }, { fetchPolicy: 'no-cache' })) as any;
 
     expect(queryResult.errors).toBeUndefined();
     expect(queryResult.data).toBeDefined();

--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/function-migration.test.ts
@@ -48,7 +48,7 @@ describe('api directives @function v1 to v2 migration', () => {
 
     let awsconfig = configureAmplify(projectDir);
     let apiKey = getApiKey(projectDir);
-    let appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+    let appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
     await testQueries(testModule, appSyncClient);
 
@@ -62,7 +62,7 @@ describe('api directives @function v1 to v2 migration', () => {
 
     awsconfig = configureAmplify(projectDir);
     apiKey = getApiKey(projectDir);
-    appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+    appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
     await testQueries(testModule, appSyncClient);
   });

--- a/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/common.ts
@@ -26,7 +26,7 @@ export async function runTest(projectDir: string, testModule: any) {
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);
@@ -47,7 +47,7 @@ export async function runAuthTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);
@@ -71,7 +71,7 @@ export async function runMultiAutTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/functionTester.ts
@@ -21,7 +21,7 @@ export async function runFunctionTest(projectDir: string, testModule: any) {
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testQueries(testModule, appSyncClient);
 }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
@@ -31,7 +31,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutation(appSyncClient, createPostMutation, undefined, expected_result_createPostMutation);
 }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-customClaims2.ts
@@ -32,7 +32,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutation(appSyncClient, createPostMutation, undefined, expectedResultCreatePostMutation);
 }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner10.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner10.ts
@@ -9,7 +9,7 @@ import {
   signInUser,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
@@ -33,7 +33,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner11.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner11.ts
@@ -9,7 +9,7 @@ import {
   signInUser,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';
@@ -33,11 +33,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(
-    amplifyConfig.aws_appsync_graphqlEndpoint,
-    amplifyConfig.aws_appsync_region,
-    user,
-  );
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(amplifyConfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner8.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner8.ts
@@ -30,7 +30,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
@@ -9,7 +9,7 @@ import {
   signInUser,
   updateAuthAddUserGroups,
 } from '@aws-amplify/amplify-e2e-core';
-import Amplify from 'aws-amplify';
+import { Amplify } from 'aws-amplify';
 import { testMutations, testQueries, testSubscriptions, updateSchemaInTestProject } from '../common';
 
 const GROUPNAME = 'Admin';

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-owner9.ts
@@ -33,7 +33,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
@@ -11,7 +11,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await amplifyPush(projectDir);
 
   const awsconfig = configureAmplify(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientIAMAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region);
+  const appSyncClient = getConfiguredAppsyncClientIAMAuth(awsconfig);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
@@ -9,7 +9,7 @@ export async function runTest(projectDir: string, testModule: any) {
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
@@ -11,7 +11,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await amplifyPush(projectDir);
 
   const awsconfig = configureAmplify(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientIAMAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region);
+  const appSyncClient = getConfiguredAppsyncClientIAMAuth(awsconfig);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
@@ -44,9 +44,9 @@ export async function runTest(projectDir: string, testModule: any) {
   const userPoolId = getUserPoolId(projectDir);
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
 
-  const appSyncClientIAM = getConfiguredAppsyncClientIAMAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region);
+  const appSyncClientIAM = getConfiguredAppsyncClientIAMAuth(awsconfig);
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClientOIDC = getConfiguredAppsyncClientOIDCAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClientOIDC = getConfiguredAppsyncClientOIDCAuth(awsconfig, user);
 
   //test create post mutation with private iam provider
   await testMutation(appSyncClientIAM, createPostMutation, undefined, expected_result_createPostMutation);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
@@ -15,7 +15,7 @@ export async function runTest(projectDir: string, testModule: any) {
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testQueries(testModule, appSyncClient);
 }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
@@ -35,7 +35,7 @@ export async function runTest(projectDir: string, testModule: any) {
 
     const awsconfig = configureAmplify(projectDir);
     const apiKey = getApiKey(projectDir);
-    const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+    const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
     await testQueries(testModule, appSyncClient);
   } finally {

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/function-example2.ts
@@ -40,7 +40,7 @@ export async function runTest(projectDir: string, testModule: any) {
   const userPoolId = getUserPoolId(projectDir);
   await setupUser(userPoolId, USERNAME, PASSWORD, GROUPNAME);
   const user = await signInUser(USERNAME, PASSWORD);
-  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, user);
+  const appSyncClient = getConfiguredAppsyncClientCognitoAuth(awsconfig, user);
 
   await testQueries(testModule, appSyncClient);
 }

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
@@ -281,7 +281,7 @@ export async function runTest(projectDir: string, testModule: any, appName: stri
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testMutations(testModule, appSyncClient);
   await testQueries(testModule, appSyncClient);

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -9,7 +9,6 @@ import {
   getApiKey,
   getConfiguredAppsyncClientAPIKeyAuth,
 } from '@aws-amplify/amplify-e2e-core';
-import gql from 'graphql-tag';
 
 import { updateSchemaInTestProject } from '../common';
 
@@ -25,11 +24,7 @@ export async function runTest(projectDir: string, testModule: any) {
   const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   try {
-    const result = await appSyncClient.query({
-      query: gql(query),
-      fetchPolicy: 'no-cache',
-    });
-
+    const result = (await appSyncClient.graphql({ query }, { fetchPolicy: 'no-cache' })) as any;
     expect(result).toBeDefined();
     const pollyURL = result.data.speakTranslatedImageText;
     // check that return format is a url

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -22,7 +22,7 @@ export async function runTest(projectDir: string, testModule: any) {
   await amplifyPush(projectDir);
   const apiKey = getApiKey(projectDir);
   const awsconfig = configureAmplify(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   try {
     const result = await appSyncClient.query({

--- a/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
+++ b/packages/amplify-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
@@ -10,7 +10,7 @@ export async function runTest(projectDir: string, testModule: any) {
 
   const awsconfig = configureAmplify(projectDir);
   const apiKey = getApiKey(projectDir);
-  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig.aws_appsync_graphqlEndpoint, awsconfig.aws_appsync_region, apiKey);
+  const appSyncClient = getConfiguredAppsyncClientAPIKeyAuth(awsconfig, apiKey);
 
   await testMutations(testModule, appSyncClient);
   await new Promise<void>((res) => setTimeout(() => res(), 60000));

--- a/packages/amplify-migration-tests/package.json
+++ b/packages/amplify-migration-tests/package.json
@@ -31,7 +31,7 @@
     "@aws-cdk/cloudformation-diff": "~2.68.0",
     "@aws-sdk/client-s3": "^3.303.0",
     "amplify-headless-interface": "1.17.6",
-    "aws-amplify": "^4.2.8",
+    "aws-amplify": "^6.0.4",
     "aws-cdk-lib": "~2.80.0",
     "constructs": "^10.0.5",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v12/auth-role-mapping-migration-test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v12/auth-role-mapping-migration-test.ts
@@ -19,7 +19,7 @@ import {
   updateHeadlessAuth,
 } from '@aws-amplify/amplify-e2e-core';
 import { initJSProjectWithProfileV12 } from '../../migration-helpers-v12/init';
-import { Auth } from 'aws-amplify';
+import { fetchAuthSession } from 'aws-amplify/auth';
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { UpdateAuthRequest } from 'amplify-headless-interface';
 
@@ -76,11 +76,11 @@ describe('amplify auth group mapping', () => {
 
     // Check that user 1 can interact with S3 bucket
     await signInUser(username1, password1);
-    const user1Credentials = await Auth.currentCredentials();
+    const user1Credentials = await fetchAuthSession();
 
     const s3Client1 = new S3Client({
       region,
-      credentials: Auth.essentialCredentials(user1Credentials),
+      credentials: user1Credentials.credentials,
     });
     await s3Client1.send(
       new PutObjectCommand({
@@ -102,10 +102,10 @@ describe('amplify auth group mapping', () => {
 
     // Check that user 2 does not have permissions to interact with S3 bucket
     await signInUser(username2, password2);
-    const user2Credentials = await Auth.currentCredentials();
+    const user2Credentials = await fetchAuthSession();
     const s3Client2 = new S3Client({
       region,
-      credentials: Auth.essentialCredentials(user2Credentials),
+      credentials: user2Credentials.credentials,
     });
     await expect(
       s3Client2.send(

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,7 +535,7 @@ __metadata:
     "@aws-sdk/credential-providers": ^3.303.0
     "@types/glob": ^7.1.1
     amplify-headless-interface: 1.17.6
-    aws-amplify: ^4.2.8
+    aws-amplify: ^6.0.4
     aws-appsync: ^4.1.1
     aws-sdk: ^2.1464.0
     chalk: ^4.1.1
@@ -730,7 +730,7 @@ __metadata:
     "@aws-cdk/cloudformation-diff": ~2.68.0
     "@aws-sdk/client-s3": ^3.303.0
     amplify-headless-interface: 1.17.6
-    aws-amplify: ^4.2.8
+    aws-amplify: ^6.0.4
     aws-cdk-lib: ~2.80.0
     constructs: ^10.0.5
     fs-extra: ^8.1.0
@@ -962,56 +962,56 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-amplify/analytics@npm:5.1.9":
-  version: 5.1.9
-  resolution: "@aws-amplify/analytics@npm:5.1.9"
+"@aws-amplify/analytics@npm:7.0.4":
+  version: 7.0.4
+  resolution: "@aws-amplify/analytics@npm:7.0.4"
   dependencies:
-    "@aws-amplify/cache": 4.0.31
-    "@aws-amplify/core": 4.3.11
-    "@aws-sdk/client-firehose": 3.6.1
-    "@aws-sdk/client-kinesis": 3.6.1
-    "@aws-sdk/client-personalize-events": 3.6.1
-    "@aws-sdk/client-pinpoint": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    lodash: ^4.17.20
-    uuid: ^3.2.1
-  checksum: 93ddba60a777975e4239eb84afe27b0552f3fc7edff12fc4c6e2d945114c84cc175aac3179fb784fee651211aed5c4148ca44a8eda278ca87006884e88cebd5a
+    "@aws-sdk/client-firehose": 3.398.0
+    "@aws-sdk/client-kinesis": 3.398.0
+    "@aws-sdk/client-personalize-events": 3.398.0
+    "@smithy/util-utf8": 2.0.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: cc935002b350567b00e7173e1a57f513ecb863da0178c0d3513c0d8e7d6d9550e1aeab0510879ee3d88f5279a1584c1038d536e5d33d06dd8b7e3df32a904434
   languageName: node
   linkType: hard
 
-"@aws-amplify/api-graphql@npm:2.2.18":
-  version: 2.2.18
-  resolution: "@aws-amplify/api-graphql@npm:2.2.18"
+"@aws-amplify/api-graphql@npm:4.0.4":
+  version: 4.0.4
+  resolution: "@aws-amplify/api-graphql@npm:4.0.4"
   dependencies:
-    "@aws-amplify/api-rest": 2.0.29
-    "@aws-amplify/auth": 4.3.19
-    "@aws-amplify/cache": 4.0.31
-    "@aws-amplify/core": 4.3.11
-    "@aws-amplify/pubsub": 4.2.5
+    "@aws-amplify/api-rest": 4.0.4
+    "@aws-amplify/core": 6.0.4
+    "@aws-amplify/data-schema-types": ^0.6.6
+    "@aws-sdk/types": 3.387.0
     graphql: 15.8.0
-    uuid: ^3.2.1
-    zen-observable-ts: 0.8.19
-  checksum: dd5f95a1493c1b4ab0f669da7089dcd67c4711ab6f4f2b3e083558c2d620781847e8b0930c1d3c4a2888a8de1272de997ce187afc5fb77125dbe2d9ca1c926b9
+    rxjs: ^7.8.1
+    tslib: ^2.5.0
+    uuid: ^9.0.0
+  checksum: 140710e975f57316f408c9fb185297a1f44e60acef53ca551747465159b39ba372ac6b575239dc43557eacd716c3b004a93da1c8227ef94744e9ff3e3cf0ab2b
   languageName: node
   linkType: hard
 
-"@aws-amplify/api-rest@npm:2.0.29":
-  version: 2.0.29
-  resolution: "@aws-amplify/api-rest@npm:2.0.29"
+"@aws-amplify/api-rest@npm:4.0.4":
+  version: 4.0.4
+  resolution: "@aws-amplify/api-rest@npm:4.0.4"
   dependencies:
-    "@aws-amplify/core": 4.3.11
-    axios: 0.21.4
-  checksum: 4641d9e69ac6837c80e69e7688890b6955aeda5303a7b9b672cbf610307a0b48ece325636bec6509269153bacd1fc4023b03c7b5873ea416bbabf77ef0b52db1
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: 91441f3290665fafb549351978f26e2157713cbe68b14ee9725b6511465e2a82eb5b3f066a930b71ba0b8978094a168785f582fdfca3c1b13e193d97f484f6a0
   languageName: node
   linkType: hard
 
-"@aws-amplify/api@npm:4.0.29":
-  version: 4.0.29
-  resolution: "@aws-amplify/api@npm:4.0.29"
+"@aws-amplify/api@npm:6.0.4":
+  version: 6.0.4
+  resolution: "@aws-amplify/api@npm:6.0.4"
   dependencies:
-    "@aws-amplify/api-graphql": 2.2.18
-    "@aws-amplify/api-rest": 2.0.29
-  checksum: bb3a8b3a6edc765e0c5a37083832833291aed7edcc012f0d219d7450b93e98554414e21537d0ec84bad402b9ce7d3364d0328ff58e45ff6b8ca6a56250e18f39
+    "@aws-amplify/api-graphql": 4.0.4
+    "@aws-amplify/api-rest": 4.0.4
+    tslib: ^2.5.0
+  checksum: e1a1da82fb521908561d0128edc0fe327115cc4c4f417a7edf9c26bf642adb928400200ea87d2d3921558620a8bf1cabdf280abd70c53d04e34e89357ef0cfaf
   languageName: node
   linkType: hard
 
@@ -1036,24 +1036,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/auth@npm:4.3.19":
-  version: 4.3.19
-  resolution: "@aws-amplify/auth@npm:4.3.19"
+"@aws-amplify/auth@npm:6.0.4":
+  version: 6.0.4
+  resolution: "@aws-amplify/auth@npm:6.0.4"
   dependencies:
-    "@aws-amplify/cache": 4.0.31
-    "@aws-amplify/core": 4.3.11
-    amazon-cognito-identity-js: 5.2.3
-    crypto-js: ^4.1.1
-  checksum: bd202241c639fec7c74f323689f1b8691946fc1907dacd1f5bdfb6a67fcb499fd426a6ca042f03ef7894764a5857b890b9763b9f817007772c2eecaa51915bfc
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/cache@npm:4.0.31":
-  version: 4.0.31
-  resolution: "@aws-amplify/cache@npm:4.0.31"
-  dependencies:
-    "@aws-amplify/core": 4.3.11
-  checksum: 81c3add804bda06c44535d385d4ab0bdb7ae57f996fff8bc78c1e4b281382f3ba5f131f38bd6b0bfe9fc5d0284c31917e924f85d320785a6443fcca6c9a380d0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: b6f42891d08eb04f4b08a19cb4608da23f377ff012e4194547fe7321ff68c2319c66ee0a1c6b3b2ac027efe98a8474befa0e92d48e2793846a6ec13d2e8bd9e7
   languageName: node
   linkType: hard
 
@@ -1205,49 +1195,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/core@npm:4.3.11":
-  version: 4.3.11
-  resolution: "@aws-amplify/core@npm:4.3.11"
+"@aws-amplify/core@npm:6.0.4":
+  version: 6.0.4
+  resolution: "@aws-amplify/core@npm:6.0.4"
   dependencies:
-    "@aws-crypto/sha256-js": 1.0.0-alpha.0
-    "@aws-sdk/client-cloudwatch-logs": 3.6.1
-    "@aws-sdk/client-cognito-identity": 3.6.1
-    "@aws-sdk/credential-provider-cognito-identity": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-hex-encoding": 3.6.1
-    universal-cookie: ^4.0.4
-    zen-observable-ts: 0.8.19
-  checksum: b749fdf7ee82ca988932651ec15a8e2096e96c8b17d896909f90cf1e2310eb528ee3f34364a3681f1ea28ed985b7d31704ee79dffe0c29004f281fea2192ea5f
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/util-hex-encoding": 2.0.0
+    "@types/uuid": ^9.0.0
+    js-cookie: ^3.0.5
+    rxjs: ^7.8.1
+    tslib: ^2.5.0
+    uuid: ^9.0.0
+  checksum: 8992c760e0e6613e2046319d5a8291f1ea24d5941289aa4ed7c600ae29903d851a6102e8b15eb97af58c6f6ec3168ce767e28ad7f0f27ff4a9a53c46318ccce9
   languageName: node
   linkType: hard
 
-"@aws-amplify/datastore@npm:3.7.3":
-  version: 3.7.3
-  resolution: "@aws-amplify/datastore@npm:3.7.3"
+"@aws-amplify/data-schema-types@npm:^0.6.6":
+  version: 0.6.7
+  resolution: "@aws-amplify/data-schema-types@npm:0.6.7"
   dependencies:
-    "@aws-amplify/api": 4.0.29
-    "@aws-amplify/auth": 4.3.19
-    "@aws-amplify/core": 4.3.11
-    "@aws-amplify/pubsub": 4.2.5
-    amazon-cognito-identity-js: 5.2.3
+    rxjs: ^7.8.1
+  checksum: a0fc36dba99f4265088195317ec871c839da2f87abe21d5ad6594d3eede6e15142cbb4ef8828d4846c083a7d36d11a0eb4a331d17e05261ae6cda795d4e54f3a
+  languageName: node
+  linkType: hard
+
+"@aws-amplify/datastore@npm:5.0.4":
+  version: 5.0.4
+  resolution: "@aws-amplify/datastore@npm:5.0.4"
+  dependencies:
+    "@aws-amplify/api": 6.0.4
+    buffer: 4.9.2
     idb: 5.0.6
     immer: 9.0.6
-    ulid: 2.3.0
-    uuid: 3.3.2
-    zen-observable-ts: 0.8.19
-    zen-push: 0.2.1
-  checksum: 6299c9034a3c33ebedea6602c712d57626e06019e8e7147e3d972378547f3a04a5ee20eea34c0055a46feb3838a0af783ff3dca89da5e17aacb8f94fa03cc98a
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/geo@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@aws-amplify/geo@npm:1.1.11"
-  dependencies:
-    "@aws-amplify/core": 4.3.11
-    "@aws-sdk/client-location": 3.41.0
-    camelcase-keys: 6.2.2
-  checksum: 4a8fd4d76938819d9698fa8e85056811296a69b825314be27a489cadb7ce0eef882171e53f92fa1ee750e42a1297b97830426d8814baef49caa28fe9ab400131
+    rxjs: ^7.8.1
+    ulid: ^2.3.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: ca6ebd493654d8d051e57349e30ffd2cce208b7c43caa3334b2d39355c67d111d61aae65e69365878ec6ec52efd39cba21a1070b4ce7df15a81c6ffbc6d30996
   languageName: node
   linkType: hard
 
@@ -1585,78 +1570,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-amplify/interactions@npm:4.0.29":
-  version: 4.0.29
-  resolution: "@aws-amplify/interactions@npm:4.0.29"
+"@aws-amplify/notifications@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@aws-amplify/notifications@npm:2.0.4"
   dependencies:
-    "@aws-amplify/core": 4.3.11
-    "@aws-sdk/client-lex-runtime-service": 3.6.1
-  checksum: 823716790ad22498d40fa055957736a18c474d116d298b2464967db74fffa53107ab4b1efee59ab94384d51f89711291576db32a8180020ce70637d944c576b4
+    lodash: ^4.17.21
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: e56224ee6a9d78d674052877fb4ffcc8b7ced90b0f3f478128335c3a394e9632f2917fb08e6cd6a5bdad707d5790d5933fa350c4a45612673c9193d7025f2d69
   languageName: node
   linkType: hard
 
-"@aws-amplify/predictions@npm:4.0.29":
-  version: 4.0.29
-  resolution: "@aws-amplify/predictions@npm:4.0.29"
+"@aws-amplify/storage@npm:6.0.4":
+  version: 6.0.4
+  resolution: "@aws-amplify/storage@npm:6.0.4"
   dependencies:
-    "@aws-amplify/core": 4.3.11
-    "@aws-amplify/storage": 4.4.12
-    "@aws-sdk/client-comprehend": 3.6.1
-    "@aws-sdk/client-polly": 3.6.1
-    "@aws-sdk/client-rekognition": 3.6.1
-    "@aws-sdk/client-textract": 3.6.1
-    "@aws-sdk/client-translate": 3.6.1
-    "@aws-sdk/eventstream-marshaller": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    uuid: ^3.2.1
-  checksum: 8d0007677eea9372d395d9e41e663af6ddf0c524eb5be3016d773b34bcb4f7c716b34a8972b7fab2b6b9456ac2fae77ca11ccdbe1d64e523c101d65ffb7e4fe1
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/pubsub@npm:4.2.5":
-  version: 4.2.5
-  resolution: "@aws-amplify/pubsub@npm:4.2.5"
-  dependencies:
-    "@aws-amplify/auth": 4.3.19
-    "@aws-amplify/cache": 4.0.31
-    "@aws-amplify/core": 4.3.11
-    graphql: 15.8.0
-    paho-mqtt: ^1.1.0
-    uuid: ^3.2.1
-    zen-observable-ts: 0.8.19
-  checksum: edde4286082a22680442705d6e1defb67e80ee9bd82547cf20f56cb8c9419c606f283d27175919aa45f893b4c17c49158756668453ed84366742e8c34e4dfe55
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/storage@npm:4.4.12":
-  version: 4.4.12
-  resolution: "@aws-amplify/storage@npm:4.4.12"
-  dependencies:
-    "@aws-amplify/core": 4.3.11
-    "@aws-sdk/client-s3": 3.6.1
-    "@aws-sdk/s3-request-presigner": 3.6.1
-    "@aws-sdk/util-create-request": 3.6.1
-    "@aws-sdk/util-format-url": 3.6.1
-    axios: 0.21.4
-    events: ^3.1.0
-    sinon: ^7.5.0
-  checksum: c5a4feb3099709595ac9f1de687647130be757b8c0ebda0dd0331d438120628572276023cfdcefd8f03ed0d84e0d457d0c66b5ddd3d97521a61ee3472805a318
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/ui@npm:2.0.5":
-  version: 2.0.5
-  resolution: "@aws-amplify/ui@npm:2.0.5"
-  checksum: 5b08faf8f7fca6c0bb716573686ef15bdf0de5a621a815ca7b0accca5847d18f8118b136ffda0e09556ffb780aed424a33a1c6fefadd3c00d8e8429b6b4d49da
-  languageName: node
-  linkType: hard
-
-"@aws-amplify/xr@npm:3.0.29":
-  version: 3.0.29
-  resolution: "@aws-amplify/xr@npm:3.0.29"
-  dependencies:
-    "@aws-amplify/core": 4.3.11
-  checksum: 0e8d3a2c7c695874611b0ff5dccd9657639cffcac28495af1b114737e337ac098a3f042f94b9d68fc0291e13a8babbe924037c66e35881aa9cf01ef92c09f3e6
+    "@aws-sdk/types": 3.398.0
+    "@smithy/md5-js": 2.0.7
+    buffer: 4.9.2
+    fast-xml-parser: ^4.2.5
+    tslib: ^2.5.0
+  peerDependencies:
+    "@aws-amplify/core": ^6.0.0
+  checksum: 500ab0ec0cd77a201d1eb8384a448334ff90f3952cf0eade4d8aa4d8f7f2cd02c2c9a4db915ce0583f8e15a53343c396ff1fe52325092f26995bce7db699896b
   languageName: node
   linkType: hard
 
@@ -1726,17 +1663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/crc32@npm:^1.0.0":
-  version: 1.2.2
-  resolution: "@aws-crypto/crc32@npm:1.2.2"
-  dependencies:
-    "@aws-crypto/util": ^1.2.2
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: a353b1b4add3be3b9fbb0933e86fcc13c7911883249582379b785f016f2e01acd0c2f8548323a3f7451bda4f31ae72dd0b30c08d191905bf9e9130fb081d995c
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/crc32c@npm:3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/crc32c@npm:3.0.0"
@@ -1754,15 +1680,6 @@ __metadata:
   dependencies:
     tslib: ^1.11.1
   checksum: 1a45744b507ca6d962df458ec63696dca9f25eeeb9abefc52f6b77f18b16d9e4f895451a7334390be07b7121980a1d4942de6244a7950a2e661d8b5be7630c3d
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/ie11-detection@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/ie11-detection@npm:2.0.0"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: 09daee4c876c4bbd66ac81ee5ae226a5b21b613cf0231b3c7bd35a4c66c0f501886af9978a43476857989eff1178e9808b9bdf5f11b788224b2848f752f5d812
   languageName: node
   linkType: hard
 
@@ -1790,22 +1707,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-browser@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/ie11-detection": ^2.0.0
-    "@aws-crypto/sha256-js": ^2.0.0
-    "@aws-crypto/supports-web-crypto": ^2.0.0
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-locate-window": ^3.0.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: 8d9fd68693d86fea0c67d18031c28fae8c1d71f9d546eed4575bc679da71697da3186c3d0f29e61cfc2be37a6fbdd4cab25845e2cd577c30c2f59d031f753c9b
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/sha256-browser@npm:3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/sha256-browser@npm:3.0.0"
@@ -1822,7 +1723,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-browser@npm:^1.0.0, @aws-crypto/sha256-browser@npm:^1.2.2":
+"@aws-crypto/sha256-browser@npm:^1.2.2":
   version: 1.2.2
   resolution: "@aws-crypto/sha256-browser@npm:1.2.2"
   dependencies:
@@ -1837,28 +1738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:1.0.0-alpha.0":
-  version: 1.0.0-alpha.0
-  resolution: "@aws-crypto/sha256-js@npm:1.0.0-alpha.0"
-  dependencies:
-    "@aws-sdk/types": ^1.0.0-alpha.0
-    "@aws-sdk/util-utf8-browser": ^1.0.0-alpha.0
-    tslib: ^1.9.3
-  checksum: 9deca542ab32f38c0af526f2d786dcd92747e5a9ed643d3e02ed9561578740df8aabad8bf6221b8223a1781c87ab6793807b9ccaa079184be0038414af9d0835
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-js@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
-  dependencies:
-    "@aws-crypto/util": ^2.0.0
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: 387649a350ea6d756711670e26c0ed3b884f17f0aa9f1c80a38f9de8049ae8b22ba3131b1e4e83c6cf9ad35f8eea499af058b9b96dee4177aeb8fb88862ef489
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/sha256-js@npm:3.0.0, @aws-crypto/sha256-js@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/sha256-js@npm:3.0.0"
@@ -1870,7 +1749,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/sha256-js@npm:^1.0.0, @aws-crypto/sha256-js@npm:^1.2.0, @aws-crypto/sha256-js@npm:^1.2.2":
+"@aws-crypto/sha256-js@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": ^5.2.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^2.6.2
+  checksum: 6c48701f8336341bb104dfde3d0050c89c288051f6b5e9bdfeb8091cf3ffc86efcd5c9e6ff2a4a134406b019c07aca9db608128f8d9267c952578a3108db9fd1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:^1.2.0, @aws-crypto/sha256-js@npm:^1.2.2":
   version: 1.2.2
   resolution: "@aws-crypto/sha256-js@npm:1.2.2"
   dependencies:
@@ -1878,17 +1768,6 @@ __metadata:
     "@aws-sdk/types": ^3.1.0
     tslib: ^1.11.1
   checksum: f4e8593cfbc48591413f00c744569b21e5ed5fab0e27fa4b59c517f2024ca4f46fab7b3874f2a207ceeef8feefc22d143a82d6c6bfe5303ea717f579d8d7ad0a
-  languageName: node
-  linkType: hard
-
-"@aws-crypto/sha256-js@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@aws-crypto/sha256-js@npm:2.0.1"
-  dependencies:
-    "@aws-crypto/util": ^2.0.1
-    "@aws-sdk/types": ^3.1.0
-    tslib: ^1.11.1
-  checksum: a37f30b8fb33814c0a8107cc9356795a54c147ffec45064b617b0cf7517e6ee8dcaae484dedd34397a230a671794778183d3fa4ec48083ab574ca42efd0d4143
   languageName: node
   linkType: hard
 
@@ -1913,15 +1792,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/supports-web-crypto@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.0"
-  dependencies:
-    tslib: ^1.11.1
-  checksum: f85bfbe50120f93d1987cf038e2f0fe1a61f6901016ed983c5c22a41a247be0b7c4f4ce2ac8c71e742e6885f54f55b2702a565762af127f635ca4f4de05f98ed
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/supports-web-crypto@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/supports-web-crypto@npm:3.0.0"
@@ -1942,17 +1812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@aws-crypto/util@npm:2.0.1"
-  dependencies:
-    "@aws-sdk/types": ^3.1.0
-    "@aws-sdk/util-utf8-browser": ^3.0.0
-    tslib: ^1.11.1
-  checksum: a9943a48b0c5c69101aa533d12e926eacc7e07dcaf1dd306dcf2c3886bcd41f7f0c2e42bd6d84c16dc6416d0315c2e9e70d7e7a676615eb35c118a736703f2f9
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/util@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/util@npm:3.0.0"
@@ -1961,6 +1820,17 @@ __metadata:
     "@aws-sdk/util-utf8-browser": ^3.0.0
     tslib: ^1.11.1
   checksum: 71ab6963daabbf080b274e24d160e4af6c8bbb6832bb885644018849ff53356bf82bb8000b8596cf296e7d6b14ad6201872b6b902f944e97e121eb2b2f692667
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": ^3.222.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.6.2
+  checksum: 0362d4c197b1fd64b423966945130207d1fe23e1bb2878a18e361f7743c8d339dad3f8729895a29aa34fff6a86c65f281cf5167c4bf253f21627ae80b6dd2951
   languageName: node
   linkType: hard
 
@@ -1981,45 +1851,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 6d0c0d4911f67bbb4f98831b7664565f6cc880cc5d26cbc73e39abacc248fabfdcc3096b4a440255ff4fa26221ddb16f70ea0cc24ceb438187d45827409e635c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/abort-controller@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/abort-controller@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: c3d35d9e8f2e2e9395eea7809248bdc36e03f2784628c00ad7a6cc0f388a8101647cc9471a0e3c056429de1661423a289921c516ddf023cd1a79c3b07dbbb9ed
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/abort-controller@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/abort-controller@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: b996c94fdc422758bcae9bdc45585170855100e2f1ec1e7d61a0672b1136589c9c9f0e5599ed57ea18f4d43106301b6bb0e84def048d352a00a415295eb2515b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/chunked-blob-reader-native@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/chunked-blob-reader-native@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/util-base64-browser": 3.6.1
-    tslib: ^1.8.0
-  checksum: 3675cb16d43f82cadb709ff1b7cf0610d4ef645887789b29cec7a0c17a100e89fb375843358532f17e7ca86c0fa6dffb6347a07e5d67cbf184cffd9a75636119
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/chunked-blob-reader@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/chunked-blob-reader@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: eaeab744e768c99b051837e844318ddb3d29f40657c5f53e1f343766c08ff9069c6c431edcfbe88e1ffce525da34714dc683302c3acc2ba54257434ff7eb4b9f
   languageName: node
   linkType: hard
 
@@ -2063,45 +1894,6 @@ __metadata:
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
   checksum: ba242b7dbb214ea6150f7034334e7cc9bc3b0b6b6674e8e3e8c7b6a043b5996085a323541a206ccf1c6d1bbae071813aa91186362429fb6a9bd6718901f3a66b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cloudwatch-logs@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 09c323310e4f7afd0a12049e27817e664002245538d4bf3b2d76a85a7a80de12cb7e21d66fc076ef6d636e3339ceccd8013d736f6f0594eb821af01573c22ec9
   languageName: node
   linkType: hard
 
@@ -2189,85 +1981,6 @@ __metadata:
     "@smithy/util-utf8": ^2.0.0
     tslib: ^2.5.0
   checksum: 25682691a7d681eb6fc1104b9fcb3aba3014b57cdac20d89b66f51f23eaf7e2afd64034e39b2b94e102fc884831c0471ac5153608e72b0fec141dbf40b5d8109
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cognito-identity@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: b11909a0f5bab378da90dc3e9fead6ba3fac75a2edbcbc1436da121434f6f256369180e410536f4a55b870fc3e52fd2860f844d78ee141092948d671d12f9c59
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-comprehend@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-comprehend@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-    uuid: ^3.0.0
-  checksum: 6ca9adc591ce4da8309591bc18f52d825ba3fa129b4fa8f1093bb1575aeacc297bcbf5a750196988153f2463e3ee130168b4bfc0ef0ff0b8ab98a68affe45872
   languageName: node
   linkType: hard
 
@@ -2365,42 +2078,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-firehose@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-firehose@npm:3.6.1"
+"@aws-sdk/client-firehose@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/client-firehose@npm:3.398.0"
   dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 0e666e285877cabd8b8e5c5bdeff34bebc2354522e5df5e8b19359d709fbd7dcbe7dfb44c6191dc3ed45972a0c228a6042e9eaa3580fb2a9ae52a45fdd4f0e19
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.398.0
+    "@aws-sdk/credential-provider-node": 3.398.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-signing": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: e66f38625df99fd7daf9056562cf34f080ced3c7a160e2db96940972d948da59aed43a9d20329fab4e39cc91f98fa02babfed747accdc3502eeca52ba02b4e37
   languageName: node
   linkType: hard
 
@@ -2496,46 +2214,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-kinesis@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-kinesis@npm:3.6.1"
+"@aws-sdk/client-kinesis@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/client-kinesis@npm:3.398.0"
   dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/eventstream-serde-browser": 3.6.1
-    "@aws-sdk/eventstream-serde-config-resolver": 3.6.1
-    "@aws-sdk/eventstream-serde-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    "@aws-sdk/util-waiter": 3.6.1
-    tslib: ^2.0.0
-  checksum: 10d30fe93951551aefd886ed220583925f0ffe4213fc560ba4e3618c2964a1571efa52a540bd71e7cba40412525c6c541d8bff947c4b39ff020253d3f8eedf89
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.398.0
+    "@aws-sdk/credential-provider-node": 3.398.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-signing": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/eventstream-serde-browser": ^2.0.5
+    "@smithy/eventstream-serde-config-resolver": ^2.0.5
+    "@smithy/eventstream-serde-node": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    "@smithy/util-waiter": ^2.0.5
+    tslib: ^2.5.0
+  checksum: 0a7c100be165e9b6b91092c36cc7f809bcd4631605d0d92b2734357e9ea363c17211823727f4ad0e2fa533c8b1da9c59f41877b7673b5096465ddd3305a3e1f5
   languageName: node
   linkType: hard
 
@@ -2587,84 +2310,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-lex-runtime-service@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-lex-runtime-service@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 731a2a0822722d11fb076acff70720cb610d8d105ae8679f42a194b7f701b07f8f0d811156470cb9988b5e2d12dbc67695aec80a4db1eff6de8e10130120dfcf
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-location@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/client-location@npm:3.41.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.41.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/credential-provider-node": 3.41.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: 39f4904d23cc0f4fefa84ee2711265fa771b3fde592927ec1e244b32fce3c8c6f69fbd1fbf62cb0c11a769b5d0d00bbaebc11b841d57988d82a62f608c12c2c3
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/client-location@npm:^3.303.0":
   version: 3.319.0
   resolution: "@aws-sdk/client-location@npm:3.319.0"
@@ -2708,120 +2353,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-personalize-events@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-personalize-events@npm:3.6.1"
+"@aws-sdk/client-personalize-events@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/client-personalize-events@npm:3.398.0"
   dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 1565569e7cc28bc637223ca99e9e51bb4901a89c260375243ea917aaa041fe946ba595ff0d9256ca0fe25ff004a492c6d730a08999ba2639346ddb9261d276ba
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-pinpoint@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-pinpoint@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: ca5928a7f161b9b22727b92a3c2366c40726631cc4a2f2689149e36d8c2e39f37ca2bedba48d47d52f13bf3bb62e4692f0481c30bd0901522a9427e866e815ab
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-polly@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-polly@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 344551cd31e022f2273d146c9995ac569b8ef5825aef0ba934e504d554f76a23620e70a88ace8d5f4211ba26db5d51da7229d5c96143b19045142bdf106bf546
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.398.0
+    "@aws-sdk/credential-provider-node": 3.398.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-signing": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 14825c5fcf435aeeb5853089d7f9ed6de40983db0126fa9e999ce53b7d2c5c5370fd2401e4a5d405061ca55cf9d98bf3a2f8f4630fc888405ecc0b40ad8e7631
   languageName: node
   linkType: hard
 
@@ -2872,46 +2444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-rekognition@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-rekognition@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    "@aws-sdk/util-waiter": 3.6.1
-    tslib: ^2.0.0
-  checksum: 26b967261746a456d850c7d06ac2dbccd493f364a46d2b57b372ccb8cb8034f7e1bc1ae71330bdb7682b1ce259dd36592038b8f68a26342a7641b19437321903
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/client-rekognition@npm:^3.303.0":
   version: 3.319.0
   resolution: "@aws-sdk/client-rekognition@npm:3.319.0"
@@ -2953,60 +2485,6 @@ __metadata:
     "@aws-sdk/util-waiter": 3.310.0
     tslib: ^2.5.0
   checksum: 6cc15cdab351235fff8a06ea1f86e0b68984694cd1e0841d587686fa9d4fe31d226e5fe0add85fdcd4e6d4746cf92272c89f3d9e3382782639b7bc37258f6994
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-s3@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-s3@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/eventstream-serde-browser": 3.6.1
-    "@aws-sdk/eventstream-serde-config-resolver": 3.6.1
-    "@aws-sdk/eventstream-serde-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-blob-browser": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/hash-stream-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/md5-js": 3.6.1
-    "@aws-sdk/middleware-apply-body-checksum": 3.6.1
-    "@aws-sdk/middleware-bucket-endpoint": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-expect-continue": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-location-constraint": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-sdk-s3": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-ssec": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    "@aws-sdk/util-waiter": 3.6.1
-    "@aws-sdk/xml-builder": 3.6.1
-    fast-xml-parser: ^3.16.0
-    tslib: ^2.0.0
-  checksum: 948c59e999b5c85b24a7b275fc778a83019b207e85d4467d6dd88155869ba790c603f6ebee55807fbf6a05493708ba0e8a179380811efa401b4084fc5056cb77
   languageName: node
   linkType: hard
 
@@ -3443,39 +2921,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/client-sso@npm:3.41.0"
+"@aws-sdk/client-sso@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/client-sso@npm:3.398.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: 72a3f772ab467489f9772c84ab942b4c4b13c5ef51e6c5b7de53001edee540c9d2e2b9a36fe1ca6f3a92188c7053c8b3e7344c29003a5f91770e5a09dc16ae4a
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 9783421bcc4eb48dde299652ecb44df595cd9e8cadac1354831d5c403b75bf9e474cc4e01fcb519f9901dbffbadfbe094afce1535159cddf588fa596727dbe9c
   languageName: node
   linkType: hard
 
@@ -3658,123 +3141,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/client-sts@npm:3.41.0"
+"@aws-sdk/client-sts@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/client-sts@npm:3.398.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 2.0.0
-    "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.40.0
-    "@aws-sdk/credential-provider-node": 3.41.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-sdk-sts": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
-    tslib: ^2.3.0
-  checksum: 7b969e9067b09dffe2ed286af586faaa36fb25d3387e0c134b970c8f6a214e44bbb1167f17f9c5ec723e83e2540addc6a5e09313d27f8ddf283b6f4d34396814
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-textract@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-textract@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-  checksum: 43827519ce7af8bc93d0a687644e015b2635da2a44cbde0ca379dff1d4a32190afacdea024beb825c3f485066bec2bf6ed9422d0d274bf74740952c12c878489
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-translate@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/client-translate@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/sha256-browser": ^1.0.0
-    "@aws-crypto/sha256-js": ^1.0.0
-    "@aws-sdk/config-resolver": 3.6.1
-    "@aws-sdk/credential-provider-node": 3.6.1
-    "@aws-sdk/fetch-http-handler": 3.6.1
-    "@aws-sdk/hash-node": 3.6.1
-    "@aws-sdk/invalid-dependency": 3.6.1
-    "@aws-sdk/middleware-content-length": 3.6.1
-    "@aws-sdk/middleware-host-header": 3.6.1
-    "@aws-sdk/middleware-logger": 3.6.1
-    "@aws-sdk/middleware-retry": 3.6.1
-    "@aws-sdk/middleware-serde": 3.6.1
-    "@aws-sdk/middleware-signing": 3.6.1
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/middleware-user-agent": 3.6.1
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/node-http-handler": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/url-parser": 3.6.1
-    "@aws-sdk/url-parser-native": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    "@aws-sdk/util-base64-node": 3.6.1
-    "@aws-sdk/util-body-length-browser": 3.6.1
-    "@aws-sdk/util-body-length-node": 3.6.1
-    "@aws-sdk/util-user-agent-browser": 3.6.1
-    "@aws-sdk/util-user-agent-node": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    "@aws-sdk/util-utf8-node": 3.6.1
-    tslib: ^2.0.0
-    uuid: ^3.0.0
-  checksum: c9692e193d7f14445c364508c45076ec0da623f51326f65cbbdb33fa56bdc7ef450bee5244871914e64213e3f84e387753c80d77a5d1389c205a194d6c155967
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/credential-provider-node": 3.398.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-sdk-sts": 3.398.0
+    "@aws-sdk/middleware-signing": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  checksum: 7c6d771769e6e2d4bd42143dcf4a3af65f67ea3769fc75a8f24508677d1a2e1d046fa0968c9810c28e6ad061450c9bf47b80d5c397d67902cef35ada7cc347f6
   languageName: node
   linkType: hard
 
@@ -3802,29 +3210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/config-resolver@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-config-provider": 3.40.0
-    tslib: ^2.3.0
-  checksum: d4e7cefa0d70e75ae1aa876f1ee668a7970b3227b1b9fead93955708e92baf21062302abbc1b210abcce878b224618fb6a7da668c3f44d08037af77788428bee
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/config-resolver@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/config-resolver@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/signature-v4": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 8b7ce641a2c2881631afc316200e7f7e80166e8d4d461e342917da686ab900ec1fc6f4bb0763cd6c7b6503047c86262df56d6fe910fbbfb984c458da837372b6
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/credential-provider-cognito-identity@npm:3.382.0":
   version: 3.382.0
   resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.382.0"
@@ -3835,18 +3220,6 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: d162179760f0631b121f97cac97366ae9afffb71ef14aca6d84c1cbcebb53e1ec383c26b66d865a23d665a7a4920d6d90a4b986420003e1e12b3b283497eae70
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-cognito-identity@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/client-cognito-identity": 3.6.1
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 5ab9b84be4904389fd14866e85fd60e60ab90f16a3cf5782a72b14baff4019a4f5399521b73af487775ac1c56d6f1a855916d23a94866b064d5b797daba47a72
   languageName: node
   linkType: hard
 
@@ -3896,25 +3269,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.40.0"
+"@aws-sdk/credential-provider-env@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.398.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: d20fdf95ef981e29e729a0224b4fd4102dcdf51b6286d6b60742cd7105dc274dc1e6a5c48eaf2241d95a0d01554ca37aba264b1234f8adf18bc1ec2cd8233bec
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-env@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 1bae0e3c2c570ce8c75fe34c25974a86f14a94cd2112c8085b1291f12eb307d29be2194e6fa34497f6d5b1275a537a605dc701dc547fb2eb33b121b5eea299fa
+    "@aws-sdk/types": 3.398.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 26aef00721a8e703147db06c55813c50e39bdda5c31c9b40896d1ce62a2f57044cf0cd84121303262899141171723ec33db35bcc41a3d6a88eabf77627c379f9
   languageName: node
   linkType: hard
 
@@ -3941,30 +3304,6 @@ __metadata:
     "@aws-sdk/url-parser": 3.338.0
     tslib: ^2.5.0
   checksum: 2438f66d4e2b158c9094654752c60b12590f48a71d52bb68095a6b97f610922501e6ea732c1ab533da51eaa56d9685cce91ed1da9518c94600dad38ff6edb8f2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    tslib: ^2.3.0
-  checksum: 1db102abd4cb9eca502069162a3eea90c38d45a71ba11aecbb0671f04905f138ab567dd59208877ef53a2e0ba5463850fec648d5f830128ec499c327a6232946
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 6036b6ef4b1fc3b35237bf4a8dcb15982e1aa6c1f0894febcee601c9cc2fc4f9c2ccd9d9ea8dfcd8768a87a7f7212ae0cb09c4b22de299a7a08c9b04a3a9e01c
   languageName: node
   linkType: hard
 
@@ -4038,32 +3377,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.41.0"
+"@aws-sdk/credential-provider-ini@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.398.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.41.0
-    "@aws-sdk/credential-provider-web-identity": 3.41.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 2bd118ef0998806aa66346f4db2291e117658245a181f35af715229985999c6da375f828b052f5f1b061c1a968dd572352cce343ea1c4770594189e464afad2a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/shared-ini-file-loader": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: ba813d3808a8659ef0eb089a46715d6937ea9b18311481427c032dd9df43082ca5dccebacd9301a6b5fe3675e2f6b0af7217101a81645f98bbdb36fdc3465221
+    "@aws-sdk/credential-provider-env": 3.398.0
+    "@aws-sdk/credential-provider-process": 3.398.0
+    "@aws-sdk/credential-provider-sso": 3.398.0
+    "@aws-sdk/credential-provider-web-identity": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: abd1bfa44428f73d59d262030b498a09217e8b8119e0389e92313a2317d0b6ec37c22aa8e8f976661661cd84d972a2bda14ea41b6d59a2eea79df07e2571bd2a
   languageName: node
   linkType: hard
 
@@ -4141,38 +3469,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.41.0"
+"@aws-sdk/credential-provider-node@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.398.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-ini": 3.41.0
-    "@aws-sdk/credential-provider-process": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.41.0
-    "@aws-sdk/credential-provider-web-identity": 3.41.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 91e3b8d72ef2a064d8aaf6af3503591dd7fac7fe5b27b3b604c76eb9c2ff7d7de59c69f9d84f12f8f4990adadb310851e663d41e646c25a97aad6fe56604f8c5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.6.1
-    "@aws-sdk/credential-provider-imds": 3.6.1
-    "@aws-sdk/credential-provider-ini": 3.6.1
-    "@aws-sdk/credential-provider-process": 3.6.1
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/shared-ini-file-loader": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 46d2e9205a708d9a16eaf73c2f4f99407922e5722fd00950f2a5ea22615a63b82210985663e9bed0ffa6e3735cff6c51be227200727b219ace87e52699c7ca0c
+    "@aws-sdk/credential-provider-env": 3.398.0
+    "@aws-sdk/credential-provider-ini": 3.398.0
+    "@aws-sdk/credential-provider-process": 3.398.0
+    "@aws-sdk/credential-provider-sso": 3.398.0
+    "@aws-sdk/credential-provider-web-identity": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 02cda1820ba9312b26724825c585693ac5878fff637eaa88bb97600b35d4529f775e6acfa6d5c4877273f085743e6dc3cdfce8786db3c5c5db76731b42e3edb1
   languageName: node
   linkType: hard
 
@@ -4226,29 +3538,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.40.0"
+"@aws-sdk/credential-provider-process@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.398.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: eb802731bb52b1f949cadbe2bcede10c038c3be5975370905eb93f719aab393327b6dc2d0c96a2d518395c8b7f9dfa52d2ad4da1e4913028fc3817965780c4ca
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/credential-provider-process@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/credential-provider-ini": 3.6.1
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/shared-ini-file-loader": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: ebe2c9420e12bd1cd89be23031e7ab69bfd6000c5be6c7707423000e472edefcf7114a9acc31c43eefbed6a1ed8f254b13f9f735bbb8cb44e88cfd9a211f03f3
+    "@aws-sdk/types": 3.398.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: ceb3093e77c66f920e07dfd73bbf0df784688b4d7d83ec48489b90d4e2dcdafd6618b68a2b70c74510cb9c854bfb2ae3489b2ec6c95cc81f02f3baa56f5f1c3c
   languageName: node
   linkType: hard
 
@@ -4310,17 +3609,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.41.0"
+"@aws-sdk/credential-provider-sso@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.398.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.41.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 1c24fef28719ad84eb2e48145dbf02b9ad5528c8c1c3e1adfd027a3a59064292013e1b5cdafbed577dbb61eaa3961ece41f2fdcbf8b2b3412644e4f8417699c1
+    "@aws-sdk/client-sso": 3.398.0
+    "@aws-sdk/token-providers": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 40a14518c2464a920b6a2465221ffa8248c54fd963d0bc58749062798321e6f29074e6c32197bc22ea219cddb58b67c0f102e30968fc55b928a4248a99894539
   languageName: node
   linkType: hard
 
@@ -4370,14 +3670,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.41.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.398.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 5980a3bc21bad2e6ce9eb92f0c0a696f6b5879a37efa284a16398431a4d7647de31671d3a3dbec26a1eeb3b676164c8e1e6a7b764e7bd3a367a122c8ba36e5ec
+    "@aws-sdk/types": 3.398.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 97b6cfc5c0b8fcaaeb7fffceabcb0779fcf8cd6f78d9e5b1562bf131a7c691417a9d50f8e129bacce48a7b440072652ecf7e3698e0d68ccd22551bff639b1d34
   languageName: node
   linkType: hard
 
@@ -4426,18 +3727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-marshaller@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/eventstream-marshaller@npm:3.6.1"
-  dependencies:
-    "@aws-crypto/crc32": ^1.0.0
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-hex-encoding": 3.6.1
-    tslib: ^1.8.0
-  checksum: a1a2eaa7215298da18473494e5315f17dafeb933fd76c76772a20a964641e64822d359c259dd12f62fd8500b92c538e00be1a4eb117a89a88797ccf422eea40d
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/eventstream-serde-browser@npm:3.338.0":
   version: 3.338.0
   resolution: "@aws-sdk/eventstream-serde-browser@npm:3.338.0"
@@ -4449,18 +3738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.6.1
-    "@aws-sdk/eventstream-serde-universal": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 34d34209993935c94ce2348c78611b01d9e0b1811fd04f9ad18adbe05a243aa1380dd3a9000c0dcf8b6c4770862643fc6ef306320683d284c1b3d4cb983d3250
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/eventstream-serde-config-resolver@npm:3.338.0":
   version: 3.338.0
   resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.338.0"
@@ -4468,16 +3745,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: d0d421eba93b62fecac5ffb5f9b23e373533e3e71b9e3cac1669ebcf911294138ce7e5c5e7f9cec355eee4ddc7d77577d0d50224c8f2708cdd46920e8f2166d6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-config-resolver@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 2254a829efe66fff4f9aad800ec629cf0ff4ac6e1d6a95fa2d02e314d6339227cde01b60f7d5ab5633b28ed55befc4d9577d3e768283962a53233d7603149301
   languageName: node
   linkType: hard
 
@@ -4492,18 +3759,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/eventstream-serde-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/eventstream-serde-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.6.1
-    "@aws-sdk/eventstream-serde-universal": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: a0ecf2589e16ce284c08251d8d4a635d64f30a8a50ac50a1a36c0ceb52854d4a8943e28daca4a2f8c322e1bb68ea54edf1567e6d5a63889678b550055d789d60
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/eventstream-serde-universal@npm:3.338.0":
   version: 3.338.0
   resolution: "@aws-sdk/eventstream-serde-universal@npm:3.338.0"
@@ -4512,17 +3767,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: e3da52538f877562567557f9d8e1c219620d2bc86798f1e8c95b558628a3494e3dc6fd66cae37e3808febd517b2400fc68d47e7e9fc05c9d975c3787416986cd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-serde-universal@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/eventstream-marshaller": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: ae298b379d853d1371f17da49d13aeeb78b9b2f1bec6eebc7547cfe4ca06e3d6578f787fe71be639ce550bc1e090694e5b62ab0a6e4790991869665621f2bd88
   languageName: node
   linkType: hard
 
@@ -4552,44 +3796,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/fetch-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    tslib: ^2.3.0
-  checksum: 4c9610ac358249f6c163c9015b29fb5a4e22103766df5150cf9b88b4cd02e57371da26c53f96153579d50f1cc39832baee930b79125477469676a024f34e4579
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/querystring-builder": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-base64-browser": 3.6.1
-    tslib: ^1.8.0
-  checksum: 67d2eaefa41072483d4ce8114b800e4aa8ae78a3647498ec32c094cd9c56ff952b8a8b97b5cf65271833fe2f2a867c364c072ab860786621ef0d4a978f843b04
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-blob-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/hash-blob-browser@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/chunked-blob-reader": 3.6.1
-    "@aws-sdk/chunked-blob-reader-native": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 07c96d158007c08385be00d30adfd33e68adbe1e95ad8b41f77cb70ee7b68cc6a5becd71d11e2be394d01bb1c109de4d02c260e0cbb33e5bbec6e1dd7801e3ef
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/hash-node@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/hash-node@npm:3.310.0"
@@ -4614,28 +3820,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/hash-node@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 9ac6c77d9774fb5721d2236da5f1cb3de61293f9a46ba53c554befac616cea6eaeca771a055eb81fbcd2bbbe1bacfbd29cb5732c898e2f08cab1a6042495117b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/hash-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-buffer-from": 3.6.1
-    tslib: ^1.8.0
-  checksum: fddc0b926e7d92d72947bd91b7389f548f48f8d428be1d3f1a49a26acf680a9c92f7257312ce5294c902d7ba4a57e50053128a17aefb8035c86d7fef443fb9d7
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/hash-stream-node@npm:3.370.0":
   version: 3.370.0
   resolution: "@aws-sdk/hash-stream-node@npm:3.370.0"
@@ -4644,16 +3828,6 @@ __metadata:
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
   checksum: 99a34fde124ea86c2a083bf396877c26aa88b5db945cb889b5b946f8bc1158257fce6b5e4f24d7bcb0d1c8bddae72996b0a2225870dc25b57cb6be55e13ab15a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-stream-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/hash-stream-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 4bc254b8d6c934e05ddaead68bcdc272af5ded80c971497e79a2c84e0e6a0660a902ed5f7f15bd2891ef0bf57add174efffac65268eac6060fd1942ff4e1c5d8
   languageName: node
   linkType: hard
 
@@ -4677,50 +3851,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: cf94a75e9e88a7e2c90ba53d2f4a1a6fa24e3074981f0025720ab9b8def217c71945da442c743346b87b474e45c5da47a084db0fd34b09c4493ba786bfcba2a5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/invalid-dependency@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 839b5445469b32880d8e98490a752086ae4f1badd5930e77a66958c0a95273130a3e2de9e254128a9f86b0bb7e9cb65d8ec242ba3c4f2e9c62389b62ffe0715e
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/is-array-buffer@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/is-array-buffer@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 9e409bbdcf40aba872cdaa573adebd1bfebd0af4afedd1645d6782a8e0f942aeb53cb65da510ec52a8291682187f6b7091fd7d2631193a747c211ef6efae7960
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 280114bfab30578022369b620119097ccfb395b36da9b138f3a04258e04b49a53b72c091660a81b587700eedb67736031d6c7cc54e42b3c33e89de123b5bebff
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/is-array-buffer@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 23c06a1ff1fc334340fbfefe94f07166782b65507e4d9ca94a65049596a3a505458ede7fc29a1681a6b2c1f67cb5470e2dc4ca3a81f62251b4b3b69272d9689d
   languageName: node
   linkType: hard
 
@@ -4739,29 +3875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/md5-js@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/md5-js@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-utf8-browser": 3.6.1
-    tslib: ^1.8.0
-  checksum: 8fe9c0f3d80ae755ce03c77a89ac534fd77431ebe0dc69cf964e4b3781d2adc7ed897f1393ecf6a55572d311d3551ecc866a00d7362a1ddf68f111285690d07f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-apply-body-checksum@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-apply-body-checksum@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 2acaad4288812730a76c6efa24de5da86f3fd853260107bbdf0f9430d97205ca85bec5945eef318fd2985c6d03a444a02a58aaa2b8c9ac61b8cca74565793192
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-bucket-endpoint@npm:3.370.0":
   version: 3.370.0
   resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.370.0"
@@ -4773,18 +3886,6 @@ __metadata:
     "@smithy/util-config-provider": ^1.0.1
     tslib: ^2.5.0
   checksum: a3cf9637592e0e9bfabaacee9e948b87f70482150cdab4e04b373368a3b300ea8d076aae65c0d39c693ad24c54e443c513f879439ef7eaf1f343af6495eac477
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-bucket-endpoint@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-arn-parser": 3.6.1
-    tslib: ^1.8.0
-  checksum: ad807856e443099ca0dac15a4033d7b9a4a1682e297df805da586bc058f4248762ef0a6240e443cdadaf21f65b24fe6173b36f384735e588d2216bde19e5a298
   languageName: node
   linkType: hard
 
@@ -4807,28 +3908,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 4856a6b73e70bc96a1a5cc2683d2f8776fcddf5f65513e270ddc1ed5a0d22dd51754bc849674c712b856e5a3fe8e1aac5c936b3d85b1f56c2317a9b4765a2bc5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 12ddfd6584a21fba448d6f8740011b0628197e5d81d04716a3832c1ca01d21cbde00f80ab8a017f1d7c24c6ac176314708bc8a2df1b69afd783de402c08ad0f8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-content-length@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: db1bdd207a4dc5c2fc8c05de0b9dcd8a55f1dd8ba758ebb79448c6241e2d974c807484a5feae8637b38a842e8a87b3af0e2285050a2021e98756b9ff3e72d923
   languageName: node
   linkType: hard
 
@@ -4882,18 +3961,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/middleware-header-default": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: dd9c1f15fd0b71928395ae1d794e55abcc677f65eee3425a10018a957a7b72a21c818b833ea62569d3f5de36afaef90ce2882c4b8d349edbc075426907cc7bec
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/middleware-flexible-checksums@npm:3.370.0":
   version: 3.370.0
   resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.370.0"
@@ -4907,17 +3974,6 @@ __metadata:
     "@smithy/util-utf8": ^1.0.1
     tslib: ^2.5.0
   checksum: 55c90ea807f8725007566bf8900a0c4b029ae53574d772ecf28b214deb13158ee4978b87167987abbcefd94ea5107bd221c2fb204a29fa93a1ac54dd8a787a75
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-header-default@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-header-default@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 701b302cae98adbed192f64800c2915413f427e7666cab9a0275d2c969fdeb560f5bf5c242e2e09ef756e4ed4dbeea38cb400a40fea54c90ba95afb2b1ff876f
   languageName: node
   linkType: hard
 
@@ -4967,25 +4023,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.40.0"
+"@aws-sdk/middleware-host-header@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.398.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 91449253be4ac9cd5844a57b3610f8b2ae115de6da22d5577ad2a8e5c1c0ea0f08a364fe56de649db38aa4fb37328172c6da2f2e79ee39042133b6bbdc55b823
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-host-header@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: cc2123de25e9c151182f141aee0d70a7ab9e7949d4de90fa1aae51a233cee6c9dbf2a4ac55bca2f9a10529f11ca5a83e4b106bf684941f32df14caa195b05bb3
+    "@aws-sdk/types": 3.398.0
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: d075fdfb19abbcaee28d2e93cd95994619d418132bae7659f1220f8b454fe2f1bdf8db273ad6c7f6d5f3d8e56de3fb7e7f84f886be71f1cbf9d43898ea10be0f
   languageName: node
   linkType: hard
 
@@ -4997,16 +4043,6 @@ __metadata:
     "@smithy/types": ^1.1.0
     tslib: ^2.5.0
   checksum: b1abfd9924052849ef739e8df07fe5c2c8fa1b2fa2500f6a97682f08e062628a98c5cf4bdf1a3767122ef700be87221cc84fb2f3cdb6e21b2730ae4982fa9d92
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-location-constraint@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 4da1f48924321b64a36f79fd39198d5100edf28863d5b517764bb064305f7bdad90a26a2b398bce8a4a40a00617689dddcb2932899998e8cdf642ac8fc9abaa6
   languageName: node
   linkType: hard
 
@@ -5052,23 +4088,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.40.0"
+"@aws-sdk/middleware-logger@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.398.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: a5c9c84ecf99768a7f470c742a060bf851802010cf8002d7362bca3067260f1e53d6986c3934273e846c2e83455d0f3d69ccce35fa6d8ff67036c4c69770c2ef
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-logger@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 96b0cbd9b8fb7e2849ea944f86d4bc39e63fe52d8c846eb97eca57bea4374407c749d6016c748bc4d621004f6ba91495b4e8e0ca2eec457e26b17262cc0fb7ae
+    "@aws-sdk/types": 3.398.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 1527b9a7425af359d91f99d42b73eecf9ca5a1ae405cdcfc2f42eb5a9074ba4626689af44959a94ee6d5ccd204c587ba1019a8bea0c2e4dbc772a1a9180db326
   languageName: node
   linkType: hard
 
@@ -5118,6 +4145,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-recursion-detection@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.398.0"
+  dependencies:
+    "@aws-sdk/types": 3.398.0
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: c61f1931cee6f1f63d1678d7b051a7d2056592b41ae122d06f718a69919599eb5e34eb34fff57737fa7afee9cda52350f2786ce1c372a6c7d614e9f67e805d7e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-retry@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/middleware-retry@npm:3.310.0"
@@ -5145,33 +4184,6 @@ __metadata:
     tslib: ^2.5.0
     uuid: ^8.3.2
   checksum: a2f1d6acdbf28d060b67cbbc9cb661492dc8f651475c0133e7eb55c949c865416647a1932b316e1e2d8987205def1efb9c1f529ea858ec452c63ff897fa6af2a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/service-error-classification": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-    uuid: ^8.3.2
-  checksum: 5f2728499b7ef09d90effaa3cfd2aea130c58afa8118246d074df81d1880bf9a91252fc74429a2f17ed714a2add50c5b52bae7a17d79bb2a64bba22ea7a8491d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-retry@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/service-error-classification": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    react-native-get-random-values: ^1.4.0
-    tslib: ^1.8.0
-    uuid: ^3.0.0
-  checksum: 0753b8d546b126dbe15ae03839eb9913f0c64e69ecc9cf285a5647c6f6bf924c4704478ff6b1cd58da141d8038f9985f9a5779de2ae15a292a890390ca735a34
   languageName: node
   linkType: hard
 
@@ -5214,18 +4226,6 @@ __metadata:
     "@smithy/types": ^1.1.0
     tslib: ^2.5.0
   checksum: 91d907b7815d3863fbf3865c8b0b87b382fcba16f6b97d347b9fb391bf11dec1c0d952468d8bcfacc917d39ccecc6b0d04e4f6a89fc856da2da7574d58470e5d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-s3@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-arn-parser": 3.6.1
-    tslib: ^1.8.0
-  checksum: 066e0bc584cbc5412fbe284e2cceb1cd443ddf86b43092f0b645dd3b20dd0dbf192fa2cd17e2a51a90223c362625ef3f6f6f386eb018309abc5bc91d7d021666
   languageName: node
   linkType: hard
 
@@ -5275,17 +4275,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.40.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.398.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 119f816d9ab459fb9df88b85b235e83f3ad923c996df4389729b3575a73b29fe10ecbf297729a2ec9d848f58b14ba1089ad7fb4ef5ff53adb99f237938e3b0c3
+    "@aws-sdk/middleware-signing": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 80eb12ea90eed4d6682b7e2b347687123f539792cb9d6d98a7fc42487236ae2dee3b465a2727700013fa2942f293657bf026d60e23b7a760db7eca797f0aa2ea
   languageName: node
   linkType: hard
 
@@ -5306,26 +4304,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 77e46b14cefa1f69779113400103f98746fc83a45ff48f2a1ffd20d96fe85a51266300d9d09d216fb9bb1f732a96c755582560ea8406fcde037574a85b8b11a4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: a998c493e991b47f8c68e0dd88a915f45a01e9924755794b88f934a41fd8cd570ecee93c9ea33a13f404cecb707e2fc29061edada04727f3241804b8b2aa58ab
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-serde@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: cb0234d729d6469ee96c8602cb4dcdc69434892d6dd18fa5a00597d6a883d474f1563b51a78cd16203c5ae1678f0f27c5f5c50a2a597e7980ac898dbeb9c3777
   languageName: node
   linkType: hard
 
@@ -5387,28 +4365,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.40.0"
+"@aws-sdk/middleware-signing@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.398.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 17694000ecf9575aa2a6263608125cab4f786dfec749d0cb247fe4717ce864bd40524b7864a5e7deda89451125bc92b302430a6229a45b6be959fd38fe626080
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-signing@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/signature-v4": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: c4363bb9a33382ea0d749b4f2e504ce504a619b5d354fd7793aac6d1c631bbd75212f007701f4d9c83678b4771d83c964ba6e1d8bf6a460e08bf615d96e28363
+    "@aws-sdk/types": 3.398.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/signature-v4": ^2.0.0
+    "@smithy/types": ^2.2.2
+    "@smithy/util-middleware": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 7ed8e1fe763a182de4196176733d61fb822bee9ad4ee24e57e6119534ddbaa3c0191ffde4bf6c6d2d384c616411ab558199d532e1ee3551679efe92324c353da
   languageName: node
   linkType: hard
 
@@ -5420,16 +4388,6 @@ __metadata:
     "@smithy/types": ^1.1.0
     tslib: ^2.5.0
   checksum: 3fa2334741d14bd0cbdc4cc13ff2ddd20afd193d38c1aac8d8946952af926b64f72a4f2af0ca2041b0acf10ac530aacec4e5eea5c959d47eb2d20d9fe8b11bf7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-ssec@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-ssec@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 8f5a0046ac205c2f5ee8bcaabc54c142693b67b46c75ab49b743719603fa7c34c93365a4d4d8f3307e73ef92a6fabda2455a53ee8970b3857559a7d77780bef7
   languageName: node
   linkType: hard
 
@@ -5448,24 +4406,6 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: 40e1a2447adc29a671056dc9dd0bbc9e24f7fb8ca08ccf0569b96c285f65c7e4ae5bc56a3939d7a9ef20cf8c1a7fb6b948ab8c9421a3353259291953c95bb6c0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.40.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 914d6c967abe94d0ce92541f45ca93d1bb9cbb52292d46741dad89ad66d49040c0670e06cb6cb5b1c9f3edc1858e81953539d488eb7f48e0dbc6e86110a45d47
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-stack@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 37ca6452a16a42d466f7fcd0ba4a8743fc7aa448575b6559f5a7f0856a77f7def771e15b381fe479cdf6c528acda7c33e7792b02895fcebc546e290019cae530
   languageName: node
   linkType: hard
 
@@ -5519,25 +4459,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.40.0"
+"@aws-sdk/middleware-user-agent@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.398.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 46fa61cde2a408b4b228bde33733b867e6ff1d29fea9a3addf3a832ca49acac431277c8a6199e43eb48b84cb58641126851f827b1acd13451339efc51521572c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: e8bade3cf4dacfdab1e724100beef889f4d13b42003eb1c8c698a43f1e72f55491526c07fc5ac19c4ecc5796927e3dc8edfab6e3e76d2d3405dcedc7bc673dce
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: 272d60048dec99c9f0bfec3ef004b236eeb14a15497a7e9b7eda0f2badc317334e4ab5dcffade271768fad43359932ecbe3cb1e5dea942659e020923de0af3d2
   languageName: node
   linkType: hard
 
@@ -5562,30 +4493,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 1c7d49bee4266b00b653c41b590fde95f7c30c0c4272c492104fc3629118ec194fc59aa5d63b59b8b63e86430289abb9c6538e7c3d8b1339b0167bac113ea7c6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: fe76aa1bbafbee26a1e9cc334b2889c9b7d6f659233cdcdb4ab48d51e3eb81a508b3b2474e01b82f93ada4130a82957bb8416ffd79c9348c4e037fa7a0c08b71
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/node-config-provider@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/property-provider": 3.6.1
-    "@aws-sdk/shared-ini-file-loader": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: a2c978e6d7d625ff38b403d6a4ebfe2347fdc66da2286fa81c3d3272ccf00dd8089cb9dfabdfa5924c11e857b3b4a776489131c36930df07a81965afe4192785
   languageName: node
   linkType: hard
 
@@ -5615,32 +4522,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 5dfe1c1b8d22896add23301aa9c706fbca73bc3ba298636edb0483843ec23565992df2349b872e34ca91d1b8d7e0dd3b328413a93468b35880405c2e2bdcfd09
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/node-http-handler@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.6.1
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/querystring-builder": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 64f8427eb548de20064ab5ca5c19b76fd15d4c4c184de033aeeab7efbda5af4999156bc7c5b13e14e8bb107a7788a87df62016c22bbefe2937f86ff8d30566a4
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/property-provider@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/property-provider@npm:3.310.0"
@@ -5661,26 +4542,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/property-provider@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 8621397ffe9552e0640f9ad78e99f321c512d2d28fcb58147fff29a346b9f7b1456b416ba0fd4797247cc60ce911775b967fc5bad12bad9846f589c54873474e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/property-provider@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 6397719628d56cf146779fa3e2f05305289951994a9d84a3385d90e9d4cdf096792a571e23125e5b581680a4a1ac41881f5a19f26266ed69845aa9619c4ed172
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/protocol-http@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/protocol-http@npm:3.310.0"
@@ -5698,26 +4559,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 82a4c5c1ea0856c34e3a7ab01bddf2e4d69bd4d54e9feaa22ada342553f58979ff0a204bd4813fa4aa1246c91cc6afb4a6fd14006a0a754991af9263416935aa
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/protocol-http@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 1206de92a643dc8664a0370093a110e88feb33a1e4ee6f6b0a1e8ba035f5e9c13caef12b6f24fabfe5478ecf76824225ddcac3fc059b5ff4d3bb3ebd8f88846f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/protocol-http@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: fc16fdb2bdb9d07fa4b69d343be869da0f3c600d11352708e4d6b6afeee858629a2b7e00583fec8a40560796a1cad0480bc7bc4d0b696b46a32eae5ee3dea887
   languageName: node
   linkType: hard
 
@@ -5743,28 +4584,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-builder@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: 43a847bb7633b4afd4173bdc724bea4d06ac912dbbcdf730efeeef89bae268e9477d5f5a88fbe7b01344551f46b6cd4a34d93ba24b0a79297f2ced68933fc8d2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/querystring-builder@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-uri-escape": 3.6.1
-    tslib: ^1.8.0
-  checksum: 2b9477748e4c8099aadadc26d576f0edef1ff85e2cbb89bdf0e4714841fefb04bdc857623c90c1252c2b2d618248bb52d3dd5c6204f94cf12047a2f8ecc220c0
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/querystring-parser@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/querystring-parser@npm:3.310.0"
@@ -5785,41 +4604,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: f50d4779a79b0cc4e9b3e0c39fee97ef6c121ff1ccadfb7033e3c73efc317e0629f26f80217fb48d314aded84530d71deec4477037263666730454887cdde724
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-parser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/querystring-parser@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: dc3344516bd9ba554e14f46321c741a1301ea184dfb4f7704413542d8c5b8e0cebe07d19d079e4c5adb4a57b3dcab9423e325f524bef807fbad29e9d7349e3c1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/s3-request-presigner@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.6.1
-    "@aws-sdk/signature-v4": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-create-request": 3.6.1
-    "@aws-sdk/util-format-url": 3.6.1
-    tslib: ^1.8.0
-  checksum: 30cc0b81cecc9aac5d31228c8eba92bb171e3eae40a665351ec1faca8f871d0d15cad9ee06d7971d3e00ea7ff1c2f3bbbf230920d2e46168b4bb546ff01e5636
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/service-error-classification@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/service-error-classification@npm:3.310.0"
@@ -5831,20 +4615,6 @@ __metadata:
   version: 3.338.0
   resolution: "@aws-sdk/service-error-classification@npm:3.338.0"
   checksum: 323dea99468a19bc662ac9565168774de98376d6548baf37527f56a9c2cf5d42ac148b4f629ea65e014588b2f8460737025ead11f8f9b54c99c4c123724fe438
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.40.0"
-  checksum: cd026b7ab7648319aa1e67fff3ff4bb20dd4e6eb17df8f4518bb65339c5816383ba70785256415db7e0e48db028ea594f9a9ad08e23cfb90f74a5ff6e8a51f8b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/service-error-classification@npm:3.6.1"
-  checksum: c81c813e9f04c7b0316369b53916df0a22f75013da3c391599fe7698b063963bc3cf4b052f312ddf59ba000aa82df6c3c0eb49a1cc17c26e641b3f1b44d2168b
   languageName: node
   linkType: hard
 
@@ -5865,24 +4635,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: 014576d3f4a31782ef33feae30852fbe30f3eb599f1d823f5b25a430a5a3b6e94f52cf827a1e8d6dde3505d113188b3451b61618d5697c11011842ce0dd126ec
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 74e6be5252d5cf863e8eec37fd1667beef2b0159c590b228750ca3144355bbbda01b28b76cffe70c05287dd64f8bcaf92af3a1488afc8daa712244abbcfff610
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 82c9ec244c4bf8132a954e483cc6df83c8170add5ce6e66d575c76e01c8b90f209391257057559cb2348898d59205b63ac28aec86607baf11cee371c678f36d7
   languageName: node
   linkType: hard
 
@@ -5934,32 +4686,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/signature-v4@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-hex-encoding": 3.37.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: c0fed0deb102c309b09a6e8c9ff01154c3e5b3caa3e9a6855e6ee7df01ec3f31f97621ee4c5bf785dc3106a75bc438953bbcdf550005858c60a8a94cc42f9f81
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/signature-v4@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    "@aws-sdk/util-hex-encoding": 3.6.1
-    "@aws-sdk/util-uri-escape": 3.6.1
-    tslib: ^1.8.0
-  checksum: 27c08b6905fa0ddb5fd3dc62aa7608829818c2368ef4c1b0d72fa751672c37b8b93b51b53b59171fba9e5784f6d76afe03d8d04416057b8196aaddc2e6682df4
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/smithy-client@npm:3.316.0":
   version: 3.316.0
   resolution: "@aws-sdk/smithy-client@npm:3.316.0"
@@ -5979,28 +4705,6 @@ __metadata:
     "@aws-sdk/types": 3.338.0
     tslib: ^2.5.0
   checksum: f09153f1b7cf54f207e9f2e84974970c630565a9f0d70ea57bf1e6681acf1e281395ceaf4f22b69c203867bcd1eb206fa4a219a31f2bc9354224fe3fe0ebf13d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/smithy-client@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/smithy-client@npm:3.41.0"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 39f45f324d9778a21f4a3926ee79af65eba2b7e4e91f4708ac3c964ff7360b76eb4a0043000ec35691f377ff0c76c3cc2190b3459df881e93ed0951e4a626461
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/smithy-client@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/smithy-client@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: ecad63941fc0b99f66cde2a6edfa2c7b97ad16a007acf5f34f3d3175663ac930d5c33fdfd6e097d85ed7ca0f39ed528e36376eb99f453baf21588bcced734334
   languageName: node
   linkType: hard
 
@@ -6058,6 +4762,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/token-providers@npm:3.398.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.398.0
+    "@aws-sdk/middleware-logger": 3.398.0
+    "@aws-sdk/middleware-recursion-detection": 3.398.0
+    "@aws-sdk/middleware-user-agent": 3.398.0
+    "@aws-sdk/types": 3.398.0
+    "@aws-sdk/util-endpoints": 3.398.0
+    "@aws-sdk/util-user-agent-browser": 3.398.0
+    "@aws-sdk/util-user-agent-node": 3.398.0
+    "@smithy/config-resolver": ^2.0.5
+    "@smithy/fetch-http-handler": ^2.0.5
+    "@smithy/hash-node": ^2.0.5
+    "@smithy/invalid-dependency": ^2.0.5
+    "@smithy/middleware-content-length": ^2.0.5
+    "@smithy/middleware-endpoint": ^2.0.5
+    "@smithy/middleware-retry": ^2.0.5
+    "@smithy/middleware-serde": ^2.0.5
+    "@smithy/middleware-stack": ^2.0.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/node-http-handler": ^2.0.5
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^2.0.5
+    "@smithy/shared-ini-file-loader": ^2.0.0
+    "@smithy/smithy-client": ^2.0.5
+    "@smithy/types": ^2.2.2
+    "@smithy/url-parser": ^2.0.5
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.5
+    "@smithy/util-defaults-mode-node": ^2.0.5
+    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: f5591ac8cfd2a9876e90bbbc35c1e48e95b74f98c9d57a52483e09ef3ef6d0b63cad1f65e830f67fa450be332b3a1a41b828622cf5220ac78e13e9212098138c
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/types@npm:3.310.0"
@@ -6096,36 +4843,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/types@npm:3.40.0"
-  checksum: 4fd66137407f43532d5bb61859e491d86d67e674bbab1316ab2ef2702b6825b0f2ff354f124ebfc509b772ad11fa9f571f385cf088008f5d3f2dec7abf9484ec
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/types@npm:3.6.1"
-  checksum: dcf81db8ad59f8f362bf69ae957dbdf3147ee84960c795c9e89f3c80cc9c0e8a4873820fe769defe4dae6c0a700de404d11b519c578143cf986779e9e68dd97f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:^1.0.0-alpha.0":
-  version: 1.0.0-rc.10
-  resolution: "@aws-sdk/types@npm:1.0.0-rc.10"
-  checksum: 1274a1c5c973be829975fd52e17ed1217c72232f744b60b20e7bd443f51cf3a777beb1c7dfb0841701d79556d45336775798c7dfc266ab7ce1ee94202cba4b53
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser-native@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/url-parser-native@npm:3.6.1"
+"@aws-sdk/types@npm:3.387.0":
+  version: 3.387.0
+  resolution: "@aws-sdk/types@npm:3.387.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-    url: ^0.11.0
-  checksum: e1b2bfdf3affd587c7551ff6b9fee094c16839d05b358fcd00f6df7e6f7231342a27a1bf663841ae6de463d8a3c801e0d92eb32b42b6fc6f21ab9b17fc7fa2ae
+    "@smithy/types": ^2.1.0
+    tslib: ^2.5.0
+  checksum: a8a3771197c5196bec598e435c7e3ae851224a9ce59e18389564a65cde13cf62ba979bfc49608e3c2feed2ebbacc0615b9ea80051c89ad2b6166270c5e5e6aff
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/types@npm:3.398.0"
+  dependencies:
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: a41a60d64840eb8df11f126c644e4569dc3b0cfab4107751530fdff2af90740ee5ed840bf7cf90c81fb82ddb9d8f309b8ee1d2328a1bc9729c6409f90fa11674
   languageName: node
   linkType: hard
 
@@ -6151,81 +4885,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/url-parser@npm:3.40.0"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: a2221055f899a0488a3714f7d22a8aee12f4c47f5df3b05eba0649a033e9fdf334e0515c93d4d49a84597825db21bfd95a77c5ae4709d4d9d624ef1c114f18c2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/url-parser@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 083b690d45b0c3748838ee8d54b0e1eb454a58eee2f2119f241fc6ea4d347f760cc6f3997e5a3bcbba16a68cfc05d20f6d0cb02eeeaa69ed77465e9480060e05
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-arn-parser@npm:3.310.0, @aws-sdk/util-arn-parser@npm:^3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-arn-parser@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 7214c1291748751976d2d5125d79d49dcb40a0f2276b6da41403c2fd4ecdeb611a604afe06d35c74f66231af78234367698c472b18b671f6e1685890d2508563
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-arn-parser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-arn-parser@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 94a2c489490b336761c1e8268a87b0bc5d390e32cf70d805a0984d3fe0800bad789909c3ca837427354ec5694ca68fa031804fdb5101dd3873460200b520110e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 08af85efe7633e02f5216125df597342dcac745e1bad6d7165f71bcd03fdfa5cecaee2c402ee62b97b5caab7045f47e838e654ec7f272d871a571ee59b2b9dc6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-base64-browser@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: dc874cea9f7d04502c07312800ec81f8300418631627ecf55e956adbd73b305c23399ef0b0828903fb5940117484e5024c4f5e0b9da6c9a333463cf1faeaa60d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 3f58c152a6770e81291ef3254f19da0b8370871b173d1edcb71fff0c6bd1e6703c72617f6f76dad783e1744f4a2a4288ef125b1e2dd613414aa0c0f4a1fb3b5d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-base64-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.6.1
-    tslib: ^1.8.0
-  checksum: 0e044302a1dbd299de69eb20f0c02712c3aacf796d336c607c246c5acb3940987caa3178362b76e61a352140dc8218fb2253a58f27c2e74c93569d4151652a75
   languageName: node
   linkType: hard
 
@@ -6248,48 +4913,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 52ba4d2cf532ca165b56a3a26cd8837f7e43de8f2865d678a545b084890e3db3f0e9b6c845e0dcdb913b79ec8e3d88b601512b8f5761d86469084bbdbc620acd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: ef1f5f9daa3972272f6682ac17906c13abe9431f6e720fcd59a960185e56b73f1c20c7d4590029a7a631229fbe82270fe2363dade6898eb17a312ffbafb1c174
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-body-length-node@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-body-length-node@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 4b2b1f3bf25cf3d5e9b10f9c2004490f220986d8d7be5ccd63bbc9c42ee6e729e1403a4ea97c4e669315809517860e007bc15b27dd45c5d31c38d4a27b818660
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 19def34b23ab5cea73d2b0dca52911fb043d00945f2982b2d023855976808451f4f9153e68edf09577620ed43e306ab59a11a6bb22866e5f2b1d6d8826873d73
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-body-length-node@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 052f370055c77bc7327cdee365d235b7529dd0d71de7677c4e5adb9a2c5524bc51935a7f1ed1de693ea8502f69a354dde10414f03268d9628c1216c288d3df0c
   languageName: node
   linkType: hard
 
@@ -6303,63 +4932,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    tslib: ^2.3.0
-  checksum: f6412b0aaff533fc9209bbe4e62c70cb92e2f9977cb0a4ad4210ed2d4a1442dbb297f7546ecff6077a955c281226cfb2bfd5c9eb9f4c3f75b5a4f69d2a6a89c8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-buffer-from@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-buffer-from@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.6.1
-    tslib: ^1.8.0
-  checksum: c1c82afb1439bcb51f025325a8e6063db61998e11a38eb6716ca92c5cf58f010606ac5a788bf8e3c52bd204af9d150c22965ce4dc2e5047f4ed176314734efc0
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-config-provider@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-config-provider@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 9903264661ffa976b9944e5b33fbc31fac34a7c2d9dada8286d859a163432781f102452f7676ed057359ce3b1b2a30716034b3dfc6fa7e9e627997339bdc2b1b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.40.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 65f2da4f01f036fa3ee34f421945be2ec6dc4b273808b130b8fe317e5b0f63caed26877be135960769b7c14c1da9d36c2b1f17cb11f4f145e0915acb8bff2af1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-create-request@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-create-request@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.6.1
-    "@aws-sdk/smithy-client": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: a6a1864f357327cb54ed1e0dbed8e604c6d0385f3f6527884f4fe5ce55659bb3e6f3d33a6f33222c36b142acc8bdac49ce76e360282827863849688a76fd620b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-credentials@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-credentials@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    tslib: ^2.3.0
-  checksum: 6a1e55ee7201f2aef7ad43348fb2deee2f14432526af887aa776998e4d14d9e7af6e68247ba70584617c3278a512c23e73e848916c1b9c02f7724bb427df1223
   languageName: node
   linkType: hard
 
@@ -6455,6 +5033,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-endpoints@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.398.0"
+  dependencies:
+    "@aws-sdk/types": 3.398.0
+    tslib: ^2.5.0
+  checksum: a819c2b188553f5fae5c25af58a3ddf10dd537fb103fdfccfb3b1f488f7345ac112dce425eef74a8e361952ad1ee939ed81b37a2b4c64632c4631212e3584693
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-format-url@npm:3.338.0":
   version: 3.338.0
   resolution: "@aws-sdk/util-format-url@npm:3.338.0"
@@ -6466,41 +5054,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-format-url@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-format-url@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/querystring-builder": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 0909240999ac160a5bc1ca38f9e5937d27fdb31947addf07e2daf5c2d77c6541f62201b46ec3794485b7bbc8e6b1a70a9b7590c81093053d453753f5625bbab1
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-hex-encoding@npm:3.310.0, @aws-sdk/util-hex-encoding@npm:^3.29.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-hex-encoding@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 92157c8a02c12fd7e19c888cd62f51e361be5311e4b018c3ed8ce5e740b1517bbe58b49553a6f7d6d7b5703e0ff3d9d8afd8927b1e9ee64ad07df9a5e41568d7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 739ce869da7f3a6bf0cec72f7c1cf65501d7f1fd07811a56d4a65a1f69a2f360229c10f0356d8e779157e007f458119d1e179dfe1a0ac1101803d3a0da946443
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 275629d93235c507a657bc19da83d392dd5ffef28db36ab7b1508920693040a47b9f58012e6cc4778ad86c0bb5166d0f3e943bbdb38b1491d8f8d190b73673da
   languageName: node
   linkType: hard
 
@@ -6560,24 +5119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-uri-escape@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 3f9ad6f3fef3f327ec7edff1abb8f73b837fe253150006496378d577d9290a3caf4c6c25970931057b46b03a35aeb9af00d5aab8b7d7cf267cc67f5398e0e861
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-uri-escape@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-uri-escape@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 618f0d3344e11d4fc716fcf14b8f0ab8a35c59ae14d6f68b2de2d6fc3613fca3e86d566a6286dd11317bf0639a0351492baee1787a42c6cea7fee20c894d8614
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-user-agent-browser@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-user-agent-browser@npm:3.310.0"
@@ -6624,25 +5165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.40.0"
+"@aws-sdk/util-user-agent-browser@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.398.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
+    "@aws-sdk/types": 3.398.0
+    "@smithy/types": ^2.2.2
     bowser: ^2.11.0
-    tslib: ^2.3.0
-  checksum: e49539dfaa694fb7e44edd2539bb9fd6fd21ba8e1f58e6181faaadb3cf01f196e3b2ceef984594ddcf54a806a17f7ad8b842d17ef60516f069967eafd8a6d941
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/types": 3.6.1
-    bowser: ^2.11.0
-    tslib: ^1.8.0
-  checksum: 7091a1a234cb67d8de3951999e7120945480a686bbd71420106928742b6500fdd8d50ae309840d17d8e8c8531b232fa47c02e89e7e3527385c05e02b728cb6e0
+    tslib: ^2.5.0
+  checksum: b3e89e1d7a6efbf0b096b47b518d2ec15b93d0383a4581007be75377b7b37a39a0bd3a229037653973d45eaed484a97f852af0e40f1e562709055623eaaf27a9
   languageName: node
   linkType: hard
 
@@ -6712,52 +5243,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.40.0"
+"@aws-sdk/util-user-agent-node@npm:3.398.0":
+  version: 3.398.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.398.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: aa681672fb96b765dd16920656fc5257199b85d11e8e8705399299eba54febb0302d918714a3753797e9686b9423ce8f85a413486edb374ea3c2f5aef7682b60
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: 1365cc51c08086b0e1a26ec10c1ae7790043989c9c3478cd6a19f3c55d2371ec3f02974def02483370c9d91f1fe1a640428a0a4fdfd4d07fbd8184bf30a9724f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 16e740f35be5816dff45e05171052e7566dae0454e9ba388ead39c7abf6750c7b468ed9e3a90cb6fbca07292b5f15fdf52c97d9eac20ba86664f3221e23db57b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: bba9c1dc40081d9b55a01c222e1f1253c777f7e414d09dbfc31a8d33f43ab549a33c6838aa3fb73ad707e9386991e33a85911f96720f804c1fe952f0f8801940
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-browser@npm:^1.0.0-alpha.0":
-  version: 1.0.0-rc.8
-  resolution: "@aws-sdk/util-utf8-browser@npm:1.0.0-rc.8"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 4bb8788d14dd7739fe5a894dbca94521df52817eed1406eed45133ad249b8086b520922f2c38fdfd8d50c9bb850214139ac91fc2811eb57b92690a94e630922a
+    "@aws-sdk/types": 3.398.0
+    "@smithy/node-config-provider": ^2.0.5
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 2713090e04d23865ae701728a24011ef98414e0635ab7cba44a1b261ccb58c575a9659df34e762bb08d3473062ef8e2b9bc30f8234e68639edd36ee7a8633ade
   languageName: node
   linkType: hard
 
@@ -6767,26 +5266,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: 8f18e203133d0dec38d07c954916ab2c3a6861050bd2f14d9f149ef7012c0d9f27a36b02439d610ff51a0dfdea0c84f1e9a51ca3c3ee3516d8d8e48d7e0ea3d4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 181ec7feb9089220d3ff3e84e3743a55fce87afceeedb8861623ff2e2e81f542f3556bf90d9bcd0f1c91ba3c2010dbc8a72251994498426132c9bc55142fd06c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8-node@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-utf8-node@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.6.1
-    tslib: ^1.8.0
-  checksum: 23f023a8061a66fb594ff3b89b8653bc0f96708c4ad92721cf3cd3aeb5a5afc576e55095f91f16d231e1ad3caa8d413eb05851a09fb46b91be5cb05ea68f3b67
   languageName: node
   linkType: hard
 
@@ -6822,32 +5301,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/util-waiter@npm:3.6.1"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.6.1
-    "@aws-sdk/types": 3.6.1
-    tslib: ^1.8.0
-  checksum: b5c1986747fe75b8625ce929f6b79346a8af92f989c5154e3679bd63d15ac02518e0b22390c3e76d6d65ae4688e76eb1c8a1ab391ed01e40467aa1165c5c92c3
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/xml-builder@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/xml-builder@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: cb9a18c6331f92e2e92c5a1d4022bab13470424d55d991527ddc024a5cf4fab31074b352cea413ee7aed211f3202edd28039c32954200cf94e5b8bced012a486
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/xml-builder@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@aws-sdk/xml-builder@npm:3.6.1"
-  dependencies:
-    tslib: ^1.8.0
-  checksum: 35a3ab5e7fb4a143a21e82114f44fe1a7ecad335c0ebedb6f359542d3de5cc14acf10238269ddf5457ae9cb78ba24d526776a22d12c3a36e42f87928e987ca3b
   languageName: node
   linkType: hard
 
@@ -11065,7 +9524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^1, @sinonjs/commons@npm:^1.3.0, @sinonjs/commons@npm:^1.4.0, @sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.3":
+"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.3":
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
   dependencies:
@@ -11119,27 +9578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/formatio@npm:^3.2.1":
-  version: 3.2.2
-  resolution: "@sinonjs/formatio@npm:3.2.2"
-  dependencies:
-    "@sinonjs/commons": ^1
-    "@sinonjs/samsam": ^3.1.0
-  checksum: 13412a8cbcc5ea861745b27b18eb51ee4aacca59108c17690944d1f2d8cc8fa2e80420780f0e6c3b8bfbc8944b0af8715745db108df20d0aab13255f5c3b9883
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^3.1.0, @sinonjs/samsam@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "@sinonjs/samsam@npm:3.3.3"
-  dependencies:
-    "@sinonjs/commons": ^1.3.0
-    array-from: ^2.1.1
-    lodash: ^4.17.15
-  checksum: 01b0f1eb28fa54dca2c544153f0ac2e8790a89e5031b8437d27524944f8cc1013d1cb77390533eaefb528e6349936ff96adc30886147ccbdd7daa24d907e83e0
-  languageName: node
-  linkType: hard
-
 "@sinonjs/samsam@npm:^6.1.1":
   version: 6.1.1
   resolution: "@sinonjs/samsam@npm:6.1.1"
@@ -11175,6 +9613,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 995c3a719edec798b057f961b321b41471543f72cb567413b37cca5400cbe177da18392ae734ab8603016616fa326e0c08138bfcb454287bfc8cc8356649698d
+  languageName: node
+  linkType: hard
+
+"@smithy/abort-controller@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "@smithy/abort-controller@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 31a8116b1c94dc6f04c4c7183116c0be33cdc608ef37f9459e0fe2ef7433891010cd8935670d79f41d2e2988bde5d37f13c07a1359109da592fdad8bcca29400
   languageName: node
   linkType: hard
 
@@ -11221,6 +9669,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^2.0.18, @smithy/config-resolver@npm:^2.0.5":
+  version: 2.0.18
+  resolution: "@smithy/config-resolver@npm:2.0.18"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.5
+    "@smithy/types": ^2.5.0
+    "@smithy/util-config-provider": ^2.0.0
+    "@smithy/util-middleware": ^2.0.6
+    tslib: ^2.5.0
+  checksum: d8a8732983833a50d22b48aa8f5c266ac30b5d8740b4e39a5b678a96a4e75b5eba7b6fcc7942561f05845ce3947fcc5429b19dc13a303e9d16ceb027bf693f76
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^1.0.1, @smithy/credential-provider-imds@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/credential-provider-imds@npm:1.0.2"
@@ -11244,6 +9705,19 @@ __metadata:
     "@smithy/url-parser": ^2.0.1
     tslib: ^2.5.0
   checksum: e795f3a91fa079495d809e082fba1e5871a45c4a1774e25a1e6a7f0664889ad5b8a1b32f1e2254bad93c074c8ab5b194ab2c02e3a53a900c8f8a2d907859f5d2
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/credential-provider-imds@npm:2.1.1"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.5
+    "@smithy/property-provider": ^2.0.14
+    "@smithy/types": ^2.5.0
+    "@smithy/url-parser": ^2.0.13
+    tslib: ^2.5.0
+  checksum: 2a725d4de8651a16e3e74f569819599f846ccfaff53553b536e10f333481141c496a6fa42097d9c8bfa5d1771aed2067c0933d10d7e1708c220bc0e0d440139c
   languageName: node
   linkType: hard
 
@@ -11271,6 +9745,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/eventstream-codec@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "@smithy/eventstream-codec@npm:2.0.13"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@smithy/types": ^2.5.0
+    "@smithy/util-hex-encoding": ^2.0.0
+    tslib: ^2.5.0
+  checksum: cd06a885eafab30aae5bc40c29a2a17e25c3c4fac2a06f35728d634d41d19813130a85d27a14ab636382bd90dd8f510f2c1de65fdd3535daed2dd4b1afe08161
+  languageName: node
+  linkType: hard
+
 "@smithy/eventstream-serde-browser@npm:^1.0.1":
   version: 1.0.2
   resolution: "@smithy/eventstream-serde-browser@npm:1.0.2"
@@ -11282,6 +9768,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/eventstream-serde-browser@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/eventstream-serde-browser@npm:2.0.13"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: f4fded0ab5fee167daf580c308a7afe9988a21dd88407d3aac01e21b8f3d4e90a6a1b13bea270c61a4087c20ce276283d2745b6389f0b27ddf40e4c783c2afa8
+  languageName: node
+  linkType: hard
+
 "@smithy/eventstream-serde-config-resolver@npm:^1.0.1":
   version: 1.0.2
   resolution: "@smithy/eventstream-serde-config-resolver@npm:1.0.2"
@@ -11289,6 +9786,16 @@ __metadata:
     "@smithy/types": ^1.1.1
     tslib: ^2.5.0
   checksum: c9ee4cdcda89d04b6dd0442d9ab8797dc68e89b4ec5603d9a4ad76f0cc46afaf257969c6a239dfd5ee02ec6524c01ecefe0b6613f637e923f1307eee51644436
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-config-resolver@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 4e3aac24ee6b16a9d4e364ca5bd49c0d2a8877126e6a271870fdf9794190731de790753732decd50bb3bb7c417acea62bff3b79244d3e3b26b8a73b9a00ac0fb
   languageName: node
   linkType: hard
 
@@ -11303,6 +9810,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/eventstream-serde-node@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/eventstream-serde-node@npm:2.0.13"
+  dependencies:
+    "@smithy/eventstream-serde-universal": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: cf467cb7c06b545a507eb0bc376a2a71eb2f64a0330ebf8700befaa8d35117fc9aa4cb05e8874622a54d5e6a85c3c4404dff3ab5f08bcd420c877381541d5671
+  languageName: node
+  linkType: hard
+
 "@smithy/eventstream-serde-universal@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/eventstream-serde-universal@npm:1.0.2"
@@ -11311,6 +9829,17 @@ __metadata:
     "@smithy/types": ^1.1.1
     tslib: ^2.5.0
   checksum: 4882ec294632c8af3cce6daaf3c4ea1d4c12c8c8200580a692530315bcac4f8dd507412a14bf27b96fc1e957e5e62f6aec9599fb05f238d599f8b877bcc56e0c
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-universal@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "@smithy/eventstream-serde-universal@npm:2.0.13"
+  dependencies:
+    "@smithy/eventstream-codec": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 1faa76834eb5a6987e3c227e76d648c3d7162f7c76e04eac0ea3d2b19df7e001e8e111d033a4c51bb289747624587387966e3ed3a62f98c164167466f925581e
   languageName: node
   linkType: hard
 
@@ -11337,6 +9866,19 @@ __metadata:
     "@smithy/util-base64": ^2.0.0
     tslib: ^2.5.0
   checksum: 7bae59b44772496677eb1de11b3ab48ac9e0a3e6d4011d83271e08e7414fa2116d812479d05c8052ad498f496159ce34488b873ed22b6561fd20a8a5933eef8b
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^2.0.5, @smithy/fetch-http-handler@npm:^2.2.6":
+  version: 2.2.6
+  resolution: "@smithy/fetch-http-handler@npm:2.2.6"
+  dependencies:
+    "@smithy/protocol-http": ^3.0.9
+    "@smithy/querystring-builder": ^2.0.13
+    "@smithy/types": ^2.5.0
+    "@smithy/util-base64": ^2.0.1
+    tslib: ^2.5.0
+  checksum: c8534f2dc622e56c32293bebec3520e808050f57569eaa583f294c978db66c042c9f723f8fde69f076d29e7169991d78a33aababbb74dda67c120e0e64cdc77d
   languageName: node
   linkType: hard
 
@@ -11376,6 +9918,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/hash-node@npm:^2.0.5":
+  version: 2.0.15
+  resolution: "@smithy/hash-node@npm:2.0.15"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    "@smithy/util-buffer-from": ^2.0.0
+    "@smithy/util-utf8": ^2.0.2
+    tslib: ^2.5.0
+  checksum: b87ef1653bf823b3a0b7150a5190f9670599cdcb4459aa53468fb135f69d3745952c05b78abbfedc12acab16b39cd4488ce7dd3575d5b9edcb8334afc9b77820
+  languageName: node
+  linkType: hard
+
 "@smithy/invalid-dependency@npm:^1.0.1":
   version: 1.0.2
   resolution: "@smithy/invalid-dependency@npm:1.0.2"
@@ -11396,6 +9950,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/invalid-dependency@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/invalid-dependency@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 5f794fa0058c19a5e683f1ebb5475c6af7bb6c35a6e150d839613e6b442067a6c48505d96e732c68ed378df86273af3d0cdb6b1ba78c5b912ea65ccab9099441
+  languageName: node
+  linkType: hard
+
 "@smithy/is-array-buffer@npm:^1.0.1, @smithy/is-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/is-array-buffer@npm:1.0.2"
@@ -11411,6 +9975,17 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: c0f8983a402da853fd6ee33f60e70c561e44f83a7aae1af9675a40aeb57980d1a64ac7a9b892b69fdfcf282f54accc7e531619ba1ae5e447f17c27efd109802e
+  languageName: node
+  linkType: hard
+
+"@smithy/md5-js@npm:2.0.7":
+  version: 2.0.7
+  resolution: "@smithy/md5-js@npm:2.0.7"
+  dependencies:
+    "@smithy/types": ^2.3.1
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: ac6a4b74d95e74f90987da58fe44b27073b7571ecd7085669284a36bfd20c5d64cb1c8225ec2c44a2898b46f17524b4aae2ae75022950f80f9b8dbdb3999b3b5
   languageName: node
   linkType: hard
 
@@ -11447,6 +10022,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-content-length@npm:^2.0.5":
+  version: 2.0.15
+  resolution: "@smithy/middleware-content-length@npm:2.0.15"
+  dependencies:
+    "@smithy/protocol-http": ^3.0.9
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 49db217bd7224425f8363887384d8b4ba73b9ceadd3fa8aa955e7f11272d06a2ba9163d699002a7ef64972002547cfb27ebefd7aa75ee8ed25227e4e173560e2
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-endpoint@npm:^1.0.2":
   version: 1.0.3
   resolution: "@smithy/middleware-endpoint@npm:1.0.3"
@@ -11470,6 +10056,21 @@ __metadata:
     "@smithy/util-middleware": ^2.0.0
     tslib: ^2.5.0
   checksum: ad557e680eb64cdeb9c867ff227e62b98bf781b77c284dfc9ed17b19e67d86b782a1cc39282c4b9a1bc11783fff862b04418b789a6398816b26a09d44492c0c9
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^2.0.5":
+  version: 2.2.0
+  resolution: "@smithy/middleware-endpoint@npm:2.2.0"
+  dependencies:
+    "@smithy/middleware-serde": ^2.0.13
+    "@smithy/node-config-provider": ^2.1.5
+    "@smithy/shared-ini-file-loader": ^2.2.4
+    "@smithy/types": ^2.5.0
+    "@smithy/url-parser": ^2.0.13
+    "@smithy/util-middleware": ^2.0.6
+    tslib: ^2.5.0
+  checksum: 9be114332ad25657a001d07d3d7aa1da330ca5c8a54e7e4e11f11f46d944fe222d7ec4254b13d82aba7542ac4b7c92e5664413070a9a7485c6ff18a69886c02d
   languageName: node
   linkType: hard
 
@@ -11503,6 +10104,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-retry@npm:^2.0.5":
+  version: 2.0.20
+  resolution: "@smithy/middleware-retry@npm:2.0.20"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.5
+    "@smithy/protocol-http": ^3.0.9
+    "@smithy/service-error-classification": ^2.0.6
+    "@smithy/types": ^2.5.0
+    "@smithy/util-middleware": ^2.0.6
+    "@smithy/util-retry": ^2.0.6
+    tslib: ^2.5.0
+    uuid: ^8.3.2
+  checksum: b2833a3edf3c08da8f1b26da679e61b5b68de788d5f92e0d97ac319a04dbe6032d1e46f2374f8834e8e4222de115b33be4d64375801dfafe6e1b36c3bd923c60
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-serde@npm:^1.0.1, @smithy/middleware-serde@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/middleware-serde@npm:1.0.2"
@@ -11523,6 +10140,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-serde@npm:^2.0.13, @smithy/middleware-serde@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/middleware-serde@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 7d40f381b989ed866a6075091a5933880fe5d71a7dc5a986d0e030562ef71a6f43a295a7a6e201d6837c48a05134678f10874bde1bf58f1955e16be93654105d
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^1.0.1, @smithy/middleware-stack@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/middleware-stack@npm:1.0.2"
@@ -11538,6 +10165,16 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: dd1507d599f9fa70d720f0be7e5ecf3aa24f0f0f23879c19a2d65fe6ba60184f641944116724612a240212361bb2b533c6aac8de4c1f4417611cf951d8001ccb
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@smithy/middleware-stack@npm:2.0.7"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 71ac7a4e96bdfe77e00abbc5070fc51fc9d366e94e99f379bc4880ef1ac32529eb4e7dc6549e60d35f57015b28b1cf40815620ee5fd389bad5113c75c13279d4
   languageName: node
   linkType: hard
 
@@ -11562,6 +10199,18 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 2ea3ab568bb3871ad87a760e7889668e6662aeb96662f4d040dd32e12437c8168fb2989d2aa51e16b3544d521b29aa1d61f9c93a905f23dee96a3d97242b4ac2
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^2.0.5, @smithy/node-config-provider@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@smithy/node-config-provider@npm:2.1.5"
+  dependencies:
+    "@smithy/property-provider": ^2.0.14
+    "@smithy/shared-ini-file-loader": ^2.2.4
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: dd5ad7917567bb049e11de6fd428de2f5dcf1db74398c82ebffe7f8565332cb2ca6386930130d23c1da95613d017f3d72ad53110c08d607005f9603915cbd618
   languageName: node
   linkType: hard
 
@@ -11591,6 +10240,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^2.0.5, @smithy/node-http-handler@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@smithy/node-http-handler@npm:2.1.9"
+  dependencies:
+    "@smithy/abort-controller": ^2.0.13
+    "@smithy/protocol-http": ^3.0.9
+    "@smithy/querystring-builder": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 6d3abf4b962b287160b69fccfc520ade9d694c9d3e273db0caecafafc08a3106f7426da0cdb515b6a1ad3393045ae0edcffe0d0b94ee7d304d30ed8a37857f03
+  languageName: node
+  linkType: hard
+
 "@smithy/property-provider@npm:^1.0.1, @smithy/property-provider@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/property-provider@npm:1.0.2"
@@ -11611,6 +10273,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/property-provider@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "@smithy/property-provider@npm:2.0.14"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 2404b317f3e3fe5628781db969efc43917583f25c598959525bf4fed46afc46b6f73f4bac443ae7ce61265c2bf59b4761653bc9ae1a2462176e8b2cd4bc3d85c
+  languageName: node
+  linkType: hard
+
 "@smithy/protocol-http@npm:^1.0.1, @smithy/protocol-http@npm:^1.1.0, @smithy/protocol-http@npm:^1.1.1":
   version: 1.1.1
   resolution: "@smithy/protocol-http@npm:1.1.1"
@@ -11628,6 +10300,26 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 350f59d2a92afe711115dd3ff52571c9b7d31bb652d39f44c1012947ff26b46bbe00edaeaa1a001b974b62c32c88fa54798244819029b82b7744535c509fed2e
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@smithy/protocol-http@npm:2.0.5"
+  dependencies:
+    "@smithy/types": ^2.2.2
+    tslib: ^2.5.0
+  checksum: f5124439e05542b90bd3e1b0e777ba6acf6dc615ef13f8a74ba337aead17cd7944e0d6f4d8117dfe02125be7d7034419891e414f0f3b75238fa9b4f1ff768732
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "@smithy/protocol-http@npm:3.0.9"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: c4ff3815502b3e8201471310b3fd9ffda4675138287c68742493681f997df04cdbd9faf63e375d17e64848c075fb0a758f7f66b497aa9210fe54662fd6c62e0b
   languageName: node
   linkType: hard
 
@@ -11653,6 +10345,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-builder@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "@smithy/querystring-builder@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    "@smithy/util-uri-escape": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 9c3a0a3cf3be55d1c8a1ee819f6082294a0e3598707e1a76ee2a68e4806d911fc8e2c0477dc4a86e0a22e81618c1af007f8236cb9227883ba22b3d82b6f16422
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-parser@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/querystring-parser@npm:1.0.2"
@@ -11673,6 +10376,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-parser@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "@smithy/querystring-parser@npm:2.0.13"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 33e1a5f20688cd62f7c64d812509feb39ab31979ad6ecb831b47ff44641a3eb0138cba5063e1bcd12713644626c4a5f8d1c7d9a7d7aa319616d77898b917eb34
+  languageName: node
+  linkType: hard
+
 "@smithy/service-error-classification@npm:^1.0.3":
   version: 1.0.3
   resolution: "@smithy/service-error-classification@npm:1.0.3"
@@ -11684,6 +10397,15 @@ __metadata:
   version: 2.0.0
   resolution: "@smithy/service-error-classification@npm:2.0.0"
   checksum: 01eff69704f8d3c0a4e556b06d7566d905856ab069517b81e232b08e966c303bd24f2441f62518c0bd0ecb7e25069afd47db442223bb80b455e8f6c6a77bb57b
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/service-error-classification@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.5.0
+  checksum: 496f85c9c3f1cf65ac50aee0c41273d5aa4b5b4b1c7ac04e17f1554dd3271702e686b96612d36aa84a48001803dc379ed5b54657ee45a1c9a7987f7387451e64
   languageName: node
   linkType: hard
 
@@ -11704,6 +10426,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 53840d0524adfed2a2ad9887014c357df0ccf07b3bf23f775d999c8c7f0c0b314c1b01992cd2901f6b44a3e59a3f3c7fcaf71aa8a2c4c1948d2fe153af320679
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "@smithy/shared-ini-file-loader@npm:2.2.4"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: b8500ef3debe0a51c458aa4db883401d9af899516ca416900790d539e24194640f64a23126bbedbe03f0feb7a00c801e99ea98f8083279f146ff24d0a9406c6e
   languageName: node
   linkType: hard
 
@@ -11763,6 +10495,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^2.0.5, @smithy/smithy-client@npm:^2.1.15":
+  version: 2.1.15
+  resolution: "@smithy/smithy-client@npm:2.1.15"
+  dependencies:
+    "@smithy/middleware-stack": ^2.0.7
+    "@smithy/types": ^2.5.0
+    "@smithy/util-stream": ^2.0.20
+    tslib: ^2.5.0
+  checksum: b8406ed2c47f5cc73d6b741055ce7b0a338efc26a6ea1065bb384ee2f6032615289021a591ebd0ffdb0dbce28f13fb38fb3bc9bc0bbba357984b6b37fe1fe116
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^1.0.0, @smithy/types@npm:^1.1.0, @smithy/types@npm:^1.1.1":
   version: 1.1.1
   resolution: "@smithy/types@npm:1.1.1"
@@ -11778,6 +10522,15 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: 2decf04dd0c2f9f5976485eb40392227ee8c0cd68f2433a7c38ccc47b10af39cdc21a26368ede26871ac02701f58828aecb6ab091074cc0468e3913104835794
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.1.0, @smithy/types@npm:^2.2.2, @smithy/types@npm:^2.3.1, @smithy/types@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@smithy/types@npm:2.5.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 6522f56a9f7d6ca05b191636e7612d72c6439263c9f8af06520c30b98945a6f88b362ea624ec4641f9bfd38f04c5548c4eb03340bb06fdd03d9cca9345ad7250
   languageName: node
   linkType: hard
 
@@ -11803,6 +10556,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/url-parser@npm:^2.0.13, @smithy/url-parser@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/url-parser@npm:2.0.13"
+  dependencies:
+    "@smithy/querystring-parser": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: fdc15c36218249e989b560adcbb039db8a0767bb9fb09db8c0434bcfebb2a366302a74a6f6ac4efdb091f34a99e76b3c032c9b98ebedd422332ab623432e2105
+  languageName: node
+  linkType: hard
+
 "@smithy/util-base64@npm:^1.0.1, @smithy/util-base64@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/util-base64@npm:1.0.2"
@@ -11820,6 +10584,16 @@ __metadata:
     "@smithy/util-buffer-from": ^2.0.0
     tslib: ^2.5.0
   checksum: 89ca476b119e9cb14563c4b0c901d4b54b93732be7a56bf16f192cc17ecefaa782423bc10e22b92e7dd96b4a191fa90141e615460d2797a640478b2dc1be0681
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@smithy/util-base64@npm:2.0.1"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 6e7ce2fb6f2871e187c2cb7eb952b1cd9a5f9b8b31a179babe83b4e9b39c7509fa524a834bc8016f1a8bad59f3a67f0cc0e33df60951c6091f62af8c48274195
   languageName: node
   linkType: hard
 
@@ -11856,6 +10630,15 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: ce6437f2aa3079e8ecca93300c1712c3296f0ede6792323365566d7382c3b26aff1713cdee19ce3bf56a516d23c17792982af3621f077181ce4a6bd6cfc23dad
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@smithy/util-body-length-node@npm:2.1.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 88f86ec026b17b9f59d3e55a395999a2c3c06d2634b784709fb597183b8c2ef048a1fceed963cce5a7deb40590fc1861ac470d87f1a5c37dcf2fbbeb7478b698
   languageName: node
   linkType: hard
 
@@ -11921,6 +10704,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-browser@npm:^2.0.5":
+  version: 2.0.19
+  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.19"
+  dependencies:
+    "@smithy/property-provider": ^2.0.14
+    "@smithy/smithy-client": ^2.1.15
+    "@smithy/types": ^2.5.0
+    bowser: ^2.11.0
+    tslib: ^2.5.0
+  checksum: 59cc1a40318fc99b624440adfd9c2d4ff9720675f4a05d5159b35b9f3c8adbc5c00239683278c5f3e609b1dcb53b84aac33ad1b30cdf80a677654a6cea141fa5
+  languageName: node
+  linkType: hard
+
 "@smithy/util-defaults-mode-node@npm:^1.0.1":
   version: 1.0.2
   resolution: "@smithy/util-defaults-mode-node@npm:1.0.2"
@@ -11949,21 +10745,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-node@npm:^2.0.5":
+  version: 2.0.25
+  resolution: "@smithy/util-defaults-mode-node@npm:2.0.25"
+  dependencies:
+    "@smithy/config-resolver": ^2.0.18
+    "@smithy/credential-provider-imds": ^2.1.1
+    "@smithy/node-config-provider": ^2.1.5
+    "@smithy/property-provider": ^2.0.14
+    "@smithy/smithy-client": ^2.1.15
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 980dc05efc6f848a5725565c1269c281f1e4d4587909781c396373a4b9dc3bf8a5d9b1645a9faf0f9673590fc7dab8dd2ae55df2cdad339a6143b7df6096ae3f
+  languageName: node
+  linkType: hard
+
+"@smithy/util-hex-encoding@npm:2.0.0, @smithy/util-hex-encoding@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-hex-encoding@npm:2.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 50c3d855b8f3e7a6ef087969e451327cb5ebc1e582ba34f0523d73341f944ae1afa80bb950d2bc6298f4021146193dc84c892d5932f4e47275c3818e8426b338
+  languageName: node
+  linkType: hard
+
 "@smithy/util-hex-encoding@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/util-hex-encoding@npm:1.0.2"
   dependencies:
     tslib: ^2.5.0
   checksum: d8ca09dada52daaa18aa40cd477397b50668fd1a769de529051575185f3e0afae8190c13feb38fd9eaca4f0484f8ed23256de96918c6ee7ef7a23f36f107231d
-  languageName: node
-  linkType: hard
-
-"@smithy/util-hex-encoding@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-hex-encoding@npm:2.0.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 50c3d855b8f3e7a6ef087969e451327cb5ebc1e582ba34f0523d73341f944ae1afa80bb950d2bc6298f4021146193dc84c892d5932f4e47275c3818e8426b338
   languageName: node
   linkType: hard
 
@@ -11985,6 +10796,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-middleware@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/util-middleware@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 8c3cd5e3adb9762ef98401fd61c7d5cadbf725757dd5dc6a65dff408c818f3c6b29d052b0ddc27b5ff01ee7adf4dac817db6e722c1d1a3f79df57500a4cf116a
+  languageName: node
+  linkType: hard
+
 "@smithy/util-retry@npm:^1.0.3, @smithy/util-retry@npm:^1.0.4":
   version: 1.0.4
   resolution: "@smithy/util-retry@npm:1.0.4"
@@ -12002,6 +10823,17 @@ __metadata:
     "@smithy/service-error-classification": ^2.0.0
     tslib: ^2.5.0
   checksum: 03b69046d7736f11430147772463685246918560b70ff54799b8dee59a4819fa4349917fa9df841953224f5ec95ef1aa3e5ee5818450ad2f92a2397caede41bd
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/util-retry@npm:2.0.6"
+  dependencies:
+    "@smithy/service-error-classification": ^2.0.6
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: c6ab66ee301692aa54b97d44b745d64be01b45101cd8f587b0ecfd81ea697708af26944df35df521ee707e7df89629d6b9fd490d797fc4ae6ad9233276fffd36
   languageName: node
   linkType: hard
 
@@ -12037,6 +10869,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-stream@npm:^2.0.20":
+  version: 2.0.20
+  resolution: "@smithy/util-stream@npm:2.0.20"
+  dependencies:
+    "@smithy/fetch-http-handler": ^2.2.6
+    "@smithy/node-http-handler": ^2.1.9
+    "@smithy/types": ^2.5.0
+    "@smithy/util-base64": ^2.0.1
+    "@smithy/util-buffer-from": ^2.0.0
+    "@smithy/util-hex-encoding": ^2.0.0
+    "@smithy/util-utf8": ^2.0.2
+    tslib: ^2.5.0
+  checksum: 0f64b254956d798a8be107ec3c7e62f10c71735a662a836e352b6aab82eeae18eea93a874cb657354ec481648e6c95d8594df18a0679692e1493cc06d11ad277
+  languageName: node
+  linkType: hard
+
 "@smithy/util-uri-escape@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/util-uri-escape@npm:1.0.2"
@@ -12055,6 +10903,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-utf8@npm:2.0.0, @smithy/util-utf8@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@smithy/util-utf8@npm:2.0.0"
+  dependencies:
+    "@smithy/util-buffer-from": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 26ecfc2a3c022f9e71dd5ede5d9fe8f1c3ecae6d623fe7504c398bc8ca7387e6a94c9fee4370da543b83220e51ee57c1fea189798c03884cecef21216918c56a
+  languageName: node
+  linkType: hard
+
 "@smithy/util-utf8@npm:^1.0.1, @smithy/util-utf8@npm:^1.0.2":
   version: 1.0.2
   resolution: "@smithy/util-utf8@npm:1.0.2"
@@ -12065,13 +10923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-utf8@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-utf8@npm:2.0.0"
+"@smithy/util-utf8@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@smithy/util-utf8@npm:2.0.2"
   dependencies:
     "@smithy/util-buffer-from": ^2.0.0
     tslib: ^2.5.0
-  checksum: 26ecfc2a3c022f9e71dd5ede5d9fe8f1c3ecae6d623fe7504c398bc8ca7387e6a94c9fee4370da543b83220e51ee57c1fea189798c03884cecef21216918c56a
+  checksum: 99ee9bad29535a66ba3eafeae4a1c927afe1487addd9b24b2a2ca992778b87346981b97f9474c9197273b9d863b393d59d8028054085d4d45333680f15e8c9b3
   languageName: node
   linkType: hard
 
@@ -12083,6 +10941,17 @@ __metadata:
     "@smithy/types": ^1.1.1
     tslib: ^2.5.0
   checksum: fba7d8dc176343f0a9990c69f44937966bb3ec2b6b84fa6c552fb457ba2285e215740f30534d183dfc8b11c4105fd293b814d941a4fe7a7108458bcb296d0865
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^2.0.5":
+  version: 2.0.13
+  resolution: "@smithy/util-waiter@npm:2.0.13"
+  dependencies:
+    "@smithy/abort-controller": ^2.0.13
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: 48afd7fd33d755e483f97c5eeb695f0a4a42925fb240fc1d77ac88c342541ad6ed11b018bd0974ed1314c0f21c7b0682cfa12b0ed4fd2c3616cf5123ea27b02d
   languageName: node
   linkType: hard
 
@@ -12509,13 +11378,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: f11a1ccfed540723dddd7cb496543ad40a2f663f22ff825e9b220f0bae86db8b1ced2184ee41d3fb358b019ad6519e39481b06386db91ebb859003ad1d54fe6a
-  languageName: node
-  linkType: hard
-
-"@types/cookie@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "@types/cookie@npm:0.3.3"
-  checksum: 96521593ca46d865d03b04b4af0324a45a1da8312b13aa2026d97a284cd6f559cc0d695a4f3255405cd301a8c93c13b22e77400ad42a0b903e06056202d49fed
   languageName: node
   linkType: hard
 
@@ -13146,6 +12008,13 @@ __metadata:
   version: 8.3.4
   resolution: "@types/uuid@npm:8.3.4"
   checksum: b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.0":
+  version: 9.0.7
+  resolution: "@types/uuid@npm:9.0.7"
+  checksum: b329ebd4f9d1d8e08d4f2cc211be4922d70d1149f73d5772630e4a3acfb5170c6d37b3d7a39a0412f1a56e86e8a844c7f297c798b082f90380608bf766688787
   languageName: node
   linkType: hard
 
@@ -13944,19 +12813,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"amazon-cognito-identity-js@npm:5.2.3":
-  version: 5.2.3
-  resolution: "amazon-cognito-identity-js@npm:5.2.3"
-  dependencies:
-    buffer: 4.9.2
-    crypto-js: ^4.1.1
-    fast-base64-decode: ^1.0.0
-    isomorphic-unfetch: ^3.0.0
-    js-cookie: ^2.2.1
-  checksum: 2210b65a0f87744ce017512fa13856e67fa3c7c0766a79ab991b67e8fe3776eeb763ce33061e6bba223090c9c8a85e9502ecf3c4e40c1f5c1aea4c43b72f31fa
-  languageName: node
-  linkType: hard
-
 "amdefine@npm:>=0.0.4":
   version: 1.0.1
   resolution: "amdefine@npm:1.0.1"
@@ -14117,7 +12973,7 @@ __metadata:
     amplify-dynamodb-simulator: 2.9.8
     amplify-headless-interface: 1.17.6
     amplify-storage-simulator: 1.11.3
-    aws-amplify: ^4.2.8
+    aws-amplify: ^6.0.4
     aws-appsync: ^4.1.1
     aws-cdk-lib: ~2.80.0
     aws-sdk: ^2.1464.0
@@ -14705,13 +13561,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-from@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "array-from@npm:2.1.1"
-  checksum: 565fe078a3fb8be3d1b17d1b1a6b514d14d7f6c7349fb1de0b0f4cb7e0e4ffb6d35e03ff234ac978cffb67fc8f1e93e477271b70fe2f9e0ef76d10b0402d4d26
-  languageName: node
-  linkType: hard
-
 "array-ify@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-ify@npm:1.0.0"
@@ -14912,24 +13761,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-amplify@npm:^4.2.8":
-  version: 4.3.11
-  resolution: "aws-amplify@npm:4.3.11"
+"aws-amplify@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "aws-amplify@npm:6.0.4"
   dependencies:
-    "@aws-amplify/analytics": 5.1.9
-    "@aws-amplify/api": 4.0.29
-    "@aws-amplify/auth": 4.3.19
-    "@aws-amplify/cache": 4.0.31
-    "@aws-amplify/core": 4.3.11
-    "@aws-amplify/datastore": 3.7.3
-    "@aws-amplify/geo": 1.1.11
-    "@aws-amplify/interactions": 4.0.29
-    "@aws-amplify/predictions": 4.0.29
-    "@aws-amplify/pubsub": 4.2.5
-    "@aws-amplify/storage": 4.4.12
-    "@aws-amplify/ui": 2.0.5
-    "@aws-amplify/xr": 3.0.29
-  checksum: f576c7f173442f64ec4eed9c564823f21386575a2714022bd9cb8ada361ae0966f54dc9528a01b2dd07a8b99da727e1af0645b2979e28fa76d9a2fe55647146c
+    "@aws-amplify/analytics": 7.0.4
+    "@aws-amplify/api": 6.0.4
+    "@aws-amplify/auth": 6.0.4
+    "@aws-amplify/core": 6.0.4
+    "@aws-amplify/datastore": 5.0.4
+    "@aws-amplify/notifications": 2.0.4
+    "@aws-amplify/storage": 6.0.4
+    tslib: ^2.5.0
+  checksum: 7df41be3a43a80086d80b6469ce41824739676178b78fcb6c3370bf5ae60e3d80b3d57218610071690662a958d291fad8a5f6ee110f177ccb17ddf1c6bfe5701
   languageName: node
   linkType: hard
 
@@ -15062,15 +13906,6 @@ __metadata:
   version: 4.3.5
   resolution: "axe-core@npm:4.3.5"
   checksum: 48c08748271964b9a09e523cd5739cc3b8be8982ffffda30269b7e4f75af35b56ba951467a0e37eb213380f7b3544b7503e1a213660aadc00b990d6427e11b1e
-  languageName: node
-  linkType: hard
-
-"axios@npm:0.21.4":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
-  dependencies:
-    follow-redirects: ^1.14.0
-  checksum: fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
   languageName: node
   linkType: hard
 
@@ -16074,7 +14909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-keys@npm:6.2.2, camelcase-keys@npm:^6.2.2":
+"camelcase-keys@npm:^6.2.2":
   version: 6.2.2
   resolution: "camelcase-keys@npm:6.2.2"
   dependencies:
@@ -17177,7 +16012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.4.2, cookie@npm:^0.4.0":
+"cookie@npm:0.4.2":
   version: 0.4.2
   resolution: "cookie@npm:0.4.2"
   checksum: beab41fbd7c20175e3a2799ba948c1dcc71ef69f23fe14eeeff59fc09f50c517b0f77098db87dbb4c55da802f9d86ee86cdc1cd3efd87760341551838d53fca2
@@ -17488,13 +16323,6 @@ __metadata:
     randombytes: ^2.0.0
     randomfill: ^1.0.3
   checksum: 0c20198886576050a6aa5ba6ae42f2b82778bfba1753d80c5e7a090836890dc372bdc780986b2568b4fb8ed2a91c958e61db1f0b6b1cc96af4bd03ffc298ba92
-  languageName: node
-  linkType: hard
-
-"crypto-js@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "crypto-js@npm:4.2.0"
-  checksum: 8fbdf9d56f47aea0794ab87b0eb9833baf80b01a7c5c1b0edc7faf25f662fb69ab18dc2199e2afcac54670ff0cd9607a9045a3f7a80336cccd18d77a55b9fdf0
   languageName: node
   linkType: hard
 
@@ -18208,13 +17036,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "diff@npm:3.5.0"
-  checksum: fc62d5ba9f6d1b8b5833380969037007913d4886997838c247c54ec6934f09ae5a07e17ae28b1f016018149d81df8ad89306f52eac1afa899e0bed49015a64d1
-  languageName: node
-  linkType: hard
-
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -18591,7 +17412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:2.2.0, entities@npm:^2.0.0":
+"entities@npm:^2.0.0":
   version: 2.2.0
   resolution: "entities@npm:2.2.0"
   checksum: 7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
@@ -19396,7 +18217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:3.3.0, events@npm:^3.1.0, events@npm:^3.2.0, events@npm:^3.3.0":
+"events@npm:3.3.0, events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
@@ -19595,13 +18416,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 6d8feab513222a463d1cb58d24e04d2e04b0791ac6559861f99543daaa590e2636d040d611b40a50799bfb5c5304265d05e3658b5adf6b841a50ef6bf833d821
-  languageName: node
-  linkType: hard
-
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -19681,15 +18495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:3.19.0":
-  version: 3.19.0
-  resolution: "fast-xml-parser@npm:3.19.0"
-  bin:
-    xml2js: cli.js
-  checksum: b8e11f45c6e0763cbeb13bf7f1294a0c6924b3b3737cc89015b3d827fa20a847670fff523aed04f24350d9787efc1de05ad942184e184a4af06cb9834608e9bd
-  languageName: node
-  linkType: hard
-
 "fast-xml-parser@npm:4.1.2":
   version: 4.1.2
   resolution: "fast-xml-parser@npm:4.1.2"
@@ -19712,14 +18517,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^3.16.0":
-  version: 3.21.1
-  resolution: "fast-xml-parser@npm:3.21.1"
+"fast-xml-parser@npm:^4.2.5":
+  version: 4.3.2
+  resolution: "fast-xml-parser@npm:4.3.2"
   dependencies:
-    strnum: ^1.0.4
+    strnum: ^1.0.5
   bin:
-    xml2js: cli.js
-  checksum: 26ed57fd3cb86434959cffa6852ab63231850ff5be6836aef7744b1abc8013fa5696c05179e422965677e116606611242d91ceebf246d91a5247e262d8b59996
+    fxparser: src/cli/cli.js
+  checksum: 7c1611349384656ec4faa9802fbc8cf8c01206a1b79193d5cd54586307801562509007f6cf16e5da7d43da4fa4639770f38959a285b9466aa98dab0a9b8ca171
   languageName: node
   linkType: hard
 
@@ -19978,7 +18783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -22706,16 +21511,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-unfetch@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "isomorphic-unfetch@npm:3.1.0"
-  dependencies:
-    node-fetch: ^2.6.1
-    unfetch: ^4.2.0
-  checksum: d3b61fca06304db692b7f76bdfd3a00f410e42cfa7403c3b250546bf71589d18cf2f355922f57198e4cc4a9872d3647b20397a5c3edf1a347c90d57c83cf2a89
-  languageName: node
-  linkType: hard
-
 "isomorphic-ws@npm:^4.0.1":
   version: 4.0.1
   resolution: "isomorphic-ws@npm:4.0.1"
@@ -23694,10 +22489,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
+"js-cookie@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "js-cookie@npm:3.0.5"
+  checksum: 04a0e560407b4489daac3a63e231d35f4e86f78bff9d792011391b49c59f721b513411cd75714c418049c8dc9750b20fcddad1ca5a2ca616c3aca4874cce5b3a
   languageName: node
   linkType: hard
 
@@ -24649,22 +23444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lolex@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "lolex@npm:4.2.0"
-  checksum: b56fbffec393eaaff0f950e528ab7762507527743e4678646a485a0049c830d078960a66a2ddc68ddfde72cbbdde5bc98d9fbe7c487b419317d293d978e8ab20
-  languageName: node
-  linkType: hard
-
-"lolex@npm:^5.0.1":
-  version: 5.1.2
-  resolution: "lolex@npm:5.1.2"
-  dependencies:
-    "@sinonjs/commons": ^1.7.0
-  checksum: 310f55bb9b756b3b5661eff9532843d7bbc9e3b82fe51f7330d17ab258c2b43101f98c6650778cf81827c13d6d239b878a95d87a06eeef2349b1c074b37ee8ee
-  languageName: node
-  linkType: hard
-
 "long@npm:^4.0.0":
   version: 4.0.0
   resolution: "long@npm:4.0.0"
@@ -25589,19 +24368,6 @@ __metadata:
   version: 2.0.2
   resolution: "netmask@npm:2.0.2"
   checksum: cafd28388e698e1138ace947929f842944d0f1c0b87d3fa2601a61b38dc89397d33c0ce2c8e7b99e968584b91d15f6810b91bef3f3826adf71b1833b61d4bf4f
-  languageName: node
-  linkType: hard
-
-"nise@npm:^1.5.2":
-  version: 1.5.3
-  resolution: "nise@npm:1.5.3"
-  dependencies:
-    "@sinonjs/formatio": ^3.2.1
-    "@sinonjs/text-encoding": ^0.7.1
-    just-extend: ^4.0.2
-    lolex: ^5.0.1
-    path-to-regexp: ^1.7.0
-  checksum: c142f35719f2d1e173d1bb041aeeaff42045ba665dc2e41393c3a9c102829ad3c555ec4271b41c66bf2ed8d2fbd56dbd29fbd5a3467ac743d46966161898357c
   languageName: node
   linkType: hard
 
@@ -26821,13 +25587,6 @@ node-pty@beta:
   bin:
     pacote: lib/bin.js
   checksum: c23663846a3db76dfa78944fea137e230363ad30f336f76aea53c8eee315aafd26fb7fe126dd69243173a6cbe86a9b525397727fa65e10e08b9ea71e1981702b
-  languageName: node
-  linkType: hard
-
-"paho-mqtt@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "paho-mqtt@npm:1.1.0"
-  checksum: 499a130b8daf3712a91efad4ce3856a067571de7b5dd2c13d872ab209558903332ba961198dab458d09fc3a64e8a7bc9d374f929e4cffa0b23bbce944d4cb1d8
   languageName: node
   linkType: hard
 
@@ -28838,17 +27597,6 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:^1.4.0":
-  version: 1.7.1
-  resolution: "react-native-get-random-values@npm:1.7.1"
-  dependencies:
-    fast-base64-decode: ^1.0.0
-  peerDependencies:
-    react-native: ">=0.56"
-  checksum: 56da68d9cb9dba5e0a7cc3c22cf3374961133c58f1c34c9b91c462e1ec927d5a267edb17c96f095f9061225f541adb8cc2d62c94cec87c2fd5dce9bbc97c5c24
-  languageName: node
-  linkType: hard
-
 "react-popper@npm:^2.3.0":
   version: 2.3.0
   resolution: "react-popper@npm:2.3.0"
@@ -29687,7 +28435,7 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.5":
+"rxjs@npm:^7.5.5, rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -30237,21 +28985,6 @@ node-pty@beta:
     nise: ^5.1.1
     supports-color: ^7.2.0
   checksum: 085ca6f1c89ee7ba8a5020ff1518551dd27a27a817850cabe4287ba66c25ad9b62228d2d7be8385004744507314591d2b3a34fd23a91c5c819c107dd424cad9c
-  languageName: node
-  linkType: hard
-
-"sinon@npm:^7.5.0":
-  version: 7.5.0
-  resolution: "sinon@npm:7.5.0"
-  dependencies:
-    "@sinonjs/commons": ^1.4.0
-    "@sinonjs/formatio": ^3.2.1
-    "@sinonjs/samsam": ^3.3.3
-    diff: ^3.5.0
-    lolex: ^4.2.0
-    nise: ^1.5.2
-    supports-color: ^5.5.0
-  checksum: 44efbca7bc3ba7b91773f666a1a816a12f420aff1ddd7f62d894bfea37a0b6994224a89abf24f2a98cbca708b8a66a36bb96158e9f103a427483aa4b41236201
   languageName: node
   linkType: hard
 
@@ -30950,7 +29683,7 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.0.4, strnum@npm:^1.0.5":
+"strnum@npm:^1.0.5":
   version: 1.0.5
   resolution: "strnum@npm:1.0.5"
   checksum: 64fb8cc2effbd585a6821faa73ad97d4b553c8927e49086a162ffd2cc818787643390b89d567460a8e74300148d11ac052e21c921ef2049f2987f4b1b89a7ff1
@@ -31038,7 +29771,7 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -31761,14 +30494,14 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.11.1, tslib@npm:^1.8.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.10.0, tslib@npm:^1.11.1, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
   languageName: node
   linkType: hard
 
-"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
+"tslib@npm:^2, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
@@ -32074,7 +30807,7 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"ulid@npm:2.3.0, ulid@npm:^2.3.0":
+"ulid@npm:^2.3.0":
   version: 2.3.0
   resolution: "ulid@npm:2.3.0"
   bin:
@@ -32108,13 +30841,6 @@ node-pty@beta:
   dependencies:
     "@fastify/busboy": ^2.0.0
   checksum: 68a14e0981c4ccaa9e6192bb530e1d5d608cde8423bcca8ae18a6d230366b07b328d98b1ed092c53cbd751dca3067642ab5bdaffa75c3d6d6c69b98cdb4436ce
-  languageName: node
-  linkType: hard
-
-"unfetch@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "unfetch@npm:4.2.0"
-  checksum: a5c0a896a6f09f278b868075aea65652ad185db30e827cb7df45826fe5ab850124bf9c44c4dafca4bf0c55a0844b17031e8243467fcc38dd7a7d435007151f1b
   languageName: node
   linkType: hard
 
@@ -32200,16 +30926,6 @@ node-pty@beta:
   dependencies:
     crypto-random-string: ^4.0.0
   checksum: b35ea034b161b2a573666ec16c93076b4b6106b8b16c2415808d747ab3a0566b5db0c4be231d4b11cfbc16d7fd915c9d8a45884bff0e2db11b799775b2e1e017
-  languageName: node
-  linkType: hard
-
-"universal-cookie@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "universal-cookie@npm:4.0.4"
-  dependencies:
-    "@types/cookie": ^0.3.3
-    cookie: ^0.4.0
-  checksum: db5950601c2f0dbb22af930656bd6abe1f3a9eee4c488703fa806c38b27b98e2ad212445c152a4721c84ee05d1a8dd26decd13690f1c9870fac355682e17998a
   languageName: node
   linkType: hard
 
@@ -32463,16 +31179,7 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"uuid@npm:3.3.2":
-  version: 3.3.2
-  resolution: "uuid@npm:3.3.2"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 847bd7b389f44d05cf5341134d52803116b616c7344f12c74040effd75280b58273ea3a2bee6ba6e5405688c5edbb0696f4adcbc89e1206dc1d8650bdaece7a6
-  languageName: node
-  linkType: hard
-
-"uuid@npm:3.x, uuid@npm:^3.0.0, uuid@npm:^3.2.1, uuid@npm:^3.3.2":
+"uuid@npm:3.x, uuid@npm:^3.3.2":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
   bin:
@@ -32496,6 +31203,15 @@ node-pty@beta:
   bin:
     uuid: dist/bin/uuid
   checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 
@@ -33715,16 +32431,6 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"zen-observable-ts@npm:0.8.19":
-  version: 0.8.19
-  resolution: "zen-observable-ts@npm:0.8.19"
-  dependencies:
-    tslib: ^1.9.3
-    zen-observable: ^0.8.0
-  checksum: d10bd1661ad0dacde17891846105848d71302bcc150283cde7940e32c7a065016c8efd68e6cc149809caea58eb8a93167301e45e83797e36b87bce321a346049
-  languageName: node
-  linkType: hard
-
 "zen-observable-ts@npm:^0.8.12, zen-observable-ts@npm:^0.8.21":
   version: 0.8.21
   resolution: "zen-observable-ts@npm:0.8.21"
@@ -33735,26 +32441,10 @@ node-pty@beta:
   languageName: node
   linkType: hard
 
-"zen-observable@npm:^0.7.0":
-  version: 0.7.1
-  resolution: "zen-observable@npm:0.7.1"
-  checksum: 6f64bb38d728f93fe70b216f4df34602242e08569ee83748a2b7fec49c7ab2bae9b97ac53e2b6535e40f9a6c845fb5ad395bef7b47355a812319a692df50a44b
-  languageName: node
-  linkType: hard
-
 "zen-observable@npm:^0.8.0":
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: 71cc2f2bbb537300c3f569e25693d37b3bc91f225cefce251a71c30bc6bb3e7f8e9420ca0eb57f2ac9e492b085b8dfa075fd1e8195c40b83c951dd59c6e4fbf8
-  languageName: node
-  linkType: hard
-
-"zen-push@npm:0.2.1":
-  version: 0.2.1
-  resolution: "zen-push@npm:0.2.1"
-  dependencies:
-    zen-observable: ^0.7.0
-  checksum: 6347a48ea3bcbf07d0282b593d7d689fb7bf082b6484f091e7e2e1ea2c1644afc035f6910670f5f8edb533c6f90f289c5089db9da4947caa1e007f020fcbf5ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

When working on https://github.com/aws-amplify/amplify-cli/security/dependabot/201, I noticed that it's caused by the out-dated aws-amplify, so migrate it to v6.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
