### PR TITLE
Feat: Auth triggers comments to gen 1 function source directory

### DIFF
--- a/packages/amplify-gen1-codegen-auth-adapter/src/index.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/index.ts
@@ -1,1 +1,1 @@
-export { AuthSynthesizerOptions, getAuthDefinition, PasswordPolicyOverrides } from './auth_render_adapter.js';
+export { AuthSynthesizerOptions, getAuthDefinition, PasswordPolicyOverrides, AuthTriggerConnections } from './auth_render_adapter.js';

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.test.ts
@@ -30,7 +30,7 @@ describe('render auth node', () => {
     for (const testCase of Object.keys(testCases)) {
       const rendered = renderAuthNode({ lambdaTriggers: { [testCase]: { source: "console.log('hello, world!')" } } });
       const source = printNodeArray(rendered);
-      assert.match(source, new RegExp(`triggers: \\{\\s+${testCase}: defineFunction\\(\\{`));
+      assert.match(source, new RegExp(`triggers: \\{\\s+\\/\\*[\\S\\s]*?\\*\\/\\s+${testCase}: defineFunction\\(\\{`));
     }
   });
   describe('mfa', () => {
@@ -43,14 +43,14 @@ describe('render auth node', () => {
       it('renders false if totp is not specified', () => {
         const rendered = renderAuthNode({ mfa: { mode: 'OPTIONAL' } });
         const source = printNodeArray(rendered);
-        assert.match(source, new RegExp(`multifactor:\\s+\\{.*?totp:\\sfalse`));
+        assert.match(source, new RegExp(`multifactor:\\s+\\{[\\s\\S]*totp:\\sfalse`));
       });
       const totpStates: boolean[] = [true, false];
       for (const state of totpStates) {
         it(`correctly renders totp state of ${state}`, async () => {
           const rendered = renderAuthNode({ mfa: { mode: 'OPTIONAL', totp: state } });
           const source = printNodeArray(rendered);
-          assert.match(source, new RegExp(`multifactor:\\s+\\{.*?totp:\\s${state}`));
+          assert.match(source, new RegExp(`multifactor:\\s+\\{[\\s\\S]*totp:\\s${state}`));
         });
       }
     });
@@ -123,7 +123,7 @@ describe('render auth node', () => {
       };
       const node = renderAuthNode(authDefinition);
       const source = printNodeArray(node);
-      assert.match(source, /defineAuth\(\{.*?groups:\s\["manager"\]/);
+      assert.match(source, /defineAuth\(\{[\s\S]*groups:\s\["manager"\]/);
     });
   });
   describe('loginWith', () => {
@@ -164,7 +164,7 @@ describe('render auth node', () => {
           assert.match(
             source,
             new RegExp(
-              `defineAuth\\(\\{\\s?loginWith:\\s?\\{\\s?email:\\s?\\{.*?${gen2DefinitionProperty}: ${searchPattern} \\}\\s?\\}\\s?\\}\\)`,
+              `defineAuth\\(\\{\\s+loginWith:\\s+\\{\\s+email:\\s+\\{\\s+${gen2DefinitionProperty}: ${searchPattern}\\s+\\}\\s+\\}\\s+\\}\\)`,
             ),
           );
         });
@@ -177,7 +177,7 @@ describe('render auth node', () => {
         };
         const node = renderAuthNode(authDefinition);
         const source = printNodeArray(node);
-        assert.match(source, /defineAuth\(\{\s?loginWith:\s?\{\s?email:\s?true\s?\}\s?\}\)/);
+        assert.match(source, /defineAuth\(\{\s+loginWith:\s+\{\s+email:\s?true\s+\}\s+\}\)/);
       });
     });
   });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -73,7 +73,7 @@ describe('BackendRenderer', () => {
           },
         });
         const output = printNodeArray(rendered);
-        assert(output.includes('storage: storage'));
+        assert(output.includes('storage'));
       });
     });
     describe('auth', () => {
@@ -81,7 +81,7 @@ describe('BackendRenderer', () => {
         const renderer = new BackendSynthesizer();
         const rendered = renderer.render({});
         const output = printNodeArray(rendered);
-        assert(!output.includes('storage: storage'));
+        assert(!output.includes('storage'));
       });
       it('adds property assignment when defined', () => {
         const renderer = new BackendSynthesizer();
@@ -91,7 +91,7 @@ describe('BackendRenderer', () => {
           },
         });
         const output = printNodeArray(rendered);
-        assert(output.includes('auth: auth'));
+        assert(output.includes('auth'));
       });
     });
   });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -23,7 +23,7 @@ export class BackendSynthesizer {
       factory.createStringLiteral(backendPackageName),
     );
   };
-  private defineBackendCall = (backendFunctionIdentifier: Identifier, properties: ts.PropertyAssignment[]): ts.CallExpression => {
+  private defineBackendCall = (backendFunctionIdentifier: Identifier, properties: ts.ObjectLiteralElementLike[]): ts.CallExpression => {
     const backendFunctionArgs = factory.createObjectLiteralExpression(properties, true);
     return factory.createCallExpression(backendFunctionIdentifier, undefined, [backendFunctionArgs]);
   };
@@ -36,12 +36,12 @@ export class BackendSynthesizer {
     const defineBackendProperties = [];
     if (renderArgs.auth) {
       imports.push(this.createImportStatement([authFunctionIdentifier], renderArgs.auth.importFrom));
-      const auth = factory.createPropertyAssignment('auth', authFunctionIdentifier);
+      const auth = factory.createShorthandPropertyAssignment(authFunctionIdentifier);
       defineBackendProperties.push(auth);
     }
     if (renderArgs.storage) {
       imports.push(this.createImportStatement([storageFunctionIdentifier], renderArgs.storage.importFrom));
-      const storage = factory.createPropertyAssignment('storage', storageFunctionIdentifier);
+      const storage = factory.createShorthandPropertyAssignment(storageFunctionIdentifier);
       defineBackendProperties.push(storage);
     }
     imports.push(this.createImportStatement([backendFunctionIdentifier], '@aws-amplify/backend'));

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -38,7 +38,7 @@ export const createGen2Renderer = ({
   auth,
   storage,
   fileWriter = (content, path) => createFileWriter(path)(content),
-}: Gen2RenderingOptions): Renderer => {
+}: Readonly<Gen2RenderingOptions>): Renderer => {
   const ensureOutputDir = new EnsureDirectory(outputDir);
   const ensureAmplifyDirectory = new EnsureDirectory(path.join(outputDir, 'amplify'));
   const amplifyPackageJson = new JsonRenderer(

--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
+import path from 'node:path';
+
 import { Gen2RenderingOptions, createGen2Renderer } from '@aws-amplify/amplify-gen2-codegen';
 
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import assert from 'node:assert';
 import { resolveAppId } from '@aws-amplify/amplify-provider-awscloudformation';
-import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+import { CognitoIdentityProviderClient, LambdaConfigType } from '@aws-sdk/client-cognito-identity-provider';
 import { S3Client } from '@aws-sdk/client-s3';
 import { BackendDownloader } from './backend_downloader.js';
 import { Logger } from './logger.js';
@@ -13,7 +15,8 @@ import { BackendEnvironmentSelector } from './backend_environment_selector.js';
 import { Analytics, DummyAnalytics } from './analytics.js';
 import { AppAuthDefinitionFetcher } from './app_auth_definition_fetcher.js';
 import { AppStorageDefinitionFetcher } from './app_storage_definition_fetcher.js';
-import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, AmplifyCategories, stateManager } from '@aws-amplify/amplify-cli-core';
+import { AuthTriggerConnections } from '@aws-amplify/amplify-gen1-codegen-auth-adapter';
 
 interface CodegenCommandParameters {
   analytics: Analytics;
@@ -50,13 +53,11 @@ const generateGen2Code = async ({
 
   logger.log('Getting latest environment info');
 
-  const gen2RenderOptions: Gen2RenderingOptions = {
+  const gen2RenderOptions: Readonly<Gen2RenderingOptions> = {
     outputDir: outputDirectory,
+    auth: await authDefinitionFetcher.getDefinition(backendEnvironment.stackName),
+    storage: await storageDefinitionFetcher.getDefinition(backendEnvironment.deploymentArtifacts),
   };
-
-  gen2RenderOptions.auth = await authDefinitionFetcher.getDefinition(backendEnvironment.stackName);
-
-  gen2RenderOptions.storage = await storageDefinitionFetcher.getDefinition(backendEnvironment.deploymentArtifacts);
 
   const pipeline = createGen2Renderer(gen2RenderOptions);
   try {
@@ -65,6 +66,40 @@ const generateGen2Code = async ({
   } catch (e) {
     await analytics.logEvent('failedMigration', { appId });
   }
+};
+
+type AmplifyMetaAuth = {
+  service: 'Cognito';
+  providerPlugin: 'awscloudformation';
+};
+
+type AmplifyMeta = {
+  auth: Record<string, AmplifyMetaAuth>;
+};
+
+const getFunctionPath = (context: $TSContext, functionName: string) => {
+  //  const amplifyDir = context.amplify.pathManager.getAmplifyDirPath();
+  return path.join('amplify', 'backend', 'function', functionName, 'src');
+};
+
+const getAuthTriggersConnections = async (context: $TSContext): Promise<Partial<Record<keyof LambdaConfigType, string>>> => {
+  const amplifyMeta: AmplifyMeta = stateManager.getMeta();
+  const resourceName = Object.keys(amplifyMeta.auth)[0];
+  const authInputs = stateManager.getResourceInputsJson(undefined, AmplifyCategories.AUTH, resourceName);
+  if ('cognitoConfig' in authInputs && 'authTriggerConnections' in authInputs.cognitoConfig) {
+    try {
+      const triggerConnections: AuthTriggerConnections[] = JSON.parse(authInputs.cognitoConfig.authTriggerConnections);
+      const connections = triggerConnections.reduce((prev, curr) => {
+        prev[curr.triggerType] = getFunctionPath(context, curr.lambdaFunctionName);
+        return prev;
+      }, {} as Partial<Record<keyof LambdaConfigType, string>>);
+      console.log(JSON.stringify(connections, null, 2));
+      return connections;
+    } catch (e) {
+      throw new Error('Error parsing auth trigger connections');
+    }
+  }
+  return {};
 };
 
 export async function executeAmplifyCommand(context: $TSContext) {
@@ -78,7 +113,9 @@ export async function executeAmplifyCommand(context: $TSContext) {
     outputDirectory: './output',
     appId,
     storageDefinitionFetcher: new AppStorageDefinitionFetcher(new BackendDownloader(s3Client)),
-    authDefinitionFetcher: new AppAuthDefinitionFetcher(cognitoIdentityProviderClient, cloudFormationClient),
+    authDefinitionFetcher: new AppAuthDefinitionFetcher(cognitoIdentityProviderClient, cloudFormationClient, () =>
+      getAuthTriggersConnections(context),
+    ),
     analytics: new DummyAnalytics(),
     logger: new Logger(),
     backendEnvironmentSelector: new BackendEnvironmentSelector(amplifyClient),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Adds a comment to the directory where the Gen 1 source for a given trigger is stored:
```typescript
  import { defineAuth, defineFunction } from "@aws-amplify/backend";
  export const auth = defineAuth({
    loginWith: {
      email: true,
    },
    triggers: {
      /*
          Source code for this function can be found in your Amplify Gen 1 Directory.
          See amplify/backend/function/authwithcustompasswoc8d0cd5bPostAuthentication/src
          */
      postAuthentication: defineFunction({}),
    },
    multifactor: {
      mode: "OPTIONAL",
      totp: false,
    },
  }); 
   ```

#### Description of how you validated changes
Unit tests and manual validation
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
