### PR TITLE
fix(migrate): rename generate-templates to execute command

### DIFF
--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -4,9 +4,9 @@ import fs from 'node:fs/promises';
 import assert from 'node:assert';
 import { v4 as uuid } from 'uuid';
 
-import { Gen2RenderingOptions, createGen2Renderer } from '@aws-amplify/amplify-gen2-codegen';
+import { createGen2Renderer, Gen2RenderingOptions } from '@aws-amplify/amplify-gen2-codegen';
 
-import { UsageData, getProjectSettings } from '@aws-amplify/cli-internal';
+import { getProjectSettings, UsageData } from '@aws-amplify/cli-internal';
 import { AmplifyClient } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { CognitoIdentityProviderClient, LambdaConfigType } from '@aws-sdk/client-cognito-identity-provider';
@@ -121,8 +121,7 @@ const getUsageDataMetric = async (): Promise<IUsageData> => {
 const getAccountId = async (): Promise<string | undefined> => {
   const stsClient = new STSClient();
   const callerIdentityResult = await stsClient.send(new GetCallerIdentityCommand());
-  const accountId = callerIdentityResult.Account;
-  return accountId;
+  return callerIdentityResult.Account;
 };
 
 const getAuthTriggersConnections = async (): Promise<Partial<Record<keyof LambdaConfigType, string>>> => {
@@ -238,7 +237,12 @@ export async function execute() {
   await fs.rm(TEMP_GEN_2_OUTPUT_DIR, { recursive: true });
 }
 
-export async function generateTemplates(fromStack: string, toStack: string) {
+/**
+ * Executes the stack refactor operation to move Gen1 resources from Gen1 stack into Gen2 stack
+ * @param fromStack
+ * @param toStack
+ */
+export async function executeStackRefactor(fromStack: string, toStack: string) {
   const cfnClient = new CloudFormationClient();
   const ssmClient = new SSMClient();
   const cognitoIdpClient = new CognitoIdentityProviderClient();

--- a/packages/amplify-migration/src/commands/gen2/execute/execute_command.test.ts
+++ b/packages/amplify-migration/src/commands/gen2/execute/execute_command.test.ts
@@ -1,4 +1,4 @@
-import { GenerateTemplatesCommand } from './generate-templates_command';
+import { Gen2ExecuteCommand } from './execute_command';
 import { runCommandAsync } from '../../../test-utils/command_runner';
 import yargs, { CommandModule } from 'yargs';
 import assert from 'node:assert';
@@ -6,21 +6,21 @@ import assert from 'node:assert';
 const mockHandler = jest.fn();
 jest.mock('../../../command-handlers', () => ({
   ...jest.requireActual('../../../command-handlers'),
-  generateTemplates: (from: string, to: string) => mockHandler(from, to),
+  executeStackRefactor: (from: string, to: string) => mockHandler(from, to),
 }));
 
-describe('GenerateTemplateCommand', () => {
+describe('Gen2ExecuteCommand', () => {
   it('should run command successfully', async () => {
-    const parser = yargs().command(new GenerateTemplatesCommand() as unknown as CommandModule);
-    await runCommandAsync(parser, 'generate-templates --from foo --to bar');
+    const parser = yargs().command(new Gen2ExecuteCommand() as unknown as CommandModule);
+    await runCommandAsync(parser, 'execute --from foo --to bar');
     expect(mockHandler).toHaveBeenCalledTimes(1);
     expect(mockHandler).toHaveBeenCalledWith('foo', 'bar');
   });
 
   it('should fail command when arguments are not provided', async () => {
-    const parser = yargs().command(new GenerateTemplatesCommand() as unknown as CommandModule);
+    const parser = yargs().command(new Gen2ExecuteCommand() as unknown as CommandModule);
     await assert.rejects(
-      () => runCommandAsync(parser, 'generate-templates'),
+      () => runCommandAsync(parser, 'execute'),
       (err: Error) => {
         assert.equal(err.message, 'Missing required arguments: from, to');
         return true;

--- a/packages/amplify-migration/src/commands/gen2/execute/execute_command.ts
+++ b/packages/amplify-migration/src/commands/gen2/execute/execute_command.ts
@@ -1,16 +1,16 @@
 import { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-import { generateTemplates } from '../../../command-handlers';
+import { executeStackRefactor } from '../../../command-handlers';
 import assert from 'node:assert';
 
-export interface GenerateTemplatesCommandOptions {
+export interface ExecuteCommandOptions {
   from: string | undefined;
   to: string | undefined;
 }
 
 /**
- * Command that generates templates needed for Gen2 migration.
+ * Command that executes stack refactor operation needed for Gen2 migration.
  */
-export class GenerateTemplatesCommand implements CommandModule<object, GenerateTemplatesCommandOptions> {
+export class Gen2ExecuteCommand implements CommandModule<object, ExecuteCommandOptions> {
   /**
    * @inheritDoc
    */
@@ -22,11 +22,11 @@ export class GenerateTemplatesCommand implements CommandModule<object, GenerateT
   readonly describe: string;
 
   constructor() {
-    this.command = 'generate-templates';
-    this.describe = 'Generates stack refactor inputs (CFN templates)';
+    this.command = 'execute';
+    this.describe = 'Moves Amplify Gen1 resources from a Gen1 stack into a Gen2 stack';
   }
 
-  builder = (yargs: Argv): Argv<GenerateTemplatesCommandOptions> => {
+  builder = (yargs: Argv): Argv<ExecuteCommandOptions> => {
     return yargs
       .version(false)
       .option('from', {
@@ -40,10 +40,10 @@ export class GenerateTemplatesCommand implements CommandModule<object, GenerateT
         demandOption: true,
       });
   };
-  handler = async (args: ArgumentsCamelCase<GenerateTemplatesCommandOptions>): Promise<void> => {
+  handler = async (args: ArgumentsCamelCase<ExecuteCommandOptions>): Promise<void> => {
     const { from, to } = args;
     assert(from);
     assert(to);
-    await generateTemplates(from, to);
+    await executeStackRefactor(from, to);
   };
 }

--- a/packages/amplify-migration/src/commands/gen2/gen2_command_factory.ts
+++ b/packages/amplify-migration/src/commands/gen2/gen2_command_factory.ts
@@ -1,10 +1,10 @@
 import { CommandModule } from 'yargs';
 import { Gen2Command } from './gen2_command';
 import { Gen2StartCommand } from './start/start_command';
-import { GenerateTemplatesCommand } from './generate-templates/generate-templates_command';
+import { Gen2ExecuteCommand } from './execute/execute_command';
 
 export const createGen2Command = (): CommandModule => {
   const gen2StartCommand = new Gen2StartCommand();
-  const generateTemplatesCommand = new GenerateTemplatesCommand();
-  return new Gen2Command([gen2StartCommand, generateTemplatesCommand as unknown as CommandModule]);
+  const gen2ExecuteCommand = new Gen2ExecuteCommand();
+  return new Gen2Command([gen2StartCommand, gen2ExecuteCommand as unknown as CommandModule]);
 };


### PR DESCRIPTION
#### Description of changes

Rename the `generate-templates` to `execute` command since we are going to automate the preprocessing of gen1 and gen2 stack updates as well as stack refactor operations.

**Note**: Stack refactor operation has not yet been automated since the stack refactor APIs are not yet launched.

Confirmed with @josefaidt  on the command name.

#### Description of how you validated changes
`yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
