### PR TITLE
Add rollback step for stack refactor

### DIFF
--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
@@ -27,6 +27,10 @@ describe('CFNOutputResolver', () => {
         Description: 'User pool',
         Value: { Ref: 'MyUserPoolClient' },
       },
+      LambdaRole: {
+        Description: 'Lambda execution role',
+        Value: { Ref: 'TestLambdaRole' },
+      },
     },
     Resources: {
       MyS3Bucket: {
@@ -82,6 +86,33 @@ describe('CFNOutputResolver', () => {
           UserPoolId: { Ref: 'MyUserPool' },
         },
       },
+      TestLambda: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          FunctionName: 'TestLambda',
+          Handler: 'index.handler',
+          Role: { 'Fn::GetAtt': ['TestLambdaRole', 'Arn'] },
+          Code: {
+            ZipFile: 'exports.handler = function() {}',
+          },
+          Runtime: 'nodejs14.x',
+        },
+      },
+      TestLambdaRole: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          RoleName: 'TestLambdaRole',
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {},
+              },
+            ],
+          },
+        },
+      },
     },
   };
   const expectedTemplate: CFNTemplate = {
@@ -108,6 +139,10 @@ describe('CFNOutputResolver', () => {
       MyUserPoolClientOutputRef: {
         Description: 'User pool',
         Value: 'test-userpoolclientid',
+      },
+      LambdaRole: {
+        Description: 'Lambda execution role',
+        Value: 'lambda-exec-role',
       },
     },
     Resources: {
@@ -164,6 +199,33 @@ describe('CFNOutputResolver', () => {
           UserPoolId: 'test-userpoolid',
         },
       },
+      TestLambda: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          FunctionName: 'TestLambda',
+          Handler: 'index.handler',
+          Role: { 'Fn::GetAtt': ['TestLambdaRole', 'Arn'] },
+          Code: {
+            ZipFile: 'exports.handler = function() {}',
+          },
+          Runtime: 'nodejs14.x',
+        },
+      },
+      TestLambdaRole: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          RoleName: 'TestLambdaRole',
+          AssumeRolePolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: {},
+              },
+            ],
+          },
+        },
+      },
     },
   };
   it('should resolve output references', () => {
@@ -186,6 +248,10 @@ describe('CFNOutputResolver', () => {
           {
             OutputKey: 'MyUserPoolClientOutputRef',
             OutputValue: 'test-userpoolclientid',
+          },
+          {
+            OutputKey: 'LambdaRole',
+            OutputValue: 'lambda-exec-role',
           },
         ],
       ),

--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -10,6 +10,7 @@ const mockReadMeInitialize = jest.fn();
 const mockReadMeRenderStep1 = jest.fn();
 const mockReadMeRenderStep2 = jest.fn();
 const mockReadMeRenderStep3 = jest.fn();
+const mockReadMeRenderStep4 = jest.fn();
 
 const NUM_CATEGORIES_TO_REFACTOR = 2;
 const GEN1_ROOT_STACK_NAME = 'amplify-gen1-dev-12345';
@@ -27,6 +28,7 @@ jest.mock('./migration-readme-generator', () => {
       renderStep1: mockReadMeRenderStep1,
       renderStep2: mockReadMeRenderStep2,
       renderStep3: mockReadMeRenderStep3,
+      renderStep4: mockReadMeRenderStep4,
     };
   };
 });

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -143,7 +143,8 @@ class TemplateGenerator {
         newGen1Template,
         newGen2Template,
       );
-      await migrationReadMeGenerator.renderStep3(sourceTemplate, destinationTemplate, logicalIdMapping);
+      await migrationReadMeGenerator.renderStep3(sourceTemplate, destinationTemplate, logicalIdMapping, newGen1Template, newGen2Template);
+      await migrationReadMeGenerator.renderStep4();
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Add rollback step for stack refactor

- Skip instead of throwing error when `GetAtt` prop is not implemented for a resource

#### Description of how you validated changes
local testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
