### PR TITLE
chore: reduce active polling in code build workflows

### DIFF
--- a/codebuild_specs/build_pkg_binaries_arm.yml
+++ b/codebuild_specs/build_pkg_binaries_arm.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs publish_to_local_registry requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _buildBinaries arm
 
 artifacts:

--- a/codebuild_specs/build_pkg_binaries_linux.yml
+++ b/codebuild_specs/build_pkg_binaries_linux.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs publish_to_local_registry requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _buildBinaries linux
 
 artifacts:

--- a/codebuild_specs/build_pkg_binaries_macos.yml
+++ b/codebuild_specs/build_pkg_binaries_macos.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs publish_to_local_registry requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _buildBinaries macos
 
 artifacts:

--- a/codebuild_specs/build_pkg_binaries_win.yml
+++ b/codebuild_specs/build_pkg_binaries_win.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs publish_to_local_registry requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _buildBinaries win
 
 artifacts:

--- a/codebuild_specs/e2e_workflow.yml
+++ b/codebuild_specs/e2e_workflow.yml
@@ -58,36 +58,54 @@ batch:
         - build_linux
     - identifier: publish_to_local_registry
       buildspec: codebuild_specs/publish_to_local_registry.yml
+      depend-on:
+        - build_linux
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
+      depend-on:
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: run_e2e_tests_linux

--- a/codebuild_specs/e2e_workflow_base.yml
+++ b/codebuild_specs/e2e_workflow_base.yml
@@ -60,36 +60,54 @@ batch:
         - build_linux
     - identifier: publish_to_local_registry
       buildspec: codebuild_specs/publish_to_local_registry.yml
+      depend-on:
+        - build_linux
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
+      depend-on:
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: integration_test

--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -60,6 +60,8 @@ batch:
         - build_linux
     - identifier: publish_to_local_registry
       buildspec: codebuild_specs/publish_to_local_registry.yml
+      depend-on:
+        - build_linux
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_arm
@@ -80,16 +82,24 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
+      depend-on:
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: integration_test

--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -66,18 +66,26 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
+      depend-on:
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb

--- a/codebuild_specs/pr_workflow.yml
+++ b/codebuild_specs/pr_workflow.yml
@@ -63,37 +63,40 @@ batch:
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: verify_e2e_workflow_generated
       buildspec: codebuild_specs/verify_e2e_workflow_generated.yml
       depend-on:

--- a/codebuild_specs/publish_to_local_registry.yml
+++ b/codebuild_specs/publish_to_local_registry.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs build_linux requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _publishToLocalRegistry
 
 artifacts:

--- a/codebuild_specs/release_workflows/hotfix_workflow.yml
+++ b/codebuild_specs/release_workflows/hotfix_workflow.yml
@@ -56,34 +56,37 @@ batch:
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild_specs/release_workflows/release_rc_workflow.yml
+++ b/codebuild_specs/release_workflows/release_rc_workflow.yml
@@ -35,43 +35,49 @@ batch:
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: publish_to_npm
       buildspec: codebuild_specs/publish_to_npm.yml
       env:

--- a/codebuild_specs/release_workflows/release_workflow.yml
+++ b/codebuild_specs/release_workflows/release_workflow.yml
@@ -35,43 +35,49 @@ batch:
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: github_prerelease
       buildspec: codebuild_specs/release_workflows/github_prerelease.yml
       env:

--- a/codebuild_specs/release_workflows/tagged_release_without_e2e_workflow.yml
+++ b/codebuild_specs/release_workflows/tagged_release_without_e2e_workflow.yml
@@ -34,43 +34,49 @@ batch:
     - identifier: build_pkg_binaries_arm
       buildspec: codebuild_specs/build_pkg_binaries_arm.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_linux
       buildspec: codebuild_specs/build_pkg_binaries_linux.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_macos
       buildspec: codebuild_specs/build_pkg_binaries_macos.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: build_pkg_binaries_win
       buildspec: codebuild_specs/build_pkg_binaries_win.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: upb
       buildspec: codebuild_specs/upload_pkg_binaries.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_pkg_cli
       buildspec: codebuild_specs/verify_pkg_cli.yml
       depend-on:
-        - build_linux
+        - build_pkg_binaries_arm
+        - build_pkg_binaries_linux
+        - build_pkg_binaries_macos
+        - build_pkg_binaries_win
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: verify_versions_match
       buildspec: codebuild_specs/verify_versions_match.yml
       depend-on:
-        - build_linux
+        - publish_to_local_registry
     - identifier: publish_to_npm
       buildspec: codebuild_specs/publish_to_npm.yml
       env:

--- a/codebuild_specs/upload_pkg_binaries.yml
+++ b/codebuild_specs/upload_pkg_binaries.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs $CODEBUILD_SRC_DIR/codebuild_specs/wait_upb.json requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _uploadPkgBinaries
 
 artifacts:

--- a/codebuild_specs/verify_pkg_cli.yml
+++ b/codebuild_specs/verify_pkg_cli.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs $CODEBUILD_SRC_DIR/codebuild_specs/wait_upb.json requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _verifyPkgCLI
 artifacts:
   files:

--- a/codebuild_specs/verify_versions_match.yml
+++ b/codebuild_specs/verify_versions_match.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - source shared-scripts.sh && _waitForJobs publish_to_local_registry requirePrevJobsToSucceed
       - source ./shared-scripts.sh && _verifyVersionsMatch
 artifacts:
   files:

--- a/codebuild_specs/wait_upb.json
+++ b/codebuild_specs/wait_upb.json
@@ -1,1 +1,0 @@
-["build_pkg_binaries_arm", "build_pkg_binaries_linux", "build_pkg_binaries_macos", "build_pkg_binaries_win"]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR removes active polling that was in place to mitigate CodeBuild graph evaluation inefficiencies. Please see https://github.com/aws-amplify/amplify-cli/pull/13121 for details about inefficiencies.

These inefficiencies has been adressed and this PR removes most of active polling. The only place with active polling that remains is the job that runs after all e2e tests and needs to await on all job ids. Producing `depends-on` statement for that job must remain in place for now due to us hitting YML file size limits.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Kicked off PR and E2E workflows.

Observed that jobs are awaiting on only required ones from previous level of nesting.

See

![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/5d452362-eb6e-4b3f-a442-5bfa0e720d87)

![image](https://github.com/aws-amplify/amplify-cli/assets/5849952/6450caa5-f0d4-4af6-b0f8-70cad6eec615)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
