### PR TITLE
Gen2 migration- Retrieve oauth values for Gen1 stack update

### DIFF
--- a/packages/amplify-migration-template-gen/API.md
+++ b/packages/amplify-migration-template-gen/API.md
@@ -5,10 +5,12 @@
 ```ts
 
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+import { SSMClient } from '@aws-sdk/client-ssm';
 
 // @public (undocumented)
 export class TemplateGenerator {
-    constructor(fromStack: string, toStack: string, accountId: string, cfnClient: CloudFormationClient);
+    constructor(fromStack: string, toStack: string, accountId: string, cfnClient: CloudFormationClient, ssmClient: SSMClient, cognitoIdpClient: CognitoIdentityProviderClient, appId: string, environmentName: string);
     // (undocumented)
     generate(): Promise<void>;
 }

--- a/packages/amplify-migration-template-gen/package.json
+++ b/packages/amplify-migration-template-gen/package.json
@@ -9,7 +9,9 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudformation": "^3.592.0"
+    "@aws-sdk/client-cloudformation": "^3.592.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.592.0",
+    "@aws-sdk/client-ssm": "^3.592.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -15,9 +15,11 @@ import {
   DescribeIdentityProviderResponse,
 } from '@aws-sdk/client-cognito-identity-provider';
 
-const mockCfnClientSendMock = jest.fn();
-const mockSsmClientSendMock = jest.fn();
-const mockCognitoClientSendMock = jest.fn();
+// We use 'stub' to indicate fake implementation. If we are asserting a fake, it becomes a 'mock'.
+// Ref: https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices#lets-speak-the-same-language
+const stubCfnClientSend = jest.fn();
+const stubSsmClientSend = jest.fn();
+const stubCognitoClientSend = jest.fn();
 
 const GEN1_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-testauth-dev-12345-auth-ABCDE/12345';
 const GEN2_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
@@ -437,7 +439,7 @@ jest.mock('@aws-sdk/client-cloudformation', () => {
     ...jest.requireActual('@aws-sdk/client-cloudformation'),
     CloudFormationClient: function () {
       return {
-        send: mockCfnClientSendMock.mockImplementation((command) => {
+        send: stubCfnClientSend.mockImplementation((command) => {
           if (command instanceof DescribeStacksCommand) {
             return Promise.resolve(generateDescribeStacksResponse(command));
           } else if (command instanceof GetTemplateCommand) {
@@ -455,7 +457,7 @@ jest.mock('@aws-sdk/client-cognito-identity-provider', () => {
     ...jest.requireActual('@aws-sdk/client-cognito-identity-provider'),
     CognitoIdentityProviderClient: function () {
       return {
-        send: mockCognitoClientSendMock.mockImplementation((command) => {
+        send: stubCognitoClientSend.mockImplementation((command) => {
           if (command instanceof DescribeIdentityProviderCommand) {
             return Promise.resolve(generateDescribeIdentityProviderResponse(command));
           }
@@ -471,7 +473,7 @@ jest.mock('@aws-sdk/client-ssm', () => {
     ...jest.requireActual('@aws-sdk/client-ssm'),
     SSMClient: function () {
       return {
-        send: mockSsmClientSendMock.mockImplementation((command) => {
+        send: stubSsmClientSend.mockImplementation((command) => {
           if (command instanceof GetParameterCommand) {
             return Promise.resolve(generateGetParameterResponse(command));
           }
@@ -579,7 +581,7 @@ describe('CategoryTemplateGenerator', () => {
       }
       return Promise.resolve({});
     };
-    mockCfnClientSendMock.mockImplementationOnce(sendFailureMock).mockImplementationOnce(sendFailureMock);
+    stubCfnClientSend.mockImplementationOnce(sendFailureMock).mockImplementationOnce(sendFailureMock);
     await expect(noGen1ResourcesToMoveS3TemplateGenerator.generateGen1PreProcessTemplate()).rejects.toThrowError(
       'No resources to move in Gen1 stack.',
     );
@@ -599,7 +601,7 @@ describe('CategoryTemplateGenerator', () => {
       }
       return Promise.resolve({});
     };
-    mockCfnClientSendMock
+    stubCfnClientSend
       .mockImplementationOnce(sendFailureMock)
       .mockImplementationOnce(sendFailureMock)
       .mockImplementationOnce(sendFailureMock)

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -78,11 +78,6 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
       const oAuthProviderCredentialsParam = Parameters.find((param) => param.ParameterKey === HOSTED_PROVIDER_CREDENTIALS_PARAMETER_NAME);
       assert(oAuthProviderCredentialsParam);
       oAuthProviderCredentialsParam.ParameterValue = JSON.stringify(oAuthValues);
-      return {
-        oldTemplate: oldGen1Template,
-        newTemplate: gen1TemplateWithConditionsResolved,
-        parameters: Parameters,
-      };
     }
     return {
       oldTemplate: oldGen1Template,

--- a/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
+++ b/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
@@ -7,6 +7,7 @@ const APP_ID = 'appId';
 const ENV_NAME = 'envName';
 const USER_POOL_ID = 'userPoolId';
 
+// This test suite covers negative cases. Happy path cases are covered in its consumer (category-template-generator.test.ts)
 describe('OAuthValuesRetriever', () => {
   it('should fail if the oauth param is not an array', async () => {
     oauthValuesRetriever({

--- a/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
+++ b/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
@@ -1,0 +1,41 @@
+import oauthValuesRetriever from './oauth-values-retriever';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+
+const INVALID_OAUTH_METADATA_PARAM = 'Invalid Gen1 OAuth provider metadata';
+const APP_ID = 'appId';
+const ENV_NAME = 'envName';
+const USER_POOL_ID = 'userPoolId';
+
+describe('OAuthValuesRetriever', () => {
+  it('should fail if the oauth param is not an array', async () => {
+    oauthValuesRetriever({
+      appId: APP_ID,
+      environmentName: ENV_NAME,
+      userPoolId: USER_POOL_ID,
+      oAuthParameter: {
+        ParameterKey: 'hostedUIProviderMeta',
+        ParameterValue: JSON.stringify({}),
+      },
+      ssmClient: new SSMClient(),
+      cognitoIdpClient: new CognitoIdentityProviderClient(),
+    }).catch((error) => {
+      expect(error.message).toEqual(INVALID_OAUTH_METADATA_PARAM);
+    });
+  });
+  it('should fail if the oauth param does not have provider info', async () => {
+    oauthValuesRetriever({
+      appId: APP_ID,
+      environmentName: ENV_NAME,
+      userPoolId: USER_POOL_ID,
+      oAuthParameter: {
+        ParameterKey: 'hostedUIProviderMeta',
+        ParameterValue: JSON.stringify([{}]),
+      },
+      ssmClient: new SSMClient(),
+      cognitoIdpClient: new CognitoIdentityProviderClient(),
+    }).catch((error) => {
+      expect(error.message).toEqual(INVALID_OAUTH_METADATA_PARAM);
+    });
+  });
+});

--- a/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
+++ b/packages/amplify-migration-template-gen/src/oauth-values-retriever.test.ts
@@ -10,33 +10,33 @@ const USER_POOL_ID = 'userPoolId';
 // This test suite covers negative cases. Happy path cases are covered in its consumer (category-template-generator.test.ts)
 describe('OAuthValuesRetriever', () => {
   it('should fail if the oauth param is not an array', async () => {
-    oauthValuesRetriever({
-      appId: APP_ID,
-      environmentName: ENV_NAME,
-      userPoolId: USER_POOL_ID,
-      oAuthParameter: {
-        ParameterKey: 'hostedUIProviderMeta',
-        ParameterValue: JSON.stringify({}),
-      },
-      ssmClient: new SSMClient(),
-      cognitoIdpClient: new CognitoIdentityProviderClient(),
-    }).catch((error) => {
-      expect(error.message).toEqual(INVALID_OAUTH_METADATA_PARAM);
-    });
+    await expect(
+      oauthValuesRetriever({
+        appId: APP_ID,
+        environmentName: ENV_NAME,
+        userPoolId: USER_POOL_ID,
+        oAuthParameter: {
+          ParameterKey: 'hostedUIProviderMeta',
+          ParameterValue: JSON.stringify({}),
+        },
+        ssmClient: new SSMClient(),
+        cognitoIdpClient: new CognitoIdentityProviderClient(),
+      }),
+    ).rejects.toThrowError(INVALID_OAUTH_METADATA_PARAM);
   });
   it('should fail if the oauth param does not have provider info', async () => {
-    oauthValuesRetriever({
-      appId: APP_ID,
-      environmentName: ENV_NAME,
-      userPoolId: USER_POOL_ID,
-      oAuthParameter: {
-        ParameterKey: 'hostedUIProviderMeta',
-        ParameterValue: JSON.stringify([{}]),
-      },
-      ssmClient: new SSMClient(),
-      cognitoIdpClient: new CognitoIdentityProviderClient(),
-    }).catch((error) => {
-      expect(error.message).toEqual(INVALID_OAUTH_METADATA_PARAM);
-    });
+    await expect(
+      oauthValuesRetriever({
+        appId: APP_ID,
+        environmentName: ENV_NAME,
+        userPoolId: USER_POOL_ID,
+        oAuthParameter: {
+          ParameterKey: 'hostedUIProviderMeta',
+          ParameterValue: JSON.stringify([{}]),
+        },
+        ssmClient: new SSMClient(),
+        cognitoIdpClient: new CognitoIdentityProviderClient(),
+      }),
+    ).rejects.toThrowError(INVALID_OAUTH_METADATA_PARAM);
   });
 });

--- a/packages/amplify-migration-template-gen/src/oauth-values-retriever.ts
+++ b/packages/amplify-migration-template-gen/src/oauth-values-retriever.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert';
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { CognitoIdentityProviderClient, DescribeIdentityProviderCommand } from '@aws-sdk/client-cognito-identity-provider';
+import { Parameter } from '@aws-sdk/client-cloudformation';
+import { HostedUIProviderMeta, OAuthClient } from './types';
+
+const INVALID_OAUTH_GEN1_PROVIDER_METADATA_ERROR = 'Invalid Gen1 OAuth provider metadata';
+
+const isHostedProviderMetadata = (parsedValue: unknown): parsedValue is HostedUIProviderMeta => {
+  return typeof parsedValue === 'object' && parsedValue !== null && 'ProviderName' in parsedValue;
+};
+
+export const constructSignInWithApplePrivateKeyParamName = (appId: string, environment: string): string => {
+  return `/amplify/${appId}/${environment}/AMPLIFY_SIWA_PRIVATE_KEY`;
+};
+
+type RetrieveOAuthValuesParameters = {
+  ssmClient: SSMClient;
+  cognitoIdpClient: CognitoIdentityProviderClient;
+  oAuthParameter: Parameter;
+  userPoolId: string;
+  appId: string;
+  environmentName: string;
+};
+/**
+ * Retrieves OAuth values from Cognito and SSM
+ * @param ssmClient
+ * @param cognitoIdpClient
+ * @param oAuthParameter
+ * @param userPoolId
+ * @param appId
+ * @param environmentName
+ * @returns RetrieveOAuthValuesParameters
+ */
+const retrieveOAuthValues = async ({
+  ssmClient,
+  cognitoIdpClient,
+  oAuthParameter,
+  userPoolId,
+  appId,
+  environmentName,
+}: RetrieveOAuthValuesParameters) => {
+  const value = oAuthParameter.ParameterValue;
+  assert(value);
+  const parsedValue = JSON.parse(value);
+  if (!Array.isArray(parsedValue) || parsedValue.length === 0) {
+    throw new Error(INVALID_OAUTH_GEN1_PROVIDER_METADATA_ERROR);
+  }
+
+  const oAuthClientValues: OAuthClient[] = [];
+  for (const provider of parsedValue) {
+    if (!isHostedProviderMetadata(provider)) {
+      throw new Error(INVALID_OAUTH_GEN1_PROVIDER_METADATA_ERROR);
+    }
+
+    const { ProviderName } = provider;
+    const { IdentityProvider } = await cognitoIdpClient.send(
+      new DescribeIdentityProviderCommand({
+        UserPoolId: userPoolId,
+        ProviderName,
+      }),
+    );
+    const providerDetails = IdentityProvider?.ProviderDetails;
+    assert(providerDetails);
+    const { client_id, client_secret, team_id, key_id } = providerDetails;
+    if (ProviderName === 'SignInWithApple') {
+      // Retrieve private key
+      const { Parameter: PrivateKeyParameter } = await ssmClient.send(
+        new GetParameterCommand({
+          Name: constructSignInWithApplePrivateKeyParamName(appId, environmentName),
+          WithDecryption: true,
+        }),
+      );
+      assert(PrivateKeyParameter);
+      const privateKey = PrivateKeyParameter.Value;
+      assert(privateKey);
+      oAuthClientValues.push({
+        ProviderName,
+        client_id,
+        client_secret,
+        team_id,
+        key_id,
+        private_key: privateKey,
+      });
+    } else {
+      oAuthClientValues.push({
+        ProviderName,
+        client_id,
+        client_secret,
+        team_id,
+        key_id,
+      });
+    }
+  }
+  return oAuthClientValues;
+};
+
+export default retrieveOAuthValues;

--- a/packages/amplify-migration-template-gen/src/oauth-values-retriever.ts
+++ b/packages/amplify-migration-template-gen/src/oauth-values-retriever.ts
@@ -63,7 +63,10 @@ const retrieveOAuthValues = async ({
     const providerDetails = IdentityProvider?.ProviderDetails;
     assert(providerDetails);
     const { client_id, client_secret, team_id, key_id } = providerDetails;
+    assert(client_id);
     if (ProviderName === 'SignInWithApple') {
+      assert(team_id);
+      assert(key_id);
       // Retrieve private key
       const { Parameter: PrivateKeyParameter } = await ssmClient.send(
         new GetParameterCommand({
@@ -77,18 +80,16 @@ const retrieveOAuthValues = async ({
       oAuthClientValues.push({
         ProviderName,
         client_id,
-        client_secret,
         team_id,
         key_id,
         private_key: privateKey,
       });
     } else {
+      assert(client_secret);
       oAuthClientValues.push({
         ProviderName,
         client_id,
         client_secret,
-        team_id,
-        key_id,
       });
     }
   }

--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -28,10 +28,10 @@ const GEN2_ROOT_STACK_NAME = 'amplify-gen2-test-sandbox-12345';
 const ACCOUNT_ID = 'TEST_ACCOUNT_ID';
 const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
 const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
-const MOCK_CFN_CLIENT = new CloudFormationClient();
-const MOCK_SSM_CLIENT = new SSMClient();
-const MOCK_COGNITO_IDP_CLIENT = new CognitoIdentityProviderClient();
-const MOCK_APP_ID = 'd123456';
+const STUB_CFN_CLIENT = new CloudFormationClient();
+const STUB_SSM_CLIENT = new SSMClient();
+const STUB_COGNITO_IDP_CLIENT = new CognitoIdentityProviderClient();
+const APP_ID = 'd123456';
 const ENV_NAME = 'test';
 
 const mockDescribeGen1StackResources: DescribeStackResourcesOutput = {
@@ -190,10 +190,10 @@ describe('TemplateGenerator', () => {
       GEN1_ROOT_STACK_NAME,
       GEN2_ROOT_STACK_NAME,
       ACCOUNT_ID,
-      MOCK_CFN_CLIENT,
-      MOCK_SSM_CLIENT,
-      MOCK_COGNITO_IDP_CLIENT,
-      MOCK_APP_ID,
+      STUB_CFN_CLIENT,
+      STUB_SSM_CLIENT,
+      STUB_COGNITO_IDP_CLIENT,
+      APP_ID,
       ENV_NAME,
     );
     await generator.generate();
@@ -208,10 +208,10 @@ describe('TemplateGenerator', () => {
       GEN1_ROOT_STACK_NAME,
       GEN2_ROOT_STACK_NAME,
       ACCOUNT_ID,
-      MOCK_CFN_CLIENT,
-      MOCK_SSM_CLIENT,
-      MOCK_COGNITO_IDP_CLIENT,
-      MOCK_APP_ID,
+      STUB_CFN_CLIENT,
+      STUB_SSM_CLIENT,
+      STUB_COGNITO_IDP_CLIENT,
+      APP_ID,
       ENV_NAME,
     );
     const failureSendMock = (command: any) => {
@@ -248,10 +248,10 @@ describe('TemplateGenerator', () => {
       GEN1_ROOT_STACK_NAME,
       GEN2_ROOT_STACK_NAME,
       ACCOUNT_ID,
-      MOCK_CFN_CLIENT,
-      MOCK_SSM_CLIENT,
-      MOCK_COGNITO_IDP_CLIENT,
-      MOCK_APP_ID,
+      STUB_CFN_CLIENT,
+      STUB_SSM_CLIENT,
+      STUB_COGNITO_IDP_CLIENT,
+      APP_ID,
       ENV_NAME,
     );
     await expect(generator.generate()).rejects.toThrow(errorMessage);
@@ -281,10 +281,10 @@ describe('TemplateGenerator', () => {
       GEN1_ROOT_STACK_NAME,
       GEN2_ROOT_STACK_NAME,
       ACCOUNT_ID,
-      MOCK_CFN_CLIENT,
-      MOCK_SSM_CLIENT,
-      MOCK_COGNITO_IDP_CLIENT,
-      MOCK_APP_ID,
+      STUB_CFN_CLIENT,
+      STUB_SSM_CLIENT,
+      STUB_COGNITO_IDP_CLIENT,
+      APP_ID,
       ENV_NAME,
     );
     await generator.generate();
@@ -318,10 +318,10 @@ describe('TemplateGenerator', () => {
       GEN1_ROOT_STACK_NAME,
       GEN2_ROOT_STACK_NAME,
       ACCOUNT_ID,
-      MOCK_CFN_CLIENT,
-      MOCK_SSM_CLIENT,
-      MOCK_COGNITO_IDP_CLIENT,
-      MOCK_APP_ID,
+      STUB_CFN_CLIENT,
+      STUB_SSM_CLIENT,
+      STUB_COGNITO_IDP_CLIENT,
+      APP_ID,
       ENV_NAME,
     );
     expect.assertions(1);

--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -7,6 +7,8 @@ import {
   UpdateStackCommand,
 } from '@aws-sdk/client-cloudformation';
 import fs from 'node:fs/promises';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
 
 jest.useFakeTimers();
 
@@ -27,6 +29,10 @@ const ACCOUNT_ID = 'TEST_ACCOUNT_ID';
 const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
 const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
 const MOCK_CFN_CLIENT = new CloudFormationClient();
+const MOCK_SSM_CLIENT = new SSMClient();
+const MOCK_COGNITO_IDP_CLIENT = new CognitoIdentityProviderClient();
+const MOCK_APP_ID = 'd123456';
+const ENV_NAME = 'test';
 
 const mockDescribeGen1StackResources: DescribeStackResourcesOutput = {
   StackResources: [
@@ -180,7 +186,16 @@ describe('TemplateGenerator', () => {
 
   it('should generate a template', async () => {
     // Act
-    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const generator = new TemplateGenerator(
+      GEN1_ROOT_STACK_NAME,
+      GEN2_ROOT_STACK_NAME,
+      ACCOUNT_ID,
+      MOCK_CFN_CLIENT,
+      MOCK_SSM_CLIENT,
+      MOCK_COGNITO_IDP_CLIENT,
+      MOCK_APP_ID,
+      ENV_NAME,
+    );
     await generator.generate();
 
     // Assert
@@ -189,7 +204,16 @@ describe('TemplateGenerator', () => {
   });
 
   it('should fail to generate when no applicable categories are found', async () => {
-    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const generator = new TemplateGenerator(
+      GEN1_ROOT_STACK_NAME,
+      GEN2_ROOT_STACK_NAME,
+      ACCOUNT_ID,
+      MOCK_CFN_CLIENT,
+      MOCK_SSM_CLIENT,
+      MOCK_COGNITO_IDP_CLIENT,
+      MOCK_APP_ID,
+      ENV_NAME,
+    );
     const failureSendMock = (command: any) => {
       if (command instanceof DescribeStackResourcesCommand) {
         return Promise.resolve(
@@ -220,7 +244,16 @@ describe('TemplateGenerator', () => {
     });
 
     // Act + Assert
-    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const generator = new TemplateGenerator(
+      GEN1_ROOT_STACK_NAME,
+      GEN2_ROOT_STACK_NAME,
+      ACCOUNT_ID,
+      MOCK_CFN_CLIENT,
+      MOCK_SSM_CLIENT,
+      MOCK_COGNITO_IDP_CLIENT,
+      MOCK_APP_ID,
+      ENV_NAME,
+    );
     await expect(generator.generate()).rejects.toThrow(errorMessage);
   });
 
@@ -244,7 +277,16 @@ describe('TemplateGenerator', () => {
     });
 
     // Act
-    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const generator = new TemplateGenerator(
+      GEN1_ROOT_STACK_NAME,
+      GEN2_ROOT_STACK_NAME,
+      ACCOUNT_ID,
+      MOCK_CFN_CLIENT,
+      MOCK_SSM_CLIENT,
+      MOCK_COGNITO_IDP_CLIENT,
+      MOCK_APP_ID,
+      ENV_NAME,
+    );
     await generator.generate();
 
     // Assert
@@ -272,7 +314,16 @@ describe('TemplateGenerator', () => {
     });
 
     // Act + Assert
-    const generator = new TemplateGenerator(GEN1_ROOT_STACK_NAME, GEN2_ROOT_STACK_NAME, ACCOUNT_ID, MOCK_CFN_CLIENT);
+    const generator = new TemplateGenerator(
+      GEN1_ROOT_STACK_NAME,
+      GEN2_ROOT_STACK_NAME,
+      ACCOUNT_ID,
+      MOCK_CFN_CLIENT,
+      MOCK_SSM_CLIENT,
+      MOCK_COGNITO_IDP_CLIENT,
+      MOCK_APP_ID,
+      ENV_NAME,
+    );
     expect.assertions(1);
     // Intentionally not awaiting the below call to be able to advance timers and micro task queue in waitForPromisesAndFakeTimers
     // and catch the error below

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -5,6 +5,8 @@ import fs from 'node:fs/promises';
 import { CATEGORY, CFN_AUTH_TYPE, CFN_CATEGORY_TYPE, CFN_S3_TYPE, CFNResource, CFNStackStatus } from './types';
 import MigrationReadmeGenerator from './migration-readme-generator';
 import { tryUpdateStack } from './cfn-stack-updater';
+import { SSMClient } from '@aws-sdk/client-ssm';
+import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
 
 const CFN_RESOURCE_STACK_TYPE = 'AWS::CloudFormation::Stack';
 
@@ -20,6 +22,10 @@ class TemplateGenerator {
     private readonly toStack: string,
     private readonly accountId: string,
     private readonly cfnClient: CloudFormationClient,
+    private readonly ssmClient: SSMClient,
+    private readonly cognitoIdpClient: CognitoIdentityProviderClient,
+    private readonly appId: string,
+    private readonly environmentName: string,
   ) {
     this.categoryStackMap = new Map<CATEGORY, [string, string]>();
     this.categoryTemplateGenerators = [];
@@ -88,6 +94,10 @@ class TemplateGenerator {
               this.region,
               this.accountId,
               this.cfnClient,
+              this.ssmClient,
+              this.cognitoIdpClient,
+              this.appId,
+              this.environmentName,
               [
                 CFN_AUTH_TYPE.UserPool,
                 CFN_AUTH_TYPE.UserPoolClient,
@@ -105,9 +115,18 @@ class TemplateGenerator {
             category,
             gen1CategoryStackId,
             gen2CategoryStackId,
-            new CategoryTemplateGenerator(gen1CategoryStackId, gen2CategoryStackId, this.region, this.accountId, this.cfnClient, [
-              CFN_S3_TYPE.Bucket,
-            ]),
+            new CategoryTemplateGenerator(
+              gen1CategoryStackId,
+              gen2CategoryStackId,
+              this.region,
+              this.accountId,
+              this.cfnClient,
+              this.ssmClient,
+              this.cognitoIdpClient,
+              this.appId,
+              this.environmentName,
+              [CFN_S3_TYPE.Bucket],
+            ),
           ]);
           break;
         }

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -102,3 +102,11 @@ export enum CFN_PSEUDO_PARAMETERS_REF {
 export enum CFNStackStatus {
   UPDATE_COMPLETE = 'UPDATE_COMPLETE',
 }
+
+export type BaseOAuthClient = { ProviderName: string; client_id: string };
+export type OAuthClientWithSecret = BaseOAuthClient & { client_secret: string };
+export type SignInWithAppleOAuthClient = BaseOAuthClient & { team_id: string; key_id: string; private_key: string };
+export type OAuthClient = OAuthClientWithSecret | SignInWithAppleOAuthClient;
+export type HostedUIProviderMeta = {
+  ProviderName: 'Amazon' | 'Facebook' | 'Google' | 'SignInWithApple';
+};

--- a/packages/amplify-migration/package.json
+++ b/packages/amplify-migration/package.json
@@ -58,6 +58,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.592.0",
     "@aws-sdk/client-lambda": "^3.637.0",
     "@aws-sdk/client-s3": "^3.592.0",
+    "@aws-sdk/client-ssm": "^3.592.0",
     "@aws-sdk/client-sts": "^3.658.1",
     "@types/node": "^20.14.2",
     "@types/unzipper": "^0.10.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,6 +1812,8 @@ __metadata:
   resolution: "@aws-amplify/migrate-template-gen@workspace:packages/amplify-migration-template-gen"
   dependencies:
     "@aws-sdk/client-cloudformation": ^3.592.0
+    "@aws-sdk/client-cognito-identity-provider": ^3.592.0
+    "@aws-sdk/client-ssm": ^3.592.0
     "@jest/globals": ^29.7.0
     jest: ^29.5.0
     typescript: ^5.4.5
@@ -1836,6 +1838,7 @@ __metadata:
     "@aws-sdk/client-cognito-identity-provider": ^3.592.0
     "@aws-sdk/client-lambda": ^3.637.0
     "@aws-sdk/client-s3": ^3.592.0
+    "@aws-sdk/client-ssm": ^3.592.0
     "@aws-sdk/client-sts": ^3.658.1
     "@types/node": ^20.14.2
     "@types/unzipper": ^0.10.9
@@ -3644,6 +3647,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-ssm@npm:^3.592.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/client-ssm@npm:3.699.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.699.0
+    "@aws-sdk/client-sts": 3.699.0
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/credential-provider-node": 3.699.0
+    "@aws-sdk/middleware-host-header": 3.696.0
+    "@aws-sdk/middleware-logger": 3.696.0
+    "@aws-sdk/middleware-recursion-detection": 3.696.0
+    "@aws-sdk/middleware-user-agent": 3.696.0
+    "@aws-sdk/region-config-resolver": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@aws-sdk/util-endpoints": 3.696.0
+    "@aws-sdk/util-user-agent-browser": 3.696.0
+    "@aws-sdk/util-user-agent-node": 3.696.0
+    "@smithy/config-resolver": ^3.0.12
+    "@smithy/core": ^2.5.3
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/hash-node": ^3.0.10
+    "@smithy/invalid-dependency": ^3.0.10
+    "@smithy/middleware-content-length": ^3.0.12
+    "@smithy/middleware-endpoint": ^3.2.3
+    "@smithy/middleware-retry": ^3.0.27
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/middleware-stack": ^3.0.10
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.27
+    "@smithy/util-defaults-mode-node": ^3.0.27
+    "@smithy/util-endpoints": ^2.1.6
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-retry": ^3.0.10
+    "@smithy/util-utf8": ^3.0.0
+    "@smithy/util-waiter": ^3.1.9
+    "@types/uuid": ^9.0.1
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: 4b08bf6a509d739f68c0dbefa5ed783dbdd09d6a0370c35d885ee326a1c6e42c3981c979229837db32344a0880c60124219bafd8e5deaae7ec13bb2c3e32c43f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sso-oidc@npm:3.319.0":
   version: 3.319.0
   resolution: "@aws-sdk/client-sso-oidc@npm:3.319.0"
@@ -4065,6 +4120,55 @@ __metadata:
   peerDependencies:
     "@aws-sdk/client-sts": ^3.677.0
   checksum: 6f737277cb4eeb8d7401cfa4d4d8cb415ff950347166adc60725a6582f6e72625bbedc80bbb87061c5620897b88424526f42eed02d2f57309a663e9fa6c884cf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso-oidc@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.699.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/credential-provider-node": 3.699.0
+    "@aws-sdk/middleware-host-header": 3.696.0
+    "@aws-sdk/middleware-logger": 3.696.0
+    "@aws-sdk/middleware-recursion-detection": 3.696.0
+    "@aws-sdk/middleware-user-agent": 3.696.0
+    "@aws-sdk/region-config-resolver": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@aws-sdk/util-endpoints": 3.696.0
+    "@aws-sdk/util-user-agent-browser": 3.696.0
+    "@aws-sdk/util-user-agent-node": 3.696.0
+    "@smithy/config-resolver": ^3.0.12
+    "@smithy/core": ^2.5.3
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/hash-node": ^3.0.10
+    "@smithy/invalid-dependency": ^3.0.10
+    "@smithy/middleware-content-length": ^3.0.12
+    "@smithy/middleware-endpoint": ^3.2.3
+    "@smithy/middleware-retry": ^3.0.27
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/middleware-stack": ^3.0.10
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.27
+    "@smithy/util-defaults-mode-node": ^3.0.27
+    "@smithy/util-endpoints": ^2.1.6
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-retry": ^3.0.10
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.699.0
+  checksum: b4d277fe4a7af3934b7528e8379901ae56ab9b9d3b6ed019d0a89f22ce2f8430edbe77ef1ced413216b378e517e32a625f3c4a4e8d6ef2bc58baefb6bc5e96d9
   languageName: node
   linkType: hard
 
@@ -4507,6 +4611,52 @@ __metadata:
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
   checksum: ca632fecf6b58e3724cc9d83a3da5f2d360779372a4b9c77dfb1be1f56181be4a21a21e22be9319af2cc66a2c12ecc7b4706fa1c941e29fbb94b60f8d24b287d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/client-sso@npm:3.696.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/middleware-host-header": 3.696.0
+    "@aws-sdk/middleware-logger": 3.696.0
+    "@aws-sdk/middleware-recursion-detection": 3.696.0
+    "@aws-sdk/middleware-user-agent": 3.696.0
+    "@aws-sdk/region-config-resolver": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@aws-sdk/util-endpoints": 3.696.0
+    "@aws-sdk/util-user-agent-browser": 3.696.0
+    "@aws-sdk/util-user-agent-node": 3.696.0
+    "@smithy/config-resolver": ^3.0.12
+    "@smithy/core": ^2.5.3
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/hash-node": ^3.0.10
+    "@smithy/invalid-dependency": ^3.0.10
+    "@smithy/middleware-content-length": ^3.0.12
+    "@smithy/middleware-endpoint": ^3.2.3
+    "@smithy/middleware-retry": ^3.0.27
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/middleware-stack": ^3.0.10
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.27
+    "@smithy/util-defaults-mode-node": ^3.0.27
+    "@smithy/util-endpoints": ^2.1.6
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-retry": ^3.0.10
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: e96c907c3385ea183181eb7dbdceb01c2b96a220f67bf6147b9a116aa197ceb2860fa54667405a7f60f365ee1c056b7039ff1ac236815894b675ee76c52862f3
   languageName: node
   linkType: hard
 
@@ -4979,6 +5129,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sts@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/client-sts@npm:3.699.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.699.0
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/credential-provider-node": 3.699.0
+    "@aws-sdk/middleware-host-header": 3.696.0
+    "@aws-sdk/middleware-logger": 3.696.0
+    "@aws-sdk/middleware-recursion-detection": 3.696.0
+    "@aws-sdk/middleware-user-agent": 3.696.0
+    "@aws-sdk/region-config-resolver": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@aws-sdk/util-endpoints": 3.696.0
+    "@aws-sdk/util-user-agent-browser": 3.696.0
+    "@aws-sdk/util-user-agent-node": 3.696.0
+    "@smithy/config-resolver": ^3.0.12
+    "@smithy/core": ^2.5.3
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/hash-node": ^3.0.10
+    "@smithy/invalid-dependency": ^3.0.10
+    "@smithy/middleware-content-length": ^3.0.12
+    "@smithy/middleware-endpoint": ^3.2.3
+    "@smithy/middleware-retry": ^3.0.27
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/middleware-stack": ^3.0.10
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-body-length-node": ^3.0.0
+    "@smithy/util-defaults-mode-browser": ^3.0.27
+    "@smithy/util-defaults-mode-node": ^3.0.27
+    "@smithy/util-endpoints": ^2.1.6
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-retry": ^3.0.10
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: bdc7bc373fc518570d8d034b6e1af033c2bf272217c79ebe3e1ec3f928c5b73b4b71f6b7d0be9a95db1f909cdcbe8b5a52776f4f2290d63a78bd05ece7d9abe0
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-textract@npm:3.6.1":
   version: 3.6.1
   resolution: "@aws-sdk/client-textract@npm:3.6.1"
@@ -5204,6 +5402,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/core@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/core": ^2.5.3
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/signature-v4": ^4.2.2
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/util-middleware": ^3.0.10
+    fast-xml-parser: 4.4.1
+    tslib: ^2.6.2
+  checksum: 4a96a3e29bf6e0dcd82d8160633eb4b8a488d821a8e59c1033c79a8e0d32b2f82e241e1cf94599f48836800549e342a410318b18e055851741ddf7d5d3ad4606
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-cognito-identity@npm:3.382.0":
   version: 3.382.0
   resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.382.0"
@@ -5336,6 +5553,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-env@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: e16987ca343f9dbae2560d0d016ca005f36b27fb094f8d32b99954d0a2874aa8230f924f2dab2a0e0aebc7ee9eda6881c5f6e928d89dc759f70a7658363e20be
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-http@npm:3.622.0":
   version: 3.622.0
   resolution: "@aws-sdk/credential-provider-http@npm:3.622.0"
@@ -5437,6 +5667,24 @@ __metadata:
     "@smithy/util-stream": ^3.1.9
     tslib: ^2.6.2
   checksum: db0f3374e3dab5ab169a4228e47549a409a2a7eea83648c0d8c527d8c35b1c7e0b99cc742546f887112d131f53aa4487b6afe436f0deb3d0fac4b5d20080cbf7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/smithy-client": ^3.4.4
+    "@smithy/types": ^3.7.1
+    "@smithy/util-stream": ^3.3.1
+    tslib: ^2.6.2
+  checksum: 383dd45600b0edbcc52c8e1101485569e631fb218f1776bbd4971e43a54be0adef458cb096d06d944353675136d2043da588424c78fff1c4eeeaf5229eb6774d
   languageName: node
   linkType: hard
 
@@ -5690,6 +5938,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-ini@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.699.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/credential-provider-env": 3.696.0
+    "@aws-sdk/credential-provider-http": 3.696.0
+    "@aws-sdk/credential-provider-process": 3.696.0
+    "@aws-sdk/credential-provider-sso": 3.699.0
+    "@aws-sdk/credential-provider-web-identity": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/credential-provider-imds": ^3.2.6
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/shared-ini-file-loader": ^3.1.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.699.0
+  checksum: 1efb837da910ce4e8a43574f2fdceb82daecefbb7f3853d7ec97059a80a7193cf579d185d4f4b1ef67cb378db9c5d4d3058a252a75fd6a32caad257c6602765e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-node@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-node@npm:3.186.0"
@@ -5901,6 +6171,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.699.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.696.0
+    "@aws-sdk/credential-provider-http": 3.696.0
+    "@aws-sdk/credential-provider-ini": 3.699.0
+    "@aws-sdk/credential-provider-process": 3.696.0
+    "@aws-sdk/credential-provider-sso": 3.699.0
+    "@aws-sdk/credential-provider-web-identity": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/credential-provider-imds": ^3.2.6
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/shared-ini-file-loader": ^3.1.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: d2e690eb839d906409da293af7918ab20210c25428985f019b161b3cbf5deca681d4cc397c7d5a929aeaa0b90be8dbe3282bd5a9b17969c2e6ddb5c08d66e5c4
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-process@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-process@npm:3.186.0"
@@ -6028,6 +6318,20 @@ __metadata:
     "@smithy/types": ^3.5.0
     tslib: ^2.6.2
   checksum: 9e36eac83a38756ee135b0404fddf36ce785853772af91c40c30d94e4783d968f4695b17b62730570ab854d1ae80c67ee8d402b573a9621e6dc88c31293c0797
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/shared-ini-file-loader": ^3.1.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 61741aa3d9cbbc88ea31bad7b7e8253aa4a0860eef215ff8d9a8196cdaa7ca8fa3bb438500c558abc9ce78b9490c540b12180acee21a7a9276491344931c5279
   languageName: node
   linkType: hard
 
@@ -6181,6 +6485,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.699.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.696.0
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/token-providers": 3.699.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/shared-ini-file-loader": ^3.1.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: be78a04f971d716b24e4bb9ce5ecec8ed8ffe9fdeebb07d4e6138c1b833529b5260d7381af8460b00f1659eb26018bffa51c9955b24a327374dd79c2fb2ce0ab
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.186.0"
@@ -6298,6 +6618,21 @@ __metadata:
   peerDependencies:
     "@aws-sdk/client-sts": ^3.677.0
   checksum: d525fd0538c4b13bfc217493dff0a6d39448c5c8333be3434b82e900ce82fc7184ea41a64f19329615d5a7341281e9ac1836ace07863497c2ec68a65aab332b7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sts": ^3.696.0
+  checksum: a983867c72a6c8a1fd397f8051f4b6e64f5cac1ff5afff1b2d00815096d6c819d9ad155f4724cb27ebe3c13714eeb22cc545533f4ccaaa63980308b8bef2fa4c
   languageName: node
   linkType: hard
 
@@ -6845,6 +7180,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-host-header@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 793c61a6af5533872888d9ee1b6765e06bd9716a9b1e497fb53b39da0bdbde2c379601ddf29bd2120cc520241143bae7763691f476f81721c290ee4e71264b6e
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-location-constraint@npm:3.667.0":
   version: 3.667.0
   resolution: "@aws-sdk/middleware-location-constraint@npm:3.667.0"
@@ -6952,6 +7299,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-logger@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 978145de80cb21a59d525fe9611d78e513df506e29123c39d425dd7c77043f9b57f05f03edde33864d9494a7ce76b7e2a48ec38ee4cee213b470ff1cd11c229f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-recursion-detection@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/middleware-recursion-detection@npm:3.186.0"
@@ -7043,6 +7401,18 @@ __metadata:
     "@smithy/types": ^3.5.0
     tslib: ^2.6.2
   checksum: 87c305abb5df60883b468f000a17b4335188ba4be8845245f1de2d382dfa5f2d4f5ced2380d7b021a89029b8d488fa5139bd3f5c4b98e5c9712ee180b9a25a4d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 20db668ef267c62134e241511a6a5a49cbcacbf4eb28eb8fede903086e38bdc3d6d5277f5faae4bb0b3a5123a2f1c116b219c3c48d4b8aa49c12e97707736d51
   languageName: node
   linkType: hard
 
@@ -7448,6 +7818,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/core": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@aws-sdk/util-endpoints": 3.696.0
+    "@smithy/core": ^2.5.3
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 3af4fc987d3a3cfa9036c67f60fb939a02d801ccb2781ea0be653896dfb34382c4c895a2e3ce2c48f2db547aea09d871217d77c814331251faf10b5a472974f7
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/node-config-provider@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/node-config-provider@npm:3.186.0"
@@ -7716,6 +8101,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/region-config-resolver@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/types": ^3.7.1
+    "@smithy/util-config-provider": ^3.0.0
+    "@smithy/util-middleware": ^3.0.10
+    tslib: ^2.6.2
+  checksum: bc8765735dcd888a73336d1c0cac75fec0303446f2cd97c7818cec89d5d9f7e4b98705de1e751a47abbc3442d9237169dc967f175be27d9f828e65acb6c2d23a
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/service-error-classification@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/service-error-classification@npm:3.186.0"
@@ -7957,6 +8356,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.699.0":
+  version: 3.699.0
+  resolution: "@aws-sdk/token-providers@npm:3.699.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/property-provider": ^3.1.9
+    "@smithy/shared-ini-file-loader": ^3.1.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-sso-oidc": ^3.699.0
+  checksum: f69d005aff7e85d04930374651edb75937cadab5baaa365044bf1318207b208d7cf857142fdbb8e66055fb92043140531945986346661bc82322b7307b109d56
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/types@npm:3.186.0"
@@ -8046,6 +8460,16 @@ __metadata:
     "@smithy/types": ^3.5.0
     tslib: ^2.6.2
   checksum: c1173d4799e95f113eeb80505737d86a37b443e45fac52d1045683712078ea338678bf9b55403254615f68e1ee8176084b9647c60e286c6a3569198611ffb9f5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/types@npm:3.696.0"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 3721939d5dd2a68fa4aee89d56b4817dd6c020721e2b2ea5b702968e7055826eb37e1924bc298007686304bf9bb6623bfec26b5cfd0663f2dba9d1b48437bb91
   languageName: node
   linkType: hard
 
@@ -8385,6 +8809,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-endpoints@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/types": ^3.7.1
+    "@smithy/util-endpoints": ^2.1.6
+    tslib: ^2.6.2
+  checksum: b32822b5f6924b8e3f88c7269afb216d07eccb338627a366ff3f94d98e7f5e4a9448dcf7c5ac97fc31fd0dfec5dfec52bbbeda65d84edd33fd509ed1dbfb1993
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-format-url@npm:3.609.0":
   version: 3.609.0
   resolution: "@aws-sdk/util-format-url@npm:3.609.0"
@@ -8617,6 +9053,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-browser@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/types": 3.696.0
+    "@smithy/types": ^3.7.1
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: e72e35b21e6945d8a3cc46f92a5a6509842fe5439c2b1628f72d1f0932398d4aae2648c8a1779e2936aa4f4720047344790dc533f334ae18b20a43443d4a7b93
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-user-agent-node@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/util-user-agent-node@npm:3.186.0"
@@ -8797,6 +9245,24 @@ __metadata:
     aws-crt:
       optional: true
   checksum: cd637dabdb056ff89caa972e2e09c5fa839900bfe13aa3cdd027362a71036fd00816fd11df1f316628758f0d7f85bcce9840cf446d89dadb9bc2f149cf4f62b5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.696.0":
+  version: 3.696.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.696.0"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": 3.696.0
+    "@aws-sdk/types": 3.696.0
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 9dd7ef236ff13552f559d0e78bfffe424032dc4040306808542a2eedbe80801ae05389c415b770461b6b39a0b35cdbebf97e673e6f7132e05121708acee3db83
   languageName: node
   linkType: hard
 
@@ -12927,6 +13393,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "@smithy/abort-controller@npm:3.1.8"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: ba62148955592036502880ac68a3fd1d4b0b70e3ace36ef9f1d0f507287795875598e2b9823ab6cdf542dcdb9fe75b57872694fc4a8108f7ab71938426a1c89c
+  languageName: node
+  linkType: hard
+
 "@smithy/chunked-blob-reader-native@npm:^3.0.1":
   version: 3.0.1
   resolution: "@smithy/chunked-blob-reader-native@npm:3.0.1"
@@ -12955,6 +13431,19 @@ __metadata:
     "@smithy/util-middleware": ^2.0.0
     tslib: ^2.5.0
   checksum: c58266a9b00486d84b9e7e14cba72fd32b14860d028f7322fe197dfed705798ee8bef22f069a7dacbd273894ff64d7afbc60a585792f4345e1e3fd17ac52a90a
+  languageName: node
+  linkType: hard
+
+"@smithy/config-resolver@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@smithy/config-resolver@npm:3.0.12"
+  dependencies:
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/types": ^3.7.1
+    "@smithy/util-config-provider": ^3.0.0
+    "@smithy/util-middleware": ^3.0.10
+    tslib: ^2.6.2
+  checksum: 01686446680e1a0e98051034671813f2ea78664ee8a6b22811a12fb937c1ac5b67b63ab9a6ae5995c61991344fbacebc906189cd063512ef1c1bdfb6c491941d
   languageName: node
   linkType: hard
 
@@ -12989,6 +13478,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^2.5.3, @smithy/core@npm:^2.5.4":
+  version: 2.5.4
+  resolution: "@smithy/core@npm:2.5.4"
+  dependencies:
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    "@smithy/util-body-length-browser": ^3.0.0
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-stream": ^3.3.1
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: b966d6a7136cc9575370a75ad380fc27b85e83dd6615c04a413a3ef7ef2a496adb1a7e46b8daa256cfaf5993c4d14957834a1dfd416a3bb16402d6012229e2a0
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^2.0.0, @smithy/credential-provider-imds@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/credential-provider-imds@npm:2.0.1"
@@ -13012,6 +13517,19 @@ __metadata:
     "@smithy/url-parser": ^3.0.7
     tslib: ^2.6.2
   checksum: bafd86dd1524eafccdd0863e2ee2a59e12f6974d37f7cde6653903da58dd878f6de7d1cd6320b0749507ad959a3cdf039a0e24c76035d1abe85ff3b9c13ad019
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^3.2.6, @smithy/credential-provider-imds@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "@smithy/credential-provider-imds@npm:3.2.7"
+  dependencies:
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/property-provider": ^3.1.10
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    tslib: ^2.6.2
+  checksum: c0f1d0c439f26d046ef130057ea1727cb06cab96054ed23202d6eb7eaec3e5d8ef96380b69fbdec505c569e5f2b56ed68ba8c687f47d7d99607c30e5f6e469c1
   languageName: node
   linkType: hard
 
@@ -13108,6 +13626,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/fetch-http-handler@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@smithy/fetch-http-handler@npm:4.1.1"
+  dependencies:
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/querystring-builder": ^3.0.10
+    "@smithy/types": ^3.7.1
+    "@smithy/util-base64": ^3.0.0
+    tslib: ^2.6.2
+  checksum: e6307dfdb621a5481e7b263e2ad0a6c4b54982504c0c1ed8e2cd12d0b9b09dd99d0a7e4ebff9d8f30f1935bae24945f44cef98eca42ad119e4f1f23507ebb081
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-blob-browser@npm:^3.1.6":
   version: 3.1.7
   resolution: "@smithy/hash-blob-browser@npm:3.1.7"
@@ -13129,6 +13660,18 @@ __metadata:
     "@smithy/util-utf8": ^2.0.0
     tslib: ^2.5.0
   checksum: 516eb7f62def0ca507ffe808d6ba192d3c4f804c76439c85719e0487a3610255b68085922c4bbd5ef64f1992ab75cf21a8af899685968999291e88f3441a2dc3
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/hash-node@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    "@smithy/util-buffer-from": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 1134872f7c4ba2c35583bd0932bf0b8cb99f5f24e79235660a5e0e0914c1d587c0ee7d44d5d4a8c0ed0c77249fc3a154d28a994dc2f42e27cf212d2052a5d0bd
   languageName: node
   linkType: hard
 
@@ -13162,6 +13705,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: f7bc61822206379db94c343df056df743947c1842aff3f8581917fe4dd7a6f79b0cf6f5b4a46998110845ee63569921389262f5614bde8e284b1a823f2971332
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/invalid-dependency@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 98bae16110f3f895991c1bd0a4291d9c900380b159c6d50d7327bd5161469f63510209ea3b08cfb0a12a66dfd9de8a1dc1ac71708b68f97c06b4ee6a2cde60b7
   languageName: node
   linkType: hard
 
@@ -13215,6 +13768,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-content-length@npm:^3.0.12":
+  version: 3.0.12
+  resolution: "@smithy/middleware-content-length@npm:3.0.12"
+  dependencies:
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 6d8db9bc97e3c09133ec9dc3114ca3e9ad3db5c234a2e109c3010e8661b488b08b8b2066bb2cd13da11d6ccffb9bbfbec1fa1552386d6e0d8d433b5041a6978b
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-content-length@npm:^3.0.5, @smithy/middleware-content-length@npm:^3.0.6, @smithy/middleware-content-length@npm:^3.0.8, @smithy/middleware-content-length@npm:^3.0.9":
   version: 3.0.9
   resolution: "@smithy/middleware-content-length@npm:3.0.9"
@@ -13254,6 +13818,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-endpoint@npm:^3.2.3, @smithy/middleware-endpoint@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@smithy/middleware-endpoint@npm:3.2.4"
+  dependencies:
+    "@smithy/core": ^2.5.4
+    "@smithy/middleware-serde": ^3.0.10
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/shared-ini-file-loader": ^3.1.11
+    "@smithy/types": ^3.7.1
+    "@smithy/url-parser": ^3.0.10
+    "@smithy/util-middleware": ^3.0.10
+    tslib: ^2.6.2
+  checksum: 3d7f6322e26cc05e0ecdfa19a7fdf422fdddc2816b109a84a76b947e688c2a1c03e08a43434f660cc568b00114628b5b0f50b45a6b6bf95501aeb7d55cdef461
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/middleware-retry@npm:2.0.1"
@@ -13286,6 +13866,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-retry@npm:^3.0.27":
+  version: 3.0.28
+  resolution: "@smithy/middleware-retry@npm:3.0.28"
+  dependencies:
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/service-error-classification": ^3.0.10
+    "@smithy/smithy-client": ^3.4.5
+    "@smithy/types": ^3.7.1
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-retry": ^3.0.10
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: e2d4cf85a161ca711d4a6e9be420d2e9ae387d21d10ed68db2dbba9a5a76fdf6df03a16bfd9309075ea846661a7c292d073ad444cee82367a4389b12f543facc
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-serde@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/middleware-serde@npm:2.0.1"
@@ -13293,6 +13890,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 0d50d635cdb4ab5b688499c3e4ab0ec12066a9b40e0d31c9011f4f7f8d90b2c1dae72f4491c5ec19309e81b2d5c88484492e3333ae2ba6ab854f6d06d6de8471
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/middleware-serde@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 407ddbbf856c54ba5592b76aeeadc5a09a679614e8eaac91b8d662b6bd7e9cf16b60190eb15254befd34311ac137260c00433ac9126a734c6c60a256e55c0e69
   languageName: node
   linkType: hard
 
@@ -13315,6 +13922,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-stack@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/middleware-stack@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: badcc1d275f7fd4957b6bce4e917060f971a4199e717cde7d3b4909be5d40e61c93328e2968e6885b4e8f7f5772e84ac743ddcc80031ab52efb47a3a3168beb0
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^3.0.3, @smithy/middleware-stack@npm:^3.0.4, @smithy/middleware-stack@npm:^3.0.6, @smithy/middleware-stack@npm:^3.0.7":
   version: 3.0.7
   resolution: "@smithy/middleware-stack@npm:3.0.7"
@@ -13334,6 +13951,18 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 2ea3ab568bb3871ad87a760e7889668e6662aeb96662f4d040dd32e12437c8168fb2989d2aa51e16b3544d521b29aa1d61f9c93a905f23dee96a3d97242b4ac2
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^3.1.11":
+  version: 3.1.11
+  resolution: "@smithy/node-config-provider@npm:3.1.11"
+  dependencies:
+    "@smithy/property-provider": ^3.1.10
+    "@smithy/shared-ini-file-loader": ^3.1.11
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: b80a6d3f96979696499b27155c3e075f139fa6be6a2ea9688735bd1802f22bb41be4545dac9ea4db51519d22c6fb469e5bfad9063e2fa2b8771130d2f2d611a7
   languageName: node
   linkType: hard
 
@@ -13375,6 +14004,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@smithy/node-http-handler@npm:3.3.1"
+  dependencies:
+    "@smithy/abort-controller": ^3.1.8
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/querystring-builder": ^3.0.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 32bb521a6cc7692ee33a362256661dbdccedfe448f116595bf6870f5c4343e3152daf5f9ae0b43d4a888016ea9161375858046f141513fb1d6c61545572712fc
+  languageName: node
+  linkType: hard
+
 "@smithy/property-provider@npm:^2.0.0, @smithy/property-provider@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/property-provider@npm:2.0.1"
@@ -13382,6 +14024,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: f1ba9c699ea0113e866ecd7da34454a0e47e7f378353f008f399b0764c87fca55099d47d1b8c5fceedb3e4242b65eca635091071b48657ce7bf3ba0cc98895b8
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^3.1.10, @smithy/property-provider@npm:^3.1.9":
+  version: 3.1.10
+  resolution: "@smithy/property-provider@npm:3.1.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 8dfcf30565b00287fd3c5ad2784f5c820264251dc9d1ac7334a224e40eb3eac4762a6198961d3e261bbcc738fc0c7c88ebd1007761e994569342f339ff503e1e
   languageName: node
   linkType: hard
 
@@ -13415,6 +14067,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/protocol-http@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "@smithy/protocol-http@npm:4.1.7"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 1d5bf3e3ae9b3c7b58934163f56364228a42d50dcc64c83855be846d46f4954ed36b1bc3d949cd24bb5da3787d9b787637cffa5e3fdbbe8e1932e05ea14eace6
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-builder@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/querystring-builder@npm:2.0.1"
@@ -13423,6 +14085,17 @@ __metadata:
     "@smithy/util-uri-escape": ^2.0.0
     tslib: ^2.5.0
   checksum: 288a0c5084b7394020882130ae20f1bd61089816af686123067787845555f81e7f7436b00638fa3f0530b5557e81417e34aea297f7dbe5a4203792890509e315
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/querystring-builder@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    "@smithy/util-uri-escape": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 3a95519ee41f195c3b56978803d50ba2b5b2ce46fc0de063442cdab347528cd0e3c3d5cd0361bc33ceeec1893198cb3246c201026c3917349e0fb908ca8c3fb0
   languageName: node
   linkType: hard
 
@@ -13447,6 +14120,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-parser@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/querystring-parser@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: e57c15087246e6a50348d557b670ded987ed5d88d4279a0a4896828d2be9fb2949f6b6c8656e5be45282c25cfa2fe62fe7fd9bd159ac30177f5b99181a5f4b74
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-parser@npm:^3.0.7":
   version: 3.0.7
   resolution: "@smithy/querystring-parser@npm:3.0.7"
@@ -13461,6 +14144,15 @@ __metadata:
   version: 2.0.0
   resolution: "@smithy/service-error-classification@npm:2.0.0"
   checksum: 01eff69704f8d3c0a4e556b06d7566d905856ab069517b81e232b08e966c303bd24f2441f62518c0bd0ecb7e25069afd47db442223bb80b455e8f6c6a77bb57b
+  languageName: node
+  linkType: hard
+
+"@smithy/service-error-classification@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/service-error-classification@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+  checksum: 9b9d5e0436d168f6a3290edb008292e2cc28ec7d2d9227858aff7c9c70d732336b71898eb0cb7fa76ea04c0180ec3afaf7930c92e881efd4b91023d7d8919044
   languageName: node
   linkType: hard
 
@@ -13480,6 +14172,16 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: 53840d0524adfed2a2ad9887014c357df0ccf07b3bf23f775d999c8c7f0c0b314c1b01992cd2901f6b44a3e59a3f3c7fcaf71aa8a2c4c1948d2fe153af320679
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^3.1.10, @smithy/shared-ini-file-loader@npm:^3.1.11":
+  version: 3.1.11
+  resolution: "@smithy/shared-ini-file-loader@npm:3.1.11"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 7479713932f00a6b85380fa8012ad893bb61e7ea614976e0ab2898767ff7dc91bb1dd813a4ec72e4850d6b10296f11032cd5dd916970042be376c19d0d3954b6
   languageName: node
   linkType: hard
 
@@ -13525,6 +14227,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/signature-v4@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "@smithy/signature-v4@npm:4.2.3"
+  dependencies:
+    "@smithy/is-array-buffer": ^3.0.0
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    "@smithy/util-hex-encoding": ^3.0.0
+    "@smithy/util-middleware": ^3.0.10
+    "@smithy/util-uri-escape": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: 7cecc9c73cb863e15c4517601a2a1e82b3728fbe174c533d807beb54f59f66792891c82955d874baa27640201d719b6ea63497b376e4c7cd09d5d52ea36fe3fc
+  languageName: node
+  linkType: hard
+
 "@smithy/smithy-client@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/smithy-client@npm:2.0.1"
@@ -13551,6 +14269,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^3.4.4, @smithy/smithy-client@npm:^3.4.5":
+  version: 3.4.5
+  resolution: "@smithy/smithy-client@npm:3.4.5"
+  dependencies:
+    "@smithy/core": ^2.5.4
+    "@smithy/middleware-endpoint": ^3.2.4
+    "@smithy/middleware-stack": ^3.0.10
+    "@smithy/protocol-http": ^4.1.7
+    "@smithy/types": ^3.7.1
+    "@smithy/util-stream": ^3.3.1
+    tslib: ^2.6.2
+  checksum: b9a56e20133d29ab2339d4d3b7b28601b7a98b899a7b0a5371c2c698c48e60c733fdad42fe1dec096c48a9de10d79de170f6eaa98a1bc1bd0c18a4b63c545e0d
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^2.0.2":
   version: 2.0.2
   resolution: "@smithy/types@npm:2.0.2"
@@ -13569,6 +14302,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/types@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@smithy/types@npm:3.7.1"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: c82ad86087b6e0d2261f581a8cca1694a0af31458d7789ff5d8787973b4940a6d035082005dfc87857f266ee9cb512f7eb80535917e6dd6eb3d7d70c45d0f9aa
+  languageName: node
+  linkType: hard
+
 "@smithy/url-parser@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/url-parser@npm:2.0.1"
@@ -13577,6 +14319,17 @@ __metadata:
     "@smithy/types": ^2.0.2
     tslib: ^2.5.0
   checksum: b0b765b17b7e41ca72829bd9943dbfb33924f7bdec5e622b87e8d2d83ee570a305ed7a948c9cd085d4ab04afd7286e7e70470b912c5fad07cc60507bbc9f62e6
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/url-parser@npm:3.0.10"
+  dependencies:
+    "@smithy/querystring-parser": ^3.0.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 29c9d03ee86936ffb3bdcbb84ce14b7dacaadb2e61b5ed78ee91dfacb98e42048c70c718077347f0f39bce676168ba5fc1f1a8b19988f89f735c0b5e17cdc77a
   languageName: node
   linkType: hard
 
@@ -13711,6 +14464,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-browser@npm:^3.0.27":
+  version: 3.0.28
+  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.28"
+  dependencies:
+    "@smithy/property-provider": ^3.1.10
+    "@smithy/smithy-client": ^3.4.5
+    "@smithy/types": ^3.7.1
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: bba460478f70ef25312d3e5408e0caa5feaf0b2af11aedcfd9e4719874884b507edd2503790d938e22fff5387f1dd63cd33c920dddf16cb3e6a6588575be5522
+  languageName: node
+  linkType: hard
+
 "@smithy/util-defaults-mode-node@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/util-defaults-mode-node@npm:2.0.1"
@@ -13740,6 +14506,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-node@npm:^3.0.27":
+  version: 3.0.28
+  resolution: "@smithy/util-defaults-mode-node@npm:3.0.28"
+  dependencies:
+    "@smithy/config-resolver": ^3.0.12
+    "@smithy/credential-provider-imds": ^3.2.7
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/property-provider": ^3.1.10
+    "@smithy/smithy-client": ^3.4.5
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 6b49892d58d9c38e92e9b82ca7cdc2c9627f56fb3bc62ddef9bb5f197c38df1b7089c73c2256281888aba48a0ddd9319eb86a616af7ab40342f07aea1136dd47
+  languageName: node
+  linkType: hard
+
 "@smithy/util-endpoints@npm:^2.0.5, @smithy/util-endpoints@npm:^2.1.0, @smithy/util-endpoints@npm:^2.1.2, @smithy/util-endpoints@npm:^2.1.3":
   version: 2.1.3
   resolution: "@smithy/util-endpoints@npm:2.1.3"
@@ -13748,6 +14529,17 @@ __metadata:
     "@smithy/types": ^3.5.0
     tslib: ^2.6.2
   checksum: 1f375f997b996af9b2d17a4d1fd2ace81bf0206bf6c9e80d591d1daadce34471ea5ff8913000cd2aae4f619b7d2f3b2d38caf528b036b97ada2831ffbb9725d9
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^2.1.6":
+  version: 2.1.6
+  resolution: "@smithy/util-endpoints@npm:2.1.6"
+  dependencies:
+    "@smithy/node-config-provider": ^3.1.11
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: a1cd8cc912fb67ee07e6095990f3b237b2e53f73e493b2aaa85af904c4ce73ce739a68e4d3330a37b8c96cd00b6845205b836ee4ced97cf622413a34b913adc2
   languageName: node
   linkType: hard
 
@@ -13778,6 +14570,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-middleware@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/util-middleware@npm:3.0.10"
+  dependencies:
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: 01bbbd31044ab742985acac36aa61e240db16ed7dfa22b73779877eb5db0af14351883506fb34d2ee964598d72f4998d79409c271a62310647fb28faccd855a2
+  languageName: node
+  linkType: hard
+
 "@smithy/util-middleware@npm:^3.0.3, @smithy/util-middleware@npm:^3.0.4, @smithy/util-middleware@npm:^3.0.6, @smithy/util-middleware@npm:^3.0.7":
   version: 3.0.7
   resolution: "@smithy/util-middleware@npm:3.0.7"
@@ -13795,6 +14597,17 @@ __metadata:
     "@smithy/service-error-classification": ^2.0.0
     tslib: ^2.5.0
   checksum: 03b69046d7736f11430147772463685246918560b70ff54799b8dee59a4819fa4349917fa9df841953224f5ec95ef1aa3e5ee5818450ad2f92a2397caede41bd
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@smithy/util-retry@npm:3.0.10"
+  dependencies:
+    "@smithy/service-error-classification": ^3.0.10
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: ac1dcfd2e4ea1a4f99a42447b7fd8e4ea21589dfd87e9bc6a7bdf1d26e1f93ec71aa4cfde5e024b00d9b713b889f9db20a8d81b9e3ccdbe6f72bedb6269f01b8
   languageName: node
   linkType: hard
 
@@ -13838,6 +14651,22 @@ __metadata:
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
   checksum: 04f37b1e97692d9177a41351336bb119eb5dbe2582bc17e76bc99919defe67fe5afbf3cb52612c48c2bca3bec6f96f2d860825afc9249ab6e7e8fd9b4719f7a8
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@smithy/util-stream@npm:3.3.1"
+  dependencies:
+    "@smithy/fetch-http-handler": ^4.1.1
+    "@smithy/node-http-handler": ^3.3.1
+    "@smithy/types": ^3.7.1
+    "@smithy/util-base64": ^3.0.0
+    "@smithy/util-buffer-from": ^3.0.0
+    "@smithy/util-hex-encoding": ^3.0.0
+    "@smithy/util-utf8": ^3.0.0
+    tslib: ^2.6.2
+  checksum: dafaf4448e69cd65eda2bc7c43a48e945905808f635397e290b4e19cff2705ab444f1798829ca48b9a9efe4b7e569180eb6275ca42d04ce5abcf2dc9443f9c67
   languageName: node
   linkType: hard
 
@@ -13887,6 +14716,17 @@ __metadata:
     "@smithy/types": ^3.5.0
     tslib: ^2.6.2
   checksum: dfa7cf04afa7be4736e78f54f96c6583c2f582fef6bd179cf925f5dd737f3fed0b37446d5198d9dedfb343a0b71c481f560b5954686f8e2b51155a37752bc586
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^3.1.9":
+  version: 3.1.9
+  resolution: "@smithy/util-waiter@npm:3.1.9"
+  dependencies:
+    "@smithy/abort-controller": ^3.1.8
+    "@smithy/types": ^3.7.1
+    tslib: ^2.6.2
+  checksum: c2e4b79412e26f70f4c63aebc519046a5a58a19f36bbc91702f402db5c8d1e065e081603f0db389682b1d84c1e67922c7f8d9921994a455532d4d093fff2f356
   languageName: node
   linkType: hard
 
@@ -15006,6 +15846,13 @@ __metadata:
   version: 8.3.4
   resolution: "@types/uuid@npm:8.3.4"
   checksum: b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.1":
+  version: 9.0.8
+  resolution: "@types/uuid@npm:9.0.8"
+  checksum: b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,52 +3602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-ssm@npm:^3.303.0":
-  version: 3.319.0
-  resolution: "@aws-sdk/client-ssm@npm:3.319.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.319.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-node": 3.319.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.319.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.316.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-body-length-browser": 3.310.0
-    "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.316.0
-    "@aws-sdk/util-defaults-mode-node": 3.316.0
-    "@aws-sdk/util-endpoints": 3.319.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
-    "@aws-sdk/util-utf8": 3.310.0
-    "@aws-sdk/util-waiter": 3.310.0
-    tslib: ^2.5.0
-    uuid: ^8.3.2
-  checksum: d878a77dfafddd386e019c64d16f3c9f0059e06c1cbb61020863ea1e15a0d0baeb6e76c6d5f128364820a98e59dd90ea7829cfb8efe43b946cd16ffd8d48a029
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-ssm@npm:^3.592.0":
+"@aws-sdk/client-ssm@npm:^3.303.0, @aws-sdk/client-ssm@npm:^3.592.0":
   version: 3.699.0
   resolution: "@aws-sdk/client-ssm@npm:3.699.0"
   dependencies:
@@ -5081,7 +5036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.677.0, @aws-sdk/client-sts@npm:^3.303.0, @aws-sdk/client-sts@npm:^3.465.0, @aws-sdk/client-sts@npm:^3.658.1":
+"@aws-sdk/client-sts@npm:3.677.0":
   version: 3.677.0
   resolution: "@aws-sdk/client-sts@npm:3.677.0"
   dependencies:
@@ -5129,7 +5084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.699.0":
+"@aws-sdk/client-sts@npm:3.699.0, @aws-sdk/client-sts@npm:^3.303.0, @aws-sdk/client-sts@npm:^3.465.0, @aws-sdk/client-sts@npm:^3.658.1":
   version: 3.699.0
   resolution: "@aws-sdk/client-sts@npm:3.699.0"
   dependencies:
@@ -8453,7 +8408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.667.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.25.0":
+"@aws-sdk/types@npm:3.667.0":
   version: 3.667.0
   resolution: "@aws-sdk/types@npm:3.667.0"
   dependencies:
@@ -8463,7 +8418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.696.0":
+"@aws-sdk/types@npm:3.696.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.25.0":
   version: 3.696.0
   resolution: "@aws-sdk/types@npm:3.696.0"
   dependencies:
@@ -13383,16 +13338,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "@smithy/abort-controller@npm:3.1.5"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 384e3dca60720bc9048092b1765ec619c5c64844732ca1439ca90d6ea7454eed12d071a536d8c243410512cc39ad1683607415dbeaf89816ddb142bbe10cf789
-  languageName: node
-  linkType: hard
-
 "@smithy/abort-controller@npm:^3.1.8":
   version: 3.1.8
   resolution: "@smithy/abort-controller@npm:3.1.8"
@@ -13434,7 +13379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^3.0.12":
+"@smithy/config-resolver@npm:^3.0.12, @smithy/config-resolver@npm:^3.0.5, @smithy/config-resolver@npm:^3.0.6, @smithy/config-resolver@npm:^3.0.8, @smithy/config-resolver@npm:^3.0.9":
   version: 3.0.12
   resolution: "@smithy/config-resolver@npm:3.0.12"
   dependencies:
@@ -13447,38 +13392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^3.0.5, @smithy/config-resolver@npm:^3.0.6, @smithy/config-resolver@npm:^3.0.8, @smithy/config-resolver@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "@smithy/config-resolver@npm:3.0.9"
-  dependencies:
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/types": ^3.5.0
-    "@smithy/util-config-provider": ^3.0.0
-    "@smithy/util-middleware": ^3.0.7
-    tslib: ^2.6.2
-  checksum: 714504c9341bc4fcc0c5fc86304602a03a26c7ca589945f41d967c8449bb12b6336da423caca04e0c0349c28b6ec7615e29bbbcbc89a68406ec9f39ac5aac483
-  languageName: node
-  linkType: hard
-
-"@smithy/core@npm:^2.3.2, @smithy/core@npm:^2.4.1, @smithy/core@npm:^2.4.6, @smithy/core@npm:^2.4.8":
-  version: 2.4.8
-  resolution: "@smithy/core@npm:2.4.8"
-  dependencies:
-    "@smithy/middleware-endpoint": ^3.1.4
-    "@smithy/middleware-retry": ^3.0.23
-    "@smithy/middleware-serde": ^3.0.7
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/smithy-client": ^3.4.0
-    "@smithy/types": ^3.5.0
-    "@smithy/util-body-length-browser": ^3.0.0
-    "@smithy/util-middleware": ^3.0.7
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: cb2a93fa3e6bb6f6a2e269d1f392fa729d5bb9a5acf05f7bbd1ba0b270e0741b9aed4bf69b436984f9c17d0b4b5d54ff22cbc46f7e0562c19822c29a1d9f156d
-  languageName: node
-  linkType: hard
-
-"@smithy/core@npm:^2.5.3, @smithy/core@npm:^2.5.4":
+"@smithy/core@npm:^2.3.2, @smithy/core@npm:^2.4.1, @smithy/core@npm:^2.4.6, @smithy/core@npm:^2.4.8, @smithy/core@npm:^2.5.3, @smithy/core@npm:^2.5.4":
   version: 2.5.4
   resolution: "@smithy/core@npm:2.5.4"
   dependencies:
@@ -13507,20 +13421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^3.2.0, @smithy/credential-provider-imds@npm:^3.2.1, @smithy/credential-provider-imds@npm:^3.2.3, @smithy/credential-provider-imds@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "@smithy/credential-provider-imds@npm:3.2.4"
-  dependencies:
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/property-provider": ^3.1.7
-    "@smithy/types": ^3.5.0
-    "@smithy/url-parser": ^3.0.7
-    tslib: ^2.6.2
-  checksum: bafd86dd1524eafccdd0863e2ee2a59e12f6974d37f7cde6653903da58dd878f6de7d1cd6320b0749507ad959a3cdf039a0e24c76035d1abe85ff3b9c13ad019
-  languageName: node
-  linkType: hard
-
-"@smithy/credential-provider-imds@npm:^3.2.6, @smithy/credential-provider-imds@npm:^3.2.7":
+"@smithy/credential-provider-imds@npm:^3.2.0, @smithy/credential-provider-imds@npm:^3.2.1, @smithy/credential-provider-imds@npm:^3.2.3, @smithy/credential-provider-imds@npm:^3.2.4, @smithy/credential-provider-imds@npm:^3.2.6, @smithy/credential-provider-imds@npm:^3.2.7":
   version: 3.2.7
   resolution: "@smithy/credential-provider-imds@npm:3.2.7"
   dependencies:
@@ -13663,7 +13564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^3.0.10":
+"@smithy/hash-node@npm:^3.0.10, @smithy/hash-node@npm:^3.0.3, @smithy/hash-node@npm:^3.0.4, @smithy/hash-node@npm:^3.0.6, @smithy/hash-node@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/hash-node@npm:3.0.10"
   dependencies:
@@ -13672,18 +13573,6 @@ __metadata:
     "@smithy/util-utf8": ^3.0.0
     tslib: ^2.6.2
   checksum: 1134872f7c4ba2c35583bd0932bf0b8cb99f5f24e79235660a5e0e0914c1d587c0ee7d44d5d4a8c0ed0c77249fc3a154d28a994dc2f42e27cf212d2052a5d0bd
-  languageName: node
-  linkType: hard
-
-"@smithy/hash-node@npm:^3.0.3, @smithy/hash-node@npm:^3.0.4, @smithy/hash-node@npm:^3.0.6, @smithy/hash-node@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/hash-node@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    "@smithy/util-buffer-from": ^3.0.0
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: 88b1e642639f016f40834035d03288ea7481382e2fcda8a0d6baf38f0c6f1e8541aae51f50aea7876166976ff2e276baae428fbdfb728c0fc29ccdfdb612e853
   languageName: node
   linkType: hard
 
@@ -13708,23 +13597,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^3.0.10":
+"@smithy/invalid-dependency@npm:^3.0.10, @smithy/invalid-dependency@npm:^3.0.3, @smithy/invalid-dependency@npm:^3.0.4, @smithy/invalid-dependency@npm:^3.0.6, @smithy/invalid-dependency@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/invalid-dependency@npm:3.0.10"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 98bae16110f3f895991c1bd0a4291d9c900380b159c6d50d7327bd5161469f63510209ea3b08cfb0a12a66dfd9de8a1dc1ac71708b68f97c06b4ee6a2cde60b7
-  languageName: node
-  linkType: hard
-
-"@smithy/invalid-dependency@npm:^3.0.3, @smithy/invalid-dependency@npm:^3.0.4, @smithy/invalid-dependency@npm:^3.0.6, @smithy/invalid-dependency@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/invalid-dependency@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: b43e868d428d092f91702fe7030307129eb65f0592c60bc6f29ef2bd74799bcae90815326eb599d12aaeee6659ef7c9b2fb85fa0c843ab5132a446edb8767b98
   languageName: node
   linkType: hard
 
@@ -13768,7 +13647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^3.0.12":
+"@smithy/middleware-content-length@npm:^3.0.12, @smithy/middleware-content-length@npm:^3.0.5, @smithy/middleware-content-length@npm:^3.0.6, @smithy/middleware-content-length@npm:^3.0.8, @smithy/middleware-content-length@npm:^3.0.9":
   version: 3.0.12
   resolution: "@smithy/middleware-content-length@npm:3.0.12"
   dependencies:
@@ -13776,17 +13655,6 @@ __metadata:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 6d8db9bc97e3c09133ec9dc3114ca3e9ad3db5c234a2e109c3010e8661b488b08b8b2066bb2cd13da11d6ccffb9bbfbec1fa1552386d6e0d8d433b5041a6978b
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-content-length@npm:^3.0.5, @smithy/middleware-content-length@npm:^3.0.6, @smithy/middleware-content-length@npm:^3.0.8, @smithy/middleware-content-length@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "@smithy/middleware-content-length@npm:3.0.9"
-  dependencies:
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 7ea6d14fe64a486c024988bed41b70eacadc5e9af4b06d36f1d3902675baf9908090f4cdcc9f066ef26dddb1816035227afe778a0372473678f267e4cb37cbe8
   languageName: node
   linkType: hard
 
@@ -13803,22 +13671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^3.1.0, @smithy/middleware-endpoint@npm:^3.1.1, @smithy/middleware-endpoint@npm:^3.1.3, @smithy/middleware-endpoint@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "@smithy/middleware-endpoint@npm:3.1.4"
-  dependencies:
-    "@smithy/middleware-serde": ^3.0.7
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/shared-ini-file-loader": ^3.1.8
-    "@smithy/types": ^3.5.0
-    "@smithy/url-parser": ^3.0.7
-    "@smithy/util-middleware": ^3.0.7
-    tslib: ^2.6.2
-  checksum: 29d10c124489a1715ec10dbb45e8359fbb036c8600357f18362df4fba4899357d361402ef55d961939857755ffedc20c780203dc562ce00ca903013ac00226f7
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-endpoint@npm:^3.2.3, @smithy/middleware-endpoint@npm:^3.2.4":
+"@smithy/middleware-endpoint@npm:^3.1.0, @smithy/middleware-endpoint@npm:^3.1.1, @smithy/middleware-endpoint@npm:^3.1.3, @smithy/middleware-endpoint@npm:^3.1.4, @smithy/middleware-endpoint@npm:^3.2.3, @smithy/middleware-endpoint@npm:^3.2.4":
   version: 3.2.4
   resolution: "@smithy/middleware-endpoint@npm:3.2.4"
   dependencies:
@@ -13849,24 +13702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^3.0.14, @smithy/middleware-retry@npm:^3.0.16, @smithy/middleware-retry@npm:^3.0.21, @smithy/middleware-retry@npm:^3.0.23":
-  version: 3.0.23
-  resolution: "@smithy/middleware-retry@npm:3.0.23"
-  dependencies:
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/service-error-classification": ^3.0.7
-    "@smithy/smithy-client": ^3.4.0
-    "@smithy/types": ^3.5.0
-    "@smithy/util-middleware": ^3.0.7
-    "@smithy/util-retry": ^3.0.7
-    tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: 80e2a6e19439ecd138a15bd5d1a61d24c4e0a4d02dc28e0783bc3eb832215f8a25845231a7d6e2ad24fb00d8ff9db78fa04bfa91aae5619e1cee9dfa3be553e5
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-retry@npm:^3.0.27":
+"@smithy/middleware-retry@npm:^3.0.14, @smithy/middleware-retry@npm:^3.0.16, @smithy/middleware-retry@npm:^3.0.21, @smithy/middleware-retry@npm:^3.0.23, @smithy/middleware-retry@npm:^3.0.27":
   version: 3.0.28
   resolution: "@smithy/middleware-retry@npm:3.0.28"
   dependencies:
@@ -13893,23 +13729,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^3.0.10":
+"@smithy/middleware-serde@npm:^3.0.10, @smithy/middleware-serde@npm:^3.0.3, @smithy/middleware-serde@npm:^3.0.4, @smithy/middleware-serde@npm:^3.0.6, @smithy/middleware-serde@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/middleware-serde@npm:3.0.10"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 407ddbbf856c54ba5592b76aeeadc5a09a679614e8eaac91b8d662b6bd7e9cf16b60190eb15254befd34311ac137260c00433ac9126a734c6c60a256e55c0e69
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-serde@npm:^3.0.3, @smithy/middleware-serde@npm:^3.0.4, @smithy/middleware-serde@npm:^3.0.6, @smithy/middleware-serde@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/middleware-serde@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: b04abb0adc9a3b15ce42b0fd3bbdb78ee86a34f9c017cbb2a59ceffc1bde0740fa2f3534abf2ff861112b6fb76a7ea4f55871503e2d8d1e6207052bcccf2819a
   languageName: node
   linkType: hard
 
@@ -13922,23 +13748,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^3.0.10":
+"@smithy/middleware-stack@npm:^3.0.10, @smithy/middleware-stack@npm:^3.0.3, @smithy/middleware-stack@npm:^3.0.4, @smithy/middleware-stack@npm:^3.0.6, @smithy/middleware-stack@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/middleware-stack@npm:3.0.10"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: badcc1d275f7fd4957b6bce4e917060f971a4199e717cde7d3b4909be5d40e61c93328e2968e6885b4e8f7f5772e84ac743ddcc80031ab52efb47a3a3168beb0
-  languageName: node
-  linkType: hard
-
-"@smithy/middleware-stack@npm:^3.0.3, @smithy/middleware-stack@npm:^3.0.4, @smithy/middleware-stack@npm:^3.0.6, @smithy/middleware-stack@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/middleware-stack@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 260ddf0f785fa3118130e8174c653d7267208794feeaeeac9762783c0ebb306f0cbe71d73092347e9dd85ee4ebbe5e82ee0dd6512b3a2da0aef9789d23d020e0
   languageName: node
   linkType: hard
 
@@ -13954,7 +13770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^3.1.11":
+"@smithy/node-config-provider@npm:^3.1.11, @smithy/node-config-provider@npm:^3.1.4, @smithy/node-config-provider@npm:^3.1.5, @smithy/node-config-provider@npm:^3.1.7, @smithy/node-config-provider@npm:^3.1.8":
   version: 3.1.11
   resolution: "@smithy/node-config-provider@npm:3.1.11"
   dependencies:
@@ -13963,18 +13779,6 @@ __metadata:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: b80a6d3f96979696499b27155c3e075f139fa6be6a2ea9688735bd1802f22bb41be4545dac9ea4db51519d22c6fb469e5bfad9063e2fa2b8771130d2f2d611a7
-  languageName: node
-  linkType: hard
-
-"@smithy/node-config-provider@npm:^3.1.4, @smithy/node-config-provider@npm:^3.1.5, @smithy/node-config-provider@npm:^3.1.7, @smithy/node-config-provider@npm:^3.1.8":
-  version: 3.1.8
-  resolution: "@smithy/node-config-provider@npm:3.1.8"
-  dependencies:
-    "@smithy/property-provider": ^3.1.7
-    "@smithy/shared-ini-file-loader": ^3.1.8
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 354319e0a6a48775195eecb3486eddce57eb51bd3a88cef729db39b6592da5ac7b2b0b4f996396ed1496a9693a5a67344b4e36c0a6eeb94293ed1e50aa10b740
   languageName: node
   linkType: hard
 
@@ -13991,20 +13795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^3.1.4, @smithy/node-http-handler@npm:^3.2.0, @smithy/node-http-handler@npm:^3.2.3, @smithy/node-http-handler@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "@smithy/node-http-handler@npm:3.2.4"
-  dependencies:
-    "@smithy/abort-controller": ^3.1.5
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/querystring-builder": ^3.0.7
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: b086811ca355cff0c7cf8d897a146f309f0d48c2bbd21a2248c511fa483dd3366ffc8e85f8fe52e727207f426f57c7d9e2127ccb0616f860e2d8755481cb5be9
-  languageName: node
-  linkType: hard
-
-"@smithy/node-http-handler@npm:^3.3.1":
+"@smithy/node-http-handler@npm:^3.1.4, @smithy/node-http-handler@npm:^3.2.0, @smithy/node-http-handler@npm:^3.2.3, @smithy/node-http-handler@npm:^3.2.4, @smithy/node-http-handler@npm:^3.3.1":
   version: 3.3.1
   resolution: "@smithy/node-http-handler@npm:3.3.1"
   dependencies:
@@ -14027,23 +13818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^3.1.10, @smithy/property-provider@npm:^3.1.9":
+"@smithy/property-provider@npm:^3.1.10, @smithy/property-provider@npm:^3.1.3, @smithy/property-provider@npm:^3.1.4, @smithy/property-provider@npm:^3.1.6, @smithy/property-provider@npm:^3.1.7, @smithy/property-provider@npm:^3.1.9":
   version: 3.1.10
   resolution: "@smithy/property-provider@npm:3.1.10"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 8dfcf30565b00287fd3c5ad2784f5c820264251dc9d1ac7334a224e40eb3eac4762a6198961d3e261bbcc738fc0c7c88ebd1007761e994569342f339ff503e1e
-  languageName: node
-  linkType: hard
-
-"@smithy/property-provider@npm:^3.1.3, @smithy/property-provider@npm:^3.1.4, @smithy/property-provider@npm:^3.1.6, @smithy/property-provider@npm:^3.1.7":
-  version: 3.1.7
-  resolution: "@smithy/property-provider@npm:3.1.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 14547451d6a81678f4962717cb77a93b01e22d6578462be9a3945889923ba8c2978775f4befb639c305e89169b7e1ee56a0f41a51aabf0f14013a47cbb18be42
   languageName: node
   linkType: hard
 
@@ -14057,17 +13838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^4.1.0, @smithy/protocol-http@npm:^4.1.1, @smithy/protocol-http@npm:^4.1.3, @smithy/protocol-http@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "@smithy/protocol-http@npm:4.1.4"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 595d25edfe04764a4d51303c3c93b86837b704b7c9d192bf41facebd37bcfe2d20725ea39dda5aa3b73ee985483012447dd02851798bcd6e5e23ac66380b65be
-  languageName: node
-  linkType: hard
-
-"@smithy/protocol-http@npm:^4.1.7":
+"@smithy/protocol-http@npm:^4.1.0, @smithy/protocol-http@npm:^4.1.1, @smithy/protocol-http@npm:^4.1.3, @smithy/protocol-http@npm:^4.1.4, @smithy/protocol-http@npm:^4.1.7":
   version: 4.1.7
   resolution: "@smithy/protocol-http@npm:4.1.7"
   dependencies:
@@ -14088,7 +13859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^3.0.10":
+"@smithy/querystring-builder@npm:^3.0.10, @smithy/querystring-builder@npm:^3.0.3, @smithy/querystring-builder@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/querystring-builder@npm:3.0.10"
   dependencies:
@@ -14096,17 +13867,6 @@ __metadata:
     "@smithy/util-uri-escape": ^3.0.0
     tslib: ^2.6.2
   checksum: 3a95519ee41f195c3b56978803d50ba2b5b2ce46fc0de063442cdab347528cd0e3c3d5cd0361bc33ceeec1893198cb3246c201026c3917349e0fb908ca8c3fb0
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^3.0.3, @smithy/querystring-builder@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/querystring-builder@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    "@smithy/util-uri-escape": ^3.0.0
-    tslib: ^2.6.2
-  checksum: 3c8cf8313524a2fc58388f511c2bd81b421b4a7f36acf3979806e957191cdb9b7233c300781ff045be1c2fdf5279a6102dfc613d5c5a25bfed6306f6b2911be2
   languageName: node
   linkType: hard
 
@@ -14130,16 +13890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/querystring-parser@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: ceba87cfa24bb86402f4ca2be15753647ebb3df248e0fc2b06a5cbd0d32c1639cca3dc6469daa990e44696e0e94351424ed22326fef46ae28f8c8587c68be515
-  languageName: node
-  linkType: hard
-
 "@smithy/service-error-classification@npm:^2.0.0":
   version: 2.0.0
   resolution: "@smithy/service-error-classification@npm:2.0.0"
@@ -14156,15 +13906,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/service-error-classification@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-  checksum: 2bd5e9b9328a66c6a774526519a0b167702fcd3b7301a7f1962e03142913b6cabefbf350b0607ebd79eb989f264d31ef267ad3ebb83d9eccbee78d5fba207759
-  languageName: node
-  linkType: hard
-
 "@smithy/shared-ini-file-loader@npm:^2.0.0, @smithy/shared-ini-file-loader@npm:^2.0.1":
   version: 2.0.1
   resolution: "@smithy/shared-ini-file-loader@npm:2.0.1"
@@ -14175,23 +13916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^3.1.10, @smithy/shared-ini-file-loader@npm:^3.1.11":
+"@smithy/shared-ini-file-loader@npm:^3.1.10, @smithy/shared-ini-file-loader@npm:^3.1.11, @smithy/shared-ini-file-loader@npm:^3.1.4, @smithy/shared-ini-file-loader@npm:^3.1.5, @smithy/shared-ini-file-loader@npm:^3.1.7, @smithy/shared-ini-file-loader@npm:^3.1.8":
   version: 3.1.11
   resolution: "@smithy/shared-ini-file-loader@npm:3.1.11"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 7479713932f00a6b85380fa8012ad893bb61e7ea614976e0ab2898767ff7dc91bb1dd813a4ec72e4850d6b10296f11032cd5dd916970042be376c19d0d3954b6
-  languageName: node
-  linkType: hard
-
-"@smithy/shared-ini-file-loader@npm:^3.1.4, @smithy/shared-ini-file-loader@npm:^3.1.5, @smithy/shared-ini-file-loader@npm:^3.1.7, @smithy/shared-ini-file-loader@npm:^3.1.8":
-  version: 3.1.8
-  resolution: "@smithy/shared-ini-file-loader@npm:3.1.8"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 6f4e66b6e0ddc1250c8f7dc5ebf272165608dd5510a92f03781e2a2adeb3ab862a277cb4c48150a4d0fdc279cafd0476eab0f2a5e01b2d6fed5a15f86d81b778
   languageName: node
   linkType: hard
 
@@ -14211,23 +13942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^4.1.0, @smithy/signature-v4@npm:^4.1.1, @smithy/signature-v4@npm:^4.1.4, @smithy/signature-v4@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@smithy/signature-v4@npm:4.2.0"
-  dependencies:
-    "@smithy/is-array-buffer": ^3.0.0
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/types": ^3.5.0
-    "@smithy/util-hex-encoding": ^3.0.0
-    "@smithy/util-middleware": ^3.0.7
-    "@smithy/util-uri-escape": ^3.0.0
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: d6222c7787d51b3ed58bb09f5fc56e90b6cd0e4588735e78f43a9642549e8e233a2050fa5734e844b80ea23ff17f867e61a687d34dba5db0dd466635f51a9ccf
-  languageName: node
-  linkType: hard
-
-"@smithy/signature-v4@npm:^4.2.2":
+"@smithy/signature-v4@npm:^4.1.0, @smithy/signature-v4@npm:^4.1.1, @smithy/signature-v4@npm:^4.1.4, @smithy/signature-v4@npm:^4.2.0, @smithy/signature-v4@npm:^4.2.2":
   version: 4.2.3
   resolution: "@smithy/signature-v4@npm:4.2.3"
   dependencies:
@@ -14255,21 +13970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^3.1.12, @smithy/smithy-client@npm:^3.3.0, @smithy/smithy-client@npm:^3.3.5, @smithy/smithy-client@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@smithy/smithy-client@npm:3.4.0"
-  dependencies:
-    "@smithy/middleware-endpoint": ^3.1.4
-    "@smithy/middleware-stack": ^3.0.7
-    "@smithy/protocol-http": ^4.1.4
-    "@smithy/types": ^3.5.0
-    "@smithy/util-stream": ^3.1.9
-    tslib: ^2.6.2
-  checksum: ed2bd1ad2e0ddc6f3eee5ec7697d2ece7b022a3528c5f20b9c2a4d1687635816500aae022ca315af14fb2045ebf2ad1bce43f97d2dc28f4185096843862bd7bb
-  languageName: node
-  linkType: hard
-
-"@smithy/smithy-client@npm:^3.4.4, @smithy/smithy-client@npm:^3.4.5":
+"@smithy/smithy-client@npm:^3.1.12, @smithy/smithy-client@npm:^3.3.0, @smithy/smithy-client@npm:^3.3.5, @smithy/smithy-client@npm:^3.4.0, @smithy/smithy-client@npm:^3.4.4, @smithy/smithy-client@npm:^3.4.5":
   version: 3.4.5
   resolution: "@smithy/smithy-client@npm:3.4.5"
   dependencies:
@@ -14293,16 +13994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^3.3.0, @smithy/types@npm:^3.4.0, @smithy/types@npm:^3.4.2, @smithy/types@npm:^3.5.0, @smithy/types@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@smithy/types@npm:3.6.0"
-  dependencies:
-    tslib: ^2.6.2
-  checksum: de16293da6cf6f1aa4b2ee604df245ef33688d985f27b5dae3aa69e18ed5b17baa1bc1a42412f1454c50d09a1817c8a54e7d6261c90fee230e103ff91e55174a
-  languageName: node
-  linkType: hard
-
-"@smithy/types@npm:^3.7.1":
+"@smithy/types@npm:^3.3.0, @smithy/types@npm:^3.4.0, @smithy/types@npm:^3.4.2, @smithy/types@npm:^3.5.0, @smithy/types@npm:^3.6.0, @smithy/types@npm:^3.7.1":
   version: 3.7.1
   resolution: "@smithy/types@npm:3.7.1"
   dependencies:
@@ -14322,7 +14014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^3.0.10":
+"@smithy/url-parser@npm:^3.0.10, @smithy/url-parser@npm:^3.0.3, @smithy/url-parser@npm:^3.0.4, @smithy/url-parser@npm:^3.0.6, @smithy/url-parser@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/url-parser@npm:3.0.10"
   dependencies:
@@ -14330,17 +14022,6 @@ __metadata:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 29c9d03ee86936ffb3bdcbb84ce14b7dacaadb2e61b5ed78ee91dfacb98e42048c70c718077347f0f39bce676168ba5fc1f1a8b19988f89f735c0b5e17cdc77a
-  languageName: node
-  linkType: hard
-
-"@smithy/url-parser@npm:^3.0.3, @smithy/url-parser@npm:^3.0.4, @smithy/url-parser@npm:^3.0.6, @smithy/url-parser@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/url-parser@npm:3.0.7"
-  dependencies:
-    "@smithy/querystring-parser": ^3.0.7
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 602199c24d13e35fc59bb075a626b83655d24e639a1c287e3eea2f3f8264f42870bab4d94282d0a1a210990263fbee532a661e662b2f11c6342d42dd36140bb5
   languageName: node
   linkType: hard
 
@@ -14451,20 +14132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^3.0.14, @smithy/util-defaults-mode-browser@npm:^3.0.16, @smithy/util-defaults-mode-browser@npm:^3.0.21, @smithy/util-defaults-mode-browser@npm:^3.0.23":
-  version: 3.0.23
-  resolution: "@smithy/util-defaults-mode-browser@npm:3.0.23"
-  dependencies:
-    "@smithy/property-provider": ^3.1.7
-    "@smithy/smithy-client": ^3.4.0
-    "@smithy/types": ^3.5.0
-    bowser: ^2.11.0
-    tslib: ^2.6.2
-  checksum: fec9d5d159e6db8ae9c3ac0785b571ed810bcd0e950658036ea9685c3d2cfe0e43649860785b18aec67e833a0d3354063515aa624507540f789227ea8ca626b5
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-browser@npm:^3.0.27":
+"@smithy/util-defaults-mode-browser@npm:^3.0.14, @smithy/util-defaults-mode-browser@npm:^3.0.16, @smithy/util-defaults-mode-browser@npm:^3.0.21, @smithy/util-defaults-mode-browser@npm:^3.0.23, @smithy/util-defaults-mode-browser@npm:^3.0.27":
   version: 3.0.28
   resolution: "@smithy/util-defaults-mode-browser@npm:3.0.28"
   dependencies:
@@ -14491,22 +14159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^3.0.14, @smithy/util-defaults-mode-node@npm:^3.0.16, @smithy/util-defaults-mode-node@npm:^3.0.21, @smithy/util-defaults-mode-node@npm:^3.0.23":
-  version: 3.0.23
-  resolution: "@smithy/util-defaults-mode-node@npm:3.0.23"
-  dependencies:
-    "@smithy/config-resolver": ^3.0.9
-    "@smithy/credential-provider-imds": ^3.2.4
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/property-provider": ^3.1.7
-    "@smithy/smithy-client": ^3.4.0
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 84cf4608f5aa7e619d455ff6e159a9f80bc870c48c3ab1786590e0a14df1958502a093ca8681c123900a010d8d69a4d2740c528c07aa82366629fa9f1f6e1604
-  languageName: node
-  linkType: hard
-
-"@smithy/util-defaults-mode-node@npm:^3.0.27":
+"@smithy/util-defaults-mode-node@npm:^3.0.14, @smithy/util-defaults-mode-node@npm:^3.0.16, @smithy/util-defaults-mode-node@npm:^3.0.21, @smithy/util-defaults-mode-node@npm:^3.0.23, @smithy/util-defaults-mode-node@npm:^3.0.27":
   version: 3.0.28
   resolution: "@smithy/util-defaults-mode-node@npm:3.0.28"
   dependencies:
@@ -14521,18 +14174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^2.0.5, @smithy/util-endpoints@npm:^2.1.0, @smithy/util-endpoints@npm:^2.1.2, @smithy/util-endpoints@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@smithy/util-endpoints@npm:2.1.3"
-  dependencies:
-    "@smithy/node-config-provider": ^3.1.8
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: 1f375f997b996af9b2d17a4d1fd2ace81bf0206bf6c9e80d591d1daadce34471ea5ff8913000cd2aae4f619b7d2f3b2d38caf528b036b97ada2831ffbb9725d9
-  languageName: node
-  linkType: hard
-
-"@smithy/util-endpoints@npm:^2.1.6":
+"@smithy/util-endpoints@npm:^2.0.5, @smithy/util-endpoints@npm:^2.1.0, @smithy/util-endpoints@npm:^2.1.2, @smithy/util-endpoints@npm:^2.1.3, @smithy/util-endpoints@npm:^2.1.6":
   version: 2.1.6
   resolution: "@smithy/util-endpoints@npm:2.1.6"
   dependencies:
@@ -14570,23 +14212,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^3.0.10":
+"@smithy/util-middleware@npm:^3.0.10, @smithy/util-middleware@npm:^3.0.3, @smithy/util-middleware@npm:^3.0.4, @smithy/util-middleware@npm:^3.0.6, @smithy/util-middleware@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/util-middleware@npm:3.0.10"
   dependencies:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: 01bbbd31044ab742985acac36aa61e240db16ed7dfa22b73779877eb5db0af14351883506fb34d2ee964598d72f4998d79409c271a62310647fb28faccd855a2
-  languageName: node
-  linkType: hard
-
-"@smithy/util-middleware@npm:^3.0.3, @smithy/util-middleware@npm:^3.0.4, @smithy/util-middleware@npm:^3.0.6, @smithy/util-middleware@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/util-middleware@npm:3.0.7"
-  dependencies:
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: e625791046c73bf5a35d67127007054bb6cc8d8707575c122732de1d6474b97ce1bd5c8c02051287bd967320f768eba364f1f0a59937654dbe25a66cce21bc6d
   languageName: node
   linkType: hard
 
@@ -14600,7 +14232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^3.0.10":
+"@smithy/util-retry@npm:^3.0.10, @smithy/util-retry@npm:^3.0.3, @smithy/util-retry@npm:^3.0.4, @smithy/util-retry@npm:^3.0.6, @smithy/util-retry@npm:^3.0.7":
   version: 3.0.10
   resolution: "@smithy/util-retry@npm:3.0.10"
   dependencies:
@@ -14608,17 +14240,6 @@ __metadata:
     "@smithy/types": ^3.7.1
     tslib: ^2.6.2
   checksum: ac1dcfd2e4ea1a4f99a42447b7fd8e4ea21589dfd87e9bc6a7bdf1d26e1f93ec71aa4cfde5e024b00d9b713b889f9db20a8d81b9e3ccdbe6f72bedb6269f01b8
-  languageName: node
-  linkType: hard
-
-"@smithy/util-retry@npm:^3.0.3, @smithy/util-retry@npm:^3.0.4, @smithy/util-retry@npm:^3.0.6, @smithy/util-retry@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@smithy/util-retry@npm:3.0.7"
-  dependencies:
-    "@smithy/service-error-classification": ^3.0.7
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: d641f1e11afbda1b194e5e6a75e815eed03100e0c53305d106cd80836b22854b4ba01efd9aed32996ec538e5c49293bb8d0a77561ebd721d94d862173e40738b
   languageName: node
   linkType: hard
 
@@ -14638,23 +14259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^3.1.3, @smithy/util-stream@npm:^3.1.4, @smithy/util-stream@npm:^3.1.8, @smithy/util-stream@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "@smithy/util-stream@npm:3.1.9"
-  dependencies:
-    "@smithy/fetch-http-handler": ^3.2.9
-    "@smithy/node-http-handler": ^3.2.4
-    "@smithy/types": ^3.5.0
-    "@smithy/util-base64": ^3.0.0
-    "@smithy/util-buffer-from": ^3.0.0
-    "@smithy/util-hex-encoding": ^3.0.0
-    "@smithy/util-utf8": ^3.0.0
-    tslib: ^2.6.2
-  checksum: 04f37b1e97692d9177a41351336bb119eb5dbe2582bc17e76bc99919defe67fe5afbf3cb52612c48c2bca3bec6f96f2d860825afc9249ab6e7e8fd9b4719f7a8
-  languageName: node
-  linkType: hard
-
-"@smithy/util-stream@npm:^3.3.1":
+"@smithy/util-stream@npm:^3.1.3, @smithy/util-stream@npm:^3.1.4, @smithy/util-stream@npm:^3.1.8, @smithy/util-stream@npm:^3.1.9, @smithy/util-stream@npm:^3.3.1":
   version: 3.3.1
   resolution: "@smithy/util-stream@npm:3.3.1"
   dependencies:
@@ -14708,18 +14313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^3.1.2, @smithy/util-waiter@npm:^3.1.3, @smithy/util-waiter@npm:^3.1.5, @smithy/util-waiter@npm:^3.1.6":
-  version: 3.1.6
-  resolution: "@smithy/util-waiter@npm:3.1.6"
-  dependencies:
-    "@smithy/abort-controller": ^3.1.5
-    "@smithy/types": ^3.5.0
-    tslib: ^2.6.2
-  checksum: dfa7cf04afa7be4736e78f54f96c6583c2f582fef6bd179cf925f5dd737f3fed0b37446d5198d9dedfb343a0b71c481f560b5954686f8e2b51155a37752bc586
-  languageName: node
-  linkType: hard
-
-"@smithy/util-waiter@npm:^3.1.9":
+"@smithy/util-waiter@npm:^3.1.2, @smithy/util-waiter@npm:^3.1.3, @smithy/util-waiter@npm:^3.1.5, @smithy/util-waiter@npm:^3.1.6, @smithy/util-waiter@npm:^3.1.9":
   version: 3.1.9
   resolution: "@smithy/util-waiter@npm:3.1.9"
   dependencies:


### PR DESCRIPTION
#### Description of changes

Retrieve oauth values (Facebook, Amazon, Google, Apple) for auth gen1 stack update using Cognito and SSM. This is a required pre-step before stack refactoring.

#### Description of how you validated changes

Ran template gen locally and it successfully updated:

```
../node_modules/.bin/migrate to-gen-2 generate-templates --from amplify-oauthexecute-dev-19e93 --to amplify-mygen2app-oauthexecute-sandbox-cfab5267c9

```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
