### PR TITLE
test: update e2e coverage for policy update on auth removal

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth_3a.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth_3a.test.ts
@@ -40,7 +40,7 @@ describe('amplify add auth...a', () => {
     await removeAuthWithDefault(projRoot);
     await amplifyPushAuth(projRoot);
 
-    expect(AuthRoleName).not.toHaveValidPolicyConditionMatchingIdpId(idpId);
-    expect(UnauthRoleName).not.toHaveValidPolicyConditionMatchingIdpId(idpId);
+    expect(AuthRoleName).toHaveDenyAssumeRolePolicy();
+    expect(UnauthRoleName).toHaveDenyAssumeRolePolicy();
   });
 });

--- a/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
+++ b/packages/amplify-e2e-tests/src/aws-matchers/iamMatcher.ts
@@ -67,3 +67,30 @@ export const toHaveValidPolicyConditionMatchingIdpId = async (roleName: string, 
     pass,
   };
 };
+
+export const toHaveDenyAssumeRolePolicy = async (roleName: string) => {
+  let pass = false;
+  let message = '';
+
+  try {
+    const iam = new IAM({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+    });
+
+    const { Role: role } = await iam.getRole({ RoleName: roleName }).promise();
+    const assumeRolePolicyDocument = JSON.parse(decodeURIComponent(role.AssumeRolePolicyDocument));
+
+    pass = assumeRolePolicyDocument?.Statement?.Effect === 'Deny';
+
+    message = pass ? 'Assume role policy has Effect: Deny' : 'Assume role policy does not exist or does not have Effect: Deny';
+  } catch (e) {
+    message = 'IAM GetRole threw Error: ' + e.message;
+  }
+
+  return {
+    message: () => message,
+    pass,
+  };
+};

--- a/packages/amplify-e2e-tests/src/setup-tests.ts
+++ b/packages/amplify-e2e-tests/src/setup-tests.ts
@@ -1,4 +1,4 @@
-import { toBeIAMRoleWithArn, toHaveValidPolicyConditionMatchingIdpId, toBeAS3Bucket } from './aws-matchers';
+import { toBeIAMRoleWithArn, toHaveValidPolicyConditionMatchingIdpId, toBeAS3Bucket, toHaveDenyAssumeRolePolicy } from './aws-matchers';
 
 const removeYarnPaths = () => {
   // Remove yarn's temporary PATH modifications as they affect the yarn version used by jest tests when building the lambda functions
@@ -9,6 +9,7 @@ const removeYarnPaths = () => {
 
 expect.extend({ toBeIAMRoleWithArn });
 expect.extend({ toHaveValidPolicyConditionMatchingIdpId });
+expect.extend({ toHaveDenyAssumeRolePolicy });
 expect.extend({ toBeAS3Bucket });
 
 removeYarnPaths();

--- a/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
+++ b/packages/amplify-e2e-tests/typings/aws-matchers.d.ts
@@ -5,5 +5,6 @@ namespace jest {
     toBeIAMRoleWithArn(roleName: string, arn?: string): R;
     toBeAS3Bucket(bucketName: string): R;
     toHaveValidPolicyConditionMatchingIdpId(idpId: string): R;
+    toHaveDenyAssumeRolePolicy(): R;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Follow up to https://github.com/aws-amplify/amplify-cli/pull/13523 to add e2e coverage.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
e2e tests are running now https://us-east-1.console.aws.amazon.com/codesuite/codebuild/671107461633/projects/AmplifyCLI-E2E-Testing/batch/AmplifyCLI-E2E-Testing:1ed07888-d306-4cfa-aba2-13e66e73da22?region=us-east-1
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
