### PR TITLE
feat(migrate-template-gen): add category template generator

### DIFF
--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -1,0 +1,284 @@
+import CategoryTemplateGenerator from './category-template-generator';
+import { CFN_S3_TYPE, CFNTemplate } from './types';
+import { CloudFormationClient, DescribeStacksCommand, GetTemplateCommand, Parameter } from '@aws-sdk/client-cloudformation';
+
+const mockCfnClientSendMock = jest.fn();
+
+const GEN1_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-testauth-dev-12345-auth-ABCDE/12345';
+const GEN2_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
+const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
+const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
+
+const oldGen1Template: CFNTemplate = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'Test template',
+  Parameters: {
+    Environment: {
+      Type: 'String',
+      Description: 'Environment',
+    },
+  },
+  Outputs: {
+    BucketNameOutputRef: {
+      Description: 'Bucket name',
+      Value: { Ref: GEN1_S3_BUCKET_LOGICAL_ID },
+    },
+  },
+  Resources: {
+    [GEN1_S3_BUCKET_LOGICAL_ID]: {
+      Type: CFN_S3_TYPE.Bucket,
+      Properties: {
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', { Ref: 'Environment' }]] },
+      },
+    },
+    MyS3BucketPolicy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyName: 'MyS3BucketPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: { 'Fn::GetAtt': [GEN1_S3_BUCKET_LOGICAL_ID, 'Arn'] },
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+const newGen1Template: CFNTemplate = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'Test template',
+  Parameters: {
+    Environment: {
+      Type: 'String',
+      Description: 'Environment',
+    },
+  },
+  Outputs: {
+    BucketNameOutputRef: {
+      Description: 'Bucket name',
+      Value: 'my-test-bucket-dev',
+    },
+  },
+  Resources: {
+    [GEN1_S3_BUCKET_LOGICAL_ID]: {
+      Type: CFN_S3_TYPE.Bucket,
+      Properties: {
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev']] },
+      },
+    },
+    MyS3BucketPolicy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyName: 'MyS3BucketPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: 'arn:aws:s3:::my-test-bucket-dev',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+const oldGen2Template = {
+  ...oldGen1Template,
+  Outputs: {
+    BucketNameOutputRef: {
+      Description: 'Bucket name',
+      Value: { Ref: GEN2_S3_BUCKET_LOGICAL_ID },
+    },
+  },
+  Resources: {
+    MyS3BucketPolicy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyName: 'MyS3BucketPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: { 'Fn::GetAtt': [GEN2_S3_BUCKET_LOGICAL_ID, 'Arn'] },
+            },
+          ],
+        },
+      },
+    },
+    [GEN2_S3_BUCKET_LOGICAL_ID]: {
+      Type: CFN_S3_TYPE.Bucket,
+      Properties: {
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', { Ref: 'Environment' }]] },
+      },
+    },
+  },
+};
+const newGen2Template: CFNTemplate = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'Test template',
+  Parameters: {
+    Environment: {
+      Type: 'String',
+      Description: 'Environment',
+    },
+  },
+  Outputs: {
+    BucketNameOutputRef: {
+      Description: 'Bucket name',
+      Value: 'my-test-bucket-dev',
+    },
+  },
+  Resources: {
+    MyS3BucketPolicy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyName: 'MyS3BucketPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: 'arn:aws:s3:::my-test-bucket-dev',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+const gen1Params: Parameter[] = [
+  {
+    ParameterKey: 'Environment',
+    ParameterValue: 'dev',
+  },
+];
+const refactoredGen1Template: CFNTemplate = {
+  ...newGen1Template,
+  Resources: {
+    MyS3BucketPolicy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyName: 'MyS3BucketPolicy',
+        PolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: 's3:GetObject',
+              Resource: 'arn:aws:s3:::my-test-bucket-dev',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+jest.mock('@aws-sdk/client-cloudformation', () => {
+  return {
+    ...jest.requireActual('@aws-sdk/client-cloudformation'),
+    CloudFormationClient: function () {
+      return {
+        send: mockCfnClientSendMock.mockImplementation((command) => {
+          if (command instanceof DescribeStacksCommand) {
+            return Promise.resolve({
+              Stacks: [
+                {
+                  StackId: command.input.StackName,
+                  Capabilities: ['CAPABILITY_NAMED_IAM'],
+                  Tags: [
+                    {
+                      Key: 'amplify:category-stack',
+                      Value: 'amplify-testauth-dev-12345-auth-ABCDE',
+                    },
+                  ],
+                  CreationTime: new Date(),
+                  LastUpdatedTime: new Date(),
+                  DeletionTime: null,
+                  StackStatus: 'CREATE_COMPLETE',
+                  Parameters: gen1Params,
+                  Outputs: [
+                    {
+                      OutputKey: 'BucketNameOutputRef',
+                      OutputValue: 'my-test-bucket-dev',
+                      Description: 'My bucket',
+                    },
+                  ],
+                },
+              ],
+            });
+          } else if (command instanceof GetTemplateCommand) {
+            return Promise.resolve({
+              TemplateBody:
+                command.input.StackName === GEN1_CATEGORY_STACK_ID ? JSON.stringify(oldGen1Template) : JSON.stringify(oldGen2Template),
+            });
+          }
+          return Promise.resolve({});
+        }),
+      };
+    },
+  };
+});
+
+describe('CategoryTemplateGenerator', () => {
+  const s3TemplateGenerator = new CategoryTemplateGenerator(
+    GEN1_CATEGORY_STACK_ID,
+    GEN2_CATEGORY_STACK_ID,
+    'us-east-1',
+    '12345',
+    new CloudFormationClient(),
+    [CFN_S3_TYPE.Bucket],
+  );
+
+  const s3TemplateGeneratorWithPredicate = new CategoryTemplateGenerator(
+    GEN1_CATEGORY_STACK_ID,
+    GEN2_CATEGORY_STACK_ID,
+    'us-east-1',
+    '12345',
+    new CloudFormationClient(),
+    [CFN_S3_TYPE.Bucket],
+    // decide which resources to move based on resource properties
+    (resourcesToMove, resourceEntry) => resourcesToMove.includes(CFN_S3_TYPE.Bucket) && resourceEntry[0] === GEN1_S3_BUCKET_LOGICAL_ID,
+  );
+
+  it('should preprocess gen1 template prior to refactor', async () => {
+    await expect(s3TemplateGenerator.generateGen1PreProcessTemplate()).resolves.toEqual({
+      oldTemplate: oldGen1Template,
+      newTemplate: newGen1Template,
+      parameters: gen1Params,
+    });
+  });
+
+  it('should preprocess gen1 template with predicate prior to refactor', async () => {
+    await expect(s3TemplateGeneratorWithPredicate.generateGen1PreProcessTemplate()).resolves.toEqual({
+      oldTemplate: oldGen1Template,
+      newTemplate: newGen1Template,
+      parameters: gen1Params,
+    });
+  });
+
+  it('should remove gen2 resources from gen2 stack prior to refactor', async () => {
+    await expect(s3TemplateGenerator.generateGen2ResourceRemovalTemplate()).resolves.toEqual({
+      oldTemplate: oldGen2Template,
+      newTemplate: newGen2Template,
+      parameters: gen1Params,
+    });
+  });
+
+  it('should refactor gen1 resources into gen2 stack', async () => {
+    const { newTemplate: newGen1Template } = await s3TemplateGenerator.generateGen1PreProcessTemplate();
+    const { newTemplate: newGen2Template } = await s3TemplateGenerator.generateGen2ResourceRemovalTemplate();
+    expect(s3TemplateGenerator.generateStackRefactorTemplates(newGen1Template, newGen2Template)).toEqual({
+      sourceTemplate: refactoredGen1Template,
+      destinationTemplate: newGen2Template,
+      logicalIdMapping: new Map<string, string>([[GEN1_S3_BUCKET_LOGICAL_ID, GEN2_S3_BUCKET_LOGICAL_ID]]),
+    });
+  });
+});

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -1,4 +1,4 @@
-import { CloudFormationClient, DescribeStacksCommand, GetTemplateCommand, Stack, Parameter, Output } from '@aws-sdk/client-cloudformation';
+import { CloudFormationClient, DescribeStacksCommand, GetTemplateCommand, Stack } from '@aws-sdk/client-cloudformation';
 import assert from 'node:assert';
 import { CFN_CATEGORY_TYPE, CFNChangeTemplateWithParams, CFNResource, CFNStackRefactorTemplates, CFNTemplate } from './types';
 import CFNConditionResolver from './resolvers/cfn-condition-resolver';

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -1,0 +1,179 @@
+import { CloudFormationClient, DescribeStacksCommand, GetTemplateCommand, Stack, Parameter, Output } from '@aws-sdk/client-cloudformation';
+import assert from 'node:assert';
+import { CFN_CATEGORY_TYPE, CFNChangeTemplateWithParams, CFNResource, CFNStackRefactorTemplates, CFNTemplate } from './types';
+import CFNConditionResolver from './resolvers/cfn-condition-resolver';
+import CfnParameterResolver from './resolvers/cfn-parameter-resolver';
+import CfnOutputResolver from './resolvers/cfn-output-resolver';
+import CfnDependencyResolver from './resolvers/cfn-dependency-resolver';
+
+class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
+  private gen1DescribeStacksResponse: Stack | undefined;
+  private gen2DescribeStacksResponse: Stack | undefined;
+  private gen1ResourcesToMove: Map<string, CFNResource>;
+  private gen2ResourcesToRemove: Map<string, CFNResource>;
+  constructor(
+    private readonly gen1StackId: string,
+    private readonly gen2StackId: string,
+    private readonly region: string,
+    private readonly accountId: string,
+    private readonly cfnClient: CloudFormationClient,
+    private readonly resourcesToMove: CFNCategoryType[],
+    private readonly resourcesToMovePredicate?: (resourcesToMove: CFN_CATEGORY_TYPE[], resourceEntry: [string, CFNResource]) => boolean,
+  ) {
+    this.gen1ResourcesToMove = new Map();
+    this.gen2ResourcesToRemove = new Map();
+  }
+
+  public async generateGen1PreProcessTemplate(): Promise<CFNChangeTemplateWithParams> {
+    this.gen1DescribeStacksResponse = await this.describeStack(this.gen1StackId);
+    assert(this.gen1DescribeStacksResponse);
+    const { Parameters, Outputs } = this.gen1DescribeStacksResponse;
+    assert(Parameters);
+    assert(Outputs);
+    const oldGen1Template = await this.readTemplate(this.gen1StackId);
+    this.gen1ResourcesToMove = new Map(
+      Object.entries(oldGen1Template.Resources).filter(([logicalId, value]) => {
+        return (
+          this.resourcesToMovePredicate?.(this.resourcesToMove, [logicalId, value]) ??
+          this.resourcesToMove.some((resourceToMove) => resourceToMove.valueOf() === value.Type)
+        );
+      }),
+    );
+    const logicalResourceIds = [...this.gen1ResourcesToMove.keys()];
+    const gen1ParametersResolvedTemplate = new CfnParameterResolver(oldGen1Template).resolve(Parameters);
+    const gen1TemplateWithOutputsResolved = new CfnOutputResolver(gen1ParametersResolvedTemplate, this.region, this.accountId).resolve(
+      logicalResourceIds,
+      Outputs,
+    );
+    const gen1TemplateWithDepsResolved = new CfnDependencyResolver(gen1TemplateWithOutputsResolved).resolve(logicalResourceIds);
+    const gen1TemplateWithConditionsResolved = new CFNConditionResolver(gen1TemplateWithDepsResolved).resolve(Parameters);
+    return {
+      oldTemplate: oldGen1Template,
+      newTemplate: gen1TemplateWithConditionsResolved,
+      parameters: Parameters,
+    };
+  }
+
+  public async generateGen2ResourceRemovalTemplate(): Promise<CFNChangeTemplateWithParams> {
+    this.gen2DescribeStacksResponse = await this.describeStack(this.gen2StackId);
+    assert(this.gen2DescribeStacksResponse);
+    const { Parameters, Outputs } = this.gen2DescribeStacksResponse;
+    assert(Parameters);
+    assert(Outputs);
+    const oldGen2Template = await this.readTemplate(this.gen2StackId);
+    this.gen2ResourcesToRemove = new Map(
+      Object.entries(oldGen2Template.Resources).filter(([, value]) =>
+        this.resourcesToMove.some((resourceToMove) => resourceToMove.valueOf() === value.Type),
+      ),
+    );
+    const updatedGen2Template = this.removeGen2ResourcesFromGen2Stack(oldGen2Template, [...this.gen2ResourcesToRemove.keys()]);
+    return {
+      oldTemplate: oldGen2Template,
+      newTemplate: updatedGen2Template,
+      parameters: Parameters,
+    };
+  }
+
+  public generateStackRefactorTemplates(gen1Template: CFNTemplate, gen2Template: CFNTemplate): CFNStackRefactorTemplates {
+    return this.generateRefactorTemplates(this.gen1ResourcesToMove, this.gen2ResourcesToRemove, gen1Template, gen2Template);
+  }
+
+  private async readTemplate(stackId: string) {
+    const getTemplateResponse = await this.cfnClient.send(
+      new GetTemplateCommand({
+        StackName: stackId,
+      }),
+    );
+    const templateBody = getTemplateResponse.TemplateBody;
+    assert(templateBody);
+    return JSON.parse(templateBody) as CFNTemplate;
+  }
+
+  private async describeStack(stackId: string) {
+    return (
+      await this.cfnClient.send(
+        new DescribeStacksCommand({
+          StackName: stackId,
+        }),
+      )
+    ).Stacks?.[0];
+  }
+
+  private removeGen1ResourcesFromGen1Stack(gen1Template: CFNTemplate, resourcesToRefactor: string[]) {
+    const resources = gen1Template.Resources;
+    assert(resources);
+    for (const resourceToRefactor of resourcesToRefactor) {
+      delete resources[resourceToRefactor];
+    }
+    return gen1Template;
+  }
+
+  private addGen1ResourcesToGen2Stack(
+    resolvedGen1Template: CFNTemplate,
+    resourcesToRefactor: string[],
+    gen1ToGen2ResourceLogicalIdMapping: Map<string, string>,
+    gen2Template: CFNTemplate,
+  ) {
+    const resources = gen2Template.Resources;
+    assert(resources);
+    for (const resourceToRefactor of resourcesToRefactor) {
+      const gen2ResourceLogicalId = gen1ToGen2ResourceLogicalIdMapping.get(resourceToRefactor);
+      assert(gen2ResourceLogicalId);
+      resources[gen2ResourceLogicalId] = resolvedGen1Template.Resources[resourceToRefactor];
+    }
+    return gen2Template;
+  }
+
+  private buildGen1ToGen2ResourceLogicalIdMapping(gen1ResourceMap: Map<string, CFNResource>, gen2ResourceMap: Map<string, CFNResource>) {
+    const gen1ToGen2ResourceLogicalIdMapping = new Map<string, string>();
+    for (const [gen1ResourceLogicalId, gen1Resource] of gen1ResourceMap) {
+      for (const [gen2ResourceLogicalId, gen2Resource] of gen2ResourceMap) {
+        if (gen2Resource.Type !== gen1Resource.Type) {
+          continue;
+        }
+        gen1ToGen2ResourceLogicalIdMapping.set(gen1ResourceLogicalId, gen2ResourceLogicalId);
+      }
+    }
+    return gen1ToGen2ResourceLogicalIdMapping;
+  }
+
+  private removeGen2ResourcesFromGen2Stack(gen2Template: CFNTemplate, resourcesToRemove: string[]) {
+    const clonedGen2Template = JSON.parse(JSON.stringify(gen2Template));
+    const stackOutputs = this.gen2DescribeStacksResponse?.Outputs;
+    assert(stackOutputs);
+    const resolvedRefsGen2Template = new CfnOutputResolver(clonedGen2Template, this.region, this.accountId).resolve(
+      resourcesToRemove,
+      stackOutputs,
+    );
+    resourcesToRemove.forEach((logicalResourceId) => {
+      delete resolvedRefsGen2Template.Resources[logicalResourceId];
+    });
+    return resolvedRefsGen2Template;
+  }
+
+  private generateRefactorTemplates(
+    gen1ResourcesToMove: Map<string, CFNResource>,
+    gen2ResourcesToRemove: Map<string, CFNResource>,
+    gen1Template: CFNTemplate,
+    gen2Template: CFNTemplate,
+  ): CFNStackRefactorTemplates {
+    const gen1LogicalResourceIds = [...gen1ResourcesToMove.keys()];
+    const gen1StackOutputs = this.gen1DescribeStacksResponse?.Outputs;
+    assert(gen1StackOutputs);
+    const gen1ToGen2ResourceLogicalIdMapping = this.buildGen1ToGen2ResourceLogicalIdMapping(gen1ResourcesToMove, gen2ResourcesToRemove);
+    const gen2TemplateForRefactor = this.addGen1ResourcesToGen2Stack(
+      gen1Template,
+      gen1LogicalResourceIds,
+      gen1ToGen2ResourceLogicalIdMapping,
+      gen2Template,
+    );
+    const gen1TemplateForRefactor = this.removeGen1ResourcesFromGen1Stack(gen1Template, gen1LogicalResourceIds);
+    return {
+      sourceTemplate: gen1TemplateForRefactor,
+      destinationTemplate: gen2TemplateForRefactor,
+      logicalIdMapping: gen1ToGen2ResourceLogicalIdMapping,
+    };
+  }
+}
+
+export default CategoryTemplateGenerator;

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
@@ -11,7 +11,7 @@ class CfnParameterResolver {
     const parametersFromTemplate = this.template.Parameters;
     for (const { ParameterKey, ParameterValue } of parameters) {
       assert(ParameterKey);
-      assert(ParameterValue);
+      if (!ParameterValue) continue;
       const { Type: parameterType, NoEcho } = parametersFromTemplate[ParameterKey];
       if (NoEcho) continue;
       // All parameter values referenced by Ref are coerced to strings. List/Comma delimited are converted to arrays before coercing to string.

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -56,7 +56,7 @@ export interface CFNChangeTemplate {
 }
 
 export interface CFNChangeTemplateWithParams extends CFNChangeTemplate {
-  params: Parameter[] | undefined;
+  parameters: Parameter[] | undefined;
 }
 
 export interface CFNStackRefactorTemplates {


### PR DESCRIPTION
#### Description of changes

Add category template generator to output CFN templates for each step of refactor. The class is category agnostic and will expose 3 methods to facilitate generation of templates needed for refactor:

1. Preprocess gen1 stack resolving parameters, outputs, conditions and dependencies
2. Remove gen2 resources prior to refactor, resolving output Refs
3. Move gen1 resources from gen1 stack to gen2 stack for refactor operation

**Note**: Each step generates the necessary templates under `.amplify/migration/templates/<category>` folder but the steps will be executed later on by the customer following the `README.md` file.


#### Description of how you validated changes
Local testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
