### PR TITLE
fix: enforce ssl on s3 deployment bucket

### DIFF
--- a/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
+++ b/packages/amplify-provider-awscloudformation/resources/rootStackTemplate.json
@@ -26,6 +26,53 @@
         }
       }
     },
+    "DeploymentBucketBlockHTTP": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "DeploymentBucketName"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "AuthRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -104,6 +104,53 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "DeploymentBucketBlockHTTP": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "DeploymentBucketName",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "UnauthRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -125,6 +125,53 @@ exports[`Root stack template tests Generated root stack template during init 1`]
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "DeploymentBucketBlockHTTP": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "DeploymentBucketName",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false,
+                },
+              },
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "UnauthRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
#### Description of changes
Re-applying changes initially attempted in https://github.com/aws-amplify/amplify-cli/pull/10533

For more details on implementation, see guidance here: https://repost.aws/knowledge-center/s3-bucket-policy-for-config-rule

#### Issue #, if available

#### Description of how you validated changes
Tests updated to ensure ssl is enforced.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
