### PR TITLE
fix: prevent unknown users from accessing s3 buckets

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -110,45 +110,45 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
           "Ref": "DeploymentBucketName",
         },
         "PolicyDocument": {
-           OwnershipStatement: [
-          {
-            Action: 's3:*',
-            Condition: {
-              StringNotEquals: {
-                's3:ResourceAccount': {
-                  "Ref": "AWS:AccountId",
+          OwnershipStatement: [
+            {
+              Action: 's3:*',
+              Condition: {
+                StringNotEquals: {
+                  's3:ResourceAccount': {
+                    "Ref": "AWS:AccountId",
+                  },
                 },
               },
+              Effect: 'Deny',
+              Principal: '*',
+              Resource: {
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                    ],
+                  ],
+                },
+              }
             },
-            Effect: 'Deny',
-            Principal: '*',
-            Resource: {
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DeploymentBucketName",
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DeploymentBucketName",
-                    },
-                  ],
-                ],
-              },
-            }
-          },
-        ],
+          ],
           "Statement": [
             {
               "Action": "s3:*",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -110,19 +110,19 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
           "Ref": "DeploymentBucketName",
         },
         "PolicyDocument": {
-          OwnershipStatement: [
+          "OwnershipStatement": [
             {
-              Action: 's3:*',
-              Condition: {
-                StringNotEquals: {
-                  's3:ResourceAccount': {
+              "Action": "s3:*",
+              "Condition": {
+                "StringNotEquals": {
+                  "s3:ResourceAccount": {
                     "Ref": "AWS:AccountId",
                   },
                 },
               },
-              Effect: 'Deny',
-              Principal: '*',
-              Resource: {
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": {
                 {
                   "Fn::Join": [
                     "",
@@ -148,7 +148,7 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
                 },
               }
             },
-          ],
+            ],
           "Statement": [
             {
               "Action": "s3:*",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -116,13 +116,13 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
               "Condition": {
                 "StringNotEquals": {
                   "s3:ResourceAccount": {
-                    "Ref": "AWS:AccountId",
+                    "Ref": "AWS::AccountId",
                   },
                 },
               },
               "Effect": "Deny",
               "Principal": "*",
-              "Resource": {
+              "Resource": [
                 {
                   "Fn::Join": [
                     "",
@@ -146,7 +146,7 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
                     ],
                   ],
                 },
-              }
+              ]
             },
             ],
           "Statement": [

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -146,7 +146,7 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
                     ],
                   ],
                 },
-              ]
+              ],
             },
             ],
           "Statement": [

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-builder.test.ts.snap
@@ -110,6 +110,45 @@ exports[`Check RootStack Template generates root stack Template 1`] = `
           "Ref": "DeploymentBucketName",
         },
         "PolicyDocument": {
+           OwnershipStatement: [
+          {
+            Action: 's3:*',
+            Condition: {
+              StringNotEquals: {
+                's3:ResourceAccount': {
+                  "Ref": "AWS:AccountId",
+                },
+              },
+            },
+            Effect: 'Deny',
+            Principal: '*',
+            Resource: {
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DeploymentBucketName",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DeploymentBucketName",
+                    },
+                  ],
+                ],
+              },
+            }
+          },
+        ],
           "Statement": [
             {
               "Action": "s3:*",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -131,6 +131,45 @@ exports[`Root stack template tests Generated root stack template during init 1`]
           "Ref": "DeploymentBucketName",
         },
         "PolicyDocument": {
+          OwnershipStatement: [
+            {
+              Action: 's3:*',
+              Condition: {
+                StringNotEquals: {
+                  's3:ResourceAccount': {
+                    "Ref": "AWS:AccountId",
+                  },
+                },
+              },
+              Effect: 'Deny',
+              Principal: '*',
+              Resource: {
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "DeploymentBucketName",
+                      },
+                    ],
+                  ],
+                },
+              }
+            },
+          ],
           "Statement": [
             {
               "Action": "s3:*",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -167,7 +167,7 @@ exports[`Root stack template tests Generated root stack template during init 1`]
                     ],
                   ],
                 },
-              ]
+              ],
             },
             ],
           "Statement": [

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -131,19 +131,19 @@ exports[`Root stack template tests Generated root stack template during init 1`]
           "Ref": "DeploymentBucketName",
         },
         "PolicyDocument": {
-          OwnershipStatement: [
+          "OwnershipStatement": [
             {
-              Action: 's3:*',
-              Condition: {
-                StringNotEquals: {
-                  's3:ResourceAccount': {
+              "Action": "s3:*",
+              "Condition": {
+                "StringNotEquals": {
+                  "s3:ResourceAccount": {
                     "Ref": "AWS:AccountId",
                   },
                 },
               },
-              Effect: 'Deny',
-              Principal: '*',
-              Resource: {
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": {
                 {
                   "Fn::Join": [
                     "",
@@ -169,7 +169,7 @@ exports[`Root stack template tests Generated root stack template during init 1`]
                 },
               }
             },
-          ],
+            ],
           "Statement": [
             {
               "Action": "s3:*",

--- a/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/root-stack-builder/__snapshots__/root-stack-transform.test.ts.snap
@@ -137,13 +137,13 @@ exports[`Root stack template tests Generated root stack template during init 1`]
               "Condition": {
                 "StringNotEquals": {
                   "s3:ResourceAccount": {
-                    "Ref": "AWS:AccountId",
+                    "Ref": "AWS::AccountId",
                   },
                 },
               },
               "Effect": "Deny",
               "Principal": "*",
-              "Resource": {
+              "Resource": [
                 {
                   "Fn::Join": [
                     "",
@@ -167,7 +167,7 @@ exports[`Root stack template tests Generated root stack template during init 1`]
                     ],
                   ],
                 },
-              }
+              ]
             },
             ],
           "Statement": [

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -7,6 +7,7 @@ import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper'
 import { IStackSynthesizer } from 'aws-cdk-lib';
 import { AmplifyError, AmplifyFault, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { Construct } from 'constructs';
+import { Condition } from 'aws-cdk-lib/aws-stepfunctions';
 
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
@@ -109,6 +110,19 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
             Condition: {
               Bool: {
                 'aws:SecureTransport': false,
+              },
+            },
+          },
+        ],
+        OwnershipStatement: [
+          {
+            Action: 's3:*',
+            Effect: 'Deny',
+            Principal: '*',
+            Resource: [`arn:aws:s3:::${bucketName}/*`, `arn:aws:s3:::${bucketName}`],
+            Condition: {
+              StringEquals: {
+                's3:ResourceAccount': ['', undefined],
               },
             },
           },

--- a/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
+++ b/packages/amplify-provider-awscloudformation/src/root-stack-builder/root-stack-builder.ts
@@ -7,7 +7,6 @@ import { AmplifyRootStackTemplate } from '@aws-amplify/cli-extensibility-helper'
 import { IStackSynthesizer } from 'aws-cdk-lib';
 import { AmplifyError, AmplifyFault, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { Construct } from 'constructs';
-import { Condition } from 'aws-cdk-lib/aws-stepfunctions';
 
 const CFN_TEMPLATE_FORMAT_VERSION = '2010-09-09';
 const ROOT_CFN_DESCRIPTION = 'Root Stack for AWS Amplify CLI';
@@ -121,8 +120,8 @@ export class AmplifyRootStack extends cdk.Stack implements AmplifyRootStackTempl
             Principal: '*',
             Resource: [`arn:aws:s3:::${bucketName}/*`, `arn:aws:s3:::${bucketName}`],
             Condition: {
-              StringEquals: {
-                's3:ResourceAccount': ['', undefined],
+              StringNotEquals: {
+                's3:ResourceAccount': cdk.Stack.of(this).account,
               },
             },
           },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Added condition to verify identity when using S3 buckets.  

#### Issue #, if available 
N/A
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Temporarily hard coded stack name to "bucket-stack13f78" (this was removed before I made the PR). Created a temp AWS account and created an S3 bucket with the name "bucket-stack13f78-deployment".
<img width="670" alt="image" src="https://github.com/user-attachments/assets/b43fa3a7-8dfc-49d8-834c-9556f96bbeda">
Used an e2e test with the hard coded stack name to verify that deployment cannot happen when a bucket name is already taken. 
<img width="423" alt="image" src="https://github.com/user-attachments/assets/eca32f44-de99-43f1-9551-5ae68fb6a088">


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
