### PR TITLE
fix: move importedModels key up to defineData

### DIFF
--- a/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
@@ -27,5 +27,13 @@ describe('Data Category code generation', () => {
       const array = source.match(/importedModels:\s+\[(.*?)\]/);
       assert.deepEqual(tables, array?.[1].replaceAll('"', '').split(', '));
     });
+    it('has each each key in defineData', () => {
+      const tableMapping = { Todo: 'my-todo-mapping' };
+      const source = printNodeArray(generateDataSource({ tableMapping }));
+      assert.match(
+        source,
+        /defineData\({\n\s+importedAmplifyDynamoDBTableMap: \{\s+Todo: ['"]my-todo-mapping['"] },\n\s+importedModels:\s+\[.*?\],\n\s+schema: "TODO: Add your existing graphql schema here"\n}\)/,
+      );
+    });
   });
 });

--- a/packages/amplify-gen2-codegen/src/data/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.ts
@@ -23,19 +23,19 @@ export const generateDataSource = (dataDefinition?: DataDefinition): ts.NodeArra
       tableMappingProperties.push(
         factory.createPropertyAssignment(factory.createIdentifier(tableName), factory.createStringLiteral(tableId)),
       );
-      tableMappingProperties.push(
-        factory.createPropertyAssignment(
-          factory.createIdentifier(importedModelsKey),
-          factory.createArrayLiteralExpression(
-            Object.keys(dataDefinition.tableMapping).map((tableName) => factory.createStringLiteral(tableName)),
-          ),
-        ),
-      );
     }
     dataRenderProperties.push(
       factory.createPropertyAssignment(
         importedAmplifyDynamoDBTableMapKeyName,
         factory.createObjectLiteralExpression(tableMappingProperties),
+      ),
+    );
+    dataRenderProperties.push(
+      factory.createPropertyAssignment(
+        importedModelsKey,
+        factory.createArrayLiteralExpression(
+          Object.keys(dataDefinition.tableMapping).map((tableName) => factory.createStringLiteral(tableName)),
+        ),
       ),
     );
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

fix: move importedModels key up to defineData. It should be like the following (not nested under `importedAmplifyDynamoDBTableMap`).

```typescript
export const data = defineData({
  importedAmplifyDynamoDBTableMap: { Todo: "my-todo-mapping" },
  importedModels: ["Todo"],
  schema: "TODO: Add your existing graphql schema here"
});
```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

Add new unit test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
