### PR TITLE
fix: s3 bucket name randomizer

### DIFF
--- a/packages/amplify-provider-awscloudformation/package.json
+++ b/packages/amplify-provider-awscloudformation/package.json
@@ -61,7 +61,6 @@
     "jose": "^4.3.7",
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
-    "moment": "^2.24.0",
     "netmask": "^2.0.2",
     "node-fetch": "^2.6.7",
     "ora": "^4.0.3",

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
@@ -17,7 +17,7 @@ export async function init(amplifyServiceParams) {
 
   let amplifyAppId;
   let verifiedStackName = stackName;
-  let deploymentBucketName = `${stackName}-deployment`;
+  let deploymentBucketName = `${stackName}-deploy`;
 
   const amplifyClient = await getConfiguredAmplifyClient(context, awsConfigInfo);
   if (!amplifyClient) {

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
@@ -17,7 +17,7 @@ export async function init(amplifyServiceParams) {
 
   let amplifyAppId;
   let verifiedStackName = stackName;
-  let deploymentBucketName = `${stackName}-deploy`;
+  let deploymentBucketName = `${stackName}-deployment`;
 
   const amplifyClient = await getConfiguredAmplifyClient(context, awsConfigInfo);
   if (!amplifyClient) {

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -55,9 +55,9 @@ export const run = async (context: $TSContext): Promise<void> => {
     context.exeInfo ??= { inputParams: {}, localEnvInfo: {} as unknown as LocalEnvInfo };
     const { projectName } = context.exeInfo.projectConfig;
     const initTemplateFilePath = path.join(__dirname, '..', 'resources', 'rootStackTemplate.json');
-    const timeStamp = uuid().substring(0, 6);
+    const uuidStamp = uuid().substring(0, 5);
     const { envName = '' } = context.exeInfo.localEnvInfo;
-    let stackName = normalizeStackName(`amplify-${projectName}-${envName}-${timeStamp}`);
+    let stackName = normalizeStackName(`amplify-${projectName}-${envName}-${uuidStamp}`);
     const awsConfigInfo = await configurationManager.getAwsConfig(context);
 
     await configurePermissionsBoundaryForInit(context);

--- a/packages/amplify-provider-awscloudformation/src/initializer.ts
+++ b/packages/amplify-provider-awscloudformation/src/initializer.ts
@@ -18,7 +18,6 @@ import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 import fs from 'fs-extra';
-import moment from 'moment';
 import path from 'path';
 import sequential from 'promise-sequential';
 import { getDefaultTemplateDescription } from './template-description-utils';
@@ -56,8 +55,7 @@ export const run = async (context: $TSContext): Promise<void> => {
     context.exeInfo ??= { inputParams: {}, localEnvInfo: {} as unknown as LocalEnvInfo };
     const { projectName } = context.exeInfo.projectConfig;
     const initTemplateFilePath = path.join(__dirname, '..', 'resources', 'rootStackTemplate.json');
-    /* eslint-disable-next-line spellcheck/spell-checker */
-    const timeStamp = process.env.CIRCLECI ? uuid().substring(0, 5) : `${moment().format('Hmmss')}`;
+    const timeStamp = uuid().substring(0, 6);
     const { envName = '' } = context.exeInfo.localEnvInfo;
     let stackName = normalizeStackName(`amplify-${projectName}-${envName}-${timeStamp}`);
     const awsConfigInfo = await configurationManager.getAwsConfig(context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,7 +837,6 @@ __metadata:
     jose: ^4.3.7
     lodash: ^4.17.21
     lodash.throttle: ^4.1.1
-    moment: ^2.24.0
     netmask: ^2.0.2
     node-fetch: ^2.6.7
     ora: ^4.0.3


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**Issue**: canary run `amplify init ....` sometimes have "The specified bucket does not exist" error.

**Hypothesis**: the S3 bucket name is not random enough, so the bucket could be accidentally deleted by another task.

**Fix**: Make the bucket name more random

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
