### PR TITLE
feat(migrate-template-gen): use nested file protocol operator using @

### DIFF
--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
@@ -63,54 +63,33 @@ describe('MigrationReadMeGenerator', () => {
       `### STEP 1: CREATE AND EXECUTE CLOUDFORMATION STACK REFACTOR FOR auth CATEGORY
 This step will move the Gen1 auth resources to Gen2 stack.
 
-1.a) Upload the source and destination templates to S3
+1.a) Create stack refactor
 \`\`\`
-export BUCKET_NAME=<<YOUR_BUCKET_NAME>>
-\`\`\`
-
-\`\`\`
-aws s3 cp test/step3-sourceTemplate.json s3://$BUCKET_NAME
-\`\`\`
-
-\`\`\`
-aws s3 cp test/step3-destinationTemplate.json s3://$BUCKET_NAME
-\`\`\`
-
-1.b) Create stack refactor
-\`\`\`
-aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-testauth-dev-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-sourceTemplate.json  StackName=amplify-mygen2app-test-sandbox-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-destinationTemplate.json  --resource-mappings  '[{\"Source\":{\"StackName\":\"amplify-testauth-dev-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen1FooUserPool\"},\"Destination\":{\"StackName\":\"amplify-mygen2app-test-sandbox-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen2FooUserPool\"}}]'
+aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-testauth-dev-12345-auth-ABCDE,TemplateBody@=file://test/step3-sourceTemplate.json  StackName=amplify-mygen2app-test-sandbox-12345-auth-ABCDE,TemplateBody@=file://test/step3-destinationTemplate.json  --resource-mappings  '[{\"Source\":{\"StackName\":\"amplify-testauth-dev-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen1FooUserPool\"},\"Destination\":{\"StackName\":\"amplify-mygen2app-test-sandbox-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen2FooUserPool\"}}]'
 \`\`\`
  
 \`\`\`
 export STACK_REFACTOR_ID=<<REFACTOR-ID-FROM-CREATE-STACK-REFACTOR_CALL>>
 \`\`\`
   
-1.c) Describe stack refactor to check for creation status
+1.b) Describe stack refactor to check for creation status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-1.d) Execute stack refactor
+1.c) Execute stack refactor
 \`\`\`
  aws cloudformation execute-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
  
-1.e) Describe stack refactor to check for execution status
+1.d) Describe stack refactor to check for execution status
 \`\`\`
  aws cloudformation describe-stack-refactor --stack-refactor-id $STACK_REFACTOR_ID
 \`\`\`
 
 #### Rollback step for refactor:
 \`\`\`
-aws s3 cp test/step3-sourceTemplate-rollback.json s3://$BUCKET_NAME
-\`\`\`
-
-\`\`\`
-aws s3 cp test/step3-destinationTemplate-rollback.json s3://$BUCKET_NAME
-\`\`\`
-
-\`\`\`
- aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-testauth-dev-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-sourceTemplate-rollback.json  StackName=amplify-mygen2app-test-sandbox-12345-auth-ABCDE,TemplateURL=s3://$BUCKET_NAME/step3-destinationTemplate-rollback.json  --resource-mappings  '[{\"Source\":{\"StackName\":\"amplify-mygen2app-test-sandbox-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen2FooUserPool\"},\"Destination\":{\"StackName\":\"amplify-testauth-dev-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen1FooUserPool\"}}]'
+ aws cloudformation create-stack-refactor  --stack-definitions StackName=amplify-testauth-dev-12345-auth-ABCDE,TemplateBody@=file://test/step3-sourceTemplate-rollback.json  StackName=amplify-mygen2app-test-sandbox-12345-auth-ABCDE,TemplateBody@=file://test/step3-destinationTemplate-rollback.json  --resource-mappings  '[{\"Source\":{\"StackName\":\"amplify-mygen2app-test-sandbox-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen2FooUserPool\"},\"Destination\":{\"StackName\":\"amplify-testauth-dev-12345-auth-ABCDE\",\"LogicalResourceId\":\"Gen1FooUserPool\"}}]'
 \`\`\`
 
 \`\`\`


### PR DESCRIPTION
#### Description of changes

Use AWS CLI new `@=`  operator to support nested file protocols needed for stack refactor operations. This will remove the need for uploading the templates to S3 bucket.

AWS CLI >= 2.20 (https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst)

> * feature:shorthand: Adds support to shorthand syntax for loading parameters from files via the ``@=`` assignment operator.

#### Description of how you validated changes
Local testing using `generate-templates` command and running stack refactor operations from `README` file.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
