### PR TITLE
Gen2 Migration template gen: Add CFN parameter resolver

### DIFF
--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.test.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.test.ts
@@ -1,0 +1,115 @@
+import CfnParameterResolver from './cfn-parameter-resolver';
+import { CFNTemplate } from '../types';
+
+describe('CFNParameterResolver', () => {
+  const template: CFNTemplate = {
+    Description: 'This is a test template',
+    AWSTemplateFormatVersion: '2010-09-09',
+    Parameters: {
+      Env: {
+        Type: 'String',
+        Default: 'dev',
+      },
+      // comma delimited parameter
+      CommaDelimited: {
+        Type: 'CommaDelimitedList',
+        Default: 'a,b,c',
+      },
+      // List<number> parameter
+      NumberList: {
+        Type: 'List<Number>',
+        Default: '1,2,3',
+      },
+      // NoEcho parameter
+      NoEcho: {
+        Type: 'String',
+        Default: 'no-echo',
+        NoEcho: true,
+      },
+    },
+    Resources: {
+      MyBucket: {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          BucketName: 'my-bucket',
+          // use parameters
+          Tags: [
+            { Key: 'env', Value: { Ref: 'Env' } },
+            { Key: 'comma', Value: { Ref: 'CommaDelimited' } },
+            { Key: 'number', Value: { Ref: 'NumberList' } },
+            { Key: 'no-echo', Value: { Ref: 'NoEcho' } },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      MyBucketName: {
+        Description: 'My bucket name',
+        Value: {
+          Ref: 'MyBucket',
+        },
+      },
+    },
+  };
+
+  const expectedTemplate: CFNTemplate = {
+    Description: 'This is a test template',
+    AWSTemplateFormatVersion: '2010-09-09',
+    Parameters: {
+      Env: {
+        Type: 'String',
+        Default: 'dev',
+      },
+      CommaDelimited: {
+        Type: 'CommaDelimitedList',
+        Default: 'a,b,c',
+      },
+      NumberList: {
+        Type: 'List<Number>',
+        Default: '1,2,3',
+      },
+      NoEcho: {
+        Type: 'String',
+        Default: 'no-echo',
+        NoEcho: true,
+      },
+    },
+    Resources: {
+      MyBucket: {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          BucketName: 'my-bucket',
+          Tags: [
+            { Key: 'env', Value: 'prod' },
+            { Key: 'comma', Value: ['a', 'b', 'c', 'd'] },
+            { Key: 'number', Value: ['1', '2', '3', '4'] },
+            { Key: 'no-echo', Value: { Ref: 'NoEcho' } },
+          ],
+        },
+      },
+    },
+    Outputs: {
+      MyBucketName: {
+        Description: 'My bucket name',
+        Value: {
+          Ref: 'MyBucket',
+        },
+      },
+    },
+  };
+
+  it('should resolve parameters in template', () => {
+    const resolvedTemplate = new CfnParameterResolver(template).resolve([
+      { ParameterKey: 'Env', ParameterValue: 'prod' },
+      { ParameterKey: 'CommaDelimited', ParameterValue: 'a,b,c,d' },
+      { ParameterKey: 'NumberList', ParameterValue: '1,2,3,4' },
+      { ParameterKey: 'NoEcho', ParameterValue: 'new-no-echo' },
+    ]);
+    expect(resolvedTemplate).toEqual(expectedTemplate);
+  });
+
+  it('should not resolve when no parameters are present', () => {
+    const resolvedTemplate = new CfnParameterResolver(template).resolve([]);
+    expect(resolvedTemplate).toEqual(template);
+  });
+});

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert';
 
 class CfnParameterResolver {
   constructor(private readonly template: CFNTemplate) {}
+
   public resolve(parameters: Parameter[]) {
     if (!parameters.length) return this.template;
     let templateString = JSON.stringify(this.template);

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
@@ -1,0 +1,30 @@
+import { CFNTemplate } from '../types';
+import { Parameter } from '@aws-sdk/client-cloudformation';
+import assert from 'node:assert';
+
+class CfnParameterResolver {
+  constructor(private readonly template: CFNTemplate) {}
+  public resolve(parameters: Parameter[]) {
+    if (!parameters.length) return this.template;
+    let templateString = JSON.stringify(this.template);
+    const parametersFromTemplate = this.template.Parameters;
+    for (const { ParameterKey, ParameterValue } of parameters) {
+      assert(ParameterKey);
+      assert(ParameterValue);
+      const { Type: parameterType, NoEcho } = parametersFromTemplate[ParameterKey];
+      if (NoEcho) continue;
+      // All parameter values referenced by Ref are coerced to strings. List/Comma delimited are converted to arrays before coercing to string.
+      // Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+      let resolvedParameterValue: string = JSON.stringify(ParameterValue);
+      const isListValue = parameterType === 'CommaDelimitedList' || parameterType === 'List<Number>';
+      if (isListValue) {
+        resolvedParameterValue = JSON.stringify(ParameterValue.includes(',') ? ParameterValue.split(',') : [ParameterValue]);
+      }
+      const paramRegexp = new RegExp(`{"Ref":"${ParameterKey}"}`, 'g');
+      templateString = templateString.replaceAll(paramRegexp, resolvedParameterValue);
+    }
+    return JSON.parse(templateString);
+  }
+}
+
+export default CfnParameterResolver;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Add CFN parameter resolver to resolve Gen1 resources with parameters before refactoring them into Gen2 stack.

TODO: Add code to retrieve secret values in params using CLI utils: https://github.com/aws-amplify/amplify-cli/blob/dev/packages/amplify-cli/src/extensions/amplify-helpers/envResourceParams.ts#L62


#### Description of how you validated changes
Local testing, unit tests 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
