### PR TITLE
fix: update actions/upload-artifact

### DIFF
--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -4,6 +4,9 @@ inputs:
   role-to-assume:
     description: an IAM role to use in tests
     required: true
+  cli-version:
+    description: version of Amplify CLI
+    required: true
   region:
     description: an AWS region to run in
     required: false
@@ -69,5 +72,5 @@ runs:
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
       if: always()
       with:
-        name: test report ${{ runner.os }}
+        name: test report ${{ runner.os }} ${{ inputs.cli-version }}
         path: packages/amplify-e2e-tests/amplify-e2e-reports

--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -66,7 +66,7 @@ runs:
         CIRCLECI: true
 
     - name: Upload Report
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
       if: always()
       with:
         name: test report ${{ runner.os }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -57,3 +57,4 @@ jobs:
         uses: ./.github/actions/run-smoke-tests
         with:
           role-to-assume: ${{ secrets.SMOKE_TESTS_ROLE_ARN }}
+          cli-version: ${{ matrix.cli-version }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Update to non-deprecated version of `actions/upload-artifact` since we were previously using `v3.1.2`, see:
- Failing run: https://github.com/aws-amplify/amplify-cli/actions/runs/12814158049
- More info https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also make artifact names unique so job doesn't fail when more than one version is input.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

https://github.com/aws-amplify/amplify-cli/actions/runs/12815143580

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
