### PR TITLE
Gen2 migration template gen

### DIFF
--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -1,7 +1,5 @@
 import { TemplateGenerator } from './template-generator';
 import { CloudFormationClient, DescribeStackResourcesCommand, DescribeStackResourcesOutput } from '@aws-sdk/client-cloudformation';
-// import MigrationReadMeGenerator from './migration-readme-generator';
-// import CategoryTemplateGenerator from './category-template-generator';
 import fs from 'node:fs/promises';
 
 const mockCfnClientSendMock = jest.fn();

--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -1,0 +1,189 @@
+import { TemplateGenerator } from './template-generator';
+import { CloudFormationClient, DescribeStackResourcesCommand, DescribeStackResourcesOutput } from '@aws-sdk/client-cloudformation';
+// import MigrationReadMeGenerator from './migration-readme-generator';
+// import CategoryTemplateGenerator from './category-template-generator';
+import fs from 'node:fs/promises';
+
+const mockCfnClientSendMock = jest.fn();
+const mockGenerateGen1PreProcessTemplate = jest.fn();
+const mockGenerateGen2ResourceRemovalTemplate = jest.fn();
+const mockGenerateStackRefactorTemplates = jest.fn();
+const mockReadMeInitialize = jest.fn();
+const mockReadMeRenderStep1 = jest.fn();
+const mockReadMeRenderStep2 = jest.fn();
+const mockReadMeRenderStep3 = jest.fn();
+
+const NUM_CATEGORIES_TO_REFACTOR = 2;
+const GEN1_ROOT_STACK_NAME = 'amplify-gen1-dev-12345';
+const GEN2_ROOT_STACK_NAME = 'amplify-gen2-test-sandbox-12345';
+const ACCOUNT_ID = 'TEST_ACCOUNT_ID';
+const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
+const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
+const MOCK_CFN_CLIENT = new CloudFormationClient();
+
+jest.mock('node:fs/promises');
+jest.mock('./migration-readme-generator', () => {
+  return function () {
+    return {
+      initialize: mockReadMeInitialize,
+      renderStep1: mockReadMeRenderStep1,
+      renderStep2: mockReadMeRenderStep2,
+      renderStep3: mockReadMeRenderStep3,
+    };
+  };
+});
+jest.mock('./category-template-generator', () => {
+  return function () {
+    return {
+      generateGen1PreProcessTemplate: mockGenerateGen1PreProcessTemplate.mockReturnValue({
+        oldTemplate: {},
+        newTemplate: {},
+        parameters: [],
+      }),
+      generateGen2ResourceRemovalTemplate: mockGenerateGen2ResourceRemovalTemplate.mockReturnValue({
+        oldTemplate: {},
+        newTemplate: {},
+        parameters: [],
+      }),
+      generateStackRefactorTemplates: mockGenerateStackRefactorTemplates.mockReturnValue({
+        sourceTemplate: {},
+        destinationTemplate: {},
+        logicalIdMapping: {},
+      }),
+    };
+  };
+});
+
+const mockDescribeGen1StackResources: DescribeStackResourcesOutput = {
+  StackResources: [
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'auth',
+      PhysicalResourceId: `arn:aws:cloudformation:us-east-1:${ACCOUNT_ID}:stack/${GEN1_ROOT_STACK_NAME}-auth/12345`,
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'storage',
+      PhysicalResourceId: `arn:aws:cloudformation:us-east-1:${ACCOUNT_ID}:stack/${GEN1_ROOT_STACK_NAME}-storage/12345`,
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::S3::Bucket',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: GEN1_S3_BUCKET_LOGICAL_ID,
+      PhysicalResourceId: 'my-s3-bucket-gen1',
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::Cognito::UserPoolClient',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'UserPoolClient',
+      PhysicalResourceId: 'user-pool-client-id',
+      Timestamp: new Date(),
+    },
+  ],
+};
+
+const mockDescribeGen2StackResources: DescribeStackResourcesOutput = {
+  StackResources: [
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'auth',
+      PhysicalResourceId: `arn:aws:cloudformation:us-east-1:${ACCOUNT_ID}:stack/${GEN2_ROOT_STACK_NAME}-auth/12345`,
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'storage',
+      PhysicalResourceId: `arn:aws:cloudformation:us-east-1:${ACCOUNT_ID}:stack/${GEN2_ROOT_STACK_NAME}-storage/12345`,
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::S3::Bucket',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: GEN2_S3_BUCKET_LOGICAL_ID,
+      PhysicalResourceId: 'my-s3-bucket-gen2',
+      Timestamp: new Date(),
+    },
+  ],
+};
+
+const mockDescribeGen2StackResourcesWithStorageMissing: DescribeStackResourcesOutput = {
+  StackResources: [
+    {
+      ResourceType: 'AWS::CloudFormation::Stack',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: 'auth',
+      PhysicalResourceId: `arn:aws:cloudformation:us-east-1:${ACCOUNT_ID}:stack/${GEN2_ROOT_STACK_NAME}-auth/12345`,
+      Timestamp: new Date(),
+    },
+    {
+      ResourceType: 'AWS::S3::Bucket',
+      ResourceStatus: 'CREATE_COMPLETE',
+      LogicalResourceId: GEN2_S3_BUCKET_LOGICAL_ID,
+      PhysicalResourceId: 'my-s3-bucket-gen2',
+      Timestamp: new Date(),
+    },
+  ],
+};
+
+jest.mock('@aws-sdk/client-cloudformation', () => {
+  return {
+    ...jest.requireActual('@aws-sdk/client-cloudformation'),
+    CloudFormationClient: function () {
+      return {
+        config: {
+          region: () => 'us-east-1',
+        },
+        send: mockCfnClientSendMock,
+      };
+    },
+  };
+});
+
+describe('TemplateGenerator', () => {
+  beforeEach(() => {
+    mockCfnClientSendMock.mockImplementation((command) => {
+      if (command instanceof DescribeStackResourcesCommand) {
+        return Promise.resolve(
+          command.input.StackName === GEN1_ROOT_STACK_NAME ? mockDescribeGen1StackResources : mockDescribeGen2StackResources,
+        );
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it('should generate a template', async () => {
+    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    await generator.generate();
+    expect(fs.mkdir).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR + 1);
+    expect(mockGenerateGen1PreProcessTemplate).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockGenerateGen2ResourceRemovalTemplate).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockGenerateStackRefactorTemplates).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockReadMeInitialize).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockReadMeRenderStep1).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockReadMeRenderStep2).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+    expect(mockReadMeRenderStep3).toBeCalledTimes(NUM_CATEGORIES_TO_REFACTOR);
+  });
+
+  it('should fail to generate when no applicable categories are found', async () => {
+    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const failureSendMock = (command: any) => {
+      if (command instanceof DescribeStackResourcesCommand) {
+        return Promise.resolve(
+          command.input.StackName === GEN1_ROOT_STACK_NAME
+            ? mockDescribeGen1StackResources
+            : mockDescribeGen2StackResourcesWithStorageMissing,
+        );
+      }
+      return Promise.resolve({});
+    };
+    mockCfnClientSendMock.mockImplementationOnce(failureSendMock).mockImplementationOnce(failureSendMock);
+    await expect(() => generator.generate()).rejects.toEqual(new Error('No corresponding category found in Gen2 for storage category'));
+  });
+});

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -1,0 +1,151 @@
+import { CloudFormationClient, DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
+import assert from 'node:assert';
+import CategoryTemplateGenerator from './category-template-generator';
+import fs from 'node:fs/promises';
+import { CATEGORY, CFN_AUTH_TYPE, CFN_CATEGORY_TYPE, CFN_S3_TYPE, CFNResource } from './types';
+import MigrationReadmeGenerator from './migration-readme-generator';
+
+const CFN_RESOURCE_STACK_TYPE = 'AWS::CloudFormation::Stack';
+
+const CATEGORIES: CATEGORY[] = ['auth', 'storage'];
+const TEMPLATES_DIR = '.amplify/migration/templates';
+
+class TemplateGenerator {
+  private readonly categoryStackMap: Map<CATEGORY, [string, string]>;
+  private readonly categoryTemplateGenerators: [CATEGORY, string, string, CategoryTemplateGenerator<CFN_CATEGORY_TYPE>][];
+  private region: string | undefined;
+  constructor(
+    private readonly fromStack: string,
+    private readonly toStack: string,
+    private readonly accountId: string,
+    private readonly cfnClient: CloudFormationClient,
+  ) {
+    this.categoryStackMap = new Map<CATEGORY, [string, string]>();
+    this.categoryTemplateGenerators = [];
+  }
+
+  public async generate() {
+    await fs.mkdir(TEMPLATES_DIR, { recursive: true });
+    this.region = await this.cfnClient.config.region();
+    await this.parseCategoryStacks();
+    await this.generateCategoryTemplates();
+  }
+
+  private async parseCategoryStacks(): Promise<void> {
+    const sourceStackResourcesResponse = await this.cfnClient.send(
+      new DescribeStackResourcesCommand({
+        StackName: this.fromStack,
+      }),
+    );
+    const destStackResourcesResponse = await this.cfnClient.send(
+      new DescribeStackResourcesCommand({
+        StackName: this.toStack,
+      }),
+    );
+    const sourceStackResources = sourceStackResourcesResponse.StackResources;
+    const destStackResources = destStackResourcesResponse.StackResources;
+    assert(sourceStackResources, 'Invalid source stack resources');
+    assert(destStackResources, 'Invalid dest stack resources');
+    const gen1CategoryStacks = sourceStackResources?.filter((stackResource) => stackResource.ResourceType === CFN_RESOURCE_STACK_TYPE);
+    const gen2CategoryStacks = destStackResources?.filter((stackResource) => stackResource.ResourceType === CFN_RESOURCE_STACK_TYPE);
+    assert(gen1CategoryStacks && gen1CategoryStacks?.length > 0, 'No gen1 category stack found');
+    assert(gen2CategoryStacks && gen2CategoryStacks?.length > 0, 'No gen2 category stack found');
+    gen1CategoryStacks.forEach(({ LogicalResourceId: Gen1LogicalResourceId, PhysicalResourceId: Gen1PhysicalResourceId }) => {
+      const category = CATEGORIES.find((category) => Gen1LogicalResourceId?.startsWith(category));
+      if (!category) return;
+      assert(Gen1PhysicalResourceId);
+      const correspondingCategoryStackInGen2 = gen2CategoryStacks.find(({ LogicalResourceId: Gen2LogicalResourceId }) =>
+        Gen2LogicalResourceId?.startsWith(category),
+      );
+      if (!correspondingCategoryStackInGen2) {
+        throw new Error(`No corresponding category found in Gen2 for ${category} category`);
+      }
+      const Gen2PhysicalResourceId = correspondingCategoryStackInGen2.PhysicalResourceId;
+      assert(Gen2PhysicalResourceId);
+      this.categoryStackMap.set(category, [Gen1PhysicalResourceId, Gen2PhysicalResourceId]);
+    });
+  }
+
+  private async generateCategoryTemplates() {
+    assert(this.region);
+    for (const [category, [gen1CategoryStackId, gen2CategoryStackId]] of this.categoryStackMap.entries()) {
+      switch (category) {
+        case 'auth': {
+          // We have 2 user pool clients in Gen1, but only 1 in Gen2. We are defaulting to moving Web client from Gen1.
+          // The native user pool will be code-genned as a CDK override.
+          const resourcesToMovePredicate = (resourcesToMove: CFN_CATEGORY_TYPE[], [logicalResourceId, value]: [string, CFNResource]) =>
+            (value.Type === CFN_AUTH_TYPE.UserPoolClient && logicalResourceId.endsWith('Web')) ||
+            (value.Type !== CFN_AUTH_TYPE.UserPoolClient &&
+              resourcesToMove.some((resourceToMove) => resourceToMove.valueOf() === value.Type));
+          this.categoryTemplateGenerators.push([
+            category,
+            gen1CategoryStackId,
+            gen2CategoryStackId,
+            new CategoryTemplateGenerator(
+              gen1CategoryStackId,
+              gen2CategoryStackId,
+              this.region,
+              this.accountId,
+              this.cfnClient,
+              [
+                CFN_AUTH_TYPE.UserPool,
+                CFN_AUTH_TYPE.UserPoolClient,
+                CFN_AUTH_TYPE.IdentityPool,
+                CFN_AUTH_TYPE.IdentityPoolRoleAttachment,
+                CFN_AUTH_TYPE.UserPoolDomain,
+              ],
+              resourcesToMovePredicate,
+            ),
+          ]);
+          break;
+        }
+        case 'storage': {
+          this.categoryTemplateGenerators.push([
+            category,
+            gen1CategoryStackId,
+            gen2CategoryStackId,
+            new CategoryTemplateGenerator(gen1CategoryStackId, gen2CategoryStackId, this.region, this.accountId, this.cfnClient, [
+              CFN_S3_TYPE.Bucket,
+            ]),
+          ]);
+          break;
+        }
+      }
+    }
+
+    for (const [category, gen1CategoryStackId, gen2CategoryStackId, categoryTemplateGenerator] of this.categoryTemplateGenerators) {
+      const categoryDir = `${TEMPLATES_DIR}/${category}`;
+      await fs.mkdir(categoryDir, { recursive: true });
+      const migrationReadMeGenerator = new MigrationReadmeGenerator({
+        path: categoryDir,
+        category,
+        gen1CategoryStackId,
+        gen2CategoryStackId,
+      });
+      await migrationReadMeGenerator.initialize();
+
+      const {
+        oldTemplate: oldGen1Template,
+        newTemplate: newGen1Template,
+        parameters: gen1StackParameters,
+      } = await categoryTemplateGenerator.generateGen1PreProcessTemplate();
+      assert(gen1StackParameters);
+      await migrationReadMeGenerator.renderStep1(oldGen1Template, newGen1Template, gen1StackParameters);
+
+      const {
+        oldTemplate: oldGen2Template,
+        newTemplate: newGen2Template,
+        parameters: gen2StackParameters,
+      } = await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
+      await migrationReadMeGenerator.renderStep2(oldGen2Template, newGen2Template, gen2StackParameters);
+
+      const { sourceTemplate, destinationTemplate, logicalIdMapping } = categoryTemplateGenerator.generateStackRefactorTemplates(
+        newGen1Template,
+        newGen2Template,
+      );
+      await migrationReadMeGenerator.renderStep3(sourceTemplate, destinationTemplate, logicalIdMapping);
+    }
+  }
+}
+
+export { TemplateGenerator };


### PR DESCRIPTION
#### Description of changes

Add template generator to instantiate category-specific generators and read me generators and orchestrate their corresponding methods to generate templates and README files.


#### Description of how you validated changes
local testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
