### PR TITLE
fix(cli): add feature flag to control subscription field redaction behavior

### DIFF
--- a/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
+++ b/packages/amplify-cli-core/src/feature-flags/featureFlags.ts
@@ -671,6 +671,12 @@ export class FeatureFlags {
         defaultValueForExistingProjects: false,
         defaultValueForNewProjects: true,
       },
+      {
+        name: 'subscriptionsInheritPrimaryAuth',
+        type: 'boolean',
+        defaultValueForExistingProjects: false,
+        defaultValueForNewProjects: false,
+      },
     ]);
 
     this.registerFlag('frontend-ios', [


### PR DESCRIPTION
Add a new FF for data plugin to allow customers to opt-in for a subscriptions field redaction behavior.

- If the feature flag is disabled (when set to `false`), relational fields will be over-redacted in mutations response and subscribed clients won't receive this data in payload.
- If the feature flag is enabled (when set to `true`), subscriptions will inherit the auth rules of the model for the relational fields. It means that the relational fields won't be over-redacted on mutations.