### PR TITLE
fix: dependabot alert for lodash.set

### DIFF
--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -71,7 +71,7 @@
     "@types/uuid": "^8.0.0",
     "@types/yarnpkg__lockfile": "^1.1.5",
     "jest": "^29.5.0",
-    "nock": "^13.0.11",
+    "nock": "^13.5.0",
     "rimraf": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "uuid": "^8.3.2"

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -122,7 +122,7 @@
     "amplify-headless-interface": "1.17.6",
     "cloudform-types": "^4.2.0",
     "jest": "^29.5.0",
-    "nock": "^12.0.3",
+    "nock": "^13.5.0",
     "typescript": "^4.9.5"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,7 +428,7 @@ __metadata:
     jest: ^29.5.0
     js-yaml: ^4.0.0
     lodash: ^4.17.21
-    nock: ^13.0.11
+    nock: ^13.5.0
     node-fetch: ^2.6.7
     open: ^8.4.0
     ora: ^4.0.3
@@ -1146,7 +1146,7 @@ __metadata:
     inquirer: ^7.3.3
     jest: ^29.5.0
     lodash: ^4.17.21
-    nock: ^12.0.3
+    nock: ^13.5.0
     node-fetch: ^2.6.7
     ora: ^4.0.3
     progress: ^2.0.3
@@ -24608,13 +24608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.set@npm:^4.3.2":
-  version: 4.3.2
-  resolution: "lodash.set@npm:4.3.2"
-  checksum: c641d31905e51df43170dce8a1d11a1cff11356e2e2e75fe2615995408e9687d58c3e1d64c3c284c2df2bc519f79a98af737d2944d382ff82ffd244ff6075c29
-  languageName: node
-  linkType: hard
-
 "lodash.snakecase@npm:^4.1.1":
   version: 4.1.1
   resolution: "lodash.snakecase@npm:4.1.1"
@@ -24671,7 +24664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.12, lodash@npm:^4.17.13, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.2.0, lodash@npm:^4.2.1, lodash@npm:~4.17.0, lodash@npm:~4.17.15":
+"lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.2.0, lodash@npm:^4.2.1, lodash@npm:~4.17.0, lodash@npm:~4.17.15":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -25719,27 +25712,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^12.0.3":
-  version: 12.0.3
-  resolution: "nock@npm:12.0.3"
+"nock@npm:^13.5.0":
+  version: 13.5.0
+  resolution: "nock@npm:13.5.0"
   dependencies:
     debug: ^4.1.0
     json-stringify-safe: ^5.0.1
-    lodash: ^4.17.13
     propagate: ^2.0.0
-  checksum: a0a76707762daac50a442d82fd96faac9e80fbd48a5a8fc491d405903d6ae5fc755d5ccbd27d2d7997e69ad409699c9e1a172aedf527c94a4278d855a6fe730b
-  languageName: node
-  linkType: hard
-
-"nock@npm:^13.0.11":
-  version: 13.2.1
-  resolution: "nock@npm:13.2.1"
-  dependencies:
-    debug: ^4.1.0
-    json-stringify-safe: ^5.0.1
-    lodash.set: ^4.3.2
-    propagate: ^2.0.0
-  checksum: e6be01052fccc619274a85485ada84b225ed483846b040d0d85fd4f41d753218f363e9be08aae051d12ea2759ffdd6b8803f3346a23b50b0cb05d73410033b13
+  checksum: ba98390042a61b8687da9174fa07282d14f8b0cb5ac50c310eba9bb70a0beb5ea8257ba1f2a3e324db5570111689485a1f16746c2527f3050357e6917666bdef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

https://github.com/aws-amplify/amplify-cli/security/dependabot/209



#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Before:

```
❯ yarn why lodash.set
└─ nock@npm:13.2.1
   └─ lodash.set@npm:4.3.2 (via npm:^4.3.2)
```

After:

```
❯ yarn why lodash.set
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
