### PR TITLE
fix(migrate-template-gen): update gen1 stack with empty tags to suppo…

### DIFF
--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
@@ -74,6 +74,7 @@ aws cloudformation update-stack \\
  --template-body file://test/step1-gen1PreProcessUpdateStackTemplate.json \\
  --parameters '[{"ParameterKey":"authSelections","ParameterValue":"identityPoolAndUserPool"}]' \\
  --capabilities CAPABILITY_NAMED_IAM
+ --tags '[]'
  \`\`\`
  
 \`\`\`

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -48,6 +48,7 @@ aws cloudformation update-stack \\
  --template-body file://${step1FileNamePath} \\
  --parameters '${paramsString}' \\
  --capabilities CAPABILITY_NAMED_IAM
+ --tags '[]'
  \`\`\`
  
 \`\`\`


### PR DESCRIPTION
#### Description of changes

Add empty stack level tags for gen1 stack preprocessing update to support stack refactoring later. This is a known issue with refactor that is being worked in and is a temporary solution.

#### Description of how you validated changes
local testing

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
