### PR TITLE
feat: storage triggers

### DIFF
--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -254,7 +254,8 @@ export interface AmplifyInternalOnlyPostEnvRemoveEventData {
 // @public (undocumented)
 export class AmplifyNodePkgDetector {
     // (undocumented)
-    detectAffectedDirectDependencies: (dependencyToSearch: string) => Array<DetectedDependency> | [];
+    detectAffectedDirectDependencies: (dependencyToSearch: string) => Array<DetectedDependency> | [
+    ];
     // (undocumented)
     static getInstance: (amplifyDetectorProps: AmplifyNodePkgDetectorProps) => Promise<AmplifyNodePkgDetector>;
 }

--- a/packages/amplify-cli-core/API.md
+++ b/packages/amplify-cli-core/API.md
@@ -254,8 +254,7 @@ export interface AmplifyInternalOnlyPostEnvRemoveEventData {
 // @public (undocumented)
 export class AmplifyNodePkgDetector {
     // (undocumented)
-    detectAffectedDirectDependencies: (dependencyToSearch: string) => Array<DetectedDependency> | [
-    ];
+    detectAffectedDirectDependencies: (dependencyToSearch: string) => Array<DetectedDependency> | [];
     // (undocumented)
     static getInstance: (amplifyDetectorProps: AmplifyNodePkgDetectorProps) => Promise<AmplifyNodePkgDetector>;
 }

--- a/packages/amplify-gen1-codegen-auth-adapter/API.md
+++ b/packages/amplify-gen1-codegen-auth-adapter/API.md
@@ -11,21 +11,22 @@ import { UserPoolType } from '@aws-sdk/client-cognito-identity-provider';
 
 // @public (undocumented)
 export interface AuthSynthesizerOptions {
-    // Warning: (ae-forgotten-export) The symbol "AuthTriggerConnectionMap" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    authTriggerConnections?: AuthTriggerConnectionMap;
+    authTriggerConnections?: AuthTriggerConnectionSourceMap;
     // (undocumented)
     userPool: UserPoolType;
 }
 
 // @public (undocumented)
-export interface AuthTriggerConnections {
+export interface AuthTriggerConnection {
     // (undocumented)
     lambdaFunctionName: string;
     // (undocumented)
     triggerType: keyof LambdaConfigType;
 }
+
+// @public (undocumented)
+export type AuthTriggerConnectionSourceMap = Partial<Record<keyof LambdaConfigType, string>>;
 
 // @public (undocumented)
 export const getAuthDefinition: ({ userPool, authTriggerConnections }: AuthSynthesizerOptions) => AuthDefinition;

--- a/packages/amplify-gen1-codegen-auth-adapter/API.md
+++ b/packages/amplify-gen1-codegen-auth-adapter/API.md
@@ -5,17 +5,30 @@
 ```ts
 
 import { AuthDefinition } from '@aws-amplify/amplify-gen2-codegen';
+import { LambdaConfigType } from '@aws-sdk/client-cognito-identity-provider';
 import { PasswordPolicyPath } from '@aws-amplify/amplify-gen2-codegen';
 import { UserPoolType } from '@aws-sdk/client-cognito-identity-provider';
 
 // @public (undocumented)
 export interface AuthSynthesizerOptions {
+    // Warning: (ae-forgotten-export) The symbol "AuthTriggerConnectionMap" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    authTriggerConnections?: AuthTriggerConnectionMap;
     // (undocumented)
     userPool: UserPoolType;
 }
 
 // @public (undocumented)
-export const getAuthDefinition: ({ userPool }: AuthSynthesizerOptions) => AuthDefinition;
+export interface AuthTriggerConnections {
+    // (undocumented)
+    lambdaFunctionName: string;
+    // (undocumented)
+    triggerType: keyof LambdaConfigType;
+}
+
+// @public (undocumented)
+export const getAuthDefinition: ({ userPool, authTriggerConnections }: AuthSynthesizerOptions) => AuthDefinition;
 
 // @public (undocumented)
 export type PasswordPolicyOverrides = Record<PasswordPolicyPath, string | boolean | number>;

--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
@@ -9,16 +9,16 @@ import {
 } from '@aws-amplify/amplify-gen2-codegen';
 import { LambdaConfigType, PasswordPolicyType, UserPoolMfaType, UserPoolType } from '@aws-sdk/client-cognito-identity-provider';
 
-export interface AuthTriggerConnections {
+export interface AuthTriggerConnection {
   triggerType: keyof LambdaConfigType;
   lambdaFunctionName: string;
 }
 
-export type AuthTriggerConnectionMap = Partial<Record<keyof LambdaConfigType, string>>;
+export type AuthTriggerConnectionSourceMap = Partial<Record<keyof LambdaConfigType, string>>;
 
 export interface AuthSynthesizerOptions {
   userPool: UserPoolType;
-  authTriggerConnections?: AuthTriggerConnectionMap;
+  authTriggerConnections?: AuthTriggerConnectionSourceMap;
 }
 
 export const DEFAULT_PASSWORD_SETTINGS: PasswordPolicyType = {
@@ -95,7 +95,7 @@ const mappedLambdaConfigKey = (key: keyof LambdaConfigType): AuthTriggerEvents =
 
 const getAuthTriggers = (
   lambdaConfig: LambdaConfigType,
-  triggerSourceFiles: AuthTriggerConnectionMap,
+  triggerSourceFiles: AuthTriggerConnectionSourceMap,
 ): Partial<Record<AuthTriggerEvents, Lambda>> => {
   return Object.keys(lambdaConfig).reduce((prev, key) => {
     const typedKey = key as keyof LambdaConfigType;

--- a/packages/amplify-gen1-codegen-auth-adapter/src/index.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/index.ts
@@ -1,1 +1,7 @@
-export { AuthSynthesizerOptions, getAuthDefinition, PasswordPolicyOverrides, AuthTriggerConnections } from './auth_render_adapter.js';
+export {
+  AuthSynthesizerOptions,
+  getAuthDefinition,
+  PasswordPolicyOverrides,
+  AuthTriggerConnection,
+  AuthTriggerConnectionSourceMap,
+} from './auth_render_adapter.js';

--- a/packages/amplify-gen2-codegen/API.md
+++ b/packages/amplify-gen2-codegen/API.md
@@ -20,6 +20,10 @@ export type Attribute = 'address' | 'birthdate' | 'email' | 'familyName' | 'gend
 export interface AuthDefinition {
     // (undocumented)
     groups?: Group[];
+    // Warning: (ae-forgotten-export) The symbol "AuthLambdaTriggers" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    lambdaTriggers?: Partial<AuthLambdaTriggers>;
     // (undocumented)
     loginOptions?: LoginOptions;
     // (undocumented)
@@ -31,7 +35,10 @@ export interface AuthDefinition {
 }
 
 // @public (undocumented)
-export const createGen2Renderer: ({ outputDir, auth, storage, fileWriter, }: Gen2RenderingOptions) => Renderer;
+export type AuthTriggerEvents = 'createAuthChallenge' | 'customMessage' | 'defineAuthChallenge' | 'postAuthentication' | 'postConfirmation' | 'preAuthentication' | 'preSignUp' | 'preTokenGeneration' | 'userMigration' | 'verifyAuthChallengeResponse';
+
+// @public (undocumented)
+export const createGen2Renderer: ({ outputDir, auth, storage, fileWriter, }: Readonly<Gen2RenderingOptions>) => Renderer;
 
 // @public (undocumented)
 export type EmailOptions = {
@@ -53,6 +60,11 @@ export interface Gen2RenderingOptions {
 
 // @public (undocumented)
 export type Group = string;
+
+// @public (undocumented)
+export type Lambda = {
+    source: string;
+};
 
 // @public (undocumented)
 export type LoginOptions = {

--- a/packages/amplify-gen2-codegen/API.md
+++ b/packages/amplify-gen2-codegen/API.md
@@ -20,8 +20,6 @@ export type Attribute = 'address' | 'birthdate' | 'email' | 'familyName' | 'gend
 export interface AuthDefinition {
     // (undocumented)
     groups?: Group[];
-    // Warning: (ae-forgotten-export) The symbol "AuthLambdaTriggers" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     lambdaTriggers?: Partial<AuthLambdaTriggers>;
     // (undocumented)
@@ -33,6 +31,9 @@ export interface AuthDefinition {
     // (undocumented)
     userPoolOverrides?: UserPoolOverrides;
 }
+
+// @public (undocumented)
+export type AuthLambdaTriggers = Record<AuthTriggerEvents, Lambda>;
 
 // @public (undocumented)
 export type AuthTriggerEvents = 'createAuthChallenge' | 'customMessage' | 'defineAuthChallenge' | 'postAuthentication' | 'postConfirmation' | 'preAuthentication' | 'preSignUp' | 'preTokenGeneration' | 'userMigration' | 'verifyAuthChallengeResponse';
@@ -115,7 +116,12 @@ export interface StorageRenderParameters {
     lambdas?: S3TriggerDefinition[];
     // (undocumented)
     storageIdentifier?: string;
+    // (undocumented)
+    triggers?: Partial<Record<StorageTriggerEvent, Lambda>>;
 }
+
+// @public (undocumented)
+export type StorageTriggerEvent = 'onDelete' | 'onUpload';
 
 // @public (undocumented)
 export type UserPoolMfaConfig = 'OFF' | 'ON' | 'OPTIONAL';

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.ts
@@ -1,8 +1,8 @@
-import ts, { PropertyAssignment, SyntaxKind } from 'typescript';
+import ts, { PropertyAssignment } from 'typescript';
 import assert from 'node:assert';
 import { PasswordPolicyType } from '@aws-sdk/client-cognito-identity-provider';
 import { renderResourceTsFile } from '../resource/resource';
-import { createDefineFunctionCall, createTriggersProperty, Lambda } from '../function/lambda';
+import { createTriggersProperty, Lambda } from '../function/lambda';
 
 export type StandardAttribute = {
   readonly mutable?: boolean;

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.ts
@@ -2,7 +2,7 @@ import ts, { PropertyAssignment, SyntaxKind } from 'typescript';
 import assert from 'node:assert';
 import { PasswordPolicyType } from '@aws-sdk/client-cognito-identity-provider';
 import { renderResourceTsFile } from '../resource/resource';
-import { Lambda } from '../function/lambda';
+import { createDefineFunctionCall, createTriggersProperty, Lambda } from '../function/lambda';
 
 export type StandardAttribute = {
   readonly mutable?: boolean;
@@ -158,27 +158,7 @@ export function renderAuthNode(definition: AuthDefinition): ts.NodeArray<ts.Node
   const hasFunctions = definition.lambdaTriggers && Object.keys(definition.lambdaTriggers).length > 0;
   if (hasFunctions) {
     assert(definition.lambdaTriggers);
-    defineAuthProperties.push(
-      factory.createPropertyAssignment(
-        factory.createIdentifier('triggers'),
-        factory.createObjectLiteralExpression(
-          Object.entries(definition.lambdaTriggers).map(([key, { source }]) => {
-            return ts.addSyntheticLeadingComment(
-              factory.createPropertyAssignment(
-                key,
-                factory.createCallExpression(factory.createIdentifier('defineFunction'), undefined, [
-                  factory.createObjectLiteralExpression([]),
-                ]),
-              ),
-              SyntaxKind.MultiLineCommentTrivia,
-              `\nSource code for this function can be found in your Amplify Gen 1 Directory.\nSee ${source}\n`,
-              true,
-            );
-          }),
-          true,
-        ),
-      ),
-    );
+    defineAuthProperties.push(createTriggersProperty(definition.lambdaTriggers));
   }
 
   if (definition.mfa) {

--- a/packages/amplify-gen2-codegen/src/function/lambda.test.ts
+++ b/packages/amplify-gen2-codegen/src/function/lambda.test.ts
@@ -1,0 +1,45 @@
+import ts, { Identifier } from 'typescript';
+import assert from 'node:assert';
+import { createDefineFunctionCall, DefineFunctionParamter } from './lambda';
+import { printNode } from '../test_utils/ts_node_printer';
+
+describe('createDefineFunctionCall', () => {
+  it('creates a call expression to defineFunction', () => {
+    const fn = createDefineFunctionCall();
+    assert(ts.isCallExpression(fn));
+    const id: Identifier = fn.expression as Identifier;
+    assert.equal(id.escapedText, 'defineFunction');
+    assert.equal(fn.arguments.at(0)?.kind, ts.SyntaxKind.ObjectLiteralExpression);
+  });
+  const parameter: DefineFunctionParamter = {
+    runtime: 18,
+    memoryMB: 1024,
+    timeoutSeconds: '35',
+    name: 'my-hello-world',
+    entry: './hello-world',
+  };
+  describe('function parameters', () => {
+    it('renders the environment object', () => {
+      const environment = {
+        hello: 'world',
+        foo: 'bar',
+      };
+
+      const fn = createDefineFunctionCall({ environment });
+      const output = printNode(fn);
+
+      for (const [envKey, envValue] of Object.entries(environment)) {
+        assert.match(output, new RegExp(`${envKey}: "${envValue}"`));
+      }
+      assert.match(output, /environment: \{/);
+    });
+    for (const [key, value] of Object.entries(parameter)) {
+      it(`${key} renders expected value ${value}`, () => {
+        const fn = createDefineFunctionCall(parameter);
+        const output = printNode(fn);
+
+        assert.match(output, new RegExp(`${key}: "?${value}"?`));
+      });
+    }
+  });
+});

--- a/packages/amplify-gen2-codegen/src/function/lambda.ts
+++ b/packages/amplify-gen2-codegen/src/function/lambda.ts
@@ -1,3 +1,70 @@
+import ts, { ObjectLiteralElementLike, SyntaxKind } from 'typescript';
 export type Lambda = {
   source: string;
+};
+
+const factory = ts.factory;
+
+export const defineFunctionIdentifier = 'defineFunction';
+
+export interface DefineFunctionParamter {
+  entry?: string;
+  name?: string;
+  timeoutSeconds?: string;
+  memoryMB?: number;
+  environment?: Record<string, string>;
+  runtime?: 16 | 18 | 19;
+}
+
+const createParameter = (name: string, value: any) => factory.createPropertyAssignment(factory.createIdentifier(name), value);
+
+export const createDefineFunctionCall = (parameter?: DefineFunctionParamter): ts.CallExpression => {
+  const parameters: ObjectLiteralElementLike[] = [];
+  if (parameter?.entry) {
+    parameters.push(createParameter('entry', factory.createStringLiteral(parameter.entry)));
+  }
+  if (parameter?.name) {
+    parameters.push(createParameter('name', factory.createStringLiteral(parameter.name)));
+  }
+  if (parameter?.timeoutSeconds) {
+    parameters.push(createParameter('timeoutSeconds', factory.createStringLiteral(parameter.timeoutSeconds)));
+  }
+  if (parameter?.memoryMB) {
+    parameters.push(createParameter('memoryMB', factory.createNumericLiteral(parameter.memoryMB)));
+  }
+  if (parameter?.environment) {
+    parameters.push(
+      createParameter(
+        'environment',
+        factory.createObjectLiteralExpression(
+          Object.entries(parameter.environment).map(([key, value]) => {
+            return createParameter(key, factory.createStringLiteral(value));
+          }),
+        ),
+      ),
+    );
+  }
+  if (parameter?.runtime) {
+    parameters.push(createParameter('runtime', factory.createNumericLiteral(parameter.runtime)));
+  }
+  return factory.createCallExpression(factory.createIdentifier(defineFunctionIdentifier), undefined, [
+    factory.createObjectLiteralExpression(parameters),
+  ]);
+};
+
+export const createTriggersProperty = (triggers: Record<string, Lambda>) => {
+  return factory.createPropertyAssignment(
+    factory.createIdentifier('triggers'),
+    factory.createObjectLiteralExpression(
+      Object.entries(triggers).map(([key, { source }]) => {
+        return ts.addSyntheticLeadingComment(
+          factory.createPropertyAssignment(key, createDefineFunctionCall({ entry: source })),
+          SyntaxKind.MultiLineCommentTrivia,
+          `\nSource code for this function can be found in your Amplify Gen 1 Directory.\nSee ${source}\n`,
+          true,
+        );
+      }),
+      true,
+    ),
+  );
 };

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -9,6 +9,7 @@ import { EnsureDirectory } from './renderers/ensure_directory';
 import { Lambda } from './function/lambda';
 import {
   AuthTriggerEvents,
+  AuthLambdaTriggers,
   AuthDefinition,
   renderAuthNode,
   SendingAccount,
@@ -23,7 +24,14 @@ import {
   StandardAttributes,
   MultifactorOptions,
 } from './auth/source_builder';
-import { StorageRenderParameters, renderStorage, AccessPatterns, Permission, S3TriggerDefinition } from './storage/source_builder.js';
+import {
+  StorageRenderParameters,
+  renderStorage,
+  AccessPatterns,
+  Permission,
+  S3TriggerDefinition,
+  StorageTriggerEvent,
+} from './storage/source_builder.js';
 
 export interface Gen2RenderingOptions {
   outputDir: string;
@@ -105,4 +113,6 @@ export {
   MultifactorOptions,
   AuthTriggerEvents,
   Lambda,
+  AuthLambdaTriggers,
+  StorageTriggerEvent,
 };

--- a/packages/amplify-gen2-codegen/src/storage/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/storage/source_builder.test.ts
@@ -1,9 +1,24 @@
 import assert from 'node:assert';
-import { AccessPatterns, Permission, renderStorage } from './source_builder';
+import { AccessPatterns, Permission, renderStorage, StorageTriggerEvent } from './source_builder';
 import { printNodeArray } from '../test_utils/ts_node_printer';
 import { getImportRegex } from '../test_utils/import_regex';
+import { Lambda } from '../function/lambda';
 
 describe('Storage source generation', () => {
+  describe('storage triggers', () => {
+    const triggers: Record<StorageTriggerEvent, Lambda> = {
+      onDelete: { source: 'onDelete' },
+      onUpload: { source: 'onUpload' },
+    };
+    for (const [key, value] of Object.entries(triggers)) {
+      it(`${key} trigger is rendered`, () => {
+        const rendered = renderStorage({ triggers });
+        const output = printNodeArray(rendered);
+        assert.match(output, new RegExp(`${key}: defineFunction\\(\\{ entry:\\s"${value.source}"`));
+        assert.match(output, /triggers: /);
+      });
+    }
+  });
   describe('imports', () => {
     it('renders the defineStorage import', () => {
       const rendered = renderStorage();

--- a/packages/amplify-gen2-codegen/src/storage/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/storage/source_builder.ts
@@ -3,6 +3,7 @@ import { getAccessPatterns } from './access';
 import { renderResourceTsFile } from '../resource/resource';
 import { createTriggersProperty, Lambda } from '../function/lambda';
 const factory = ts.factory;
+
 export type S3TriggerDefinition = Record<string, never>;
 export type Permission = 'read' | 'write' | 'create' | 'delete';
 export type GroupPermissions<G extends readonly string[]> = {

--- a/packages/amplify-gen2-codegen/src/test_utils/ts_node_printer.ts
+++ b/packages/amplify-gen2-codegen/src/test_utils/ts_node_printer.ts
@@ -1,5 +1,11 @@
 import ts from 'typescript';
 
+export const printNode = (node: ts.Node) => {
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const sourceFile = ts.createSourceFile('output.ts', '', ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  const source = printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
+  return source;
+};
 export const printNodeArray = (nodeArray: ts.NodeArray<ts.Node>) => {
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
   const sourceFile = ts.createSourceFile('output.ts', '', ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);

--- a/packages/amplify-migration/API.md
+++ b/packages/amplify-migration/API.md
@@ -7,6 +7,9 @@
 import { $TSContext } from '@aws-amplify/amplify-cli-core';
 
 // @public (undocumented)
+export type AuthCliInputs = Record<string, unknown>;
+
+// @public (undocumented)
 export function executeAmplifyCommand(context: $TSContext): Promise<void>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -16,7 +16,7 @@ import { Analytics, DummyAnalytics } from './analytics.js';
 import { AppAuthDefinitionFetcher } from './app_auth_definition_fetcher.js';
 import { AppStorageDefinitionFetcher } from './app_storage_definition_fetcher.js';
 import { $TSContext, AmplifyCategories, stateManager } from '@aws-amplify/amplify-cli-core';
-import { AuthTriggerConnections } from '@aws-amplify/amplify-gen1-codegen-auth-adapter';
+import { AuthTriggerConnection } from '@aws-amplify/amplify-gen1-codegen-auth-adapter';
 
 interface CodegenCommandParameters {
   analytics: Analytics;
@@ -88,7 +88,7 @@ const getAuthTriggersConnections = async (context: $TSContext): Promise<Partial<
   const authInputs = stateManager.getResourceInputsJson(undefined, AmplifyCategories.AUTH, resourceName);
   if ('cognitoConfig' in authInputs && 'authTriggerConnections' in authInputs.cognitoConfig) {
     try {
-      const triggerConnections: AuthTriggerConnections[] = JSON.parse(authInputs.cognitoConfig.authTriggerConnections);
+      const triggerConnections: AuthTriggerConnection[] = JSON.parse(authInputs.cognitoConfig.authTriggerConnections);
       const connections = triggerConnections.reduce((prev, curr) => {
         prev[curr.triggerType] = getFunctionPath(context, curr.lambdaFunctionName);
         return prev;

--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -93,7 +93,6 @@ const getAuthTriggersConnections = async (context: $TSContext): Promise<Partial<
         prev[curr.triggerType] = getFunctionPath(context, curr.lambdaFunctionName);
         return prev;
       }, {} as Partial<Record<keyof LambdaConfigType, string>>);
-      console.log(JSON.stringify(connections, null, 2));
       return connections;
     } catch (e) {
       throw new Error('Error parsing auth trigger connections');
@@ -112,7 +111,7 @@ export async function executeAmplifyCommand(context: $TSContext) {
   await generateGen2Code({
     outputDirectory: './output',
     appId,
-    storageDefinitionFetcher: new AppStorageDefinitionFetcher(new BackendDownloader(s3Client)),
+    storageDefinitionFetcher: new AppStorageDefinitionFetcher(new BackendDownloader(s3Client), s3Client),
     authDefinitionFetcher: new AppAuthDefinitionFetcher(cognitoIdentityProviderClient, cloudFormationClient, () =>
       getAuthTriggersConnections(context),
     ),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Begins adding triggers for storage. Refactors `defineFunction` codegen into its own module. Updates API files for last several PRs.

#### Description of how you validated changes
Unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
