### PR TITLE
fix: pin cypress version in uibuilder test

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
@@ -98,7 +98,7 @@ describe('amplify pull with uibuilder', () => {
     spawnSync(
       getNpmPath(),
       // in some runs spawnSync/npx will still use an old ver of react-scripts moving it into npm install flow
-      ['install', '-E', '@types/react', 'cypress@13.16.0', '@aws-amplify/ui-react', 'aws-amplify', 'react-scripts@5'],
+      ['install', '-E', '@types/react', 'cypress@13.15.0', '@aws-amplify/ui-react', 'aws-amplify', 'react-scripts@5'],
       { cwd: reactDir },
     );
 
@@ -114,7 +114,7 @@ describe('amplify pull with uibuilder', () => {
     const npmStartProcess = spawn(getNpmPath(), ['start'], { cwd: reactDir, timeout: 300000 });
     // Give react server time to start
     await new Promise((resolve) => setTimeout(resolve, 60000));
-    const res = execa.sync(getNpxPath(), ['cypress@13.16.0', 'run'], { cwd: reactDir, encoding: 'utf8' });
+    const res = execa.sync(getNpxPath(), ['cypress@13.15.0', 'run'], { cwd: reactDir, encoding: 'utf8' });
     // kill the react server process
     spawnSync('kill', [`${npmStartProcess.pid}`], { encoding: 'utf8' });
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
@@ -114,7 +114,7 @@ describe('amplify pull with uibuilder', () => {
     const npmStartProcess = spawn(getNpmPath(), ['start'], { cwd: reactDir, timeout: 300000 });
     // Give react server time to start
     await new Promise((resolve) => setTimeout(resolve, 60000));
-    const res = execa.sync(getNpxPath(), ['cypress', 'run'], { cwd: reactDir, encoding: 'utf8' });
+    const res = execa.sync(getNpxPath(), ['cypress@13.16.0', 'run'], { cwd: reactDir, encoding: 'utf8' });
     // kill the react server process
     spawnSync('kill', [`${npmStartProcess.pid}`], { encoding: 'utf8' });
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/uibuilder.test.ts
@@ -98,7 +98,7 @@ describe('amplify pull with uibuilder', () => {
     spawnSync(
       getNpmPath(),
       // in some runs spawnSync/npx will still use an old ver of react-scripts moving it into npm install flow
-      ['install', '-E', '@types/react', 'cypress', '@aws-amplify/ui-react', 'aws-amplify', 'react-scripts@5'],
+      ['install', '-E', '@types/react', 'cypress@13.16.0', '@aws-amplify/ui-react', 'aws-amplify', 'react-scripts@5'],
       { cwd: reactDir },
     );
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Cypress 13.16.0 broke the test (https://docs.cypress.io/app/references/changelog#13-16-0), we are going to pin to 13.15.0 to avoid this happening in the future.

13.15.0 is the last known working version.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
