### PR TITLE
test: wait for IAM role propagation in migration test

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/transformer-migrations/model-migration.test.ts
@@ -113,6 +113,9 @@ describe('transformer model migration test', () => {
     await updateApiSchema(projRoot, projectName, modelSchemaV2);
     await amplifyPushUpdate(projRoot);
 
+    // Wait for 20s to ensure the newly-created roles have propagated
+    await new Promise((resolve) => setTimeout(resolve, 20000));
+
     appSyncClient = getAppSyncClientFromProj(projRoot);
 
     createPostMutation = /* GraphQL */ `

--- a/scripts/cloud-cli-utils.sh
+++ b/scripts/cloud-cli-utils.sh
@@ -11,7 +11,11 @@ function authenticate {
     role_name=$2
     profile_name=$3
     echo Authenticating terminal...
-    mwinit
+    if [[ -n $USE_FIDO_KEY ]] ; then
+      mwinit -s -f
+    else
+      mwinit
+    fi
     echo Loading account credentials for Account $account_number with Role: $role_name...
     ada cred update --profile="${profile_name}" --account="${account_number}" --role=${role_name} --provider=isengard --once
     aws configure set region us-east-1 --profile $profile_name

--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -6,7 +6,12 @@ source $scriptDir/.env set
 printf 'What is your PR number ? '
 read PR_NUMBER
 
-mwinit
+if [[ -n $USE_FIDO_KEY ]] ; then
+  mwinit -s -f
+else
+  mwinit
+fi
+
 ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=CodeBuildE2E --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
 --profile=cb-ci-account \

--- a/scripts/cloud-rollback.sh
+++ b/scripts/cloud-rollback.sh
@@ -6,7 +6,12 @@ source $scriptDir/.env set
 printf 'What version should I rollback to ? '
 read ROLLBACK_TARGET_VERSION
 
-mwinit
+if [[ -n $USE_FIDO_KEY ]] ; then
+  mwinit -s -f
+else
+  mwinit
+fi
+
 ada cred update --profile=AmplifyCLIReleaseProd --account=$RELEASE_ACCOUNT_PROD --role=CodebuildRelease --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
 --profile=AmplifyCLIReleaseProd \


### PR DESCRIPTION
#### Description of changes

Add a hardcoded delay in `model-migration.test.ts` to account for IAM role propagation. (I experimented with using an IAM waiter rather than a hardcoded delay, but couldn't get it to work in my local environment in the time I allocated for investigation. 20s seems a reasonable price to pay on a ~1600s total test run.)

**Other changes**

* Support a new `USE_FIDO_KEY` environment variable when invoking cloud utilities, to add the `-f` flag to `mwinit` invocations.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

The `model-migration.test.ts` E2E test, which was previously reliably failing on Linux after applying new Data package versions, now passes reliably in both Linux & Windows.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] [Modified E2E test](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/671107461633/projects/AmplifyCLI-E2E-Testing/batch/AmplifyCLI-E2E-Testing:d3ebe7b0-98f3-447e-a149-ca4bfb8930ae?region=us-east-1) passes
    - E2E failures are unrelated to this change, as evidenced by those failures appearing in other E2E runs against `dev`
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
