### PR TITLE
fix: data definition fetcher handle undefined data stack

### DIFF
--- a/packages/amplify-migration/src/data_definition_fetcher.test.ts
+++ b/packages/amplify-migration/src/data_definition_fetcher.test.ts
@@ -6,54 +6,114 @@ import { AmplifyStackParser, AmplifyStacks } from './amplify_stack_parser';
 import { Stack } from '@aws-sdk/client-cloudformation';
 
 describe('DataDefinitionFetcher', () => {
-  it('maps cloudformation stack output to table mapping', async () => {
-    const mapping = { hello: 'world' };
-    const mockBackendEnvResolver: BackendEnvironmentResolver = {
-      selectBackendEnvironment: async () => {
-        return {
-          stackName: 'asdf',
-        } as BackendEnvironment;
-      },
-    } as BackendEnvironmentResolver;
-    const mockAmplifyStackParser: AmplifyStackParser = {
-      getAmplifyStacks: async () =>
-        ({
-          dataStack: {
-            Outputs: [
-              {
-                OutputKey: 'DataSourceMappingOutput',
-                OutputValue: JSON.stringify(mapping),
-              },
-            ],
-          } as unknown as Stack,
-        } as AmplifyStacks),
-    } as unknown as AmplifyStackParser;
-    const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
-    const results = await dataDefinitionFetcher.getDefinition();
-    assert(results?.tableMapping);
+  describe('if data stack is defined', () => {
+    describe('table mapping is defined', () => {
+      it('maps cloudformation stack output to table mapping', async () => {
+        const mapping = { hello: 'world' };
+        const mockBackendEnvResolver: BackendEnvironmentResolver = {
+          selectBackendEnvironment: async () => {
+            return {
+              stackName: 'asdf',
+            } as BackendEnvironment;
+          },
+        } as BackendEnvironmentResolver;
+        const mockAmplifyStackParser: AmplifyStackParser = {
+          getAmplifyStacks: async () =>
+            ({
+              dataStack: {
+                Outputs: [
+                  {
+                    OutputKey: 'DataSourceMappingOutput',
+                    OutputValue: JSON.stringify(mapping),
+                  },
+                ],
+              } as unknown as Stack,
+            } as AmplifyStacks),
+        } as unknown as AmplifyStackParser;
+        const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
+        const results = await dataDefinitionFetcher.getDefinition();
+        assert(results?.tableMapping);
+      });
+      it('throws an error if the json cannot be parsed', async () => {
+        const mockBackendEnvResolver: BackendEnvironmentResolver = {
+          selectBackendEnvironment: async () => {
+            return {
+              stackName: 'asdf',
+            } as BackendEnvironment;
+          },
+        } as BackendEnvironmentResolver;
+        const mockAmplifyStackParser: AmplifyStackParser = {
+          getAmplifyStacks: async () =>
+            ({
+              dataStack: {
+                Outputs: [
+                  {
+                    OutputKey: 'DataSourceMappingOutput',
+                    OutputValue: '(}',
+                  },
+                ],
+              } as unknown as Stack,
+            } as AmplifyStacks),
+        } as unknown as AmplifyStackParser;
+        const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
+        await assert.rejects(() => dataDefinitionFetcher.getDefinition(), { message: 'Could not parse the Amplify Data table mapping' });
+      });
+    });
+    describe('table mapping is not defined', () => {
+      it('reject with table mapping assertion', async () => {
+        const mockBackendEnvResolver: BackendEnvironmentResolver = {
+          selectBackendEnvironment: async () => {
+            return {
+              stackName: 'asdf',
+            } as BackendEnvironment;
+          },
+        } as BackendEnvironmentResolver;
+        const mockAmplifyStackParser: AmplifyStackParser = {
+          getAmplifyStacks: async () =>
+            ({
+              dataStack: {},
+            } as AmplifyStacks),
+        } as unknown as AmplifyStackParser;
+        const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
+        await assert.rejects(dataDefinitionFetcher.getDefinition);
+      });
+    });
   });
-  it('throws an error if the json cannot be parsed', async () => {
-    const mockBackendEnvResolver: BackendEnvironmentResolver = {
-      selectBackendEnvironment: async () => {
-        return {
-          stackName: 'asdf',
-        } as BackendEnvironment;
-      },
-    } as BackendEnvironmentResolver;
-    const mockAmplifyStackParser: AmplifyStackParser = {
-      getAmplifyStacks: async () =>
-        ({
-          dataStack: {
-            Outputs: [
-              {
-                OutputKey: 'DataSourceMappingOutput',
-                OutputValue: '(}',
-              },
-            ],
-          } as unknown as Stack,
-        } as AmplifyStacks),
-    } as unknown as AmplifyStackParser;
-    const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
-    await assert.rejects(() => dataDefinitionFetcher.getDefinition(), { message: 'Could not parse the Amplify Data table mapping' });
+  describe('if data stack is undefined', () => {
+    it('does not reject with table mapping assertion', async () => {
+      const mockBackendEnvResolver: BackendEnvironmentResolver = {
+        selectBackendEnvironment: async () => {
+          return {
+            stackName: 'asdf',
+          } as BackendEnvironment;
+        },
+      } as BackendEnvironmentResolver;
+      const mockAmplifyStackParser: AmplifyStackParser = {
+        getAmplifyStacks: async () =>
+          ({
+            dataStack: undefined,
+          } as AmplifyStacks),
+      } as unknown as AmplifyStackParser;
+      const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
+      await assert.doesNotReject(dataDefinitionFetcher.getDefinition);
+    });
+    it('returns undefined', async () => {
+      const mockBackendEnvResolver: BackendEnvironmentResolver = {
+        selectBackendEnvironment: async () => {
+          return {
+            stackName: 'asdf',
+          } as BackendEnvironment;
+        },
+      } as BackendEnvironmentResolver;
+      const mockAmplifyStackParser: AmplifyStackParser = {
+        getAmplifyStacks: async () =>
+          ({
+            dataStack: undefined,
+          } as AmplifyStacks),
+      } as unknown as AmplifyStackParser;
+      const dataDefinitionFetcher = new DataDefinitionFetcher(mockBackendEnvResolver, mockAmplifyStackParser);
+      const definition = await dataDefinitionFetcher.getDefinition();
+      assert.equal(definition, undefined);
+    });
   });
 });

--- a/packages/amplify-migration/src/data_definition_fetcher.ts
+++ b/packages/amplify-migration/src/data_definition_fetcher.ts
@@ -11,14 +11,16 @@ export class DataDefinitionFetcher {
     const backendEnvironment = await this.backendEnvironmentResolver.selectBackendEnvironment();
     assert(backendEnvironment?.stackName);
     const amplifyStacks = await this.amplifyStackClient.getAmplifyStacks(backendEnvironment?.stackName);
-    const tableMappingText = amplifyStacks.dataStack?.Outputs?.find((o) => o.OutputKey === dataSourceMappingOutputKey)?.OutputValue;
-    assert(tableMappingText, 'Amplify Data table mapping not found.');
-    try {
-      return {
-        tableMapping: JSON.parse(tableMappingText),
-      };
-    } catch (e) {
-      throw new Error('Could not parse the Amplify Data table mapping');
+    if (amplifyStacks.dataStack) {
+      const tableMappingText = amplifyStacks.dataStack?.Outputs?.find((o) => o.OutputKey === dataSourceMappingOutputKey)?.OutputValue;
+      assert(tableMappingText, 'Amplify Data table mapping not found.');
+      try {
+        return {
+          tableMapping: JSON.parse(tableMappingText),
+        };
+      } catch (e) {
+        throw new Error('Could not parse the Amplify Data table mapping');
+      }
     }
   };
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Handles cases where the data stack is undefined during data codegen in apps that do not have data configured.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
