### PR TITLE
fix(amplify-cli-core): gracefully handle execa race condition

### DIFF
--- a/packages/amplify-cli-core/src/hooks/hooksExecutor.ts
+++ b/packages/amplify-cli-core/src/hooks/hooksExecutor.ts
@@ -86,9 +86,17 @@ const execHelper = async (
         error: errorParameter,
       }),
       stripFinalNewline: false,
+      stdout: 'inherit',
+      // added to do further checks before throwing due to EPIPE error
+      reject: false,
     });
-    childProcess?.stdout?.pipe(process.stdout);
     const childProcessResult = await childProcess;
+
+    // throw if child process ended with anything other than exitCode 0
+    if (childProcessResult && childProcess.exitCode !== 0) {
+      throw childProcessResult;
+    }
+
     if (!childProcessResult?.stdout?.endsWith(EOL)) {
       printer.blankLine();
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When `execa` handles a hooks file that executes very fast, we have a race condition where `execa` will try to pipe inputs to the child process's `stdin` after the process finishes causing an `EPIPE` error (Refer to https://github.com/sindresorhus/execa/issues/474).

The change is to not have `execa` reject initially so we can determine what to do:
- If the hooks file executed successfully (child process exit code is 0), then we continue execution.
- If not, then we go through our existing error handling.

Also updated how we pipe `stdout` for the child process, this caused the misconception that the hooks file was not running at all (no `echo` in the hooks file is presented).

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Added unit tests and manually tested with the following pre-push and post-push hooks files:
```ts
// pre-push.sh
echo "prepush hook"
```

```ts
// post-push.sh
echo "postpush hook"
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
