### PR TITLE
fix: include only required userAttributes and generate identityPoolName in backend file

### DIFF
--- a/packages/amplify-gen1-codegen-auth-adapter/API.md
+++ b/packages/amplify-gen1-codegen-auth-adapter/API.md
@@ -23,6 +23,8 @@ export interface AuthSynthesizerOptions {
     // (undocumented)
     identityGroups?: GroupType[];
     // (undocumented)
+    identityPoolName?: string;
+    // (undocumented)
     identityProviders?: ProviderDescription[];
     // (undocumented)
     identityProvidersDetails?: IdentityProviderType[];
@@ -48,7 +50,7 @@ export interface AuthTriggerConnection {
 export type AuthTriggerConnectionSourceMap = Partial<Record<keyof LambdaConfigType, string>>;
 
 // @public (undocumented)
-export const getAuthDefinition: ({ userPool, identityProviders, identityProvidersDetails, identityGroups, webClient, authTriggerConnections, guestLogin, mfaConfig, totpConfig, }: AuthSynthesizerOptions) => AuthDefinition;
+export const getAuthDefinition: ({ userPool, identityPoolName, identityProviders, identityProvidersDetails, identityGroups, webClient, authTriggerConnections, guestLogin, mfaConfig, totpConfig, }: AuthSynthesizerOptions) => AuthDefinition;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
@@ -600,7 +600,7 @@ void describe('auth codegen', () => {
       const result = getAuthDefinition({
         userPool: { Name: 'test' },
       });
-      assert.deepEqual(result.userPoolOverrides, { userPoolName: 'test', usernameAttributes: [] });
+      assert.deepEqual(result.userPoolOverrides, { userPoolName: 'test', usernameAttributes: undefined });
     });
   });
 });

--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
@@ -40,6 +40,7 @@ export type AuthTriggerConnectionSourceMap = Partial<Record<keyof LambdaConfigTy
 
 export interface AuthSynthesizerOptions {
   userPool: UserPoolType;
+  identityPoolName?: string;
   identityProviders?: ProviderDescription[];
   identityProvidersDetails?: IdentityProviderType[];
   identityGroups?: GroupType[];
@@ -80,7 +81,7 @@ const getUserPoolOverrides = (userPool: UserPoolType): Partial<PolicyOverrides> 
     Object.assign(userPoolOverrides, userNamePolicy);
   }
   if (userPool.UsernameAttributes === undefined || userPool.UsernameAttributes.length === 0) {
-    userPoolOverrides.usernameAttributes = [];
+    userPoolOverrides.usernameAttributes = undefined;
   }
   return userPoolOverrides;
 };
@@ -118,7 +119,7 @@ const getStandardUserAttributes = (
         required: attribute.Required,
         mutable: attribute.Mutable,
       };
-      if (attribute.Name !== undefined && attribute.Name in mappedUserAttributeName) {
+      if (attribute.Name !== undefined && attribute.Name in mappedUserAttributeName && attribute.Required) {
         return {
           ...standardAttributes,
           [mappedUserAttributeName[attribute.Name as keyof typeof mappedUserAttributeName] as Attribute]: standardAttribute,
@@ -235,6 +236,7 @@ function filterAttributeMapping(
  */
 export const getAuthDefinition = ({
   userPool,
+  identityPoolName,
   identityProviders,
   identityProvidersDetails,
   identityGroups,
@@ -354,6 +356,7 @@ export const getAuthDefinition = ({
     userPoolOverrides,
     lambdaTriggers: getAuthTriggers(userPool.LambdaConfig ?? {}, authTriggerConnections ?? {}),
     guestLogin,
+    identityPoolName,
     oAuthFlows: webClient?.AllowedOAuthFlows,
     readAttributes: webClient?.ReadAttributes,
     writeAttributes: webClient?.WriteAttributes,

--- a/packages/amplify-gen2-codegen/API.md
+++ b/packages/amplify-gen2-codegen/API.md
@@ -33,6 +33,8 @@ export interface AuthDefinition {
     // (undocumented)
     guestLogin?: boolean;
     // (undocumented)
+    identityPoolName?: string;
+    // (undocumented)
     lambdaTriggers?: Partial<AuthLambdaTriggers>;
     // (undocumented)
     loginOptions?: LoginOptions;

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.ts
@@ -137,6 +137,7 @@ export interface AuthDefinition {
   userPoolOverrides?: PolicyOverrides;
   lambdaTriggers?: Partial<AuthLambdaTriggers>;
   guestLogin?: boolean;
+  identityPoolName?: string;
   oAuthFlows?: string[];
   readAttributes?: string[];
   writeAttributes?: string[];

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -27,6 +27,7 @@ describe('BackendRenderer', () => {
         'Policies.PasswordPolicy.RequireUppercase': false,
         'Policies.PasswordPolicy.TemporaryPasswordValidityDays': 10,
         userPoolName: 'Test_Name',
+        userNameAttributes: undefined,
       };
       const mappedPolicyType: Record<string, string> = {
         MinimumLength: 'minimumLength',
@@ -58,7 +59,9 @@ describe('BackendRenderer', () => {
             } else if (typeof value === 'boolean') {
               assert(output.includes(`cfnUserPool.policies = {passwordPolicy:{${policyKey}:${value}}}`));
             }
-          } else if (value) {
+          } else if (value === undefined) {
+            assert(output.includes(`cfnUserPool.${key} = ${value}`));
+          } else {
             assert(output.includes(`cfnUserPool.${key} = "${value}"`));
           }
         });
@@ -102,6 +105,31 @@ describe('BackendRenderer', () => {
       assert(output.includes('cfnIdentityPool'));
     });
     it('Does not render cfnIdentityPool accessor if guestLogin is true', () => {
+      const renderer = new BackendSynthesizer();
+      const rendered = renderer.render({
+        auth: {
+          importFrom: './auth/resource.ts',
+          guestLogin: true,
+        },
+      });
+      const output = printNodeArray(rendered);
+      assert(!output.includes('cfnIdentityPool'));
+    });
+  });
+  describe('Identity Pool Name', () => {
+    it('Renders cfnIdentityPool accessor if identityPoolName is defined', () => {
+      const renderer = new BackendSynthesizer();
+      const rendered = renderer.render({
+        auth: {
+          importFrom: './auth/resource.ts',
+          identityPoolName: 'Test_Name',
+          guestLogin: true,
+        },
+      });
+      const output = printNodeArray(rendered);
+      assert(output.includes('cfnIdentityPool'));
+    });
+    it('Does not render cfnIdentityPool accessor if identityPoolName is undefined and guestLogin is true', () => {
       const renderer = new BackendSynthesizer();
       const rendered = renderer.render({
         auth: {

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -144,6 +144,7 @@ export const createGen2Renderer = ({
       importFrom: './auth/resource',
       userPoolOverrides: auth?.userPoolOverrides,
       guestLogin: auth?.guestLogin,
+      identityPoolName: auth?.identityPoolName,
       oAuthFlows: auth?.oAuthFlows,
       readAttributes: auth?.readAttributes,
       writeAttributes: auth?.writeAttributes,

--- a/packages/amplify-migration/src/app_auth_definition_fetcher.ts
+++ b/packages/amplify-migration/src/app_auth_definition_fetcher.ts
@@ -84,7 +84,7 @@ export class AppAuthDefinitionFetcher {
       }),
     );
 
-    const { AllowUnauthenticatedIdentities: guestLogin } = await this.cognitoIdentityPoolClient.send(
+    const { AllowUnauthenticatedIdentities: guestLogin, IdentityPoolName: identityPoolName } = await this.cognitoIdentityPoolClient.send(
       new DescribeIdentityPoolCommand({
         IdentityPoolId: resourcesByLogicalId['IdentityPool'].PhysicalResourceId,
       }),
@@ -95,6 +95,7 @@ export class AppAuthDefinitionFetcher {
     assert(userPool, 'User pool not found');
     return getAuthDefinition({
       userPool,
+      identityPoolName,
       identityProviders,
       identityProvidersDetails,
       identityGroups,


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Filter `userAttributes` to include only required attributes and not all Standard Attributes in `auth/resource.ts`
- Set userNameAtttributes to `undefined` instead of `[]` in `backend.ts`
- Modify codegen to include `identityPoolName` in `backend.ts`

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Manually creating an application and running migrate command and checking the generated code. Unit tests.
#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
