### PR TITLE
New Linux Image version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 node_modules
+scripts/*
+packages/*
+.yarn/*
+.bin/*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,21 @@
 FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS core
-
+# If you need to update or test a new LINUX image, make sure to increment the DEFAULT_TAG in the build_image.yml file.
+# You will be able to generate new images to test with, without affecting the production images, by following the instructions below.
+#
+# 1. Make a branch in the main repository (aws-amplify/amplify-cli/branch/codebuild-image/<your-new-image-branch>),
+# which you will use as the 'source' for triggering the ECR Image Build codebuild project in the Codebuild Testing account.
+#
+# 2. When the image is built/available, you can test with that image by modifying the cloud-e2e script locally
+# IE - modify this section: $(aws codebuild start-build-batch --profile="${profile_name}" --project-name $project_name --source-version=$target_branch --image-override <the new linux image URI> ...
+# Then, run the yarn cloud-e2e command while you have that script modified.
+#
+# 3. If everything is good to go, you'll be able to submit a PR from your branch to the codebuild-image/latest branch, and
+# finalize the DEFAULT_TAG value for that version before you merge your PR.
+# 4. Once merged, make sure to kick off the ECR image build (in both codebuild testing, and deployment accounts) for the 'codebuild-image/latest' branch.
+# 5. Verify that the images with DEFAULT_TAG tag exist in both accounts afterwards.
+# 6. Update the codebuild pipelines to reference the new DEFAULT_TAG value.
+# ie, const buildImage = codebuild.LinuxBuildImage.fromEcrRepository(ecrRepository, '<value of new DEFAULT_TAG>');
+# Make sure do this in both codebuild testing stack and codebuild deployment stacks.
 ARG DEBIAN_FRONTEND="noninteractive"
 
 # Install git, SSH, and other utilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,11 +147,11 @@ FROM tools AS runtimes
 
 #****************     .NET-CORE     *******************************************************
 
-ENV DOTNET_6_SDK_VERSION="6.0.405"
+ENV DOTNET_8_SDK_VERSION="8.0.11"
 ENV DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 6 Global Tools install folder to PATH
-RUN  /usr/local/bin/dotnet-install.sh -v $DOTNET_6_SDK_VERSION \
+RUN  /usr/local/bin/dotnet-install.sh -v $DOTNET_8_SDK_VERSION \
      && dotnet --list-sdks \
      && rm -rf /tmp/*
 
@@ -165,8 +165,10 @@ RUN set -ex \
     && rm -rf warmup \
     && rm -rf /tmp/NuGetScratch
 
-RUN dotnet tool install -g amazon.lambda.tools && \
-    dotnet tool install -g amazon.lambda.testtool-6.0
+# https://www.nuget.org/packages/Amazon.Lambda.Tools
+# https://www.nuget.org/packages/Amazon.Lambda.TestTool-8.0
+RUN dotnet tool install -g Amazon.Lambda.Tools --version 5.12.0 && \
+    dotnet tool install -g Amazon.Lambda.TestTool-8.0 --version 0.16.0
 
 # Install Powershell Core
 # See instructions at https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-powershell-core-on-linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ FROM tools AS runtimes
 
 #****************     .NET-CORE     *******************************************************
 
-ENV DOTNET_8_SDK_VERSION="8.0.11"
+ENV DOTNET_8_SDK_VERSION="8.0.404"
 ENV DOTNET_ROOT="/root/.dotnet"
 
 # Add .NET Core 6 Global Tools install folder to PATH

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -6,8 +6,9 @@ phases:
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
   build:
     commands:
-      - export BRANCH_TAG=${CODEBUILD_WEBHOOK_TRIGGER#branch/codebuild-image/*}
-      - export IMAGE_TAG=${CUSTOM_TAG:=$BRANCH_TAG}
+      # increment DEFAULT_TAG version to a unique consecutive version whenever you make changes to the dockerfile or image settings
+      - export DEFAULT_TAG=1.0.3
+      - export IMAGE_TAG=${CUSTOM_TAG:=$DEFAULT_TAG}
       - echo $IMAGE_TAG
       - echo $PKG_BINARY_CACHE_BUCKET_NAME
       - mkdir pkg-cache


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adds a new linux image version for dotnet8.

Also -IMPORTANT: updates logic so that we don't always publish to 'latest' tag.
This will allow us to pin our builds to specific versions, without replacing the 'latest' image when the ECR pipeline runs.



<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
