### PR TITLE
fix: log batch trigger

### DIFF
--- a/scripts/wait-for-all-codebuild.ts
+++ b/scripts/wait-for-all-codebuild.ts
@@ -55,7 +55,7 @@ const main = async () => {
   console.log('jobsDependedOnFilepathOrId:', jobsDependedOnFilepathOrId);
   console.log('codeBuildProjectName', codeBuildProjectName);
   console.log('codebuildWebhookTrigger', codebuildWebhookTrigger);
-  console.log('accountForFailures', accountForFailures);
+  console.log('accountForFailures', process.argv[6]);
 
   let jobsDependedOn: string[];
   if (fs.existsSync(jobsDependedOnFilepathOrId)) {

--- a/scripts/wait-for-all-codebuild.ts
+++ b/scripts/wait-for-all-codebuild.ts
@@ -80,14 +80,14 @@ const main = async () => {
   let intersectingIncompleteJobs: string[];
   do {
     await new Promise((resolve) => setTimeout(resolve, 180 * 1000)); // sleep for 180 seconds
+    const failedJobsInBatch = await getFailedJobIdsFromBatchId(cb, batchId);
+    const intersectingFailedJobs = failedJobsInBatch.filter((jobId) => jobsDependedOn.includes(jobId));
+    const batchFailed = failedJobsInBatch.length || intersectingFailedJobs.length;
+    console.log(`Batch triggered by ${codebuildWebhookTrigger} ${batchFailed ? 'failed' : 'succeeded'}.`);
+
     if (accountForFailures) {
-      const failedJobsInBatch = await getFailedJobIdsFromBatchId(cb, batchId);
-      const intersectingFailedJobs = failedJobsInBatch.filter((jobId) => jobsDependedOn.includes(jobId));
       console.log(`failedJobsInBatch: ${JSON.stringify(failedJobsInBatch)}`);
       console.log(`intersectingFailedJobs: ${JSON.stringify(intersectingFailedJobs)}`);
-      if (failedJobsInBatch.length || intersectingFailedJobs.length) {
-        console.log(`Batch triggered by ${codebuildWebhookTrigger} failed.`);
-      }
       if (intersectingFailedJobs.length > 0) {
         console.log(`${jobsDependedOn[0]} failed. Exiting.`);
         process.exit(1);

--- a/scripts/wait-for-all-codebuild.ts
+++ b/scripts/wait-for-all-codebuild.ts
@@ -51,6 +51,12 @@ const main = async () => {
   const codeBuildProjectName = process.argv[4];
   const codebuildWebhookTrigger = process.argv[5];
   const accountForFailures: boolean = process.argv.length >= 7 && process.argv[6] === 'requirePrevJobsToSucceed';
+  console.log('expectedSourceVersion:', expectedSourceVersion);
+  console.log('jobsDependedOnFilepathOrId:', jobsDependedOnFilepathOrId);
+  console.log('codeBuildProjectName', codeBuildProjectName);
+  console.log('codebuildWebhookTrigger', codebuildWebhookTrigger);
+  console.log('accountForFailures', accountForFailures);
+
   let jobsDependedOn: string[];
   if (fs.existsSync(jobsDependedOnFilepathOrId)) {
     const jobsDependedOnRaw = fs.readFileSync(jobsDependedOnFilepathOrId, 'utf8');

--- a/scripts/wait-for-all-codebuild.ts
+++ b/scripts/wait-for-all-codebuild.ts
@@ -51,11 +51,6 @@ const main = async () => {
   const codeBuildProjectName = process.argv[4];
   const codebuildWebhookTrigger = process.argv[5];
   const accountForFailures: boolean = process.argv.length >= 7 && process.argv[6] === 'requirePrevJobsToSucceed';
-  console.log('expectedSourceVersion:', expectedSourceVersion);
-  console.log('jobsDependedOnFilepathOrId:', jobsDependedOnFilepathOrId);
-  console.log('codeBuildProjectName', codeBuildProjectName);
-  console.log('codebuildWebhookTrigger', codebuildWebhookTrigger);
-  console.log('accountForFailures', process.argv[6]);
 
   let jobsDependedOn: string[];
   if (fs.existsSync(jobsDependedOnFilepathOrId)) {

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -670,6 +670,7 @@ function _waitForJobs {
     cd ./scripts
     npm install -g ts-node
     npm install aws-sdk
+    echo "RUNNING RUNNING...ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME $CODEBUILD_WEBHOOK_TRIGGER $account_for_failures"
     ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME $CODEBUILD_WEBHOOK_TRIGGER $account_for_failures
     cd ..
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -670,7 +670,6 @@ function _waitForJobs {
     cd ./scripts
     npm install -g ts-node
     npm install aws-sdk
-    echo "RUNNING RUNNING...ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME ${CODEBUILD_WEBHOOK_TRIGGER:-empty} $account_for_failures"
     ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME ${CODEBUILD_WEBHOOK_TRIGGER:-empty} $account_for_failures
     cd ..
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -670,8 +670,8 @@ function _waitForJobs {
     cd ./scripts
     npm install -g ts-node
     npm install aws-sdk
-    echo "RUNNING RUNNING...ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME $CODEBUILD_WEBHOOK_TRIGGER $account_for_failures"
-    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME $CODEBUILD_WEBHOOK_TRIGGER $account_for_failures
+    echo "RUNNING RUNNING...ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME ${CODEBUILD_WEBHOOK_TRIGGER:-empty} $account_for_failures"
+    ts-node ./wait-for-all-codebuild.ts $CODEBUILD_RESOLVED_SOURCE_VERSION $file_path $PROJECT_NAME ${CODEBUILD_WEBHOOK_TRIGGER:-empty} $account_for_failures
     cd ..
 }
 function _verifyPkgCLI {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

After https://github.com/aws-amplify/amplify-cli/pull/13738, there are 2 problems found:
1. the log only works if `accountForFailures` is `true`
2. if `CODEBUILD_WEBHOOK_TRIGGER` is `unset` or `null`, `accountForFailures` would become the 5th param

In this PR:
- moved the `CODEBUILD_WEBHOOK_TRIGGER` log out of the `accountForFailures` check
- set a default value `empty` for `CODEBUILD_WEBHOOK_TRIGGER`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

tested in codebuild

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
