### PR TITLE
Gen2 migration - Resolve CFN Outputs

### DIFF
--- a/packages/amplify-migration-template-gen/package.json
+++ b/packages/amplify-migration-template-gen/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "pretest": "mkdir -p coverage",
-    "test": "jest --logHeapUsage",
+    "test": "jest --logHeapUsagemig",
     "build": "tsc",
     "watch": "tsc -w",
     "extract-api": "ts-node ../../scripts/extract-api.ts"

--- a/packages/amplify-migration-template-gen/package.json
+++ b/packages/amplify-migration-template-gen/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "pretest": "mkdir -p coverage",
-    "test": "jest --logHeapUsagemig",
+    "test": "jest --logHeapUsage",
     "build": "tsc",
     "watch": "tsc -w",
     "extract-api": "ts-node ../../scripts/extract-api.ts"

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
@@ -1,0 +1,194 @@
+import CfnOutputResolver from './cfn-output-resolver';
+import { CFNTemplate } from '../types';
+
+describe('CFNOutputResolver', () => {
+  const template: CFNTemplate = {
+    AWSTemplateFormatVersion: '2010-09-09',
+    Description: 'Test template',
+    Parameters: {
+      AuthenticatedRole: {
+        Type: 'String',
+      },
+    },
+    Outputs: {
+      MyS3BucketOutputRef: {
+        Description: 'S3 bucket',
+        Value: { Ref: 'MyS3Bucket' },
+      },
+      AnotherOutput: {
+        Description: 'Another output',
+        Value: 'another value',
+      },
+      MyUserPoolOutputRef: {
+        Description: 'User pool',
+        Value: { Ref: 'MyUserPool' },
+      },
+      MyUserPoolClientOutputRef: {
+        Description: 'User pool',
+        Value: { Ref: 'MyUserPoolClient' },
+      },
+    },
+    Resources: {
+      MyS3Bucket: {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          UpdateReplacePolicy: 'Delete',
+          DeletionPolicy: 'Delete',
+        },
+      },
+      MyS3BucketPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: {
+          PolicyName: 'MyS3BucketPolicy',
+          PolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: { 'Fn::GetAtt': ['MyS3Bucket', 'Arn'] },
+              },
+            ],
+          },
+          Roles: [{ Ref: 'AuthenticatedRole' }],
+        },
+      },
+      MyUserPool: {
+        Type: 'AWS::Cognito::UserPool',
+        Properties: {
+          UserPoolName: 'MyUserPool',
+        },
+      },
+      HostedUICustomResourcePolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: {
+          PolicyName: 'HostedUICustomResourcePolicy',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 'cognito-idp:DescribeUserPool',
+                Resource: { 'Fn::GetAtt': ['MyUserPool', 'Arn'] },
+              },
+            ],
+          },
+          Roles: [{ Ref: 'AuthenticatedRole' }],
+        },
+      },
+      MyUserPoolClient: {
+        Type: 'AWS::Cognito::UserPoolClient',
+        Properties: {
+          ClientName: 'MyUserPoolClient',
+          UserPoolId: { Ref: 'MyUserPool' },
+        },
+      },
+    },
+  };
+  const expectedTemplate: CFNTemplate = {
+    AWSTemplateFormatVersion: '2010-09-09',
+    Description: 'Test template',
+    Parameters: {
+      AuthenticatedRole: {
+        Type: 'String',
+      },
+    },
+    Outputs: {
+      MyS3BucketOutputRef: {
+        Description: 'S3 bucket',
+        Value: 'test-bucket',
+      },
+      AnotherOutput: {
+        Description: 'Another output',
+        Value: 'another value',
+      },
+      MyUserPoolOutputRef: {
+        Description: 'User pool',
+        Value: 'test-userpoolid',
+      },
+      MyUserPoolClientOutputRef: {
+        Description: 'User pool',
+        Value: 'test-userpoolclientid',
+      },
+    },
+    Resources: {
+      MyS3Bucket: {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          UpdateReplacePolicy: 'Delete',
+          DeletionPolicy: 'Delete',
+        },
+      },
+      MyS3BucketPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: {
+          PolicyName: 'MyS3BucketPolicy',
+          PolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: 'arn:aws:s3:::test-bucket',
+              },
+            ],
+          },
+          Roles: [{ Ref: 'AuthenticatedRole' }],
+        },
+      },
+      MyUserPool: {
+        Type: 'AWS::Cognito::UserPool',
+        Properties: {
+          UserPoolName: 'MyUserPool',
+        },
+      },
+      HostedUICustomResourcePolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: {
+          PolicyName: 'HostedUICustomResourcePolicy',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 'cognito-idp:DescribeUserPool',
+                Resource: 'arn:aws:cognito-idp:us-east-1:12345:userpool/test-userpoolid',
+              },
+            ],
+          },
+          Roles: [{ Ref: 'AuthenticatedRole' }],
+        },
+      },
+      MyUserPoolClient: {
+        Type: 'AWS::Cognito::UserPoolClient',
+        Properties: {
+          ClientName: 'MyUserPoolClient',
+          UserPoolId: 'test-userpoolid',
+        },
+      },
+    },
+  };
+  it('should resolve output references', () => {
+    expect(
+      new CfnOutputResolver(template, 'us-east-1', '12345').resolve(
+        ['MyS3Bucket', 'MyUserPool', 'MyUserPoolClient'],
+        [
+          {
+            OutputKey: 'MyS3BucketOutputRef',
+            OutputValue: 'test-bucket',
+          },
+          {
+            OutputKey: 'AnotherOutput',
+            OutputValue: 'another value',
+          },
+          {
+            OutputKey: 'MyUserPoolOutputRef',
+            OutputValue: 'test-userpoolid',
+          },
+          {
+            OutputKey: 'MyUserPoolClientOutputRef',
+            OutputValue: 'test-userpoolclientid',
+          },
+        ],
+      ),
+    ).toEqual(expectedTemplate);
+  });
+});

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
@@ -1,0 +1,96 @@
+import { AWS_RESOURCE_ATTRIBUTES, CFN_RESOURCE_TYPES, CFNTemplate } from '../types';
+import assert from 'node:assert';
+import { Output } from '@aws-sdk/client-cloudformation';
+
+const REF = 'Ref';
+const GET_ATT = 'Fn::GetAtt';
+
+/**
+ * This class is responsible for resolving logical resource ids in a CloudFormation template
+ * with their corresponding stack outputs.
+ */
+class CfnOutputResolver {
+  constructor(private readonly template: CFNTemplate, private readonly region: string, private readonly accountId: string) {}
+
+  public resolve(logicalResourceIds: string[], stackOutputs: Output[]): CFNTemplate {
+    const resources = this.template?.Resources;
+    assert(resources);
+    let stackTemplateString = JSON.stringify(this.template);
+    const stackTemplateOutputs = this.template?.Outputs;
+    assert(stackOutputs);
+    assert(stackTemplateOutputs);
+
+    for (const logicalResourceId of logicalResourceIds) {
+      Object.entries(stackTemplateOutputs).forEach(([outputKey, outputValue]) => {
+        const value = outputValue.Value;
+        const stackOutputValue = stackOutputs?.find((op) => op.OutputKey === outputKey)?.OutputValue;
+        assert(stackOutputValue);
+
+        // Replace logicalId references using stack output values
+        if (typeof value === 'object' && REF in value && value[REF] === logicalResourceId) {
+          const outputRegexp = new RegExp(`{"${REF}":"${logicalResourceId}"}`, 'g');
+          stackTemplateString = stackTemplateString.replaceAll(outputRegexp, `"${stackOutputValue}"`);
+
+          // Replace Fn:GetAtt references using stack output values
+          const fnGetAttRegExp = new RegExp(`{"${GET_ATT}":\\["${logicalResourceId}","(?<AttributeName>\\w+)"]}`, 'g');
+          const fnGetAttRegExpResult = stackTemplateString.matchAll(fnGetAttRegExp).next();
+          const resourceType = this.template.Resources[logicalResourceId].Type as CFN_RESOURCE_TYPES;
+          if (!fnGetAttRegExpResult.done) {
+            const attributeName = fnGetAttRegExpResult.value.groups?.AttributeName;
+            assert(attributeName);
+            const resource = this.getResourceAttribute(attributeName as AWS_RESOURCE_ATTRIBUTES, resourceType, stackOutputValue);
+            stackTemplateString = stackTemplateString.replaceAll(fnGetAttRegExp, this.buildFnGetAttReplace(resource));
+          }
+        }
+      });
+    }
+
+    return JSON.parse(stackTemplateString);
+  }
+
+  /**
+   * Get resource attribute based on attribute name, resource type and resource identifier.
+   * Only Arn is supported for now since that is what is used in gen1 and gen2 stacks for Auth and Storage categories.
+   * @param attributeName
+   * @param resourceType
+   * @param resourceIdentifier
+   * @private
+   */
+  private getResourceAttribute(
+    attributeName: AWS_RESOURCE_ATTRIBUTES,
+    resourceType: CFN_RESOURCE_TYPES,
+    resourceIdentifier: string,
+  ): Record<string, string> {
+    switch (attributeName) {
+      case 'Arn': {
+        switch (resourceType) {
+          case 'AWS::S3::Bucket':
+            return {
+              Arn: `arn:aws:s3:::${resourceIdentifier}`,
+            };
+          case 'AWS::Cognito::UserPool':
+            return {
+              Arn: `arn:aws:cognito-idp:${this.region}:${this.accountId}:userpool/${resourceIdentifier}`,
+            };
+          default:
+            throw new Error(`getResourceAttribute not implemented for ${resourceType}`);
+        }
+      }
+      default:
+        throw new Error(`getResourceAttribute not implemented for ${attributeName}`);
+    }
+  }
+
+  /**
+   * Build a custom replacer function to replace Fn::GetAtt references with resource attribute values.
+   * @param resource
+   * @param record
+   * @private
+   */
+  private buildFnGetAttReplace(record: Record<string, string>) {
+    return (_match: string, _p1: string, _offset: number, _text: string, groups: Record<string, string>) =>
+      `"${record[groups.AttributeName]}"`;
+  }
+}
+
+export default CfnOutputResolver;


### PR DESCRIPTION
#### Description of changes

Add CFN outputs resolver to resolve Output references in Gen1 and Gen2 stacks prior to Refactor operation.


#### Description of how you validated changes
local testing, unit tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
