### PR TITLE
Resolve CFN pseudo parameter references

### DIFF
--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -1,5 +1,5 @@
 import CategoryTemplateGenerator from './category-template-generator';
-import { CFN_S3_TYPE, CFNTemplate } from './types';
+import { CFN_PSEUDO_PARAMETERS_REF, CFN_S3_TYPE, CFNTemplate } from './types';
 import {
   CloudFormationClient,
   DescribeStacksCommand,
@@ -37,7 +37,7 @@ const oldGen1Template: CFNTemplate = {
     [GEN1_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', { Ref: 'Environment' }]] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', { Ref: 'Environment' }, { Ref: CFN_PSEUDO_PARAMETERS_REF.StackName }]] },
       },
     },
     MyS3BucketPolicy: {
@@ -84,7 +84,7 @@ const newGen1Template: CFNTemplate = {
     [GEN1_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
       },
     },
     MyS3BucketPolicy: {
@@ -131,7 +131,7 @@ const newGen1TemplateWithPredicate: CFNTemplate = {
     [GEN1_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
       },
     },
     MyS3BucketPolicy: {
@@ -282,7 +282,7 @@ const refactoredGen2Template: CFNTemplate = {
     [GEN2_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
       },
     },
     [GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID]: {

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -5,6 +5,7 @@ import CFNConditionResolver from './resolvers/cfn-condition-resolver';
 import CfnParameterResolver from './resolvers/cfn-parameter-resolver';
 import CfnOutputResolver from './resolvers/cfn-output-resolver';
 import CfnDependencyResolver from './resolvers/cfn-dependency-resolver';
+import extractStackNameFromId from './cfn-stack-name-extractor';
 
 class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
   private gen1DescribeStacksResponse: Stack | undefined;
@@ -42,7 +43,9 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
     // validate empty resources
     if (this.gen1ResourcesToMove.size === 0) throw new Error('No resources to move in Gen1 stack.');
     const logicalResourceIds = [...this.gen1ResourcesToMove.keys()];
-    const gen1ParametersResolvedTemplate = new CfnParameterResolver(oldGen1Template).resolve(Parameters);
+    const gen1ParametersResolvedTemplate = new CfnParameterResolver(oldGen1Template, extractStackNameFromId(this.gen1StackId)).resolve(
+      Parameters,
+    );
     const gen1TemplateWithOutputsResolved = new CfnOutputResolver(gen1ParametersResolvedTemplate, this.region, this.accountId).resolve(
       logicalResourceIds,
       Outputs,

--- a/packages/amplify-migration-template-gen/src/cfn-stack-name-extractor.ts
+++ b/packages/amplify-migration-template-gen/src/cfn-stack-name-extractor.ts
@@ -1,0 +1,3 @@
+export default function extractStackNameFromId(stackId: string): string {
+  return stackId.split('/')[1];
+}

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import { CATEGORY, CFNTemplate, ResourceMapping } from './types';
 import { Parameter } from '@aws-sdk/client-cloudformation';
+import extractStackNameFromId from './cfn-stack-name-extractor';
 
 interface MigrationReadMeGeneratorOptions {
   path: string;
@@ -19,8 +20,8 @@ class MigrationReadmeGenerator {
   constructor({ path, category, gen1CategoryStackId, gen2CategoryStackId }: MigrationReadMeGeneratorOptions) {
     this.path = path;
     this.category = category;
-    this.gen1CategoryStackName = this.extractStackNameFromId(gen1CategoryStackId);
-    this.gen2CategoryStackName = this.extractStackNameFromId(gen2CategoryStackId);
+    this.gen1CategoryStackName = extractStackNameFromId(gen1CategoryStackId);
+    this.gen2CategoryStackName = extractStackNameFromId(gen2CategoryStackId);
     this.migrationReadMePath = `${this.path}/MIGRATION_README.md`;
   }
 
@@ -278,10 +279,6 @@ npx ampx sandbox
 \`\`\`
 `,
     );
-  }
-
-  private extractStackNameFromId(stackId: string): string {
-    return stackId.split('/')[1];
   }
 }
 

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-parameter-resolver.ts
@@ -38,10 +38,6 @@ class CfnParameterResolver {
       const paramRegexp = new RegExp(`{"Ref":"${ParameterKey}"}`, 'g');
       templateString = templateString.replaceAll(paramRegexp, resolvedParameterValue);
     }
-    // remove stack name pseudo param from template
-    if (this.stackName) {
-      delete clonedParametersFromTemplate[CFN_PSEUDO_PARAMETERS_REF.StackName];
-    }
     return JSON.parse(templateString);
   }
 }

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -94,3 +94,7 @@ export type CFN_RESOURCE_TYPES = CFN_AUTH_TYPE | CFN_S3_TYPE;
 export type AWS_RESOURCE_ATTRIBUTES = 'Arn';
 
 export type CFN_CATEGORY_TYPE = CFN_AUTH_TYPE | CFN_S3_TYPE;
+
+export enum CFN_PSEUDO_PARAMETERS_REF {
+  StackName = 'AWS::StackName',
+}


### PR DESCRIPTION
#### Description of changes

Resolve CFN pseudo parameter references, e.g. [`AWS::StackName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-stackname).  This is needed since Gen1 Bucket name has a `Ref` on the Gen 1 StackName and needs to be resolved prior to moving it to Gen2 stack.

#### Description of how you validated changes
unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
