### PR TITLE
Gen2 migrations execute

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lerna": "^6.6.1",
     "node-gyp": "^9.3.1",
     "strip-ansi": "^6.0.0",
+    "vite": "^6.0.3",
     "yargs": "^17.7.2"
   },
   "workspaces": {
@@ -111,6 +112,8 @@
     "@commitlint/cz-commitlint": "^17.5.0",
     "@commitlint/prompt": "^17.6.1",
     "@microsoft/api-extractor": "^7.34.6",
+    "@swc/cli": "^0.5.2",
+    "@swc/core": "^1.10.1",
     "@types/glob": "^7.1.1",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^4.0.0",
@@ -123,6 +126,7 @@
     "babel-loader": "^8.3.0",
     "codecov": "^3.7.0",
     "copyfiles": "^2.2.0",
+    "esbuild": "^0.24.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "lerna": "^6.6.1",
     "node-gyp": "^9.3.1",
     "strip-ansi": "^6.0.0",
-    "vite": "^6.0.3",
     "yargs": "^17.7.2"
   },
   "workspaces": {
@@ -112,8 +111,6 @@
     "@commitlint/cz-commitlint": "^17.5.0",
     "@commitlint/prompt": "^17.6.1",
     "@microsoft/api-extractor": "^7.34.6",
-    "@swc/cli": "^0.5.2",
-    "@swc/core": "^1.10.1",
     "@types/glob": "^7.1.1",
     "@types/jest": "^29.0.0",
     "@types/js-yaml": "^4.0.0",
@@ -126,7 +123,6 @@
     "babel-loader": "^8.3.0",
     "codecov": "^3.7.0",
     "copyfiles": "^2.2.0",
-    "esbuild": "^0.24.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/amplify-gen1-codegen-data-adapter/src/get_data_definition.ts
+++ b/packages/amplify-gen1-codegen-data-adapter/src/get_data_definition.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { DataDefinition } from '@aws-amplify/amplify-gen2-codegen';
 import { Stack } from '@aws-sdk/client-cloudformation';
 
-export const tableMappingKey = 'TableMapping';
+export const tableMappingKey = 'DataSourceMappingOutput';
 
 export const getDataDefinition = (dataStack: Stack): DataDefinition => {
   const rawTableMapping = dataStack.Outputs?.find((o) => o.OutputKey === tableMappingKey)?.OutputValue;

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -334,7 +334,7 @@ describe('BackendRenderer', () => {
         },
       });
       const output = printNodeArray(rendered);
-      assert(output.includes('s3Bucket.applyRemovalPolicy'));
+      assert(output.includes('// s3Bucket.applyRemovalPolicy'));
       assert(output.includes('import { RemovalPolicy } from "aws-cdk-lib";'));
     });
   });
@@ -410,7 +410,7 @@ describe('BackendRenderer', () => {
             CallbackURLs: ['XXXXXXXXXXXXXXXXXX', 'XXXXXXXXXXXXXXXXXXXXXX'],
             LogoutURLs: ['XXXXXXXXXXXXXXXXXX', 'XXXXXXXXXXXXXXXXXXXXXX'],
             DefaultRedirectURI: 'XXXXXXXXXXXXXXXXXX',
-            SupportedIdentityProviders: ['COGNITO'],
+            SupportedIdentityProviders: ['COGNITO', 'Facebook'],
             AuthSessionValidity: 3,
             EnableTokenRevocation: true,
             EnablePropagateAdditionalUserContextData: true,
@@ -455,7 +455,9 @@ describe('BackendRenderer', () => {
       expect(output).toContain('authFlows: { adminUserPassword: false, custom: false, userPassword: false, userSrp: false }');
 
       // Additional settings
-      expect(output).toContain('supportedIdentityProviders');
+      expect(output).toContain(`supportedIdentityProviders`);
+      expect(output).toContain(`UserPoolClientIdentityProvider.COGNITO`);
+      expect(output).toContain(`UserPoolClientIdentityProvider.FACEBOOK`);
       expect(output).toContain('authSessionValidity: Duration.minutes(3)');
       expect(output).toContain('enableTokenRevocation: true');
       expect(output).toContain('enablePropagateAdditionalUserContextData: true');
@@ -470,8 +472,8 @@ describe('BackendRenderer', () => {
         },
       });
       const output = printNodeArray(rendered);
-      assert(output.includes('cfnUserPool.applyRemovalPolicy'));
-      assert(output.includes('cfnIdentityPool.applyRemovalPolicy'));
+      assert(output.includes('// cfnUserPool.applyRemovalPolicy'));
+      assert(output.includes('// cfnIdentityPool.applyRemovalPolicy'));
       assert(output.includes('import { RemovalPolicy } from "aws-cdk-lib";'));
     });
   });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -1,19 +1,21 @@
 import ts, {
-  Node,
-  ExpressionStatement,
   CallExpression,
   Expression,
-  VariableDeclaration,
+  ExpressionStatement,
   Identifier,
-  NodeArray,
   ImportDeclaration,
-  VariableStatement,
+  Node,
+  NodeArray,
+  SyntaxKind,
+  VariableDeclaration,
+  VariableStatement
 } from 'typescript';
 import { PolicyOverrides, ReferenceAuth } from '../auth/source_builder.js';
 import { BucketAccelerateStatus, BucketVersioningStatus } from '@aws-sdk/client-s3';
 import { AccessPatterns, ServerSideEncryptionConfiguration } from '../storage/source_builder.js';
-import { UserPoolClientType, OAuthFlowType, ExplicitAuthFlowsType } from '@aws-sdk/client-cognito-identity-provider';
+import { ExplicitAuthFlowsType, OAuthFlowType, UserPoolClientType } from '@aws-sdk/client-cognito-identity-provider';
 import assert from 'assert';
+
 const factory = ts.factory;
 export interface BackendRenderParameters {
   data?: {
@@ -162,7 +164,7 @@ export class BackendSynthesizer {
 
   private addRemovalPolicyAssignment(identifier: string) {
     return factory.createCallExpression(
-      factory.createPropertyAccessExpression(factory.createIdentifier(identifier), factory.createIdentifier('applyRemovalPolicy')),
+      factory.createPropertyAccessExpression(factory.createIdentifier(`// ${identifier}`), factory.createIdentifier('applyRemovalPolicy')),
       undefined,
       [
         factory.createIdentifier('RemovalPolicy.RETAIN'),
@@ -233,7 +235,12 @@ export class BackendSynthesizer {
       const mappedProperty = gen2PropertyMap.get(key);
       if (mappedProperty) {
         if (typeof value == 'boolean') {
-          objectLiterals.push(this.createBooleanPropertyAssignment(mappedProperty, value));
+          if (key === 'AllowedOAuthFlowsUserPoolClient') {
+            // CDK equivalent is disableOAuth which is opposite of this prop
+            objectLiterals.push(this.createBooleanPropertyAssignment(mappedProperty, !value));
+          } else {
+            objectLiterals.push(this.createBooleanPropertyAssignment(mappedProperty, value));
+          }
         } else if (typeof value == 'string') {
           if (!this.oAuthFlag && key == 'DefaultRedirectURI') {
             this.oAuthFlag = true;
@@ -276,7 +283,8 @@ export class BackendSynthesizer {
             objectLiterals.push(this.createReadWriteAttributes(mappedProperty, value));
           } else if (key == 'SupportedIdentityProviders') {
             this.supportedIdentityProviderFlag = true;
-            objectLiterals.push(this.createEnumListPropertyAssignment(mappedProperty, 'UserPoolClientIdentityProvider', value));
+            // Providers are upper case in CDK
+            objectLiterals.push(this.createEnumListPropertyAssignment(mappedProperty, 'UserPoolClientIdentityProvider', value.map(provider => provider.toUpperCase())));
           } else if (!this.oAuthFlag && key == 'AllowedOAuthFlows') {
             this.oAuthFlag = true;
             objectLiterals.push(this.createOAuthObjectExpression(object, gen2PropertyMap));
@@ -445,9 +453,12 @@ export class BackendSynthesizer {
       TemporaryPasswordValidityDays: 'temporaryPasswordValidityDays',
     };
 
+    if (renderArgs.auth || renderArgs.storage?.hasS3Bucket) {
+      imports.push(this.createImportStatement([factory.createIdentifier('RemovalPolicy')], 'aws-cdk-lib'));
+    }
+
     if (renderArgs.auth) {
       imports.push(this.createImportStatement([authFunctionIdentifier], renderArgs.auth.importFrom));
-      imports.push(this.createImportStatement([factory.createIdentifier('RemovalPolicy')], 'aws-cdk-lib'));
       const auth = factory.createShorthandPropertyAssignment(authFunctionIdentifier);
       defineBackendProperties.push(auth);
     }
@@ -460,13 +471,12 @@ export class BackendSynthesizer {
 
     if (renderArgs.storage?.hasS3Bucket) {
       imports.push(this.createImportStatement([storageFunctionIdentifier], renderArgs.storage.importFrom));
-      imports.push(this.createImportStatement([factory.createIdentifier('RemovalPolicy')], 'aws-cdk-lib'));
       const storage = factory.createShorthandPropertyAssignment(storageFunctionIdentifier);
       defineBackendProperties.push(storage);
     }
 
     if (renderArgs.function) {
-      const functionIdentifiers: Identifier[] = [];
+      const functionIdentifiers: Identifier[] = []; 
       const functionNameCategories = renderArgs.function.functionNamesAndCategories;
       for (const [functionName, category] of functionNameCategories) {
         functionIdentifiers.push(factory.createIdentifier(functionName));

--- a/packages/amplify-migration/src/app_auth_definition_fetcher.test.ts
+++ b/packages/amplify-migration/src/app_auth_definition_fetcher.test.ts
@@ -1,6 +1,6 @@
 import { CognitoIdentityProviderClient, DescribeUserPoolCommand, ListGroupsCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoIdentityClient, GetIdentityPoolRolesCommand, ListIdentityPoolsCommand } from '@aws-sdk/client-cognito-identity';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { CloudFormationClient, DescribeStackResourcesCommand, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { AmplifyClient, ListBackendEnvironmentsCommand } from '@aws-sdk/client-amplify';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
@@ -131,6 +131,7 @@ jest.mock('@aws-sdk/client-amplify', () => {
                 {
                   environmentName: 'dev',
                   deploymentArtifacts: 's3://deploymentArtifacts',
+                  stackName: 'stackName',
                 },
               ],
             });
@@ -160,6 +161,24 @@ jest.mock('@aws-sdk/client-s3', () => {
   };
 });
 
+jest.mock('@aws-sdk/client-cloudformation', () => {
+  return {
+    ...jest.requireActual('@aws-sdk/client-cloudformation'),
+    CloudFormationClient: function () {
+      return {
+        send: jest.fn().mockImplementation((command) => {
+          if (command instanceof DescribeStackResourcesCommand) {
+            return Promise.resolve({
+              StackResources: [],
+            });
+          }
+          return Promise.resolve();
+        }),
+      };
+    },
+  };
+});
+
 const cognitoIdentityProviderClient = new CognitoIdentityProviderClient();
 const cognitoIdentityClient = new CognitoIdentityClient();
 const cloudFormationClient = new CloudFormationClient();
@@ -179,6 +198,16 @@ describe('Auth definition Fetcher tests', () => {
     () => Promise.resolve({}),
     ccbFetcher,
   );
+  it('should not fetch imported auth definitions when not present', async () => {
+    // arrange
+    mockReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        api: {},
+      }),
+    );
+    // act + assert
+    await expect(appAuthDefinitionFetcher.getDefinition()).resolves.toEqual(undefined);
+  });
   it('should fetch imported auth definitions', async () => {
     await expect(appAuthDefinitionFetcher.getDefinition()).resolves.toEqual({
       referenceAuth: {
@@ -195,7 +224,7 @@ describe('Auth definition Fetcher tests', () => {
   });
 
   it('should not fetch imported auth definitions if there is no related cognito resource information', async () => {
-    mockReadFile.mockResolvedValue(
+    mockReadFile.mockResolvedValueOnce(
       JSON.stringify({
         auth: {
           importedAuth: {

--- a/packages/amplify-migration/src/app_auth_definition_fetcher.ts
+++ b/packages/amplify-migration/src/app_auth_definition_fetcher.ts
@@ -51,8 +51,7 @@ export class AppAuthDefinitionFetcher {
     }
 
     const amplifyMeta = (await this.readJsonFile(amplifyMetaPath)) ?? {};
-    const isImported = Object.keys(amplifyMeta.auth).map((key) => amplifyMeta.auth[key])[0].serviceType === 'imported';
-
+    const isImported = 'auth' in amplifyMeta && Object.keys(amplifyMeta.auth).map((key) => amplifyMeta.auth[key])[0].serviceType === 'imported';
     if (!isImported) {
       return undefined;
     }
@@ -118,6 +117,8 @@ export class AppAuthDefinitionFetcher {
         referenceAuth,
       };
     }
+
+
 
     const backendEnvironment = await this.backendEnvironmentResolver.selectBackendEnvironment();
     assert(backendEnvironment?.stackName);

--- a/packages/amplify-migration/src/app_functions_definition_fetcher.ts
+++ b/packages/amplify-migration/src/app_functions_definition_fetcher.ts
@@ -31,12 +31,13 @@ export class AppFunctionsDefinitionFetcher {
     const meta = this.stateManager.getMeta();
     const functions = meta?.function ?? {};
 
-    const auth = meta?.auth;
+    const auth = meta?.auth ?? {};
     const storageList = meta?.storage ?? {};
 
     const functionCategoryMap = new Map<string, string>();
 
     const authValues: AuthConfig | undefined = Object.values(auth)[0] as AuthConfig;
+
 
     // auth triggers
     if (auth && authValues && authValues.dependsOn) {


### PR DESCRIPTION
#### Description of changes

- Fix Userpool client provider casing (needs to be uppercase) in CDK
- Fix Data table mapping output key name
- Check for absence of auth in gen1 definition fetcher
- Add comment for RemovalPolicy statements to force a CI/CD or sandbox deploy post Refactor by instructing customers to remove the comment.


#### Description of how you validated changes
`yarn test`, manual testing of running gen2 codegen

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
