### PR TITLE
feat: lambda dotnet 8 support

### DIFF
--- a/codebuild_specs/build_windows.yml
+++ b/codebuild_specs/build_windows.yml
@@ -4,7 +4,6 @@ env:
 phases:
   build:
     commands:
-      - choco install -fy nodejs-lts --version=18.20.0
       - cd scripts
       - yarn
       - cd ..

--- a/codebuild_specs/build_windows.yml
+++ b/codebuild_specs/build_windows.yml
@@ -4,7 +4,7 @@ env:
 phases:
   build:
     commands:
-      - choco install -y nodejs.install --version=18.17.0
+      - choco install -fy nodejs-lts --version=18.20.0
       - cd scripts
       - yarn
       - cd ..

--- a/codebuild_specs/build_windows.yml
+++ b/codebuild_specs/build_windows.yml
@@ -4,7 +4,7 @@ env:
 phases:
   build:
     commands:
-      - choco install nodejs.install --version=18.17.0
+      - choco install nodejs.install --version=18.17.0 -y
       - cd scripts
       - yarn
       - cd ..

--- a/codebuild_specs/build_windows.yml
+++ b/codebuild_specs/build_windows.yml
@@ -4,7 +4,7 @@ env:
 phases:
   build:
     commands:
-      - choco install nodejs.install --version=18.17.0 -y
+      - choco install -y nodejs.install --version=18.17.0
       - cd scripts
       - yarn
       - cd ..

--- a/codebuild_specs/build_windows.yml
+++ b/codebuild_specs/build_windows.yml
@@ -4,6 +4,7 @@ env:
 phases:
   build:
     commands:
+      - choco install nodejs.install --version=18.17.0
       - cd scripts
       - yarn
       - cd ..

--- a/codebuild_specs/run_e2e_tests_windows.yml
+++ b/codebuild_specs/run_e2e_tests_windows.yml
@@ -25,7 +25,6 @@ env:
 phases:
   build:
     commands:
-      - choco install -fy jq
       - git config --global core.longpaths true
       - bash ./codebuild_specs/scripts-windows/load-e2e-cache.sh
       - bash ./codebuild_specs/scripts-windows/rename-packaged-cli.sh

--- a/codebuild_specs/scripts-windows/shared-scripts-windows.sh
+++ b/codebuild_specs/scripts-windows/shared-scripts-windows.sh
@@ -117,8 +117,8 @@ function _install_packaged_cli_win {
     echo Move to CLI Binary to already existing PATH
     # This is a Hack to make sure the Amplify CLI is in the PATH
 
-    cp $CODEBUILD_SRC_DIR/out/amplify.exe /AppData/Local/Microsoft/WindowsApps
-    ls /AppData/Local/Microsoft/WindowsApps
+    cp $CODEBUILD_SRC_DIR/out/amplify.exe /root/AppData/Local/Microsoft/WindowsApps
+    ls /root/AppData/Local/Microsoft/WindowsApps
 
     # reset working directory
     cd $CODEBUILD_SRC_DIR

--- a/codebuild_specs/scripts-windows/shared-scripts-windows.sh
+++ b/codebuild_specs/scripts-windows/shared-scripts-windows.sh
@@ -117,8 +117,8 @@ function _install_packaged_cli_win {
     echo Move to CLI Binary to already existing PATH
     # This is a Hack to make sure the Amplify CLI is in the PATH
 
-    cp $CODEBUILD_SRC_DIR/out/amplify.exe $HOME/AppData/Local/Microsoft/WindowsApps
-    ls $HOME/AppData/Local/Microsoft/WindowsApps
+    cp $CODEBUILD_SRC_DIR/out/amplify.exe /AppData/Local/Microsoft/WindowsApps
+    ls /AppData/Local/Microsoft/WindowsApps
 
     # reset working directory
     cd $CODEBUILD_SRC_DIR

--- a/codebuild_specs/scripts-windows/shared-scripts-windows.sh
+++ b/codebuild_specs/scripts-windows/shared-scripts-windows.sh
@@ -117,8 +117,8 @@ function _install_packaged_cli_win {
     echo Move to CLI Binary to already existing PATH
     # This is a Hack to make sure the Amplify CLI is in the PATH
 
-    cp $CODEBUILD_SRC_DIR/out/amplify.exe /root/AppData/Local/Microsoft/WindowsApps
-    ls /root/AppData/Local/Microsoft/WindowsApps
+    cp $CODEBUILD_SRC_DIR/out/amplify.exe C:/Users/ContainerAdministrator/AppData/Local/Microsoft/WindowsApps
+    ls C:/Users/ContainerAdministrator/AppData/Local/Microsoft/WindowsApps
 
     # reset working directory
     cd $CODEBUILD_SRC_DIR

--- a/codebuild_specs/scripts-windows/shared-scripts-windows.sh
+++ b/codebuild_specs/scripts-windows/shared-scripts-windows.sh
@@ -98,9 +98,6 @@ function _loadTestAccountCredentials {
 function _lsOut {
     ls ..
     ls ~
-    ls $HOME
-    ls $HOME/..
-    ls $HOME/../..
 }
 function _build {
     echo Windows Build

--- a/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
@@ -7,12 +7,14 @@
     "pluginId": "amplify-dotnet-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["Lambda"]
+      "services": [
+        "Lambda"
+      ]
     },
     "runtimes": [
       {
-        "name": ".NET 6",
-        "value": "dotnet6"
+        "name": ".NET 8",
+        "value": "dotnet8"
       }
     ]
   }

--- a/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-runtime-provider/amplify-plugin.json
@@ -7,9 +7,7 @@
     "pluginId": "amplify-dotnet-function-runtime-provider",
     "conditions": {
       "provider": "awscloudformation",
-      "services": [
-        "Lambda"
-      ]
+      "services": ["Lambda"]
     },
     "runtimes": [
       {

--- a/packages/amplify-dotnet-function-runtime-provider/src/constants.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/constants.ts
@@ -1,4 +1,6 @@
-export const currentSupportedVersion = '6.0';
-export const dotnet6 = 'dotnet6';
+// see https://aws.amazon.com/blogs/compute/introducing-the-net-8-runtime-for-aws-lambda
+// https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html
+export const currentSupportedVersion = '8.0';
+export const dotnet8 = 'dotnet8';
 export const handlerMethodName = 'LambdaHandler';
 export const executableName = 'dotnet';

--- a/packages/amplify-dotnet-function-runtime-provider/src/index.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/index.ts
@@ -1,5 +1,5 @@
 import { FunctionRuntimeContributorFactory } from '@aws-amplify/amplify-function-plugin-interface';
-import { dotnet6 } from './constants';
+import { dotnet8 } from './constants';
 import { detectDotNet } from './utils/detect';
 import { build } from './utils/build';
 import { packageAssemblies } from './utils/package';
@@ -10,14 +10,14 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
     checkDependencies: detectDotNet,
     contribute: async (contributionRequest) => {
       switch (contributionRequest.selection) {
-        case dotnet6:
+        case dotnet8:
           return {
             runtime: {
-              name: '.NET 6',
-              value: dotnet6,
-              cloudTemplateValue: dotnet6,
+              name: '.NET 8',
+              value: dotnet8,
+              cloudTemplateValue: dotnet8,
               defaultHandler: `${contributionRequest.contributionContext.resourceName}::${contributionRequest.contributionContext.resourceName}.${contributionRequest.contributionContext.functionName}::LambdaHandler`,
-              layerExecutablePath: dotnet6,
+              layerExecutablePath: dotnet8,
             },
           };
         default:

--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/detect.ts
@@ -21,7 +21,7 @@ export const detectDotNet = async (): Promise<CheckDependenciesResult> => {
   if (sdkResult.exitCode !== 0) {
     throw new Error(`${executableName} failed SDK detection, exit code was ${sdkResult.exitCode}`);
   }
-  const requiredSdkRegex = /^6\.0/m;
+  const requiredSdkRegex = /^8\.0/m;
   const sdkInstalled = installedSdks && installedSdks.match(requiredSdkRegex);
 
   const toolResult = execa.sync(executableName, ['tool', 'list', '--global']);
@@ -37,13 +37,13 @@ export const detectDotNet = async (): Promise<CheckDependenciesResult> => {
     if (installedToolList.match(/^amazon\.lambda\.tools/m)) {
       toolInstalled = true;
     }
-    const requiredTestToolVersionRegex = /^amazon\.lambda\.testtool-6\.0/m;
+    const requiredTestToolVersionRegex = /^amazon\.lambda\.testtool-8\.0/m;
     if (installedToolList.match(requiredTestToolVersionRegex)) {
       testToolInstalled = true;
     }
   }
 
-  // Verify that a dotnet 6 SDK and the dotnet Lambda tools is installed locally
+  // Verify that a dotnet 8 SDK and the dotnet Lambda tools is installed locally
   if (sdkInstalled && toolInstalled && testToolInstalled) {
     return {
       hasRequiredDependencies: true,
@@ -54,7 +54,7 @@ export const detectDotNet = async (): Promise<CheckDependenciesResult> => {
       errorMessage: 'Unable to detect required dependencies:\n',
     };
     if (!sdkInstalled) {
-      result.errorMessage += '- The .NET 6 SDK must be installed. It can be installed from https://dotnet.microsoft.com/download\n';
+      result.errorMessage += '- The .NET 8 SDK must be installed. It can be installed from https://dotnet.microsoft.com/download\n';
     }
     if (!toolInstalled) {
       result.errorMessage +=
@@ -62,7 +62,7 @@ export const detectDotNet = async (): Promise<CheckDependenciesResult> => {
     }
     if (!testToolInstalled) {
       result.errorMessage +=
-        '- The Amazon.Lambda.TestTool-6.0 global tool must be installed. Please install by running "dotnet tool install -g Amazon.Lambda.TestTool-6.0".\n';
+        '- The Amazon.Lambda.TestTool-8.0 global tool must be installed. Please install by running "dotnet tool install -g Amazon.Lambda.TestTool-8.0".\n';
     }
     return result;
   }

--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/invoke.ts
@@ -14,7 +14,7 @@ export const invoke = async (request: InvocationRequest): Promise<string> => {
     tempDir = fs.mkdtempSync(path.join(request.srcRoot, 'amplify'));
     eventFile = path.join(tempDir, 'event.json');
     fs.writeFileSync(eventFile, request.event);
-    const lambdaTestTool = 'lambda-test-tool-6.0';
+    const lambdaTestTool = 'lambda-test-tool-8.0';
     const execPromise = execa(
       executableName,
       [lambdaTestTool, '--no-ui', '--function-handler', request.handler, '--payload', eventFile, '--pause-exit', 'false'],

--- a/packages/amplify-dotnet-function-runtime-provider/src/utils/package.ts
+++ b/packages/amplify-dotnet-function-runtime-provider/src/utils/package.ts
@@ -14,7 +14,7 @@ export const packageAssemblies = async (request: PackageRequest, context: any): 
   }
 
   const packageHash = (await context.amplify.hashDir(distPath, [])) as string;
-  const framework = 'net6.0';
+  const framework = 'net8.0';
   try {
     const result = execa.sync(
       executableName,

--- a/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
@@ -6,12 +6,8 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": [
-        "Lambda"
-      ],
-      "runtime": [
-        "dotnet8"
-      ]
+      "services": ["Lambda"],
+      "runtime": ["dotnet8"]
     },
     "templates": [
       {

--- a/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
+++ b/packages/amplify-dotnet-function-template-provider/amplify-plugin.json
@@ -6,8 +6,12 @@
   "functionTemplate": {
     "conditions": {
       "provider": "awscloudformation",
-      "services": ["Lambda"],
-      "runtime": ["dotnet6"]
+      "services": [
+        "Lambda"
+      ],
+      "runtime": [
+        "dotnet8"
+      ]
     },
     "templates": [
       {

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Crud/Function.csproj.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Crud/Function.csproj.ejs
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Crud/aws-lambda-tools-defaults.json.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Crud/aws-lambda-tools-defaults.json.ejs
@@ -11,9 +11,9 @@
   "profile":"",
   "region" : "",
   "configuration" : "Release",
-  "framework" : "net6.0",
+  "framework" : "net8.0",
   "function-runtime":"props.runtime.value",
-  "function-memory-size" : 256,
+  "function-memory-size" : 512,
   "function-timeout" : 30,
   "function-handler" : "<%= props.resourceName %>::<%= props.resourceName %>.<%= props.functionName %>::LambdaHandler"
 }

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/HelloWorld/Function.csproj.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/HelloWorld/Function.csproj.ejs
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/HelloWorld/aws-lambda-tools-defaults.json.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/HelloWorld/aws-lambda-tools-defaults.json.ejs
@@ -11,9 +11,9 @@
   "profile":"",
   "region" : "",
   "configuration" : "Release",
-  "framework" : "net6.0",
+  "framework" : "net8.0",
   "function-runtime":"props.runtime.value",
-  "function-memory-size" : 256,
+  "function-memory-size" : 512,
   "function-timeout" : 30,
   "function-handler" : "<%= props.resourceName %>::<%= props.resourceName %>.<%= props.functionName %>::LambdaHandler"
 }

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/Function.csproj.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/Function.csproj.ejs
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/aws-lambda-tools-defaults.json.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Serverless/aws-lambda-tools-defaults.json.ejs
@@ -11,9 +11,9 @@
   "profile":"",
   "region" : "",
   "configuration" : "Release",
-  "framework" : "net6.0",
+  "framework" : "net8.0",
   "function-runtime":"props.runtime.value",
-  "function-memory-size" : 256,
+  "function-memory-size" : 512,
   "function-timeout" : 30,
   "function-handler" : "<%= props.resourceName %>::<%= props.resourceName %>.<%= props.functionName %>::LambdaHandler"
 }

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Trigger/Function.csproj.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Trigger/Function.csproj.ejs
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/Trigger/aws-lambda-tools-defaults.json.ejs
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/Trigger/aws-lambda-tools-defaults.json.ejs
@@ -11,9 +11,9 @@
   "profile":"",
   "region" : "",
   "configuration" : "Release",
-  "framework" : "net6.0",
+  "framework" : "net8.0",
   "function-runtime":"props.runtime.value",
-  "function-memory-size" : 256,
+  "function-memory-size" : 512,
   "function-timeout" : 30,
   "function-handler" : "<%= props.resourceName %>::<%= props.resourceName %>.<%= props.functionName %>::LambdaHandler"
 }

--- a/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
+++ b/packages/amplify-dotnet-function-template-provider/resources/lambda/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.404",
     "rollForward": "latestFeature"
   }
 }

--- a/packages/amplify-e2e-core/src/categories/lambda-function.ts
+++ b/packages/amplify-e2e-core/src/categories/lambda-function.ts
@@ -7,12 +7,12 @@ import _ from 'lodash';
 import { loadFeatureFlags } from '../utils/feature-flags';
 type FunctionActions = 'create' | 'update';
 
-type FunctionRuntimes = 'dotnet6' | 'go' | 'java' | 'nodejs' | 'python';
+type FunctionRuntimes = 'dotnet8' | 'go' | 'java' | 'nodejs' | 'python';
 
 type FunctionCallback = (chain: any, cwd: string, settings: any) => any;
 
 // runtimeChoices are shared between tests
-export const runtimeChoices = ['.NET 6', 'Go', 'Java', 'NodeJS', 'Python'];
+export const runtimeChoices = ['.NET 8', 'Go', 'Java', 'NodeJS', 'Python'];
 
 // templateChoices is per runtime
 const dotNetTemplateChoices = [
@@ -655,7 +655,7 @@ export const functionCloudInvoke = async (
 
 const getTemplateChoices = (runtime: FunctionRuntimes) => {
   switch (runtime) {
-    case 'dotnet6':
+    case 'dotnet8':
       return dotNetTemplateChoices;
     case 'go':
       return goTemplateChoices;
@@ -672,8 +672,8 @@ const getTemplateChoices = (runtime: FunctionRuntimes) => {
 
 const getRuntimeDisplayName = (runtime: FunctionRuntimes) => {
   switch (runtime) {
-    case 'dotnet6':
-      return '.NET 6';
+    case 'dotnet8':
+      return '.NET 8';
     case 'go':
       return 'Go';
     case 'java':

--- a/packages/amplify-e2e-tests/src/__tests__/function_3a_dotnet.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3a_dotnet.test.ts
@@ -32,7 +32,7 @@ describe('dotnet function tests', () => {
         name: funcName,
         functionTemplate: 'Hello World',
       },
-      'dotnet6',
+      'dotnet8',
     );
   });
 

--- a/packages/amplify-e2e-tests/src/__tests__/function_3b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3b.test.ts
@@ -43,7 +43,7 @@ describe('dotnet function tests', () => {
   const assertDotNetVersion = (): void => {
     const functionPath = pathManager.getResourceDirectoryPath(projRoot, AmplifyCategories.FUNCTION, funcName);
     const { functionRuntime } = JSONUtilities.readJson<any>(path.join(functionPath, 'amplify.state'));
-    expect(functionRuntime).toEqual('dotnet6');
+    expect(functionRuntime).toEqual('dotnet8');
     const functionProjFilePath = path.join(functionPath, 'src', `${funcName}.csproj`);
     const functionProjFileContent = fs.readFileSync(functionProjFilePath, 'utf8');
     expect(functionProjFileContent).toContain('<TargetFramework>net6.0</TargetFramework>');
@@ -56,7 +56,7 @@ describe('dotnet function tests', () => {
         name: funcName,
         functionTemplate: 'Hello World',
       },
-      'dotnet6',
+      'dotnet8',
     );
     await functionMockAssert(projRoot, {
       funcName,
@@ -74,7 +74,7 @@ describe('dotnet function tests', () => {
         name: funcName,
         functionTemplate: 'Hello World',
       },
-      'dotnet6',
+      'dotnet8',
     );
     const payload = '{"key1":"value1","key2":"value2","key3":"value3"}';
     await amplifyPushAuth(projRoot);
@@ -91,7 +91,7 @@ describe('dotnet function tests', () => {
         name: funcName,
         functionTemplate: 'Serverless',
       },
-      'dotnet6',
+      'dotnet8',
     );
     await functionMockAssert(projRoot, {
       funcName,
@@ -109,7 +109,7 @@ describe('dotnet function tests', () => {
         name: funcName,
         functionTemplate: 'CRUD function for DynamoDB (Integration with API Gateway)',
       },
-      'dotnet6',
+      'dotnet8',
       createNewDynamoDBForCrudTemplate,
     );
     const payload = JSON.stringify({
@@ -135,7 +135,7 @@ describe('dotnet function tests', () => {
         triggerType: 'DynamoDB',
         eventSource: 'DynamoDB',
       },
-      'dotnet6',
+      'dotnet8',
       addLambdaTrigger, // Adds DDB trigger by default
     );
     await functionMockAssert(projRoot, {
@@ -156,7 +156,7 @@ describe('dotnet function tests', () => {
         functionTemplate: 'Trigger (DynamoDb, Kinesis)',
         triggerType: 'Kinesis',
       },
-      'dotnet6',
+      'dotnet8',
       addLambdaTrigger, // Adds DDB trigger by default
     );
     await functionMockAssert(projRoot, {

--- a/packages/amplify-e2e-tests/src/__tests__/function_3b.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/function_3b.test.ts
@@ -46,7 +46,7 @@ describe('dotnet function tests', () => {
     expect(functionRuntime).toEqual('dotnet8');
     const functionProjFilePath = path.join(functionPath, 'src', `${funcName}.csproj`);
     const functionProjFileContent = fs.readFileSync(functionProjFilePath, 'utf8');
-    expect(functionProjFileContent).toContain('<TargetFramework>net6.0</TargetFramework>');
+    expect(functionProjFileContent).toContain('<TargetFramework>net8.0</TargetFramework>');
   };
 
   it('add dotnet hello world function and mock locally', async () => {

--- a/packages/amplify-e2e-tests/src/__tests__/import_s3_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/import_s3_3.test.ts
@@ -19,8 +19,6 @@ import {
   getS3ResourceName,
 } from '../import-helpers';
 
-const profileName = 'amplify-integ-test-user';
-
 describe('headless s3 import', () => {
   const projectPrefix = 'sssheadimp';
   const bucketPrefix = 'sss-headless-import-test';
@@ -37,9 +35,6 @@ describe('headless s3 import', () => {
   beforeAll(async () => {
     const shortId = getShortId();
     bucketNameToImport = `${bucketPrefix}${shortId}`;
-
-    const credentials = new aws.SharedIniFileCredentials({ profile: profileName });
-    aws.config.credentials = credentials;
 
     const s3 = new aws.S3();
 

--- a/packages/amplify-migration-tests/src/migration-helpers/lambda-function.ts
+++ b/packages/amplify-migration-tests/src/migration-helpers/lambda-function.ts
@@ -13,7 +13,7 @@ import {
 import _ from 'lodash';
 
 type FunctionActions = 'create' | 'update';
-type FunctionRuntimes = 'dotnet6' | 'go' | 'java' | 'nodejs' | 'python';
+type FunctionRuntimes = 'dotnet8' | 'go' | 'java' | 'nodejs' | 'python';
 type FunctionCallback = (chain: $TSAny, cwd: string, settings: $TSAny) => $TSAny;
 
 // runtimeChoices are shared between tests
@@ -507,7 +507,7 @@ const addCron = (chain: ExecutionContext, settings: $TSAny) => {
 
 const getTemplateChoices = (runtime: FunctionRuntimes) => {
   switch (runtime) {
-    case 'dotnet6':
+    case 'dotnet8':
       return dotNetTemplateChoices;
     case 'go':
       return goTemplateChoices;
@@ -524,8 +524,8 @@ const getTemplateChoices = (runtime: FunctionRuntimes) => {
 
 const getRuntimeDisplayName = (runtime: FunctionRuntimes) => {
   switch (runtime) {
-    case 'dotnet6':
-      return '.NET 6';
+    case 'dotnet8':
+      return '.NET 8';
     case 'go':
       return 'Go';
     case 'java':


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Re: https://aws.amazon.com/blogs/compute/introducing-the-net-8-runtime-for-aws-lambda/
Migrate Lambda functions to .Net 8

Related: https://github.com/aws-amplify/amplify-cli/pull/14023
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
