### PR TITLE
fix: add opt-out for appId mismatch check during init

### DIFF
--- a/packages/amplify-cli/src/commands/init.ts
+++ b/packages/amplify-cli/src/commands/init.ts
@@ -44,7 +44,7 @@ export const run = async (context: $TSContext): Promise<void> => {
       if (inputAppId && appId && inputAppId !== appId) {
         throw new AmplifyError('InvalidAmplifyAppIdError', {
           message: `Amplify appId mismatch.`,
-          resolution: `You are currently working in the amplify project with Id ${appId}`,
+          resolution: `You are currently working in the amplify project with Id ${appId}. If this is intentional, you may bypass this protection by setting the environment variable AMPLIFY_SKIP_APP_ID_MISMATCH_CHECK to true.`,
         });
       }
     }

--- a/packages/amplify-cli/src/commands/init.ts
+++ b/packages/amplify-cli/src/commands/init.ts
@@ -33,15 +33,20 @@ export const run = async (context: $TSContext): Promise<void> => {
   constructExeInfo(context);
   checkForNestedProject();
 
-  const projectPath = process.cwd();
-  if (stateManager.metaFileExists(projectPath)) {
-    const inputAppId = context.exeInfo?.inputParams?.amplify?.appId;
-    const appId = getAmplifyAppId();
-    if (inputAppId && appId && inputAppId !== appId) {
-      throw new AmplifyError('InvalidAmplifyAppIdError', {
-        message: `Amplify appId mismatch.`,
-        resolution: `You are currently working in the amplify project with Id ${appId}`,
-      });
+  // Opt-out mechanism for customers that are using old app backend environments with existing apps intentionally
+  const { AMPLIFY_SKIP_APP_ID_MISMATCH_CHECK } = process.env;
+  if (AMPLIFY_SKIP_APP_ID_MISMATCH_CHECK !== 'true') {
+    // check for appId mismatch
+    const projectPath = process.cwd();
+    if (stateManager.metaFileExists(projectPath)) {
+      const inputAppId = context.exeInfo?.inputParams?.amplify?.appId;
+      const appId = getAmplifyAppId();
+      if (inputAppId && appId && inputAppId !== appId) {
+        throw new AmplifyError('InvalidAmplifyAppIdError', {
+          message: `Amplify appId mismatch.`,
+          resolution: `You are currently working in the amplify project with Id ${appId}`,
+        });
+      }
     }
   }
 


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Environment variable which can be set locally or in studio to skip appId mismatch check that happens during init.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
