### PR TITLE
fix: ref auth - set group name prop as a string to accomodate hyphena…

### DIFF
--- a/packages/amplify-gen2-codegen/src/auth/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.test.ts
@@ -396,8 +396,8 @@ describe('render auth node', () => {
       assert.match(source, /userPoolId: "userPoolId"/);
       assert.match(source, /userPoolClientId: "userPoolClientId"/);
       assert.match(source, /groups:/);
-      assert.match(source, /Admin: "AdminRoleARN"/);
-      assert.match(source, /ReadOnly: "ReadOnlyRoleARN"/);
+      assert.match(source, /"Admin": "AdminRoleARN"/);
+      assert.match(source, /"ReadOnly": "ReadOnlyRoleARN"/);
       assert.doesNotMatch(source, /identityPoolId: "identityPoolId"/);
       assert.doesNotMatch(source, /authRoleArn: "authRoleArn"/);
       assert.doesNotMatch(source, /unauthRoleArn: "unauthRoleArn"/);
@@ -421,8 +421,8 @@ describe('render auth node', () => {
       assert.doesNotMatch(source, /userPoolId: "userPoolId"/);
       assert.doesNotMatch(source, /userPoolClientId: "userPoolClientId"/);
       assert.doesNotMatch(source, /groups:/);
-      assert.doesNotMatch(source, /Admin: "AdminRoleARN"/);
-      assert.doesNotMatch(source, /ReadOnly: "ReadOnlyRoleARN"/);
+      assert.doesNotMatch(source, /"Admin": "AdminRoleARN"/);
+      assert.doesNotMatch(source, /"ReadOnly": "ReadOnlyRoleARN"/);
     });
 
     it(`renders successfully for imported userpool and identity pool`, () => {
@@ -434,7 +434,7 @@ describe('render auth node', () => {
         unauthRoleArn: 'unauthRoleArn',
         groups: {
           Admin: 'AdminRoleARN',
-          ReadOnly: 'ReadOnlyRoleARN',
+          'Read-Only': 'ReadOnlyRoleARN',
         },
       };
       const authDefinition: AuthDefinition = {
@@ -449,8 +449,8 @@ describe('render auth node', () => {
       assert.match(source, /authRoleArn: "authRoleArn"/);
       assert.match(source, /unauthRoleArn: "unauthRoleArn"/);
       assert.match(source, /groups:/);
-      assert.match(source, /Admin: "AdminRoleARN"/);
-      assert.match(source, /ReadOnly: "ReadOnlyRoleARN"/);
+      assert.match(source, /"Admin": "AdminRoleARN"/);
+      assert.match(source, /"Read-Only": "ReadOnlyRoleARN"/);
     });
   });
 });

--- a/packages/amplify-gen2-codegen/src/auth/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/auth/source_builder.ts
@@ -484,7 +484,7 @@ export function renderAuthNode(definition: AuthDefinition): ts.NodeArray<ts.Node
             typeof value === 'object'
               ? factory.createObjectLiteralExpression(
                   Object.entries(value).map(([_key, _value]) =>
-                    factory.createPropertyAssignment(factory.createIdentifier(_key), factory.createStringLiteral(_value)),
+                    factory.createPropertyAssignment(factory.createStringLiteral(_key), factory.createStringLiteral(_value)),
                   ),
                   true,
                 )


### PR DESCRIPTION
#### Description of changes

Set the group name prop as a literal string to accommodate cases where there are hyphens (e.g `Full-Access`)


#### Description of how you validated changes
Local testing and unit tests:

```../node_modules/.bin/migrate to-gen-2 generate-code ```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
