### PR TITLE
fix(go-function-runtime-provider): fix build go error

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/constants.ts
+++ b/packages/amplify-go-function-runtime-provider/src/constants.ts
@@ -6,8 +6,8 @@ export const BIN = 'bin';
 export const SRC = 'src';
 export const DIST = 'dist';
 export const MAIN_SOURCE = 'main.go';
-export const MAIN_BINARY = 'main';
-export const MAIN_BINARY_WIN = 'main.exe';
+export const MAIN_BINARY = 'bootstrap';
+export const MAIN_BINARY_WIN = 'bootstrap.exe';
 
 export const BASE_PORT = 8900;
 export const MAX_PORT = 9999;

--- a/packages/amplify-go-function-runtime-provider/src/index.ts
+++ b/packages/amplify-go-function-runtime-provider/src/index.ts
@@ -13,10 +13,10 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
       return Promise.resolve({
         runtime: {
           name: 'Go 1.x',
-          value: 'go1.x',
-          cloudTemplateValue: 'go1.x',
+          value: 'provided.al2023',
+          cloudTemplateValue: 'provided.al2023',
           defaultHandler: 'main',
-          layerExecutablePath: 'go1.x',
+          layerExecutablePath: 'provided.al2023',
         },
       });
     },

--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -100,7 +100,7 @@ export const buildResource = async ({ buildType, srcRoot, lastBuildTimeStamp }: 
     // for go@1.16, dependencies must be manually installed
     executeCommand(['mod', 'tidy', '-v'], true, envVars, srcDir);
     // Execute the build command, cwd must be the source file directory (Windows requires it)
-    executeCommand(['build', '-o', executablePath, '.'], true, envVars, srcDir);
+    executeCommand(['build', '-tags', 'lambda.norpc', '-o', executablePath, '.'], true, envVars, srcDir);
 
     rebuilt = true;
   }

--- a/packages/amplify-go-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-go-function-template-provider/amplify-plugin.json
@@ -6,8 +6,10 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["Lambda"],
-      "runtime": "go1.x"
+      "services": [
+        "Lambda"
+      ],
+      "runtime": "provided.al2023"
     },
     "templates": [
       {


### PR DESCRIPTION
#### Description of changes
I changed object name to `bootstrap` and runtime replaced to `provided.al2023` from `go1.x`. because of the end of support in AWS Lambda. I tested on my local machine, added new function then push, tested lambda functions, it works.

#### Issue #, if available

#13658


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [X] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
