### PR TITLE
fix: prevent init if local files belong to other app

### DIFF
--- a/packages/amplify-cli/src/commands/init.ts
+++ b/packages/amplify-cli/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { $TSContext, LocalEnvInfo } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, AmplifyError, LocalEnvInfo, stateManager } from '@aws-amplify/amplify-cli-core';
 import { constructInputParams } from '../amplify-service-helper';
 import { Context } from '../domain/context';
 import { raisePostEnvAddEvent } from '../execution-manager';
@@ -10,6 +10,7 @@ import { initProviders } from '../init-steps/s2-initProviders';
 import { scaffoldProjectHeadless } from '../init-steps/s8-scaffoldHeadless';
 import { onHeadlessSuccess, onSuccess } from '../init-steps/s9-onSuccess';
 import { checkForNestedProject } from './helpers/projectUtils';
+import { getAmplifyAppId } from '../extensions/amplify-helpers/get-amplify-appId';
 
 const constructExeInfo = (context: $TSContext): void => {
   context.exeInfo = {
@@ -31,6 +32,18 @@ const runStrategy = (quickstart: boolean) =>
 export const run = async (context: $TSContext): Promise<void> => {
   constructExeInfo(context);
   checkForNestedProject();
+
+  const projectPath = process.cwd();
+  if (stateManager.metaFileExists(projectPath)) {
+    const inputAppId = context.exeInfo?.inputParams?.amplify?.appId;
+    const appId = getAmplifyAppId();
+    if (inputAppId && appId && inputAppId !== appId) {
+      throw new AmplifyError('InvalidAmplifyAppIdError', {
+        message: `Amplify appId mismatch.`,
+        resolution: `You are currently working in the amplify project with Id ${appId}`,
+      });
+    }
+  }
 
   const steps = runStrategy(!!context?.parameters?.options?.quickstart);
   for (const step of steps) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR adds validation to make sure that AppId passed via command line parameters match with appid stored in metadata files.

This is similar to existing validation that pull does here https://github.com/aws-amplify/amplify-cli/blob/33c10fdd6b3b53644a9162208b984a58f6871946/packages/amplify-cli/src/commands/pull.ts#L41-L45

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I did the following manually:
1. Created an app. Appid `d2qe95s9uhn10w`
2. Attempted to run init flow with different app id , i.e. `amplify init --amplify "{\"envName\":\"dev\",\"appId\":\"d3jmsv5lpeg234\"}" --yes  --forcePush`

![image](https://github.com/user-attachments/assets/8d23f4f2-4422-41c8-9a77-2316be347462)


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
