### PR TITLE
test: add credential refresh to long-running test

### DIFF
--- a/packages/amplify-migration-tests/src/__tests__/migration_tests_v12/auth-hosted-ui-lambda-migration.test.ts
+++ b/packages/amplify-migration-tests/src/__tests__/migration_tests_v12/auth-hosted-ui-lambda-migration.test.ts
@@ -16,6 +16,7 @@ import {
   getUserPool,
   getUserPoolDomain,
   getUserPoolId,
+  tryScheduleCredentialRefresh,
   updateAuthAddUserGroups,
   updateAuthDomainPrefixWithAllProvidersConfigured,
   updateHeadlessAuth,
@@ -25,6 +26,8 @@ import { UpdateAuthRequest } from 'amplify-headless-interface';
 
 describe('amplify auth hosted ui', () => {
   beforeAll(async () => {
+    tryScheduleCredentialRefresh();
+
     const migrateFromVersion = { v: '12.0.3' };
     const migrateToVersion = { v: 'uninitialized' };
 

--- a/scripts/cloud-cli-utils.sh
+++ b/scripts/cloud-cli-utils.sh
@@ -11,7 +11,7 @@ function authenticate {
     role_name=$2
     profile_name=$3
     echo Authenticating terminal...
-    mwinit --aea
+    mwinit
     echo Loading account credentials for Account $account_number with Role: $role_name...
     ada cred update --profile="${profile_name}" --account="${account_number}" --role=${role_name} --provider=isengard --once
     aws configure set region us-east-1 --profile $profile_name

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -6,7 +6,7 @@ source $scriptDir/.env set
 printf 'What is your PR number ? '
 read PR_NUMBER
 
-mwinit --aea
+mwinit
 ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=CodeBuildE2E --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
 --profile=cb-ci-account \


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR:
1. adds credential refresh to auth migration test (it sometimes hits token expiry)
2. removes deprecated `--aea` option from scripts

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
