### PR TITLE
fix: fix Go project with multiple files

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/runtime.ts
+++ b/packages/amplify-go-function-runtime-provider/src/runtime.ts
@@ -100,7 +100,7 @@ export const buildResource = async ({ buildType, srcRoot, lastBuildTimeStamp }: 
     executeCommand(['mod', 'tidy', '-v'], true, envVars, srcDir);
     // Execute the build command, cwd must be the source file directory (Windows requires it)
     // Details: https://github.com/aws/aws-lambda-go
-    executeCommand(['build', '-o', '../bin/bootstrap', 'main.go'], true, envVars, srcDir);
+    executeCommand(['build', '-o', '../bin/bootstrap', '.'], true, envVars, srcDir);
 
     rebuilt = true;
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

After https://github.com/aws-amplify/amplify-cli/pull/13671/files#diff-9e8ed84544b6574832f1d34bde8bc4fffff3558a54806adb09b4884758ff618aR105, Go project would fail if it has more functions than `main.go`. 

To fix it, we need to build all Go files instead of only `main.go`.

Special thanks to @ykethan  for diving into this issue.

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/13725

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

verified with my local test project. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
