### PR TITLE
Change the default MinTTL for cloudfront distributions to 0

### DIFF
--- a/packages/amplify-category-hosting/__mocks__/mockTemplate.json
+++ b/packages/amplify-category-hosting/__mocks__/mockTemplate.json
@@ -106,7 +106,7 @@
             "ViewerProtocolPolicy": "redirect-to-https",
             "DefaultTTL": 86400,
             "MaxTTL": 31536000,
-            "MinTTL": 60,
+            "MinTTL": 0,
             "Compress": true
           },
           "DefaultRootObject": "index.html",

--- a/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
+++ b/packages/amplify-category-hosting/lib/S3AndCloudFront/template.json
@@ -134,7 +134,7 @@
             "ViewerProtocolPolicy": "redirect-to-https",
             "DefaultTTL": 86400,
             "MaxTTL": 31536000,
-            "MinTTL": 60,
+            "MinTTL": 0,
             "Compress": true
           },
           "DefaultRootObject": "index.html",


### PR DESCRIPTION
#### Description of changes

It's recommended that the default template when deploying distributions has MinTTL set to 0 so that Cloudfront can still caches requests but not include other headers such as the RSC in responses.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
