### PR TITLE
fix: s3 resource fails in amplify push for too-long bucket name

### DIFF
--- a/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/validate-bucket-name.test.js
+++ b/packages/amplify-category-hosting/__tests__/lib/S3AndCloudFront/helpers/validate-bucket-name.test.js
@@ -49,4 +49,11 @@ describe('validate-bucket-name', () => {
     expect(typeof result === 'boolean').toBeTruthy();
     expect(result).toEqual(true);
   });
+
+  test('validate, good bucket name with more than 63 characters', () => {
+    const bucketName = 'my.bucket-name10-more-than-63-characters-should-not-be-allowed-pqwew-qwesd-seredasde-wqe';
+    const result = validateBucketName(bucketName);
+    expect(typeof result === 'boolean').toBeTruthy();
+    expect(result).toEqual(true);
+  });
 });

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/validate-bucket-name.js
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/helpers/validate-bucket-name.js
@@ -1,8 +1,8 @@
 module.exports = (value) => {
-  let isValid = typeof value === 'string' && value.length >= 3 && value.length <= 63 && /^[a-z0-9.-]*$/.test(value);
+  let isValid = typeof value === 'string' && value.length >= 3 && /^[a-z0-9.-]*$/.test(value);
 
   if (!isValid) {
-    return 'The bucket name must be a string between 3 and 63 characters long, and can contain only lower-case characters, numbers, periods, and dashes.';
+    return 'The bucket name must be a string more than 3 characters long, and can contain only lower-case characters, numbers, periods, and dashes.';
   }
 
   isValid = /^[a-z0-9]/.test(value);


### PR DESCRIPTION
#### Description of changes
Fix: Remove 63 character length validation

Thanks @ykethan 

#### Issue #, if available
#13364 

#### Description of how you validated changes

Added a unit test for it

#### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
