### PR TITLE
fix: error message when secret access key is invalid on init

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/amplify-service-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/amplify-service-manager.test.ts
@@ -65,4 +65,27 @@ describe('init', () => {
     };
     await expect(init(amplifyServiceParamsStub)).rejects.toMatchInlineSnapshot(`[ConfigurationError: Missing Region in Config]`);
   });
+
+  it('throws ProjectInitError if secret access key is invalid', async () => {
+    const amplifyClientStub = {
+      createApp: jest.fn().mockReturnValue({
+        promise: jest.fn().mockRejectedValue({
+          code: 'InvalidSignatureException',
+        }),
+      }),
+    } as unknown as Amplify;
+    getConfiguredAmplifyClientMock.mockClear();
+    getConfiguredAmplifyClientMock.mockResolvedValue(amplifyClientStub);
+
+    const amplifyServiceParamsStub = {
+      context: {},
+      awsConfigInfo: {},
+      projectName: 'test-project',
+      envName: 'test',
+      stackName: 'test-stack-name',
+    };
+    await expect(init(amplifyServiceParamsStub)).rejects.toMatchInlineSnapshot(
+      `[ProjectInitError: The request signature we calculated does not match the signature you provided]`,
+    );
+  });
 });

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
@@ -148,6 +148,16 @@ export async function init(amplifyServiceParams) {
           resolution: 'https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html',
         });
       }
+      if (e.code === 'InvalidSignatureException') {
+        throw new AmplifyError(
+          'ProjectInitError',
+          {
+            message: 'The request signature we calculated does not match the signature you provided',
+            resolution: 'Check your AWS Secret Access Key',
+          },
+          e,
+        );
+      }
       // default fault
       throw new AmplifyFault(
         'ProjectInitFault',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Changed `amplify init` error message when the AWS secret access key is invalid, from a message saying Forbidden to a helpful message.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

Fix #13342

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manual Testing, added unit test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
