### PR TITLE
feat: automate preprocessing steps for refactor

### DIFF
--- a/packages/amplify-migration-template-gen/package.json
+++ b/packages/amplify-migration-template-gen/package.json
@@ -4,6 +4,7 @@
   "type": "commonjs",
   "main": "lib/index.js",
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "jest": "^29.5.0",
     "typescript": "^5.4.5"
   },
@@ -31,7 +32,10 @@
       "json",
       "node"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setup-jest.ts"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
+++ b/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
@@ -14,7 +14,7 @@ export const UPDATE_COMPLETE = 'UPDATE_COMPLETE';
  * @param stackName
  * @param parameters
  * @param templateBody
- * @param attempts number of attempts to poll CFN stack for update completion state. The interval between the polls is 1 second.
+ * @param attempts number of attempts to poll CFN stack for update completion state. The interval between the polls is 1.5 seconds.
  */
 export async function tryUpdateStack(
   cfnClient: CloudFormationClient,

--- a/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
+++ b/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
@@ -2,8 +2,8 @@ import { CloudFormationClient, DescribeStacksCommand, Parameter, UpdateStackComm
 import { CFNTemplate } from './types';
 import assert from 'node:assert';
 
-const POLL_ATTEMPTS = 30;
-const POLL_INTERVAL_MS = 1000;
+const POLL_ATTEMPTS = 60;
+const POLL_INTERVAL_MS = 1500;
 const NO_UPDATES_MESSAGE = 'No updates are to be performed';
 const CFN_IAM_CAPABILIY = 'CAPABILITY_NAMED_IAM';
 const COMPLETION_STATE = '_COMPLETE';

--- a/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
+++ b/packages/amplify-migration-template-gen/src/cfn-stack-updater.ts
@@ -1,0 +1,70 @@
+import { CloudFormationClient, DescribeStacksCommand, Parameter, UpdateStackCommand } from '@aws-sdk/client-cloudformation';
+import { CFNTemplate } from './types';
+import assert from 'node:assert';
+
+const POLL_ATTEMPTS = 30;
+const POLL_INTERVAL_MS = 1000;
+const NO_UPDATES_MESSAGE = 'No updates are to be performed';
+const CFN_IAM_CAPABILIY = 'CAPABILITY_NAMED_IAM';
+const COMPLETION_STATE = '_COMPLETE';
+export const UPDATE_COMPLETE = 'UPDATE_COMPLETE';
+/**
+ * Updates a stack with given template. If no updates are present, it no-ops.
+ * @param cfnClient
+ * @param stackName
+ * @param parameters
+ * @param templateBody
+ * @param attempts number of attempts to poll CFN stack for update completion state. The interval between the polls is 1 second.
+ */
+export async function tryUpdateStack(
+  cfnClient: CloudFormationClient,
+  stackName: string,
+  parameters: Parameter[],
+  templateBody: CFNTemplate,
+  attempts = POLL_ATTEMPTS,
+): Promise<string> {
+  try {
+    await cfnClient.send(
+      new UpdateStackCommand({
+        TemplateBody: JSON.stringify(templateBody),
+        Parameters: parameters,
+        StackName: stackName,
+        Capabilities: [CFN_IAM_CAPABILIY],
+        Tags: [],
+      }),
+    );
+    return pollStackForCompletionState(cfnClient, stackName, attempts);
+  } catch (e) {
+    if (!e.message.includes(NO_UPDATES_MESSAGE)) {
+      throw e;
+    }
+    return UPDATE_COMPLETE;
+  }
+}
+
+/**
+ * Polls a stack for completion state
+ * @param cfnClient
+ * @param stackName
+ * @param attempts number of attempts to poll for completion.
+ * @returns the stack status
+ */
+async function pollStackForCompletionState(cfnClient: CloudFormationClient, stackName: string, attempts: number): Promise<string> {
+  do {
+    const { Stacks } = await cfnClient.send(
+      new DescribeStacksCommand({
+        StackName: stackName,
+      }),
+    );
+    const stack = Stacks?.[0];
+    assert(stack);
+    const stackStatus = stack.StackStatus;
+    assert(stackStatus);
+    if (stackStatus?.endsWith(COMPLETION_STATE)) {
+      return stackStatus;
+    }
+    await new Promise((res) => setTimeout(() => res(''), POLL_INTERVAL_MS));
+    attempts--;
+  } while (attempts > 0);
+  throw new Error(`Stack ${stackName} did not reach a completion state within the given time period.`);
+}

--- a/packages/amplify-migration-template-gen/src/custom-test-matchers.ts
+++ b/packages/amplify-migration-template-gen/src/custom-test-matchers.ts
@@ -1,0 +1,34 @@
+import {
+  DescribeStackResourcesCommand,
+  DescribeStackResourcesCommandInput,
+  UpdateStackCommand,
+  DescribeStacksCommand,
+  DescribeStacksCommandInput,
+  UpdateStackCommandInput,
+} from '@aws-sdk/client-cloudformation';
+
+type CFNCommand = DescribeStackResourcesCommand | DescribeStacksCommand | UpdateStackCommand;
+type CFNCommandType = typeof DescribeStackResourcesCommand | typeof DescribeStacksCommand | typeof UpdateStackCommand;
+type CFNCommandInput = DescribeStackResourcesCommandInput | DescribeStacksCommandInput | UpdateStackCommandInput;
+
+export const toBeACloudFormationCommand = (actual: [CFNCommand], expectedInput: CFNCommandInput, expectedType: CFNCommandType) => {
+  const actualInstance = actual[0];
+  expect(actualInstance.input).toEqual(expectedInput);
+  const constructorName = actualInstance.constructor.name;
+  const pass = constructorName === expectedType.prototype.constructor.name;
+
+  return {
+    pass,
+    message: () => `expected ${actual} to be instance of ${constructorName}`,
+  };
+};
+
+declare global {
+  // Needed for custom matchers.
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBeACloudFormationCommand(expectedInput: CFNCommandInput, expectedType: CFNCommandType): R;
+    }
+  }
+}

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
@@ -56,103 +56,14 @@ describe('MigrationReadMeGenerator', () => {
     });
   });
 
-  // should render step1
   it('should render step1', async () => {
-    await migrationReadMeGenerator.renderStep1(oldStackTemplate, newStackTemplate, [
-      {
-        ParameterKey: 'authSelections',
-        ParameterValue: 'identityPoolAndUserPool',
-      },
-    ]);
+    await migrationReadMeGenerator.renderStep1(oldStackTemplate, newStackTemplate, logicalIdMapping, oldStackTemplate, newStackTemplate);
     expect(fs.appendFile).toHaveBeenCalledWith(
       'test/MIGRATION_README.md',
-      `### STEP 1: UPDATE GEN-1 AUTH STACK
-It is a non-disruptive update since the template only replaces resource references with their resolved values. This is a required step to execute cloudformation stack refactor later.
-\`\`\`
-aws cloudformation update-stack \\
- --stack-name amplify-testauth-dev-12345-auth-ABCDE \\
- --template-body file://test/step1-gen1PreProcessUpdateStackTemplate.json \\
- --parameters '[{"ParameterKey":"authSelections","ParameterValue":"identityPoolAndUserPool"}]' \\
- --capabilities CAPABILITY_NAMED_IAM \\
- --tags '[]'
- \`\`\`
- 
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name amplify-testauth-dev-12345-auth-ABCDE
- \`\`\`
- 
- #### Rollback step:
- \`\`\`
- aws cloudformation update-stack \\
- --stack-name amplify-testauth-dev-12345-auth-ABCDE \\
- --template-body file://test/step1-gen1PreProcessUpdateStackTemplate-rollback.json \\
- --parameters '[{"ParameterKey\":\"authSelections\",\"ParameterValue\":\"identityPoolAndUserPool\"}]' \\
- --capabilities CAPABILITY_NAMED_IAM
- \`\`\`
- 
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name amplify-testauth-dev-12345-auth-ABCDE
- \`\`\`
- `,
-      { encoding: 'utf8' },
-    );
-  });
-
-  // should render step2
-  it('should render step2', async () => {
-    await migrationReadMeGenerator.renderStep2(oldStackTemplate, newStackTemplate, [
-      {
-        ParameterKey: 'authSelections',
-        ParameterValue: 'identityPoolAndUserPool',
-      },
-    ]);
-    expect(fs.appendFile).toHaveBeenCalledWith(
-      'test/MIGRATION_README.md',
-      `### STEP 2: REMOVE GEN-2 AUTH STACK RESOURCES
-This step is required since we will eventually replace gen-2 resources with gen-1 resources as part of Step 3 (refactor).
-\`\`\`
-aws cloudformation update-stack \\
- --stack-name amplify-mygen2app-test-sandbox-12345-auth-ABCDE \\
- --template-body file://test/step2-gen2ResourcesRemovalStackTemplate.json \\
- --parameters '[{"ParameterKey":"authSelections","ParameterValue":"identityPoolAndUserPool"}]' \\
- --capabilities CAPABILITY_NAMED_IAM \\
- --tags '[]'
- \`\`\`
-
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name amplify-mygen2app-test-sandbox-12345-auth-ABCDE
- \`\`\`
-
- #### Rollback step:
- \`\`\`
- aws cloudformation update-stack \\
- --stack-name amplify-mygen2app-test-sandbox-12345-auth-ABCDE \\
- --template-body file://test/step2-gen2ResourcesRemovalStackTemplate-rollback.json \\
- --parameters '[{"ParameterKey\":\"authSelections\",\"ParameterValue\":\"identityPoolAndUserPool\"}]' \\
- --capabilities CAPABILITY_NAMED_IAM
- \`\`\`
-
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name amplify-mygen2app-test-sandbox-12345-auth-ABCDE
- \`\`\`
- `,
-      { encoding: 'utf8' },
-    );
-  });
-
-  // should render step3
-  it('should render step3', async () => {
-    await migrationReadMeGenerator.renderStep3(oldStackTemplate, newStackTemplate, logicalIdMapping, oldStackTemplate, newStackTemplate);
-    expect(fs.appendFile).toHaveBeenCalledWith(
-      'test/MIGRATION_README.md',
-      `### STEP 3: CREATE AND EXECUTE CLOUDFORMATION STACK REFACTOR FOR auth CATEGORY
+      `### STEP 1: CREATE AND EXECUTE CLOUDFORMATION STACK REFACTOR FOR auth CATEGORY
 This step will move the Gen1 auth resources to Gen2 stack.
 
-3.a) Upload the source and destination templates to S3
+1.a) Upload the source and destination templates to S3
 \`\`\`
 export BUCKET_NAME=<<YOUR_BUCKET_NAME>>
 \`\`\`
@@ -165,7 +76,7 @@ aws s3 cp test/step3-sourceTemplate.json s3://$BUCKET_NAME
 aws s3 cp test/step3-destinationTemplate.json s3://$BUCKET_NAME
 \`\`\`
 
-3.b) Create stack refactor
+1.b) Create stack refactor
 \`\`\`
 aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-testauth-dev-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-sourceTemplate.json  StackName=amplify-mygen2app-test-sandbox-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-destinationTemplate.json  --resource-mappings  '[{\"Source\":{\"StackName\":\"amplify-testauth-dev-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen1FooUserPool\"},\"Destination\":{\"StackName\":\"amplify-mygen2app-test-sandbox-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen2FooUserPool\"}}]'
 \`\`\`
@@ -174,17 +85,17 @@ aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-
 export STACK_REFACTOR_ID=<<REFACTOR-ID-FROM-CREATE-STACK-REFACTOR_CALL>>
 \`\`\`
   
-3.c) Describe stack refactor to check for creation status
+1.c) Describe stack refactor to check for creation status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-3.d) Execute stack refactor
+1.d) Execute stack refactor
 \`\`\`
  aws cloudformation execute-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-3.e) Describe stack refactor to check for execution status
+1.e) Describe stack refactor to check for execution status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
@@ -225,19 +136,19 @@ Describe stack refactor to check for execution status
     );
   });
 
-  it('should render step4', async () => {
-    await migrationReadMeGenerator.renderStep4();
+  it('should render step2', async () => {
+    await migrationReadMeGenerator.renderStep2();
     expect(fs.appendFile).toHaveBeenCalledWith(
       'test/MIGRATION_README.md',
-      `### STEP 4: REDEPLOY GEN2 APPLICATION
+      `### STEP 2: REDEPLOY GEN2 APPLICATION
 This step will remove the hardcoded references from the template and replace them with resource references (where applicable).
 
-4.a) Only applicable to Storage category: Uncomment the following line in \`amplify/backend.ts\` file to instruct CDK to use the gen1 S3 bucket
+2.a) Only applicable to Storage category: Uncomment the following line in \`amplify/backend.ts\` file to instruct CDK to use the gen1 S3 bucket
 \`\`\`
 s3Bucket.bucketName = YOUR_GEN1_BUCKET_NAME;
 \`\`\`
 
-4.b) Deploy sandbox using the below command or trigger a CI/CD build via hosting by committing this file to your Git repository
+2.b) Deploy sandbox using the below command or trigger a CI/CD build via hosting by committing this file to your Git repository
 \`\`\`
 npx ampx sandbox
 \`\`\`

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -29,101 +29,101 @@ class MigrationReadmeGenerator {
     await fs.writeFile(this.migrationReadMePath, `## Stack refactor steps for ${this.category} category\n`, { encoding: 'utf8' });
   }
 
-  /**
-   * Resolves outputs and dependencies to prepare for refactor
-   * @param oldGen1StackTemplate
-   * @param newGen1StackTemplate
-   * @param parameters
-   */
-  async renderStep1(oldGen1StackTemplate: CFNTemplate, newGen1StackTemplate: CFNTemplate, parameters: Parameter[]): Promise<void> {
-    const step1FileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate.json`;
-    const step1RollbackFileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate-rollback.json`;
-    const paramsString = JSON.stringify(parameters);
-    await fs.appendFile(
-      this.migrationReadMePath,
-      `### STEP 1: UPDATE GEN-1 ${this.category.toUpperCase()} STACK
-It is a non-disruptive update since the template only replaces resource references with their resolved values. This is a required step to execute cloudformation stack refactor later.
-\`\`\`
-aws cloudformation update-stack \\
- --stack-name ${this.gen1CategoryStackName} \\
- --template-body file://${step1FileNamePath} \\
- --parameters '${paramsString}' \\
- --capabilities CAPABILITY_NAMED_IAM \\
- --tags '[]'
- \`\`\`
- 
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name ${this.gen1CategoryStackName}
- \`\`\`
- 
- #### Rollback step:
- \`\`\`
- aws cloudformation update-stack \\
- --stack-name ${this.gen1CategoryStackName} \\
- --template-body file://${step1RollbackFileNamePath} \\
- --parameters '${paramsString}' \\
- --capabilities CAPABILITY_NAMED_IAM
- \`\`\`
- 
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name ${this.gen1CategoryStackName}
- \`\`\`
- `,
-      { encoding: 'utf8' },
-    );
-    await fs.writeFile(step1FileNamePath, JSON.stringify(newGen1StackTemplate, null, 2), { encoding: 'utf8' });
-    await fs.writeFile(step1RollbackFileNamePath, JSON.stringify(oldGen1StackTemplate, null, 2), { encoding: 'utf8' });
-  }
-
-  /**
-   * Removes Gen2 resources from Gen2 stack to prepare for refactor
-   * @param oldGen2StackTemplate
-   * @param newGen2StackTemplate
-   * @param parameters
-   */
-  async renderStep2(oldGen2StackTemplate: CFNTemplate, newGen2StackTemplate: CFNTemplate, parameters: Parameter[] = []): Promise<void> {
-    const step2FileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate.json`;
-    const step2RollbackFileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate-rollback.json`;
-    const paramsString = JSON.stringify(parameters);
-    await fs.appendFile(
-      this.migrationReadMePath,
-      `### STEP 2: REMOVE GEN-2 ${this.category.toUpperCase()} STACK RESOURCES
-This step is required since we will eventually replace gen-2 resources with gen-1 resources as part of Step 3 (refactor).
-\`\`\`
-aws cloudformation update-stack \\
- --stack-name ${this.gen2CategoryStackName} \\
- --template-body file://${step2FileNamePath} \\
- --parameters '${paramsString}' \\
- --capabilities CAPABILITY_NAMED_IAM \\
- --tags '[]'
- \`\`\`
-
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name ${this.gen2CategoryStackName}
- \`\`\`
-
- #### Rollback step:
- \`\`\`
- aws cloudformation update-stack \\
- --stack-name ${this.gen2CategoryStackName} \\
- --template-body file://${step2RollbackFileNamePath} \\
- --parameters '${paramsString}' \\
- --capabilities CAPABILITY_NAMED_IAM
- \`\`\`
-
-\`\`\`
-aws cloudformation describe-stacks \\
- --stack-name ${this.gen2CategoryStackName}
- \`\`\`
- `,
-      { encoding: 'utf8' },
-    );
-    await fs.writeFile(step2FileNamePath, JSON.stringify(newGen2StackTemplate, null, 2), { encoding: 'utf8' });
-    await fs.writeFile(step2RollbackFileNamePath, JSON.stringify(oldGen2StackTemplate, null, 2), { encoding: 'utf8' });
-  }
+  //   /**
+  //    * Resolves outputs and dependencies to prepare for refactor
+  //    * @param oldGen1StackTemplate
+  //    * @param newGen1StackTemplate
+  //    * @param parameters
+  //    */
+  //   async renderStep1(oldGen1StackTemplate: CFNTemplate, newGen1StackTemplate: CFNTemplate, parameters: Parameter[]): Promise<void> {
+  //     const step1FileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate.json`;
+  //     const step1RollbackFileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate-rollback.json`;
+  //     const paramsString = JSON.stringify(parameters);
+  //     await fs.appendFile(
+  //       this.migrationReadMePath,
+  //       `### STEP 1: UPDATE GEN-1 ${this.category.toUpperCase()} STACK
+  // It is a non-disruptive update since the template only replaces resource references with their resolved values. This is a required step to execute cloudformation stack refactor later.
+  // \`\`\`
+  // aws cloudformation update-stack \\
+  //  --stack-name ${this.gen1CategoryStackName} \\
+  //  --template-body file://${step1FileNamePath} \\
+  //  --parameters '${paramsString}' \\
+  //  --capabilities CAPABILITY_NAMED_IAM \\
+  //  --tags '[]'
+  //  \`\`\`
+  //
+  // \`\`\`
+  // aws cloudformation describe-stacks \\
+  //  --stack-name ${this.gen1CategoryStackName}
+  //  \`\`\`
+  //
+  //  #### Rollback step:
+  //  \`\`\`
+  //  aws cloudformation update-stack \\
+  //  --stack-name ${this.gen1CategoryStackName} \\
+  //  --template-body file://${step1RollbackFileNamePath} \\
+  //  --parameters '${paramsString}' \\
+  //  --capabilities CAPABILITY_NAMED_IAM
+  //  \`\`\`
+  //
+  // \`\`\`
+  // aws cloudformation describe-stacks \\
+  //  --stack-name ${this.gen1CategoryStackName}
+  //  \`\`\`
+  //  `,
+  //       { encoding: 'utf8' },
+  //     );
+  //     await fs.writeFile(step1FileNamePath, JSON.stringify(newGen1StackTemplate, null, 2), { encoding: 'utf8' });
+  //     await fs.writeFile(step1RollbackFileNamePath, JSON.stringify(oldGen1StackTemplate, null, 2), { encoding: 'utf8' });
+  //   }
+  //
+  //   /**
+  //    * Removes Gen2 resources from Gen2 stack to prepare for refactor
+  //    * @param oldGen2StackTemplate
+  //    * @param newGen2StackTemplate
+  //    * @param parameters
+  //    */
+  //   async renderStep2(oldGen2StackTemplate: CFNTemplate, newGen2StackTemplate: CFNTemplate, parameters: Parameter[] = []): Promise<void> {
+  //     const step2FileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate.json`;
+  //     const step2RollbackFileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate-rollback.json`;
+  //     const paramsString = JSON.stringify(parameters);
+  //     await fs.appendFile(
+  //       this.migrationReadMePath,
+  //       `### STEP 2: REMOVE GEN-2 ${this.category.toUpperCase()} STACK RESOURCES
+  // This step is required since we will eventually replace gen-2 resources with gen-1 resources as part of Step 3 (refactor).
+  // \`\`\`
+  // aws cloudformation update-stack \\
+  //  --stack-name ${this.gen2CategoryStackName} \\
+  //  --template-body file://${step2FileNamePath} \\
+  //  --parameters '${paramsString}' \\
+  //  --capabilities CAPABILITY_NAMED_IAM \\
+  //  --tags '[]'
+  //  \`\`\`
+  //
+  // \`\`\`
+  // aws cloudformation describe-stacks \\
+  //  --stack-name ${this.gen2CategoryStackName}
+  //  \`\`\`
+  //
+  //  #### Rollback step:
+  //  \`\`\`
+  //  aws cloudformation update-stack \\
+  //  --stack-name ${this.gen2CategoryStackName} \\
+  //  --template-body file://${step2RollbackFileNamePath} \\
+  //  --parameters '${paramsString}' \\
+  //  --capabilities CAPABILITY_NAMED_IAM
+  //  \`\`\`
+  //
+  // \`\`\`
+  // aws cloudformation describe-stacks \\
+  //  --stack-name ${this.gen2CategoryStackName}
+  //  \`\`\`
+  //  `,
+  //       { encoding: 'utf8' },
+  //     );
+  //     await fs.writeFile(step2FileNamePath, JSON.stringify(newGen2StackTemplate, null, 2), { encoding: 'utf8' });
+  //     await fs.writeFile(step2RollbackFileNamePath, JSON.stringify(oldGen2StackTemplate, null, 2), { encoding: 'utf8' });
+  //   }
 
   /**
    * Creates and executes Stack refactor operation for the given category
@@ -131,7 +131,7 @@ aws cloudformation describe-stacks \\
    * @param destinationTemplate
    * @param logicalIdMapping
    */
-  async renderStep3(
+  async renderStep1(
     sourceTemplate: CFNTemplate,
     destinationTemplate: CFNTemplate,
     logicalIdMapping: Map<string, string>,
@@ -174,10 +174,10 @@ aws cloudformation describe-stacks \\
     }
     await fs.appendFile(
       this.migrationReadMePath,
-      `### STEP 3: CREATE AND EXECUTE CLOUDFORMATION STACK REFACTOR FOR ${this.category} CATEGORY
+      `### STEP 1: CREATE AND EXECUTE CLOUDFORMATION STACK REFACTOR FOR ${this.category} CATEGORY
 This step will move the Gen1 ${this.category} resources to Gen2 stack.
 
-3.a) Upload the source and destination templates to S3
+1.a) Upload the source and destination templates to S3
 \`\`\`
 export BUCKET_NAME=<<YOUR_BUCKET_NAME>>
 \`\`\`
@@ -190,7 +190,7 @@ aws s3 cp ${step3SourceTemplateFileNamePath} s3://$BUCKET_NAME
 aws s3 cp ${step3DestinationTemplateFileNamePath} s3://$BUCKET_NAME
 \`\`\`
 
-3.b) Create stack refactor
+1.b) Create stack refactor
 \`\`\`
 aws cloudformation create-stack-refactor \
  --stack-definitions StackName=${this.gen1CategoryStackName},TemplateURL=s3://$BUCKET_NAME/${sourceTemplateFileName} \
@@ -203,17 +203,17 @@ aws cloudformation create-stack-refactor \
 export STACK_REFACTOR_ID=<<REFACTOR-ID-FROM-CREATE-STACK-REFACTOR_CALL>>
 \`\`\`
   
-3.c) Describe stack refactor to check for creation status
+1.c) Describe stack refactor to check for creation status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-3.d) Execute stack refactor
+1.d) Execute stack refactor
 \`\`\`
  aws cloudformation execute-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-3.e) Describe stack refactor to check for execution status
+1.e) Describe stack refactor to check for execution status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
@@ -262,18 +262,18 @@ Describe stack refactor to check for execution status
     await fs.writeFile(step3RollbackDestinationTemplateFileNamePath, JSON.stringify(oldDestinationTemplate, null, 2), { encoding: 'utf8' });
   }
 
-  async renderStep4() {
+  async renderStep2() {
     await fs.appendFile(
       this.migrationReadMePath,
-      `### STEP 4: REDEPLOY GEN2 APPLICATION
+      `### STEP 2: REDEPLOY GEN2 APPLICATION
 This step will remove the hardcoded references from the template and replace them with resource references (where applicable).
 
-4.a) Only applicable to Storage category: Uncomment the following line in \`amplify/backend.ts\` file to instruct CDK to use the gen1 S3 bucket
+2.a) Only applicable to Storage category: Uncomment the following line in \`amplify/backend.ts\` file to instruct CDK to use the gen1 S3 bucket
 \`\`\`
 s3Bucket.bucketName = YOUR_GEN1_BUCKET_NAME;
 \`\`\`
 
-4.b) Deploy sandbox using the below command or trigger a CI/CD build via hosting by committing this file to your Git repository
+2.b) Deploy sandbox using the below command or trigger a CI/CD build via hosting by committing this file to your Git repository
 \`\`\`
 npx ampx sandbox
 \`\`\`

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 import { CATEGORY, CFNTemplate, ResourceMapping } from './types';
-import { Parameter } from '@aws-sdk/client-cloudformation';
 import extractStackNameFromId from './cfn-stack-name-extractor';
 
 interface MigrationReadMeGeneratorOptions {

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -29,102 +29,6 @@ class MigrationReadmeGenerator {
     await fs.writeFile(this.migrationReadMePath, `## Stack refactor steps for ${this.category} category\n`, { encoding: 'utf8' });
   }
 
-  //   /**
-  //    * Resolves outputs and dependencies to prepare for refactor
-  //    * @param oldGen1StackTemplate
-  //    * @param newGen1StackTemplate
-  //    * @param parameters
-  //    */
-  //   async renderStep1(oldGen1StackTemplate: CFNTemplate, newGen1StackTemplate: CFNTemplate, parameters: Parameter[]): Promise<void> {
-  //     const step1FileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate.json`;
-  //     const step1RollbackFileNamePath = `${this.path}/step1-gen1PreProcessUpdateStackTemplate-rollback.json`;
-  //     const paramsString = JSON.stringify(parameters);
-  //     await fs.appendFile(
-  //       this.migrationReadMePath,
-  //       `### STEP 1: UPDATE GEN-1 ${this.category.toUpperCase()} STACK
-  // It is a non-disruptive update since the template only replaces resource references with their resolved values. This is a required step to execute cloudformation stack refactor later.
-  // \`\`\`
-  // aws cloudformation update-stack \\
-  //  --stack-name ${this.gen1CategoryStackName} \\
-  //  --template-body file://${step1FileNamePath} \\
-  //  --parameters '${paramsString}' \\
-  //  --capabilities CAPABILITY_NAMED_IAM \\
-  //  --tags '[]'
-  //  \`\`\`
-  //
-  // \`\`\`
-  // aws cloudformation describe-stacks \\
-  //  --stack-name ${this.gen1CategoryStackName}
-  //  \`\`\`
-  //
-  //  #### Rollback step:
-  //  \`\`\`
-  //  aws cloudformation update-stack \\
-  //  --stack-name ${this.gen1CategoryStackName} \\
-  //  --template-body file://${step1RollbackFileNamePath} \\
-  //  --parameters '${paramsString}' \\
-  //  --capabilities CAPABILITY_NAMED_IAM
-  //  \`\`\`
-  //
-  // \`\`\`
-  // aws cloudformation describe-stacks \\
-  //  --stack-name ${this.gen1CategoryStackName}
-  //  \`\`\`
-  //  `,
-  //       { encoding: 'utf8' },
-  //     );
-  //     await fs.writeFile(step1FileNamePath, JSON.stringify(newGen1StackTemplate, null, 2), { encoding: 'utf8' });
-  //     await fs.writeFile(step1RollbackFileNamePath, JSON.stringify(oldGen1StackTemplate, null, 2), { encoding: 'utf8' });
-  //   }
-  //
-  //   /**
-  //    * Removes Gen2 resources from Gen2 stack to prepare for refactor
-  //    * @param oldGen2StackTemplate
-  //    * @param newGen2StackTemplate
-  //    * @param parameters
-  //    */
-  //   async renderStep2(oldGen2StackTemplate: CFNTemplate, newGen2StackTemplate: CFNTemplate, parameters: Parameter[] = []): Promise<void> {
-  //     const step2FileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate.json`;
-  //     const step2RollbackFileNamePath = `${this.path}/step2-gen2ResourcesRemovalStackTemplate-rollback.json`;
-  //     const paramsString = JSON.stringify(parameters);
-  //     await fs.appendFile(
-  //       this.migrationReadMePath,
-  //       `### STEP 2: REMOVE GEN-2 ${this.category.toUpperCase()} STACK RESOURCES
-  // This step is required since we will eventually replace gen-2 resources with gen-1 resources as part of Step 3 (refactor).
-  // \`\`\`
-  // aws cloudformation update-stack \\
-  //  --stack-name ${this.gen2CategoryStackName} \\
-  //  --template-body file://${step2FileNamePath} \\
-  //  --parameters '${paramsString}' \\
-  //  --capabilities CAPABILITY_NAMED_IAM \\
-  //  --tags '[]'
-  //  \`\`\`
-  //
-  // \`\`\`
-  // aws cloudformation describe-stacks \\
-  //  --stack-name ${this.gen2CategoryStackName}
-  //  \`\`\`
-  //
-  //  #### Rollback step:
-  //  \`\`\`
-  //  aws cloudformation update-stack \\
-  //  --stack-name ${this.gen2CategoryStackName} \\
-  //  --template-body file://${step2RollbackFileNamePath} \\
-  //  --parameters '${paramsString}' \\
-  //  --capabilities CAPABILITY_NAMED_IAM
-  //  \`\`\`
-  //
-  // \`\`\`
-  // aws cloudformation describe-stacks \\
-  //  --stack-name ${this.gen2CategoryStackName}
-  //  \`\`\`
-  //  `,
-  //       { encoding: 'utf8' },
-  //     );
-  //     await fs.writeFile(step2FileNamePath, JSON.stringify(newGen2StackTemplate, null, 2), { encoding: 'utf8' });
-  //     await fs.writeFile(step2RollbackFileNamePath, JSON.stringify(oldGen2StackTemplate, null, 2), { encoding: 'utf8' });
-  //   }
-
   /**
    * Creates and executes Stack refactor operation for the given category
    * @param sourceTemplate
@@ -143,10 +47,10 @@ class MigrationReadmeGenerator {
     const rollbackSourceTemplateFileName = 'step3-sourceTemplate-rollback.json';
     const rollbackDestinationTemplateFileName = 'step3-destinationTemplate-rollback.json';
 
-    const step3SourceTemplateFileNamePath = `${this.path}/${sourceTemplateFileName}`;
-    const step3DestinationTemplateFileNamePath = `${this.path}/${destinationTemplateFileName}`;
-    const step3RollbackSourceTemplateFileNamePath = `${this.path}/${rollbackSourceTemplateFileName}`;
-    const step3RollbackDestinationTemplateFileNamePath = `${this.path}/${rollbackDestinationTemplateFileName}`;
+    const step1SourceTemplateFileNamePath = `${this.path}/${sourceTemplateFileName}`;
+    const step1DestinationTemplateFileNamePath = `${this.path}/${destinationTemplateFileName}`;
+    const step1RollbackSourceTemplateFileNamePath = `${this.path}/${rollbackSourceTemplateFileName}`;
+    const step1RollbackDestinationTemplateFileNamePath = `${this.path}/${rollbackDestinationTemplateFileName}`;
 
     const resourceMappings: ResourceMapping[] = [];
     const rollbackResourceMappings: ResourceMapping[] = [];
@@ -183,11 +87,11 @@ export BUCKET_NAME=<<YOUR_BUCKET_NAME>>
 \`\`\`
 
 \`\`\`
-aws s3 cp ${step3SourceTemplateFileNamePath} s3://$BUCKET_NAME
+aws s3 cp ${step1SourceTemplateFileNamePath} s3://$BUCKET_NAME
 \`\`\`
 
 \`\`\`
-aws s3 cp ${step3DestinationTemplateFileNamePath} s3://$BUCKET_NAME
+aws s3 cp ${step1DestinationTemplateFileNamePath} s3://$BUCKET_NAME
 \`\`\`
 
 1.b) Create stack refactor
@@ -220,11 +124,11 @@ export STACK_REFACTOR_ID=<<REFACTOR-ID-FROM-CREATE-STACK-REFACTOR_CALL>>
 
 #### Rollback step for refactor:
 \`\`\`
-aws s3 cp ${step3RollbackSourceTemplateFileNamePath} s3://$BUCKET_NAME
+aws s3 cp ${step1RollbackSourceTemplateFileNamePath} s3://$BUCKET_NAME
 \`\`\`
 
 \`\`\`
-aws s3 cp ${step3RollbackDestinationTemplateFileNamePath} s3://$BUCKET_NAME
+aws s3 cp ${step1RollbackDestinationTemplateFileNamePath} s3://$BUCKET_NAME
 \`\`\`
 
 \`\`\`
@@ -256,10 +160,10 @@ Describe stack refactor to check for execution status
  `,
       { encoding: 'utf8' },
     );
-    await fs.writeFile(step3SourceTemplateFileNamePath, JSON.stringify(sourceTemplate, null, 2), { encoding: 'utf8' });
-    await fs.writeFile(step3DestinationTemplateFileNamePath, JSON.stringify(destinationTemplate, null, 2), { encoding: 'utf8' });
-    await fs.writeFile(step3RollbackSourceTemplateFileNamePath, JSON.stringify(oldSourceTemplate, null, 2), { encoding: 'utf8' });
-    await fs.writeFile(step3RollbackDestinationTemplateFileNamePath, JSON.stringify(oldDestinationTemplate, null, 2), { encoding: 'utf8' });
+    await fs.writeFile(step1SourceTemplateFileNamePath, JSON.stringify(sourceTemplate, null, 2), { encoding: 'utf8' });
+    await fs.writeFile(step1DestinationTemplateFileNamePath, JSON.stringify(destinationTemplate, null, 2), { encoding: 'utf8' });
+    await fs.writeFile(step1RollbackSourceTemplateFileNamePath, JSON.stringify(oldSourceTemplate, null, 2), { encoding: 'utf8' });
+    await fs.writeFile(step1RollbackDestinationTemplateFileNamePath, JSON.stringify(oldDestinationTemplate, null, 2), { encoding: 'utf8' });
   }
 
   async renderStep2() {

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
@@ -94,7 +94,6 @@ class CfnOutputResolver {
 
   /**
    * Build a custom replacer function to replace Fn::GetAtt references with resource attribute values.
-   * @param resource
    * @param record
    * @private
    */

--- a/packages/amplify-migration-template-gen/src/setup-jest.ts
+++ b/packages/amplify-migration-template-gen/src/setup-jest.ts
@@ -1,0 +1,6 @@
+import { expect } from '@jest/globals';
+import { toBeACloudFormationCommand } from './custom-test-matchers';
+
+expect.extend({
+  toBeACloudFormationCommand,
+});

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -125,22 +125,16 @@ class TemplateGenerator {
       });
       await migrationReadMeGenerator.initialize();
 
-      const {
-        oldTemplate: oldGen1Template,
-        newTemplate: newGen1Template,
-        parameters: gen1StackParameters,
-      } = await categoryTemplateGenerator.generateGen1PreProcessTemplate();
+      const { newTemplate: newGen1Template, parameters: gen1StackParameters } =
+        await categoryTemplateGenerator.generateGen1PreProcessTemplate();
       assert(gen1StackParameters);
       console.log(`Updating Gen1 ${category} stack...`);
       const gen1StackUpdateStatus = await tryUpdateStack(this.cfnClient, gen1CategoryStackId, gen1StackParameters, newGen1Template);
       assert(gen1StackUpdateStatus === CFNStackStatus.UPDATE_COMPLETE);
       console.log(`Updated Gen1 ${category} stack successfully`);
 
-      const {
-        oldTemplate: oldGen2Template,
-        newTemplate: newGen2Template,
-        parameters: gen2StackParameters,
-      } = await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
+      const { newTemplate: newGen2Template, parameters: gen2StackParameters } =
+        await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
       console.log(`Updating Gen2 ${category} stack...`);
       const gen2StackUpdateStatus = await tryUpdateStack(
         this.cfnClient,

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -136,13 +136,7 @@ class TemplateGenerator {
       const { newTemplate: newGen2Template, parameters: gen2StackParameters } =
         await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
       console.log(`Updating Gen2 ${category} stack...`);
-      const gen2StackUpdateStatus = await tryUpdateStack(
-        this.cfnClient,
-        gen2CategoryStackId,
-        gen2StackParameters ?? [],
-        newGen2Template,
-        60,
-      );
+      const gen2StackUpdateStatus = await tryUpdateStack(this.cfnClient, gen2CategoryStackId, gen2StackParameters ?? [], newGen2Template);
       assert(gen2StackUpdateStatus === CFNStackStatus.UPDATE_COMPLETE);
       console.log(`Updated Gen2 ${category} stack successfully`);
 

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -2,8 +2,9 @@ import { CloudFormationClient, DescribeStackResourcesCommand } from '@aws-sdk/cl
 import assert from 'node:assert';
 import CategoryTemplateGenerator from './category-template-generator';
 import fs from 'node:fs/promises';
-import { CATEGORY, CFN_AUTH_TYPE, CFN_CATEGORY_TYPE, CFN_S3_TYPE, CFNResource } from './types';
+import { CATEGORY, CFN_AUTH_TYPE, CFN_CATEGORY_TYPE, CFN_S3_TYPE, CFNResource, CFNStackStatus } from './types';
 import MigrationReadmeGenerator from './migration-readme-generator';
+import { tryUpdateStack } from './cfn-stack-updater';
 
 const CFN_RESOURCE_STACK_TYPE = 'AWS::CloudFormation::Stack';
 
@@ -130,21 +131,33 @@ class TemplateGenerator {
         parameters: gen1StackParameters,
       } = await categoryTemplateGenerator.generateGen1PreProcessTemplate();
       assert(gen1StackParameters);
-      await migrationReadMeGenerator.renderStep1(oldGen1Template, newGen1Template, gen1StackParameters);
+      console.log(`Updating Gen1 ${category} stack...`);
+      const gen1StackUpdateStatus = await tryUpdateStack(this.cfnClient, gen1CategoryStackId, gen1StackParameters, newGen1Template);
+      assert(gen1StackUpdateStatus === CFNStackStatus.UPDATE_COMPLETE);
+      console.log(`Updated Gen1 ${category} stack successfully`);
 
       const {
         oldTemplate: oldGen2Template,
         newTemplate: newGen2Template,
         parameters: gen2StackParameters,
       } = await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
-      await migrationReadMeGenerator.renderStep2(oldGen2Template, newGen2Template, gen2StackParameters);
+      console.log(`Updating Gen2 ${category} stack...`);
+      const gen2StackUpdateStatus = await tryUpdateStack(
+        this.cfnClient,
+        gen2CategoryStackId,
+        gen2StackParameters ?? [],
+        newGen2Template,
+        60,
+      );
+      assert(gen2StackUpdateStatus === CFNStackStatus.UPDATE_COMPLETE);
+      console.log(`Updated Gen2 ${category} stack successfully`);
 
       const { sourceTemplate, destinationTemplate, logicalIdMapping } = categoryTemplateGenerator.generateStackRefactorTemplates(
         newGen1Template,
         newGen2Template,
       );
-      await migrationReadMeGenerator.renderStep3(sourceTemplate, destinationTemplate, logicalIdMapping, newGen1Template, newGen2Template);
-      await migrationReadMeGenerator.renderStep4();
+      await migrationReadMeGenerator.renderStep1(sourceTemplate, destinationTemplate, logicalIdMapping, newGen1Template, newGen2Template);
+      await migrationReadMeGenerator.renderStep2();
     }
   }
 }

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -98,3 +98,7 @@ export type CFN_CATEGORY_TYPE = CFN_AUTH_TYPE | CFN_S3_TYPE;
 export enum CFN_PSEUDO_PARAMETERS_REF {
   StackName = 'AWS::StackName',
 }
+
+export enum CFNStackStatus {
+  UPDATE_COMPLETE = 'UPDATE_COMPLETE',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,6 +1812,7 @@ __metadata:
   resolution: "@aws-amplify/migrate-template-gen@workspace:packages/amplify-migration-template-gen"
   dependencies:
     "@aws-sdk/client-cloudformation": ^3.592.0
+    "@jest/globals": ^29.7.0
     jest: ^29.5.0
     typescript: ^5.4.5
   languageName: unknown


### PR DESCRIPTION
#### Description of changes

Automate the first 2 steps of template gen prior to refactor by executing `updateStack` on behalf of the customers:
1. Resolving refs, conditions and dependencies in Gen1 stack
2. Removing dummy resource in Gen2 stack

Note: Haven't changed the command name (`execute`) yet. Will be part of another PR.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ran the template gen command locally.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
