### PR TITLE
fix: migrate FCM channel authentication from ApiKey to ServiceToken based

### DIFF
--- a/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
@@ -130,6 +130,7 @@ describe('channel-FCM', () => {
       ApplicationId: undefined,
       GCMChannelRequest: {
         ServiceJson: serviceAccountJson,
+        DefaultAuthenticationMethod: 'TOKEN',
         Enabled: true,
       },
     });

--- a/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/channel-fcm.test.ts
@@ -17,7 +17,12 @@ jest.mock('@aws-amplify/amplify-cli-core', () => {
   };
 });
 
-const apiKey = 'ApiKey-abc123';
+const serviceJSONFilePath = '/my/service/account/jsonFile.json';
+const serviceAccountJson = '{ "valid": { "service": "accountJson"}}';
+jest.mock('fs-extra', () => ({
+  readFile: () => Promise.resolve(serviceAccountJson),
+  existsSync: () => true,
+}));
 jest.mock('@aws-amplify/amplify-prompts');
 const prompterMock = prompter as jest.Mocked<typeof prompter>;
 
@@ -97,7 +102,7 @@ describe('channel-FCM', () => {
   test('configure', async () => {
     mockChannelEnabledOutput.Enabled = true;
     prompterMock.yesOrNo.mockResolvedValueOnce(true);
-    prompterMock.input.mockResolvedValueOnce(apiKey);
+    prompterMock.input.mockResolvedValueOnce(serviceJSONFilePath);
 
     const mockContextObj = mockContext(mockChannelEnabledOutput, mockPinpointClient);
     await channelFCM.configure(mockContextObj).then(() => {
@@ -118,20 +123,13 @@ describe('channel-FCM', () => {
   });
 
   test('enable', async () => {
-    prompterMock.input.mockResolvedValueOnce(apiKey);
+    prompterMock.input.mockResolvedValueOnce(serviceJSONFilePath);
     const mockContextObj = mockContext(mockChannelEnabledOutput, mockPinpointClient);
     const data = await channelFCM.enable(mockContextObj, 'successMessage');
-    expect(mockPinpointClient.updateGcmChannel).toBeCalled();
-    expect(data).toEqual(mockPinpointResponseData(true, ChannelAction.ENABLE));
-  });
-
-  test('enable with newline', async () => {
-    prompterMock.input.mockResolvedValueOnce(`${apiKey}\n`);
-    const data = await channelFCM.enable(mockContext(mockChannelEnabledOutput, mockPinpointClient), 'successMessage');
     expect(mockPinpointClient.updateGcmChannel).toBeCalledWith({
       ApplicationId: undefined,
       GCMChannelRequest: {
-        ApiKey: apiKey,
+        ServiceJson: serviceAccountJson,
         Enabled: true,
       },
     });
@@ -139,7 +137,7 @@ describe('channel-FCM', () => {
   });
 
   test('enable unsuccessful', async () => {
-    prompterMock.input.mockResolvedValueOnce(apiKey);
+    prompterMock.input.mockResolvedValueOnce(serviceJSONFilePath);
 
     const context = mockContextReject(mockServiceOutput, mockPinpointClientReject);
     const errCert: AmplifyFault = await getError(async () => channelFCM.enable(context as unknown as $TSContext, 'successMessage'));

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -56,6 +56,7 @@ export const enable = async (context: $TSContext, successMessage: string | undef
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
     GCMChannelRequest: {
       ...answers,
+      DefaultAuthenticationMethod: 'TOKEN',
       Enabled: true,
     },
   };
@@ -109,6 +110,7 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
     ApplicationId: context.exeInfo.serviceMeta.output.Id,
     GCMChannelRequest: {
       ...answers,
+      DefaultAuthenticationMethod: 'TOKEN',
       Enabled: false,
     },
   };

--- a/packages/amplify-category-notifications/src/channel-fcm.ts
+++ b/packages/amplify-category-notifications/src/channel-fcm.ts
@@ -3,6 +3,8 @@ import { printer, prompter } from '@aws-amplify/amplify-prompts';
 import ora from 'ora';
 import { ChannelAction, ChannelConfigDeploymentType, IChannelAPIResponse } from './channel-types';
 import { buildPinpointChannelResponseSuccess } from './pinpoint-helper';
+import { validateFilePath } from './validate-filepath';
+import fs from 'fs-extra';
 
 const channelName = 'FCM';
 const spinner = ora('');
@@ -42,12 +44,11 @@ export const enable = async (context: $TSContext, successMessage: string | undef
   if (context.exeInfo.pinpointInputParams?.[channelName]) {
     answers = validateInputParams(context.exeInfo.pinpointInputParams[channelName]);
   } else {
-    let channelOutput: $TSAny = {};
-    if (context.exeInfo.serviceMeta.output[channelName]) {
-      channelOutput = context.exeInfo.serviceMeta.output[channelName];
-    }
     answers = {
-      ApiKey: await prompter.input('Server Key', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
+      ServiceJson: await fs.readFile(
+        await prompter.input('The service account file path (.json): ', { validate: validateFilePath }),
+        'utf8',
+      ),
     };
   }
 
@@ -78,10 +79,10 @@ export const enable = async (context: $TSContext, successMessage: string | undef
 };
 
 const validateInputParams = (channelInput: $TSAny): $TSAny => {
-  if (!channelInput.ApiKey) {
+  if (!channelInput.ServiceJson) {
     throw new AmplifyError('UserInputError', {
-      message: 'Server Key is missing for the FCM channel',
-      resolution: 'Server Key for the FCM channel',
+      message: 'ServiceJson is missing for the FCM channel',
+      resolution: 'Provide the JSON from your Firebase service account json file',
     });
   }
   return channelInput;
@@ -97,12 +98,11 @@ export const disable = async (context: $TSContext): Promise<$TSAny> => {
   if (context.exeInfo.pinpointInputParams?.[channelName]) {
     answers = validateInputParams(context.exeInfo.pinpointInputParams[channelName]);
   } else {
-    let channelOutput: $TSAny = {};
-    if (context.exeInfo.serviceMeta.output[channelName]) {
-      channelOutput = context.exeInfo.serviceMeta.output[channelName];
-    }
     answers = {
-      ApiKey: await prompter.input('Server Key', { initial: channelOutput.ApiKey, transform: (input) => input.trim() }),
+      ServiceJson: await fs.readFile(
+        await prompter.input('The service account file path (.json): ', { validate: validateFilePath }),
+        'utf8',
+      ),
     };
   }
   const params = {


### PR DESCRIPTION
#### Description of changes

migrate FCM channel authentication from ApiKey to ServiceToken based

#### Issue #, if available 

https://github.com/aws-amplify/amplify-cli/issues/13688

#### Description of how you validated changes

Manually tested and unit tested.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
