### PR TITLE
fix: unhandled error when AWS config or profile don't exist

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -354,7 +354,7 @@ const validateCredentials = (credentials: $TSAny, profileName: string): void => 
 
 const normalizeKeys = (config: $TSAny): $TSAny => {
   const configClone = { ...config };
-  if (configClone) {
+  if (config) {
     configClone.accessKeyId = config.accessKeyId || config.aws_access_key_id;
     configClone.secretAccessKey = config.secretAccessKey || config.aws_secret_access_key;
     configClone.sessionToken = config.sessionToken || config.aws_session_token;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

If the AWS profile specified in the Amplify config doesn't exist, _or_ if the AWS config files themselves don't exist, various Amplify
operations log this error:

```
🛑 Failed to get profile credentials
Cannot read properties of undefined (reading 'accessKeyId')
```

Depending on the operation and circumstances, this can be just a spurious message that doesn't interfere with the operation, or it can be an
actual error.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Tested locally with modified version and a missing AWS profile

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
