### PR TITLE
chore(cli-internal): direct to gen2 for command not found error

### DIFF
--- a/packages/amplify-cli/src/__tests__/input-validation.test.ts
+++ b/packages/amplify-cli/src/__tests__/input-validation.test.ts
@@ -34,7 +34,7 @@ describe('input validation tests', () => {
 
     const verifyInputResult = await verifyInput(pluginPlatform, input);
     expect(verifyInputResult.message).toContain('can NOT find command');
-    expect(verifyInputResult.message).toContain('npx @aws-amplify/backend-cli amplify sandbox');
+    expect(verifyInputResult.message).toContain('npx @aws-amplify/backend-cli sandbox');
   });
 
   it('display yarn dlx Amplify Gen 2 message with command not found message', async () => {
@@ -48,7 +48,7 @@ describe('input validation tests', () => {
 
     const verifyInputResult = await verifyInput(pluginPlatform, input);
     expect(verifyInputResult.message).toContain('can NOT find command');
-    expect(verifyInputResult.message).toContain('yarn dlx @aws-amplify/backend-cli amplify sandbox');
+    expect(verifyInputResult.message).toContain('yarn dlx @aws-amplify/backend-cli sandbox');
   });
 
   it('display pnpm dlx Amplify Gen 2 message with command not found message', async () => {
@@ -62,6 +62,6 @@ describe('input validation tests', () => {
 
     const verifyInputResult = await verifyInput(pluginPlatform, input);
     expect(verifyInputResult.message).toContain('can NOT find command');
-    expect(verifyInputResult.message).toContain('pnpm dlx @aws-amplify/backend-cli amplify sandbox');
+    expect(verifyInputResult.message).toContain('pnpm dlx @aws-amplify/backend-cli sandbox');
   });
 });

--- a/packages/amplify-cli/src/__tests__/input-validation.test.ts
+++ b/packages/amplify-cli/src/__tests__/input-validation.test.ts
@@ -1,14 +1,67 @@
 import { verifyInput } from '../input-manager';
-import { PluginPlatform } from '@aws-amplify/amplify-cli-core';
+import { PluginInfo, PluginManifest, PluginPlatform, getPackageManager, getPackageManagerByType } from '@aws-amplify/amplify-cli-core';
 import { CLIInput as CommandLineInput } from '../domain/command-input';
 
+jest.mock('@aws-amplify/amplify-cli-core', () => ({
+  ...(jest.requireActual('@aws-amplify/amplify-cli-core') as {}),
+  getPackageManager: jest.fn(),
+}));
+
+const npmPackageManager = getPackageManagerByType('npm');
+const yarnPackageManager = getPackageManagerByType('yarn');
+const pnpmPackageManager = getPackageManagerByType('pnpm');
+
 describe('input validation tests', () => {
-  it('status -v option should be treated as verbose', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('status -v option should be treated as verbose', async () => {
     const input = new CommandLineInput(['status', '-v']);
     input.command = 'status';
     input.options = { v: true };
 
-    verifyInput(new PluginPlatform(), input);
+    await verifyInput(new PluginPlatform(), input);
     expect(input?.options?.verbose).toBe(true);
+  });
+
+  it('display npx Amplify Gen 2 message with command not found message', async () => {
+    (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockResolvedValue(npmPackageManager);
+    const input = new CommandLineInput(['sandbox']);
+    input.command = 'sandbox';
+
+    const version = 'latestVersion';
+    const pluginPlatform = new PluginPlatform();
+    pluginPlatform.plugins.core = [new PluginInfo('', version, '', new PluginManifest('', ''))];
+
+    const verifyInputResult = await verifyInput(pluginPlatform, input);
+    expect(verifyInputResult.message).toContain('can NOT find command');
+    expect(verifyInputResult.message).toContain('npx @aws-amplify/backend-cli amplify sandbox');
+  });
+
+  it('display yarn dlx Amplify Gen 2 message with command not found message', async () => {
+    (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockResolvedValue(yarnPackageManager);
+    const input = new CommandLineInput(['sandbox']);
+    input.command = 'sandbox';
+
+    const version = 'latestVersion';
+    const pluginPlatform = new PluginPlatform();
+    pluginPlatform.plugins.core = [new PluginInfo('', version, '', new PluginManifest('', ''))];
+
+    const verifyInputResult = await verifyInput(pluginPlatform, input);
+    expect(verifyInputResult.message).toContain('can NOT find command');
+    expect(verifyInputResult.message).toContain('yarn dlx @aws-amplify/backend-cli amplify sandbox');
+  });
+
+  it('display pnpm dlx Amplify Gen 2 message with command not found message', async () => {
+    (getPackageManager as jest.MockedFunction<typeof getPackageManager>).mockResolvedValue(pnpmPackageManager);
+    const input = new CommandLineInput(['sandbox']);
+    input.command = 'sandbox';
+
+    const version = 'latestVersion';
+    const pluginPlatform = new PluginPlatform();
+    pluginPlatform.plugins.core = [new PluginInfo('', version, '', new PluginManifest('', ''))];
+
+    const verifyInputResult = await verifyInput(pluginPlatform, input);
+    expect(verifyInputResult.message).toContain('can NOT find command');
+    expect(verifyInputResult.message).toContain('pnpm dlx @aws-amplify/backend-cli amplify sandbox');
   });
 });

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -86,7 +86,7 @@ export const run = async (startTime: number): Promise<void> => {
   ensureFilePermissions(pathManager.getAWSCredentialsFilePath());
   ensureFilePermissions(pathManager.getAWSConfigFilePath());
 
-  let verificationResult = verifyInput(pluginPlatform, input);
+  let verificationResult = await verifyInput(pluginPlatform, input);
 
   // invalid input might be because plugin platform might have been updated,
   // scan and try again
@@ -96,7 +96,7 @@ export const run = async (startTime: number): Promise<void> => {
     }
     pluginPlatform = await scan();
     input = getCommandLineInput(pluginPlatform);
-    verificationResult = verifyInput(pluginPlatform, input);
+    verificationResult = await verifyInput(pluginPlatform, input);
   }
   if (!verificationResult.verified) {
     if (verificationResult.helpCommandAvailable) {
@@ -209,14 +209,14 @@ async function sigIntHandler(context: Context): Promise<void> {
  */
 export const execute = async (input: CLIInput): Promise<void> => {
   let pluginPlatform = await getPluginPlatform();
-  let verificationResult = verifyInput(pluginPlatform, input);
+  let verificationResult = await verifyInput(pluginPlatform, input);
 
   if (!verificationResult.verified) {
     if (verificationResult.message) {
       printer.warn(verificationResult.message);
     }
     pluginPlatform = await scan();
-    verificationResult = verifyInput(pluginPlatform, input);
+    verificationResult = await verifyInput(pluginPlatform, input);
   }
 
   if (!verificationResult.verified) {

--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -1,9 +1,10 @@
 // normalize command line arguments, allow verb / noun place switch
-import { constants, PluginPlatform, pathManager, stateManager, commandsInfo } from '@aws-amplify/amplify-cli-core';
+import { constants, PluginPlatform, pathManager, stateManager, commandsInfo, getPackageManager } from '@aws-amplify/amplify-cli-core';
 import { getPluginsWithName, getAllPluginNames } from './plugin-manager';
 import { InputVerificationResult } from './domain/input-verification-result';
 import { insertAmplifyIgnore } from './extensions/amplify-helpers/git-manager';
 import { CLIInput } from './domain/command-input';
+import { EOL } from 'os';
 
 export function getCommandLineInput(pluginPlatform: PluginPlatform): CLIInput {
   const result = new CLIInput(process.argv);
@@ -139,7 +140,7 @@ function normalizeInput(input: CLIInput): CLIInput {
   return input;
 }
 
-export function verifyInput(pluginPlatform: PluginPlatform, input: CLIInput): InputVerificationResult {
+export async function verifyInput(pluginPlatform: PluginPlatform, input: CLIInput): Promise<InputVerificationResult> {
   const result = new InputVerificationResult();
 
   // Normalize status command options
@@ -235,7 +236,12 @@ export function verifyInput(pluginPlatform: PluginPlatform, input: CLIInput): In
         commandString += ' ' + input.subCommands!.join(' ');
       }
 
-      result.message = `The Amplify CLI can NOT find command: ${commandString}`;
+      const packageManager = (await getPackageManager())?.packageManager ?? 'npm';
+      const executeCommand = packageManager === 'npm' ? 'npx' : `${packageManager} dlx`;
+
+      const amplifyGen2Message = `For Amplify Gen 2, install the @aws-amplify/backend-cli package or execute using the package name directly:${EOL}${executeCommand} @aws-amplify/backend-cli amplify${commandString}`;
+
+      result.message = `The Amplify CLI can NOT find command: ${commandString}${EOL}${EOL}${amplifyGen2Message}`;
     }
   } else {
     result.verified = false;

--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -239,7 +239,7 @@ export async function verifyInput(pluginPlatform: PluginPlatform, input: CLIInpu
       const packageManager = (await getPackageManager())?.packageManager ?? 'npm';
       const executeCommand = packageManager === 'npm' ? 'npx' : `${packageManager} dlx`;
 
-      const amplifyGen2Message = `For Amplify Gen 2, install the @aws-amplify/backend-cli package or execute using the package name directly:${EOL}${executeCommand} @aws-amplify/backend-cli${commandString}`;
+      const amplifyGen2Message = `If you are trying to use Amplify Gen 2, install the @aws-amplify/backend-cli package or execute using the package name directly:${EOL}${executeCommand} @aws-amplify/backend-cli${commandString}`;
 
       result.message = `The Amplify CLI can NOT find command: ${commandString}${EOL}${EOL}${amplifyGen2Message}`;
     }

--- a/packages/amplify-cli/src/input-manager.ts
+++ b/packages/amplify-cli/src/input-manager.ts
@@ -239,7 +239,7 @@ export async function verifyInput(pluginPlatform: PluginPlatform, input: CLIInpu
       const packageManager = (await getPackageManager())?.packageManager ?? 'npm';
       const executeCommand = packageManager === 'npm' ? 'npx' : `${packageManager} dlx`;
 
-      const amplifyGen2Message = `For Amplify Gen 2, install the @aws-amplify/backend-cli package or execute using the package name directly:${EOL}${executeCommand} @aws-amplify/backend-cli amplify${commandString}`;
+      const amplifyGen2Message = `For Amplify Gen 2, install the @aws-amplify/backend-cli package or execute using the package name directly:${EOL}${executeCommand} @aws-amplify/backend-cli${commandString}`;
 
       result.message = `The Amplify CLI can NOT find command: ${commandString}${EOL}${EOL}${amplifyGen2Message}`;
     }


### PR DESCRIPTION
#### Description of changes

If `@aws-amplify/cli` is installed globally and you run `npx amplify ...` for Amplify Gen 2 then you get an unhelpful command not found error.

This PR updates the error message to direct users to either install Gen 2 CLI or update their execute command to use Gen 2.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Unit tests and manually with `amplify-dev generate config`:

<img width="757" alt="Screenshot 2024-04-11 at 6 28 18 PM" src="https://github.com/aws-amplify/amplify-cli/assets/23459628/ce8434f6-d53f-46b8-876f-85e9fff16c89">

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
