### PR TITLE
fix: skip types in current cloud backend

### DIFF
--- a/packages/amplify-cli-core/package.json
+++ b/packages/amplify-cli-core/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@aws-amplify/amplify-function-plugin-interface": "1.10.3",
+    "@types/archiver": "^5.3.1",
     "@types/ejs": "^3.1.1",
     "@types/fs-extra": "^8.0.1",
     "@types/hjson": "^2.4.2",

--- a/packages/amplify-cli-core/src/__tests__/extractZip.test.ts
+++ b/packages/amplify-cli-core/src/__tests__/extractZip.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as archiver from 'archiver';
+import { extract } from '@aws-amplify/amplify-cli-core';
+import * as os from 'os';
+
+describe('extract zip', () => {
+  let tempDir: string;
+  let inputDir: string;
+  let outputDir: string;
+  let zipFilePath: string;
+  const file1RelativePath = 'file1.txt';
+  const file1Content = Math.random().toString();
+  const file2RelativePath = 'file2.txt';
+  const file2Content = Math.random().toString();
+  const dir1RelativePath = 'dir1';
+  const file3RelativePath = path.join(dir1RelativePath, 'file3.txt');
+  const file3Content: string = Math.random().toString();
+  const dir2RelativePath = 'dir2';
+  const file4RelativePath = path.join(dir2RelativePath, 'file4.txt');
+  const file4Content: string = Math.random().toString();
+
+  beforeAll(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'extractZipTest'));
+    inputDir = path.join(tempDir, 'inputDir');
+    outputDir = path.join(tempDir, 'outputDir');
+    fs.mkdirSync(inputDir);
+    fs.mkdirSync(path.join(inputDir, 'dir1'));
+    fs.mkdirSync(path.join(inputDir, 'dir2'));
+    fs.writeFileSync(path.join(inputDir, file1RelativePath), file1Content);
+    fs.writeFileSync(path.join(inputDir, file2RelativePath), file2Content);
+    fs.writeFileSync(path.join(inputDir, file3RelativePath), file3Content);
+    fs.writeFileSync(path.join(inputDir, file4RelativePath), file4Content);
+
+    zipFilePath = path.join(tempDir, 'archive.zip');
+    const output = fs.createWriteStream(zipFilePath);
+    const archive = archiver.create('zip', {});
+    archive.pipe(output);
+    archive.directory(inputDir, false);
+    await archive.finalize();
+  });
+
+  beforeEach(() => {
+    fs.removeSync(outputDir);
+  });
+
+  afterAll(() => {
+    fs.removeSync(tempDir);
+  });
+
+  it('should extract full zip', async () => {
+    await extract(zipFilePath, { dir: outputDir });
+    expect(fs.existsSync(path.join(outputDir, dir1RelativePath))).toStrictEqual(true);
+    expect(fs.existsSync(path.join(outputDir, dir2RelativePath))).toStrictEqual(true);
+    expect(fs.readFileSync(path.join(outputDir, file1RelativePath), 'utf-8')).toStrictEqual(file1Content);
+    expect(fs.readFileSync(path.join(outputDir, file2RelativePath), 'utf-8')).toStrictEqual(file2Content);
+    expect(fs.readFileSync(path.join(outputDir, file3RelativePath), 'utf-8')).toStrictEqual(file3Content);
+    expect(fs.readFileSync(path.join(outputDir, file4RelativePath), 'utf-8')).toStrictEqual(file4Content);
+  });
+
+  it('should skip directory', async () => {
+    await extract(zipFilePath, {
+      dir: outputDir,
+      skipEntryPrefixes: [dir1RelativePath],
+    });
+    expect(fs.existsSync(path.join(outputDir, dir1RelativePath))).toStrictEqual(false);
+    expect(fs.existsSync(path.join(outputDir, dir2RelativePath))).toStrictEqual(true);
+    expect(fs.readFileSync(path.join(outputDir, file1RelativePath), 'utf-8')).toStrictEqual(file1Content);
+    expect(fs.readFileSync(path.join(outputDir, file2RelativePath), 'utf-8')).toStrictEqual(file2Content);
+    expect(fs.existsSync(path.join(outputDir, file3RelativePath))).toStrictEqual(false);
+    expect(fs.readFileSync(path.join(outputDir, file4RelativePath), 'utf-8')).toStrictEqual(file4Content);
+  });
+
+  it('should skip top level file', async () => {
+    await extract(zipFilePath, {
+      dir: outputDir,
+      skipEntryPrefixes: [file1RelativePath],
+    });
+    expect(fs.existsSync(path.join(outputDir, dir1RelativePath))).toStrictEqual(true);
+    expect(fs.existsSync(path.join(outputDir, dir2RelativePath))).toStrictEqual(true);
+    expect(fs.existsSync(path.join(outputDir, file1RelativePath))).toStrictEqual(false);
+    expect(fs.readFileSync(path.join(outputDir, file2RelativePath), 'utf-8')).toStrictEqual(file2Content);
+    expect(fs.readFileSync(path.join(outputDir, file3RelativePath), 'utf-8')).toStrictEqual(file3Content);
+    expect(fs.readFileSync(path.join(outputDir, file4RelativePath), 'utf-8')).toStrictEqual(file4Content);
+  });
+
+  it('should skip nested file', async () => {
+    await extract(zipFilePath, {
+      dir: outputDir,
+      skipEntryPrefixes: [file4RelativePath],
+    });
+    expect(fs.existsSync(path.join(outputDir, dir1RelativePath))).toStrictEqual(true);
+    expect(fs.existsSync(path.join(outputDir, dir2RelativePath))).toStrictEqual(true);
+    expect(fs.readFileSync(path.join(outputDir, file1RelativePath), 'utf-8')).toStrictEqual(file1Content);
+    expect(fs.readFileSync(path.join(outputDir, file2RelativePath), 'utf-8')).toStrictEqual(file2Content);
+    expect(fs.readFileSync(path.join(outputDir, file3RelativePath), 'utf-8')).toStrictEqual(file3Content);
+    expect(fs.existsSync(path.join(outputDir, file4RelativePath))).toStrictEqual(false);
+  });
+
+  it('should skip multiple entries', async () => {
+    await extract(zipFilePath, {
+      dir: outputDir,
+      skipEntryPrefixes: [file1RelativePath, dir2RelativePath],
+    });
+    expect(fs.existsSync(path.join(outputDir, dir1RelativePath))).toStrictEqual(true);
+    expect(fs.existsSync(path.join(outputDir, dir2RelativePath))).toStrictEqual(false);
+    expect(fs.existsSync(path.join(outputDir, file1RelativePath))).toStrictEqual(false);
+    expect(fs.readFileSync(path.join(outputDir, file2RelativePath), 'utf-8')).toStrictEqual(file2Content);
+    expect(fs.readFileSync(path.join(outputDir, file3RelativePath), 'utf-8')).toStrictEqual(file3Content);
+    expect(fs.existsSync(path.join(outputDir, file4RelativePath))).toStrictEqual(false);
+  });
+});

--- a/packages/amplify-cli-core/src/extractZip.js
+++ b/packages/amplify-cli-core/src/extractZip.js
@@ -48,6 +48,15 @@ class Extractor {
           return;
         }
 
+        if (this.opts.skipEntryPrefixes && Array.isArray(this.opts.skipEntryPrefixes) && this.opts.skipEntryPrefixes.length > 0) {
+          for (const skipEntriesPrefix of this.opts.skipEntryPrefixes) {
+            if (entry.fileName.startsWith(skipEntriesPrefix)) {
+              this.zipfile.readEntry();
+              return;
+            }
+          }
+        }
+
         const destDir = path.dirname(path.join(this.opts.dir, entry.fileName));
 
         try {

--- a/packages/amplify-provider-awscloudformation/src/attach-backend.ts
+++ b/packages/amplify-provider-awscloudformation/src/attach-backend.ts
@@ -344,7 +344,7 @@ async function downloadBackend(context, backendEnv, awsConfigInfo) {
 
     const unzippedDirPath = path.join(tempDirPath, path.basename(zipFileName, '.zip'));
 
-    await extract(tempFilePath, { dir: unzippedDirPath });
+    await extract(tempFilePath, { dir: unzippedDirPath, skipEntryPrefixes: ['types/'] });
 
     // Move out cli.*json if exists in the temp directory into the amplify directory before copying backend and
     // current cloud backend directories.

--- a/packages/amplify-provider-awscloudformation/src/utils/archiver.js
+++ b/packages/amplify-provider-awscloudformation/src/utils/archiver.js
@@ -2,7 +2,7 @@ const archiver = require('archiver');
 const path = require('path');
 const fs = require('fs-extra');
 
-const DEFAULT_IGNORE_PATTERN = ['*/*/build/**', '*/*/dist/**', 'function/*/src/node_modules/**'];
+const DEFAULT_IGNORE_PATTERN = ['*/*/build/**', '*/*/dist/**', 'function/*/src/node_modules/**', 'types/**'];
 
 async function run(folder, zipFilePath, ignorePattern = DEFAULT_IGNORE_PATTERN, extraFiles) {
   const zipFileFolder = path.dirname(zipFilePath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,7 @@ __metadata:
     "@aws-amplify/amplify-prompts": 2.8.6
     "@aws-amplify/graphql-transformer-interfaces": ^3.7.0
     "@aws-sdk/util-arn-parser": ^3.310.0
+    "@types/archiver": ^5.3.1
     "@types/ejs": ^3.1.1
     "@types/fs-extra": ^8.0.1
     "@types/hjson": ^2.4.2


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR removes `types/` folder from backend -> current cloud backend -> s3 -> current cloud backend -> backend flow.

The types folder is always regenerated, therefore it's not needed to include it in that flow.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. added unit tests for unzipper
2. full e2e run

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
