### PR TITLE
fix: check for empty objects

### DIFF
--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -148,7 +148,7 @@ const unsupportedCategories = (): Map<string, string> => {
         });
       }
     } else {
-      if (unsupportedCategories.has(category)) {
+      if (unsupportedCategories.has(category) && Object.entries(meta[category]).length > 0) {
         unsupportedCategoriesList.set(category, unsupportedCategories.get(category)!);
       }
     }


### PR DESCRIPTION
Added a validation to check for empty object in case of unsupported categories