### PR TITLE
chore: switch to using four core standard github window action workers

### DIFF
--- a/.github/workflows/smoke-tests-manual.yml
+++ b/.github/workflows/smoke-tests-manual.yml
@@ -11,7 +11,7 @@ on:
       os:
         required: false
         type: string
-        default: '["macos-latest-xl", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
+        default: '["macos-latest-xl", "ubuntu-latest", "windows-latest"]'
       versions:
         required: false
         type: string

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,7 +11,7 @@ on:
       os:
         required: false
         type: string
-        default: '["macos-latest-xl", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
+        default: '["macos-latest-xl", "ubuntu-latest", "windows-latest"]'
       versions:
         required: false
         type: string


### PR DESCRIPTION

#### Description of changes

 switch to using four core standard github window action workers

#### Issue #, if available

N/A

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
