### PR TITLE
fix: package json name and deps, always set generateSecrets prop

### DIFF
--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -426,7 +426,7 @@ describe('BackendRenderer', () => {
       const output = printNodeArray(rendered);
 
       // Basic configuration
-      expect(output).toContain('"us-west-2_aaaaaaaaa"');
+      expect(output).toContain('NativeAppClient');
       expect(output).toContain('userPoolClientName: "MyApp"');
 
       // Token validity settings
@@ -461,6 +461,7 @@ describe('BackendRenderer', () => {
       expect(output).toContain('authSessionValidity: Duration.minutes(3)');
       expect(output).toContain('enableTokenRevocation: true');
       expect(output).toContain('enablePropagateAdditionalUserContextData: true');
+      expect(output).toContain('generateSecret: true');
     });
     it('renders userpool and identitypool deletion policy', () => {
       const renderer = new BackendSynthesizer();
@@ -475,6 +476,28 @@ describe('BackendRenderer', () => {
       assert(output.includes('// cfnUserPool.applyRemovalPolicy'));
       assert(output.includes('// cfnIdentityPool.applyRemovalPolicy'));
       assert(output.includes('import { RemovalPolicy } from "aws-cdk-lib";'));
+    });
+    it('renders user pool client configuration with default value for generateSecrets', () => {
+      const renderer = new BackendSynthesizer();
+      const rendered = renderer.render({
+        auth: {
+          importFrom: './auth/resource.ts',
+          userPoolClient: {
+            UserPoolId: 'us-west-2_aaaaaaaaa',
+            ClientName: 'MyApp',
+            ClientId: '38fjsnc484p94kpqsnet7mpld0',
+          },
+        },
+      });
+
+      const output = printNodeArray(rendered);
+
+      // Basic configuration
+      expect(output).toContain('NativeAppClient');
+      expect(output).toContain('userPoolClientName: "MyApp"');
+
+      // Additional settings
+      expect(output).toContain('generateSecret: false');
     });
   });
 });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -316,7 +316,7 @@ export class BackendSynthesizer {
     // We need to set generateSecret to false explicitly when not defined.
     // If it's set as undefined and current value in CFN template is false (moved from gen1 after refactor), CFN thinks the property has changed
     // and requests for creation of a new resource (user pool client) instead of an update.
-    if (!object.hasOwnProperty(clientSecretKey) && gen2PropertyMap.has(clientSecretKey)) {
+    if (object[clientSecretKey] === undefined && gen2PropertyMap.has(clientSecretKey)) {
       const mappedClientSecretKey = gen2PropertyMap.get(clientSecretKey);
       assert(mappedClientSecretKey);
       objectLiterals.push(this.createBooleanPropertyAssignment(mappedClientSecretKey, false));

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -316,7 +316,7 @@ export class BackendSynthesizer {
     // We need to set generateSecret to false explicitly when not defined.
     // If it's set as undefined and current value in CFN template is false (moved from gen1 after refactor), CFN thinks the property has changed
     // and requests for creation of a new resource (user pool client) instead of an update.
-    if (!object.hasOwnProperty(clientSecretKey)) {
+    if (!object.hasOwnProperty(clientSecretKey) && gen2PropertyMap.has(clientSecretKey)) {
       const mappedClientSecretKey = gen2PropertyMap.get(clientSecretKey);
       assert(mappedClientSecretKey);
       objectLiterals.push(this.createBooleanPropertyAssignment(mappedClientSecretKey, false));

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -85,7 +85,9 @@ export const createGen2Renderer = ({
       try {
         const packageJsonContents = await fs.readFile(`./package.json`, { encoding: 'utf-8' });
         packageJson = JSON.parse(packageJsonContents);
-      } catch (e) {}
+      } catch (e) {
+        // File doesn't exist or is inaccessible. Ignore.
+      }
       // Restrict dev dependencies to specific versions based on create-amplify gen2 flow:
       // https://github.com/aws-amplify/amplify-backend/blob/2dab201cb9a222c3b8c396a46c17d661411839ab/packages/create-amplify/src/amplify_project_creator.ts#L15-L24
       return patchNpmPackageJson(packageJson, {

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
@@ -1,4 +1,4 @@
-import { AmplifyDependencies, AmplifyDevDependencies, AmplifyPackageVersions, patchNpmPackageJson } from './renderer';
+import { AmplifyDependencies, AmplifyDevDependencies, AmplifyPackageVersions, PackageJson, patchNpmPackageJson } from './renderer';
 import assert from 'node:assert';
 interface PackageJSON {
   name?: string;
@@ -6,7 +6,7 @@ interface PackageJSON {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 }
-const createPackageJson = (): PackageJSON => ({
+const createPackageJson = (): PackageJson => ({
   name: 'my-package',
   scripts: {
     test: 'echo "hello, world"',
@@ -78,9 +78,10 @@ describe('package.json renderer', () => {
     });
   });
   describe('package name', () => {
-    it('is set to my-gen2-app when not defined', async () => {
-      const examplePackageJson = createPackageJson();
-      delete examplePackageJson.name;
+    it('is not overwritten ', async () => {
+      const examplePackageJson = {
+        name: 'my-gen2-app',
+      };
       const packageJson = patchNpmPackageJson(examplePackageJson, {});
       assert.equal(packageJson.name, 'my-gen2-app');
     });

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
@@ -1,11 +1,5 @@
 import { AmplifyDependencies, AmplifyDevDependencies, AmplifyPackageVersions, PackageJson, patchNpmPackageJson } from './renderer';
 import assert from 'node:assert';
-interface PackageJSON {
-  name?: string;
-  scripts?: Record<string, string>;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-}
 const createPackageJson = (): PackageJson => ({
   name: 'my-package',
   scripts: {

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
@@ -20,16 +20,13 @@ export type PackageJsonDependencies = {
 
 export type PackageJson = {
   name: string;
+  scripts?: Record<string, string>;
 } & PackageJsonDependencies;
 
 const withDefault = (version?: string) => version ?? '*';
 
-export const patchNpmPackageJson = (
-  packageJson: PackageJsonDependencies,
-  packageVersions: Partial<AmplifyPackageVersions> = {},
-): PackageJson => {
+export const patchNpmPackageJson = (packageJson: PackageJson, packageVersions: Partial<AmplifyPackageVersions> = {}): PackageJson => {
   return {
-    name: 'my-gen2-app',
     ...packageJson,
     devDependencies: {
       ...(packageJson.devDependencies ?? {}),

--- a/packages/amplify-gen2-codegen/src/renderers/package_json.test.ts
+++ b/packages/amplify-gen2-codegen/src/renderers/package_json.test.ts
@@ -4,7 +4,7 @@ import { JsonRenderer } from './package_json';
 describe('PackageJsonRenderer', () => {
   it('renders the json object to a string', async () => {
     const json = { name: 'my-package', version: 'my-version' };
-    const jsonCreator = () => json;
+    const jsonCreator = async () => json;
     const testWriter = jest.fn(async () => {});
     const jsonRenderer = new JsonRenderer(jsonCreator, testWriter);
     await jsonRenderer.render();

--- a/packages/amplify-gen2-codegen/src/renderers/package_json.ts
+++ b/packages/amplify-gen2-codegen/src/renderers/package_json.ts
@@ -1,10 +1,10 @@
 import { Renderer } from '../render_pipeline.js';
 
 export class JsonRenderer implements Renderer {
-  constructor(private createJson: () => Record<string, unknown>, private writeFile: (content: string) => Promise<void>) {}
+  constructor(private createJson: () => Promise<Record<string, unknown>>, private writeFile: (content: string) => Promise<void>) {}
 
   render = async (): Promise<void> => {
-    const packageJson = this.createJson();
+    const packageJson = await this.createJson();
     await this.writeFile(JSON.stringify(packageJson, null, 2));
   };
 }


### PR DESCRIPTION
#### Description of changes

QA bug fixes:

- Do not replace `package.json` `dependencies` and `devDependencies`. Only override ones that are needed.
- Pin dependencies to match the versions set in `create-amplify` npx command
- Set `generateSecret: false` when `ClientSecret` is not defined. This will prevent creation of a new user pool client post refactor
- Preserve `package.json` name
- Change logical id of user pool client to indicate its a Native one


#### Description of how you validated changes
Manual testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
