### PR TITLE
fix: bump versions

### DIFF
--- a/packages/amplify-util-mock/package.json
+++ b/packages/amplify-util-mock/package.json
@@ -80,7 +80,7 @@
     "aws-appsync": "^4.1.4",
     "aws-cdk-lib": "~2.129.0",
     "aws-sdk": "^2.1464.0",
-    "aws-sdk-mock": "^5.8.0",
+    "aws-sdk-mock": "^6.2.0",
     "axios": "^1.6.7",
     "constructs": "^10.0.5",
     "graphql": "^15.5.0",

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/helper.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/helper.test.ts
@@ -1,5 +1,5 @@
 import { waitTillTableStateIsActive } from '../../../utils/dynamo-db/helpers';
-import * as AWSMock from 'aws-sdk-mock';
+import AWS_MOCK from 'aws-sdk-mock';
 import * as AWS from 'aws-sdk';
 import { DynamoDB } from 'aws-sdk';
 
@@ -8,7 +8,7 @@ describe('waitTillTableStateIsActive', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.useFakeTimers();
-    AWSMock.setSDKInstance(AWS);
+    AWS_MOCK.setSDKInstance(AWS);
   });
   afterEach(() => {
     jest.useRealTimers();

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/index.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/index.test.ts
@@ -1,5 +1,5 @@
 import { createAndUpdateTable, MockDynamoDBConfig } from '../../../utils/dynamo-db';
-import * as AWSMock from 'aws-sdk-mock';
+import AWS_MOCK from 'aws-sdk-mock';
 import * as AWS from 'aws-sdk';
 import { DynamoDB } from 'aws-sdk';
 
@@ -73,7 +73,7 @@ describe('createAndUpdateTable', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.useFakeTimers();
-    AWSMock.setSDKInstance(AWS);
+    AWS_MOCK.setSDKInstance(AWS);
   });
 
   it('should create new tables when they are missing', async () => {
@@ -105,13 +105,13 @@ describe('createAndUpdateTable', () => {
       {
         ...table2Input,
         GlobalSecondaryUpdate: {
-          Create: [table2Input.GlobalSecondaryIndexes[0]],
+          Create: [table2Input.GlobalSecondaryIndexes![0]],
         },
       },
       {
         ...table2Input,
         GlobalSecondaryUpdate: {
-          Create: [table2Input.GlobalSecondaryIndexes[1]],
+          Create: [table2Input.GlobalSecondaryIndexes![1]],
         },
       },
     ];

--- a/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
+++ b/packages/amplify-util-mock/src/__tests__/utils/dynamo-db/util.test.ts
@@ -1,5 +1,5 @@
 import * as ddbUtils from '../../../utils/dynamo-db/utils';
-import * as AWSMock from 'aws-sdk-mock';
+import AWS_MOCK from 'aws-sdk-mock';
 import * as AWS from 'aws-sdk';
 import { DescribeTableOutput, CreateTableInput, UpdateTableInput, TableDescription } from 'aws-sdk/clients/dynamodb';
 import { waitTillTableStateIsActive } from '../../../utils/dynamo-db/helpers';
@@ -10,13 +10,13 @@ jest.mock('../../../utils/dynamo-db/helpers');
 describe('DynamoDB Utils', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    AWSMock.setSDKInstance(require('aws-sdk'));
+    AWS_MOCK.setSDKInstance(require('aws-sdk'));
   });
 
   describe('describeTables', () => {
     const describeTableMock = jest.fn();
     beforeEach(() => {
-      AWSMock.mock('DynamoDB', 'describeTable', describeTableMock);
+      AWS_MOCK.mock('DynamoDB', 'describeTable', describeTableMock);
     });
 
     it('should call DynamoDB Clients describe table and collect the results', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,7 +908,7 @@ __metadata:
     aws-appsync: ^4.1.4
     aws-cdk-lib: ~2.129.0
     aws-sdk: ^2.1464.0
-    aws-sdk-mock: ^5.8.0
+    aws-sdk-mock: ^6.2.0
     axios: ^1.6.7
     chokidar: ^3.5.3
     constructs: ^10.0.5
@@ -10709,6 +10709,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/fake-timers@npm:11.2.2":
+  version: 11.2.2
+  resolution: "@sinonjs/fake-timers@npm:11.2.2"
+  dependencies:
+    "@sinonjs/commons": ^3.0.0
+  checksum: a4218efa6fdafda622d02d4c0a6ab7df3641cb038bb0b14f0a3ee56f50c95aab4f1ab2d7798ce928b40c6fc1839465a558c9393a77e4dca879e1b2f8d60d8136
+  languageName: node
+  linkType: hard
+
 "@sinonjs/fake-timers@npm:^10.0.2":
   version: 10.0.2
   resolution: "@sinonjs/fake-timers@npm:10.0.2"
@@ -10718,12 +10727,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^11.2.2":
-  version: 11.3.1
-  resolution: "@sinonjs/fake-timers@npm:11.3.1"
+"@sinonjs/fake-timers@npm:^13.0.1":
+  version: 13.0.3
+  resolution: "@sinonjs/fake-timers@npm:13.0.3"
   dependencies:
     "@sinonjs/commons": ^3.0.1
-  checksum: c4f96ea7c3ab0e1a5fc1e2e1201e984a9302841a9fb10059120ce3b6789dae0f851c8827cf16b052a6f87db9a098cdd36f7067246e7a9b71da1d5a2c3d3a9f3d
+  checksum: 4495b12def9117b93f72b6d5d6fc1a52f2efc059166bf791381e476f197d34bcf9061bd53dce1ce6cc9d858582011d29d1360f512f746ca78ff99217545b549e
   languageName: node
   linkType: hard
 
@@ -10756,7 +10765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/text-encoding@npm:^0.7.2":
+"@sinonjs/text-encoding@npm:^0.7.3":
   version: 0.7.3
   resolution: "@sinonjs/text-encoding@npm:0.7.3"
   checksum: b112d1e97af7f99fbdc63c7dbcd35d6a60764dfec85cfcfff532e55cce8ecd8453f9fa2139e70aea47142c940fd90cd201d19f370b9a0141700d8a6de3116815
@@ -14641,14 +14650,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk-mock@npm:^5.8.0":
-  version: 5.9.0
-  resolution: "aws-sdk-mock@npm:5.9.0"
+"aws-sdk-mock@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "aws-sdk-mock@npm:6.2.0"
   dependencies:
     aws-sdk: ^2.1231.0
-    sinon: ^17.0.0
-    traverse: ^0.6.6
-  checksum: 2cc6a82acc2a97cc716c41ddeb86fd482c813a0c2eea2e50047b6c19a54b602859d6f41f1e9163d8371bdd7141ffa2dcbb15d4d64d49a34443f1277e4b4568bb
+    neotraverse: ^0.6.15
+    sinon: ^18.0.1
+  checksum: a8ef205ecc806225f5b7cc6a09864d73d23add434dc42213c2aa3bd9285741651cf56c8b9f6be5619c405cfd07c3caa64a2351ff597ace0c96b4ba30ac6c811a
   languageName: node
   linkType: hard
 
@@ -17910,7 +17919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^5.1.0":
+"diff@npm:^5.1.0, diff@npm:^5.2.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
   checksum: aed0941f206fe261ecb258dc8d0ceea8abbde3ace5827518ff8d302f0fc9cc81ce116c4d8f379151171336caf0516b79e01abdc1ed1201b6440d895a66689eb4
@@ -25260,6 +25269,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"neotraverse@npm:^0.6.15":
+  version: 0.6.18
+  resolution: "neotraverse@npm:0.6.18"
+  checksum: 46f4c53cbbdc53671150916b544a9f46e27781f8003985237507542190173bec131168d89b846535f9c34c0a2a7debb1ab3a4f7a93d08218e2c194a363708ffa
+  languageName: node
+  linkType: hard
+
 "netmask@npm:^2.0.2":
   version: 2.0.2
   resolution: "netmask@npm:2.0.2"
@@ -25267,16 +25283,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nise@npm:^5.1.5":
-  version: 5.1.9
-  resolution: "nise@npm:5.1.9"
+"nise@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "nise@npm:6.1.1"
   dependencies:
-    "@sinonjs/commons": ^3.0.0
-    "@sinonjs/fake-timers": ^11.2.2
-    "@sinonjs/text-encoding": ^0.7.2
+    "@sinonjs/commons": ^3.0.1
+    "@sinonjs/fake-timers": ^13.0.1
+    "@sinonjs/text-encoding": ^0.7.3
     just-extend: ^6.2.0
-    path-to-regexp: ^6.2.1
-  checksum: a44318e6de738b34a1f51b4b478f97f5b40a5a27175be4bf13f6e5b8e67aa70d0b3f51c77a966d6617fccdc3b436c675a89be57424833e6d8a290367faa66b28
+    path-to-regexp: ^8.1.0
+  checksum: 09471adb738dc3be2981cc7815c90879ed6a5a3e162202ca66e12f9a5a0956bea718d0ec2f0c07acc26e3f958481b8fb30c30da76c13620e922f3b9dcd249c50
   languageName: node
   linkType: hard
 
@@ -26668,10 +26684,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^6.2.1":
-  version: 6.2.2
-  resolution: "path-to-regexp@npm:6.2.2"
-  checksum: 4b60852d3501fd05ca9dd08c70033d73844e5eca14e41f499f069afa8364f780f15c5098002f93bd42af8b3514de62ac6e82a53b5662de881d2b08c9ef21ea6b
+"path-to-regexp@npm:^8.1.0":
+  version: 8.2.0
+  resolution: "path-to-regexp@npm:8.2.0"
+  checksum: ef7d0a887b603c0a142fad16ccebdcdc42910f0b14830517c724466ad676107476bba2fe9fffd28fd4c141391ccd42ea426f32bb44c2c82ecaefe10c37b90f5a
   languageName: node
   linkType: hard
 
@@ -29904,17 +29920,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:^17.0.0":
-  version: 17.0.1
-  resolution: "sinon@npm:17.0.1"
+"sinon@npm:^18.0.1":
+  version: 18.0.1
+  resolution: "sinon@npm:18.0.1"
   dependencies:
-    "@sinonjs/commons": ^3.0.0
-    "@sinonjs/fake-timers": ^11.2.2
+    "@sinonjs/commons": ^3.0.1
+    "@sinonjs/fake-timers": 11.2.2
     "@sinonjs/samsam": ^8.0.0
-    diff: ^5.1.0
-    nise: ^5.1.5
-    supports-color: ^7.2.0
-  checksum: 63e678bd58a959ebf69ddadb5410e9c31bd161b848b9dbec5f34f7e1485a8681810cd27d37bde072b68915b41b498f30bb5fb890c73e7a51dc281d1b1d573cfb
+    diff: ^5.2.0
+    nise: ^6.0.0
+    supports-color: ^7
+  checksum: c4554b8d9654d42fc4baefecd3b5ac42bcce73ad926d58521233d9c355dc2c1a0d73c55e5b2c929b6814e528cd9b54bc61096b9288579f9b284edd6e3d2da3df
   languageName: node
   linkType: hard
 
@@ -30700,7 +30716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
+"supports-color@npm:^7, supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -31199,17 +31215,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"traverse@npm:^0.6.6":
-  version: 0.6.9
-  resolution: "traverse@npm:0.6.9"
-  dependencies:
-    gopd: ^1.0.1
-    typedarray.prototype.slice: ^1.0.3
-    which-typed-array: ^1.1.15
-  checksum: 6809ef684b04cd6985a4470f93bf794ad417f04bb1c43a6b1166fe1c94506118c7a7a87c34545fe15918f4e1fe29ced7a5813d8455932042f4ccc5981634139d
-  languageName: node
-  linkType: hard
-
 "treeify@npm:^1.1.0":
   version: 1.1.0
   resolution: "treeify@npm:1.1.0"
@@ -31621,20 +31626,6 @@ __metadata:
   dependencies:
     is-typedarray: ^1.0.0
   checksum: 4ac5b7a93d604edabf3ac58d3a2f7e07487e9f6e98195a080e81dbffdc4127817f470f219d794a843b87052cedef102b53ac9b539855380b8c2172054b7d5027
-  languageName: node
-  linkType: hard
-
-"typedarray.prototype.slice@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "typedarray.prototype.slice@npm:1.0.3"
-  dependencies:
-    call-bind: ^1.0.7
-    define-properties: ^1.2.1
-    es-abstract: ^1.23.0
-    es-errors: ^1.3.0
-    typed-array-buffer: ^1.0.2
-    typed-array-byte-offset: ^1.0.2
-  checksum: 6ac110a8b58a1ccb086242f09d1ce9c7ba2885924e816364a7879083b983d4096f19aab6f9aa8c0ce5ddd3d8ae3f3ba5581e10fa6838880f296a0c54c26f424b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
bump versions of path-to-regexp from 6.2.x to 8.2.0

![image](https://github.com/user-attachments/assets/425e11f7-7ad0-4353-82bc-2033f741c10e)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
