### PR TITLE
fix: make gen2 migration packages public

### DIFF
--- a/packages/amplify-gen1-codegen-auth-adapter/package.json
+++ b/packages/amplify-gen1-codegen-auth-adapter/package.json
@@ -37,6 +37,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "pretest": "mkdir -p coverage",
     "test": "jest --logHeapUsage",

--- a/packages/amplify-gen1-codegen-data-adapter/package.json
+++ b/packages/amplify-gen1-codegen-data-adapter/package.json
@@ -38,6 +38,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "pretest": "mkdir -p coverage",
     "test": "jest --logHeapUsage",

--- a/packages/amplify-gen1-codegen-function-adapter/package.json
+++ b/packages/amplify-gen1-codegen-function-adapter/package.json
@@ -34,6 +34,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "pretest": "mkdir -p coverage",
     "test": "jest --logHeapUsage",

--- a/packages/amplify-gen1-codegen-storage-adapter/package.json
+++ b/packages/amplify-gen1-codegen-storage-adapter/package.json
@@ -37,6 +37,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "pretest": "mkdir -p coverage",
     "test": "jest --logHeapUsage",

--- a/packages/amplify-gen2-codegen/package.json
+++ b/packages/amplify-gen2-codegen/package.json
@@ -33,6 +33,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "",
   "license": "Apache-2.0",
   "description": "",

--- a/packages/amplify-migration-codegen-e2e/package.json
+++ b/packages/amplify-migration-codegen-e2e/package.json
@@ -33,6 +33,9 @@
     ],
     "collectCoverage": true
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "exit 0",
     "pretest": "mkdir -p coverage",

--- a/packages/amplify-migration/package.json
+++ b/packages/amplify-migration/package.json
@@ -4,6 +4,9 @@
   "type": "commonjs",
   "main": "lib/index.js",
   "bin": "lib/migrate.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest --logHeapUsage",


### PR DESCRIPTION
#### Description of changes

Add` public` access to `publishConfig` to be able to publish gen2 migration packages to `npm`.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
