### PR TITLE
fix: remove node-ip dependency

### DIFF
--- a/packages/amplify-appsync-simulator/package.json
+++ b/packages/amplify-appsync-simulator/package.json
@@ -44,7 +44,6 @@
     "graphql": "^15.5.0",
     "graphql-iso-date": "^3.6.1",
     "graphql-subscriptions": "^1.1.0",
-    "ip": "^1.1.9",
     "js-string-escape": "^1.0.1",
     "jwt-decode": "^2.2.0",
     "libphonenumber-js": "1.9.47",

--- a/packages/amplify-appsync-simulator/src/server/index.ts
+++ b/packages/amplify-appsync-simulator/src/server/index.ts
@@ -5,13 +5,24 @@ import { Server, createServer } from 'http';
 import { createServer as createHttpsServer } from 'https';
 import { readFileSync } from 'fs';
 import { fromEvent } from 'promise-toolbox';
-import { address as getLocalIpAddress } from 'ip';
 import { AppSyncSimulatorSubscriptionServer } from './websocket-subscription';
 import getPort from 'get-port';
 import { REALTIME_SUBSCRIPTION_PATH } from './subscription/websocket-server/server';
+import os from 'os';
 
 const BASE_PORT = 8900;
 const MAX_PORT = 9999;
+
+function getLocalIpAddress(): string {
+  const interfaces = os.networkInterfaces();
+  const internalAddresses = Object.keys(interfaces)
+    .map((nic) => {
+      const addresses = interfaces[nic].filter((details) => details.internal);
+      return addresses.length ? addresses[0].address : undefined;
+    })
+    .filter(Boolean);
+  return internalAddresses.length ? internalAddresses[0] : '127.0.0.1';
+}
 
 export class AppSyncSimulatorServer {
   private _operationServer: OperationServer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,7 +123,6 @@ __metadata:
     graphql: ^15.5.0
     graphql-iso-date: ^3.6.1
     graphql-subscriptions: ^1.1.0
-    ip: ^1.1.9
     jose: ^5.2.0
     js-string-escape: ^1.0.1
     jwt-decode: ^2.2.0
@@ -21625,7 +21624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip@npm:^1.1.8, ip@npm:^1.1.9":
+"ip@npm:^1.1.8":
   version: 1.1.9
   resolution: "ip@npm:1.1.9"
   checksum: 5af58bfe2110c9978acfd77a2ffcdf9d33a6ce1c72f49edbaf16958f7a8eb979b5163e43bb18938caf3aaa55cdacde4e470874c58ca3b4b112ea7a30461a0c27


### PR DESCRIPTION
#### Description of changes

Remove dependency on poorly maintained "ip" package, which has an open security advisory https://github.com/indutny/node-ip/issues/150

Implement an equivalent `getLocalIpAddress()` function that returns the first internal IP address. This is used by clients of the `appsync-sumulator` to connect to.

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/13890

#### Description of how you validated changes

Ran `yarn lerna run --scope @aws-amplify/amplify-appsync-simulator test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
