### PR TITLE
feat(cli): add noUpdateBackend cli argument for pull and add headless pull sample

### DIFF
--- a/packages/amplify-cli/sample-headless-scripts/headless_pull.sh
+++ b/packages/amplify-cli/sample-headless-scripts/headless_pull.sh
@@ -1,0 +1,36 @@
+!/bin/bash
+
+set -e
+IFS='|'
+
+REACTCONFIG="{\
+\"SourceDir\":\"src\",\
+\"DistributionDir\":\"build\",\
+\"BuildCommand\":\"npm run-script build\",\
+\"StartCommand\":\"npm run-script start\"\
+}"
+AWSCLOUDFORMATIONCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":true,\
+\"profileName\":\"default\",\
+}"
+AMPLIFY="{\
+\"projectName\":\"headlessProjectName\",\
+\"defaultEditor\":\"code\"\
+}"
+FRONTEND="{\
+\"frontend\":\"javascript\",\
+\"framework\":\"react\",\
+\"config\":$REACTCONFIG\
+}"
+PROVIDERS="{\
+\"awscloudformation\":$AWSCLOUDFORMATIONCONFIG\
+}"
+
+amplify pull \
+--appId myappId \
+--envName mydevabc \
+--amplify $AMPLIFY \
+--frontend $FRONTEND \
+--providers $PROVIDERS \
+--noUpdateBackend

--- a/packages/amplify-cli/src/attach-backend.ts
+++ b/packages/amplify-cli/src/attach-backend.ts
@@ -75,8 +75,10 @@ const onSuccess = async (context: $TSContext): Promise<void> => {
   await postPullCodegen(context);
 
   if (!inputParams.yes) {
-    const shouldKeepAmplifyDir = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend
-      ? !context.exeInfo.existingLocalEnvInfo.noUpdateBackend
+    const noUpdateBackend = context.exeInfo.existingLocalEnvInfo?.noUpdateBackend || inputParams.noUpdateBackend;
+
+    const shouldKeepAmplifyDir = noUpdateBackend
+      ? !noUpdateBackend
       : await context.amplify.confirmPrompt('Do you plan on modifying this backend?', true);
 
     if (shouldKeepAmplifyDir) {


### PR DESCRIPTION
#### Description of changes

Reviving #8804 

Adds ability to pull amplify config to allow for publish without overwriting local files

Running amplify pull in headless mode in a CI environment with the -y flag causes the local files to be overwritten, but that's not always desired. In my case, I want to push new changes to Amplify via CI (upon merging to main branch for example).

#### Issue #, if available

#5275 

#### Description of how you validated changes

Ran `yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.