### PR TITLE
fix: update message when expecting S3 to throw

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/auth/user-groups-s3-access.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/auth/user-groups-s3-access.test.ts
@@ -100,7 +100,7 @@ describe('user group tests', () => {
           Key: s3key,
         }),
       ),
-    ).rejects.toThrow('Access Denied');
+    ).rejects.toThrow(/not authorized to perform/);
     await expect(
       s3Client2.send(
         new PutObjectCommand({
@@ -109,7 +109,7 @@ describe('user group tests', () => {
           Body: s3val,
         }),
       ),
-    ).rejects.toThrow('Access Denied');
+    ).rejects.toThrow(/not authorized to perform/);
     await signOutUser();
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently S3 access E2E tests are looking for `Access Denied` when expecting user group that does not have permissions to interact with S3 bucket. The new message received is now something like:

`User: <user group arn> is not authorized to perform: s3:GetObject on resource: <S3 bucket> because no identity-based policy allows the s3:GetObject action`

Update E2E test to expect `not authorized to perform` instead of `Access Denied`.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
