### PR TITLE
fix: add usage data metrics for codegen

### DIFF
--- a/packages/amplify-cli/API.md
+++ b/packages/amplify-cli/API.md
@@ -34,6 +34,9 @@ export const execute: (input: CLIInput) => Promise<void>;
 export const executeAmplifyCommand: (context: Context) => Promise<void>;
 
 // @public (undocumented)
+export const getProjectSettings: () => ProjectSettings;
+
+// @public (undocumented)
 export const run: (startTime: number) => Promise<void>;
 
 // @public (undocumented)

--- a/packages/amplify-cli/src/context-manager.ts
+++ b/packages/amplify-cli/src/context-manager.ts
@@ -66,7 +66,7 @@ const getSafeAccountId = (): string => {
 
 const getVersion = (context: Context): string => context.pluginPlatform.plugins.core[0].packageVersion;
 
-const getProjectSettings = (): ProjectSettings => {
+export const getProjectSettings = (): ProjectSettings => {
   const projectSettings: ProjectSettings = {} as unknown as ProjectSettings;
   if (stateManager.projectConfigExists()) {
     const projectConfig = stateManager.getProjectConfig();

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -36,6 +36,7 @@ import { getAmplifyVersion } from './extensions/amplify-helpers/get-amplify-vers
 import { init as initErrorHandler, handleException, handleUnhandledRejection } from './amplify-exception-handler';
 
 export { UsageData } from './domain/amplify-usageData';
+export { getProjectSettings } from './context-manager';
 
 // Adjust defaultMaxListeners to make sure Inquirer will not fail under Windows because of the multiple subscriptions
 // https://github.com/SBoudrias/Inquirer.js/issues/887

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.ts
@@ -224,7 +224,7 @@ function createOidcSamlPropertyAssignments(
 function createSecretErrorStatements(secretVariables: string[]): ts.Node[] {
   return secretVariables.map((secret) =>
     factory.createCallExpression(factory.createIdentifier('throw new Error'), undefined, [
-      factory.createStringLiteral(`Secrets need to be reset, use \`npx ampx sandbox secret ${secret}\` to set the value`),
+      factory.createStringLiteral(`Secrets need to be reset, use \`npx ampx sandbox secret set ${secret}\` to set the value`),
     ]),
   );
 }

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -26,7 +26,7 @@ export function renderFunctions(definition: FunctionDefinition, appId?: string, 
     factory.createJSDocComment(
       factory.createNodeArray([
         factory.createJSDocText(
-          `Source code for this function can be found in your Amplify Gen 1 Directory.\nSee amplify/backend/function/${
+          `Source code for this function can be found in your Amplify Gen 1 Directory.\nSee .amplify/migration/amplify/backend/function/${
             definition.name?.split('-')[0]
           }/src \n`,
         ),

--- a/packages/amplify-migration/package.json
+++ b/packages/amplify-migration/package.json
@@ -50,6 +50,7 @@
     "@aws-amplify/amplify-gen1-codegen-function-adapter": "^0.1.0-gen2-migration-test-alpha.0",
     "@aws-amplify/amplify-gen1-codegen-storage-adapter": "^0.1.0-gen2-migration-test-alpha.0",
     "@aws-amplify/amplify-gen2-codegen": "^0.1.0-gen2-migration-test-alpha.0",
+    "@aws-amplify/cli-internal": "12.13.0-gen2-migration-test-alpha.0",
     "@aws-amplify/migrate-template-gen": "0.0.1",
     "@aws-sdk/client-amplify": "^3.592.0",
     "@aws-sdk/client-amplifybackend": "^3.592.0",
@@ -64,6 +65,7 @@
     "kleur": "^4.1.5",
     "typescript": "^5.4.5",
     "unzipper": "^0.12.1",
+    "uuid": "^8.3.2",
     "yargs": "^17.7.2"
   }
 }

--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -75,10 +75,10 @@ const generateGen2Code = async ({
 
   try {
     await pipeline.render();
-    await analytics.logEvent('finishedMigration');
+    await analytics.logEvent('finishedCodegen');
     await usageData.emitSuccess();
   } catch (e) {
-    await analytics.logEvent('failedMigration');
+    await analytics.logEvent('failedCodegen');
     await usageData.emitError(e);
   }
 };

--- a/packages/amplify-migration/src/index.ts
+++ b/packages/amplify-migration/src/index.ts
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import assert from 'node:assert';
+import { v4 as uuid } from 'uuid';
 
 import { Gen2RenderingOptions, createGen2Renderer } from '@aws-amplify/amplify-gen2-codegen';
 
+import { UsageData, getProjectSettings } from '@aws-amplify/cli-internal';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { CognitoIdentityProviderClient, LambdaConfigType } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { S3Client } from '@aws-sdk/client-s3';
 import { LambdaClient } from '@aws-sdk/client-lambda';
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { BackendDownloader } from './backend_downloader';
 import { AppContextLogger } from './logger';
 import { BackendEnvironmentResolver } from './backend_environment_selector';
 import { Analytics, AppAnalytics } from './analytics';
 import { AppAuthDefinitionFetcher } from './app_auth_definition_fetcher';
 import { AppStorageDefinitionFetcher } from './app_storage_definition_fetcher';
-import { AmplifyCategories, stateManager } from '@aws-amplify/amplify-cli-core';
+import { AmplifyCategories, IUsageData, stateManager } from '@aws-amplify/amplify-cli-core';
 import { AuthTriggerConnection } from '@aws-amplify/amplify-gen1-codegen-auth-adapter';
 import { DataDefinitionFetcher } from './data_definition_fetcher';
 import { AmplifyStackParser } from './amplify_stack_parser';
@@ -67,11 +71,15 @@ const generateGen2Code = async ({
   };
 
   const pipeline = createGen2Renderer(gen2RenderOptions);
+  const usageData = await getUsageDataMetric();
+
   try {
     await pipeline.render();
     await analytics.logEvent('finishedMigration');
+    await usageData.emitSuccess();
   } catch (e) {
     await analytics.logEvent('failedMigration');
+    await usageData.emitError(e);
   }
 };
 
@@ -86,6 +94,33 @@ type AmplifyMeta = {
 
 const getFunctionPath = (functionName: string) => {
   return path.join('amplify', 'backend', 'function', functionName, 'src');
+};
+
+const getUsageDataMetric = async (): Promise<IUsageData> => {
+  const usageData = UsageData.Instance;
+  const accountId = await getAccountId();
+  assert(accountId);
+
+  usageData.init(
+    uuid(),
+    '',
+    {
+      command: 'to-gen-2',
+      argv: process.argv,
+    },
+    accountId,
+    getProjectSettings(),
+    Date.now(),
+  );
+
+  return usageData;
+};
+
+const getAccountId = async (): Promise<string | undefined> => {
+  const stsClient = new STSClient();
+  const callerIdentityResult = await stsClient.send(new GetCallerIdentityCommand());
+  const accountId = callerIdentityResult.Account;
+  return accountId;
 };
 
 const getAuthTriggersConnections = async (): Promise<Partial<Record<keyof LambdaConfigType, string>>> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1822,6 +1822,7 @@ __metadata:
     "@aws-amplify/amplify-gen1-codegen-function-adapter": ^0.1.0-gen2-migration-test-alpha.0
     "@aws-amplify/amplify-gen1-codegen-storage-adapter": ^0.1.0-gen2-migration-test-alpha.0
     "@aws-amplify/amplify-gen2-codegen": ^0.1.0-gen2-migration-test-alpha.0
+    "@aws-amplify/cli-internal": 12.13.0-gen2-migration-test-alpha.0
     "@aws-amplify/migrate-template-gen": 0.0.1
     "@aws-sdk/client-amplify": ^3.592.0
     "@aws-sdk/client-amplifybackend": ^3.592.0
@@ -1837,6 +1838,7 @@ __metadata:
     kleur: ^4.1.5
     typescript: ^5.4.5
     unzipper: ^0.12.1
+    uuid: ^8.3.2
     yargs: ^17.7.2
   bin:
     migrate: lib/migrate.js


### PR DESCRIPTION
#### Description of changes
- Added a usageData metric for the codegen command
- Added the word `set` in update secret command for auth
- Updated the path to copy the source code from in functions

#### Description of how you validated changes
Tested in Beta, the metric getting generated successfully

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
