### PR TITLE
fix: add import for removal policy in gen2 codegen

### DIFF
--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -335,6 +335,7 @@ describe('BackendRenderer', () => {
       });
       const output = printNodeArray(rendered);
       assert(output.includes('s3Bucket.applyRemovalPolicy'));
+      assert(output.includes('import { RemovalPolicy } from "aws-cdk-lib";'));
     });
   });
   describe('UserPoolClient Configuration using render()', () => {
@@ -471,6 +472,7 @@ describe('BackendRenderer', () => {
       const output = printNodeArray(rendered);
       assert(output.includes('cfnUserPool.applyRemovalPolicy'));
       assert(output.includes('cfnIdentityPool.applyRemovalPolicy'));
+      assert(output.includes('import { RemovalPolicy } from "aws-cdk-lib";'));
     });
   });
 });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -447,6 +447,7 @@ export class BackendSynthesizer {
 
     if (renderArgs.auth) {
       imports.push(this.createImportStatement([authFunctionIdentifier], renderArgs.auth.importFrom));
+      imports.push(this.createImportStatement([factory.createIdentifier('RemovalPolicy')], 'aws-cdk-lib'));
       const auth = factory.createShorthandPropertyAssignment(authFunctionIdentifier);
       defineBackendProperties.push(auth);
     }


### PR DESCRIPTION
#### Description of changes

Add import for removal policy in gen2 codegen `backend.ts` file for auth.

#### Description of how you validated changes
`yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
