### PR TITLE
fix: choose current env, update gitignore for gen2, choose function name from output prop

### DIFF
--- a/packages/amplify-migration/src/app_auth_definition_fetcher.test.ts
+++ b/packages/amplify-migration/src/app_auth_definition_fetcher.test.ts
@@ -1,7 +1,7 @@
 import { CognitoIdentityProviderClient, DescribeUserPoolCommand, ListGroupsCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoIdentityClient, GetIdentityPoolRolesCommand, ListIdentityPoolsCommand } from '@aws-sdk/client-cognito-identity';
 import { CloudFormationClient, DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
-import { AmplifyClient, ListBackendEnvironmentsCommand } from '@aws-sdk/client-amplify';
+import { AmplifyClient, GetBackendEnvironmentCommand } from '@aws-sdk/client-amplify';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 
 import { AmplifyStackParser } from './amplify_stack_parser';
@@ -125,15 +125,13 @@ jest.mock('@aws-sdk/client-amplify', () => {
     AmplifyClient: function () {
       return {
         send: jest.fn().mockImplementation((command) => {
-          if (command instanceof ListBackendEnvironmentsCommand) {
+          if (command instanceof GetBackendEnvironmentCommand) {
             return Promise.resolve({
-              backendEnvironments: [
-                {
-                  environmentName: 'dev',
-                  deploymentArtifacts: 's3://deploymentArtifacts',
-                  stackName: 'stackName',
-                },
-              ],
+              backendEnvironment: {
+                environmentName: 'dev',
+                deploymentArtifacts: 's3://deploymentArtifacts',
+                stackName: 'stackName',
+              },
             });
           }
           return Promise.resolve();
@@ -176,6 +174,14 @@ jest.mock('@aws-sdk/client-cloudformation', () => {
         }),
       };
     },
+  };
+});
+
+jest.mock('@aws-amplify/cli-internal/lib/extensions/amplify-helpers/get-env-info', () => {
+  return {
+    getEnvInfo: jest.fn().mockReturnValue({
+      envName: 'dev',
+    }),
   };
 });
 

--- a/packages/amplify-migration/src/app_functions_definition_fetcher.ts
+++ b/packages/amplify-migration/src/app_functions_definition_fetcher.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { FunctionDefinition } from '@aws-amplify/amplify-gen2-codegen';
 import { getFunctionDefinition } from '@aws-amplify/amplify-gen1-codegen-function-adapter';
 import { BackendEnvironmentResolver } from './backend_environment_selector';
-import { LambdaClient, GetFunctionCommand } from '@aws-sdk/client-lambda';
+import { GetFunctionCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { StateManager } from '@aws-amplify/amplify-cli-core';
 
 interface AuthConfig {
@@ -72,10 +72,9 @@ export class AppFunctionsDefinitionFetcher {
     });
 
     const getFunctionPromises = Object.keys(functions).map((key) => {
-      const functionName = key;
       return this.lambdaClient.send(
         new GetFunctionCommand({
-          FunctionName: functionName + '-' + backendEnvironment?.environmentName,
+          FunctionName: meta.function[key].output.Name,
         }),
       );
     });

--- a/packages/amplify-migration/src/backend_environment_selector.ts
+++ b/packages/amplify-migration/src/backend_environment_selector.ts
@@ -1,13 +1,7 @@
 import assert from 'node:assert';
 import { stdin as input, stdout as output } from 'node:process';
 import readline from 'node:readline/promises';
-import {
-  AmplifyClient,
-  BackendEnvironment,
-  GetBackendEnvironmentCommand,
-  GetBackendEnvironmentCommandOutput,
-  ListBackendEnvironmentsCommand,
-} from '@aws-sdk/client-amplify';
+import { AmplifyClient, BackendEnvironment, GetBackendEnvironmentCommand } from '@aws-sdk/client-amplify';
 import { getEnvInfo } from '@aws-amplify/cli-internal/lib/extensions/amplify-helpers/get-env-info';
 
 export class BackendEnvironmentResolver {

--- a/packages/amplify-migration/src/backend_environment_selector.ts
+++ b/packages/amplify-migration/src/backend_environment_selector.ts
@@ -1,6 +1,4 @@
 import assert from 'node:assert';
-import { stdin as input, stdout as output } from 'node:process';
-import readline from 'node:readline/promises';
 import { AmplifyClient, BackendEnvironment, GetBackendEnvironmentCommand } from '@aws-sdk/client-amplify';
 import { getEnvInfo } from '@aws-amplify/cli-internal/lib/extensions/amplify-helpers/get-env-info';
 

--- a/packages/amplify-migration/src/backend_environment_selector.ts
+++ b/packages/amplify-migration/src/backend_environment_selector.ts
@@ -1,37 +1,30 @@
 import assert from 'node:assert';
 import { stdin as input, stdout as output } from 'node:process';
 import readline from 'node:readline/promises';
-import { AmplifyClient, BackendEnvironment, ListBackendEnvironmentsCommand } from '@aws-sdk/client-amplify';
+import {
+  AmplifyClient,
+  BackendEnvironment,
+  GetBackendEnvironmentCommand,
+  GetBackendEnvironmentCommandOutput,
+  ListBackendEnvironmentsCommand,
+} from '@aws-sdk/client-amplify';
+import { getEnvInfo } from '@aws-amplify/cli-internal/lib/extensions/amplify-helpers/get-env-info';
 
 export class BackendEnvironmentResolver {
   constructor(private appId: string, private amplifyClient: AmplifyClient) {}
   private selectedEnvironment: BackendEnvironment | undefined;
   selectBackendEnvironment = async (): Promise<BackendEnvironment | undefined> => {
     if (this.selectedEnvironment) return this.selectedEnvironment;
-    const { backendEnvironments } = await this.amplifyClient.send(new ListBackendEnvironmentsCommand({ appId: this.appId }));
-    assert(backendEnvironments, 'No backend environments found');
-    const selectedStack = '';
-    if (backendEnvironments?.length === 1) {
-      return backendEnvironments[0];
-    } else {
-      const rl = readline.createInterface({ input, output });
-      while (!selectedStack) {
-        console.log(
-          `Multiple available backends:\n * ${backendEnvironments
-            ?.filter((be) => be.stackName)
-            .map((be) => be.environmentName)
-            .join('\n * ')}`,
-        );
-        const answer = await rl.question('Which backend environment would you like to migrate?\n> ');
-        const matchingEnvironment = backendEnvironments.find((be) => be.environmentName?.toLowerCase() === answer.trim().toLowerCase());
-        if (matchingEnvironment) {
-          rl.close();
-          this.selectedEnvironment = matchingEnvironment;
-          return matchingEnvironment;
-        }
-      }
-      rl.close();
-    }
-    return undefined;
+    const envInfo = getEnvInfo();
+    assert(envInfo);
+    const { backendEnvironment } = await this.amplifyClient.send(
+      new GetBackendEnvironmentCommand({
+        appId: this.appId,
+        environmentName: envInfo.envName,
+      }),
+    );
+    assert(backendEnvironment, 'No backend environment found');
+    this.selectedEnvironment = backendEnvironment;
+    return this.selectedEnvironment;
   };
 }

--- a/packages/amplify-migration/src/commands/gen2/gen2_command.ts
+++ b/packages/amplify-migration/src/commands/gen2/gen2_command.ts
@@ -22,7 +22,7 @@ export class Gen2Command implements CommandModule {
   }
 
   builder = (yargs: Argv): Argv => {
-    return yargs.version(false).command(this.subCommands).demandCommand().strictCommands().recommendCommands();
+    return yargs.version(false).command(this.subCommands).strictCommands().recommendCommands();
   };
   handler = (): Promise<void> => {
     // CommandModule requires handler implementation. But this is never called if top level command

--- a/packages/amplify-migration/src/commands/gen2/gen2_command_factory.test.ts
+++ b/packages/amplify-migration/src/commands/gen2/gen2_command_factory.test.ts
@@ -21,7 +21,7 @@ describe('top level gen2 command', () => {
     await assert.rejects(
       () => runCommandAsync(parser, 'to-gen-2'),
       (err: Error) => {
-        assert.match(err.message, /Not enough non-option arguments/);
+        assert.match(err.message, /Top level gen2 handler should never be called/);
         return true;
       },
     );

--- a/packages/amplify-migration/src/printer.ts
+++ b/packages/amplify-migration/src/printer.ts
@@ -2,11 +2,18 @@ import { WriteStream } from 'node:tty';
 import { EOL } from 'os';
 
 export class Printer {
+  // Properties for ellipsis animation
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private timerSet: boolean = false;
+  /**
+   * Spinner frames
+   */
+  private spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   constructor(
     private readonly minimumLogLevel: LogLevel,
     private readonly stdout: WriteStream | NodeJS.WritableStream = process.stdout,
     private readonly stderr: WriteStream | NodeJS.WritableStream = process.stderr,
-    private readonly refreshRate: number = 500,
+    private readonly refreshRate: number = 1,
   ) {}
 
   /**
@@ -23,12 +30,112 @@ export class Printer {
   printNewLine = () => {
     this.stdout.write(EOL);
   };
+
+  /**
+   * Logs a message to the output stream at the given log level followed by a newline
+   */
+  log(message: string, level: LogLevel = LogLevel.INFO) {
+    const doLogMessage = level <= this.minimumLogLevel;
+
+    if (!doLogMessage) {
+      return;
+    }
+
+    const logMessage = this.minimumLogLevel === LogLevel.DEBUG ? `[${LogLevel[level]}] ${new Date().toISOString()}: ${message}` : message;
+
+    if (level === LogLevel.ERROR) {
+      this.stderr.write(logMessage);
+    } else {
+      this.stdout.write(logMessage);
+    }
+
+    this.printNewLine();
+  }
+
+  /**
+   * Logs a message with animated spinner.
+   * If stdout is not a TTY, the message is logged at the info level without a spinner
+   */
+  async indicateProgress(message: string, callback: () => Promise<void>) {
+    try {
+      this.startAnimatingSpinner(message);
+      await callback();
+    } finally {
+      this.stopAnimatingSpinner();
+    }
+  }
+
+  /**
+   * Writes escape sequence to stdout
+   */
+  private writeEscapeSequence(action: EscapeSequence) {
+    if (!this.isTTY()) {
+      return;
+    }
+
+    this.stdout.write(action);
+  }
+
+  /**
+   * Checks if the environment is TTY
+   */
+  private isTTY() {
+    return this.stdout instanceof WriteStream && this.stdout.isTTY;
+  }
+
+  /**
+   * Starts animating spinner with a message.
+   */
+  private startAnimatingSpinner(message: string) {
+    if (this.timerSet) {
+      throw new Error('Timer is already set to animate spinner, stop the current running timer before starting a new one.');
+    }
+
+    if (!this.isTTY()) {
+      this.log(message, LogLevel.INFO);
+      return;
+    }
+
+    let frameIndex = 0;
+    this.timerSet = true;
+    this.writeEscapeSequence(EscapeSequence.HIDE_CURSOR);
+    this.timer = setInterval(() => {
+      this.writeEscapeSequence(EscapeSequence.CLEAR_LINE);
+      this.writeEscapeSequence(EscapeSequence.MOVE_CURSOR_TO_START);
+      const frame = this.spinnerFrames[frameIndex];
+      this.stdout.write(`${frame} ${message}`);
+      frameIndex = (frameIndex + 1) % this.spinnerFrames.length;
+    }, this.refreshRate);
+  }
+
+  /**
+   * Stops animating spinner.
+   */
+  private stopAnimatingSpinner() {
+    if (!this.isTTY()) {
+      return;
+    }
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+    this.timerSet = false;
+    this.writeEscapeSequence(EscapeSequence.CLEAR_LINE);
+    this.writeEscapeSequence(EscapeSequence.MOVE_CURSOR_TO_START);
+    this.writeEscapeSequence(EscapeSequence.SHOW_CURSOR);
+  }
 }
 
 export enum LogLevel {
   ERROR = 0,
   INFO = 1,
   DEBUG = 2,
+}
+
+enum EscapeSequence {
+  CLEAR_LINE = '\x1b[2K',
+  MOVE_CURSOR_TO_START = '\x1b[0G',
+  SHOW_CURSOR = '\x1b[?25h',
+  HIDE_CURSOR = '\x1b[?25l',
 }
 
 const minimumLogLevel = process.argv.includes('--debug') ? LogLevel.DEBUG : LogLevel.INFO;


### PR DESCRIPTION

#### Description of changes

QA bug fixes/improvements:
- Choose current environment instead of listing all and asking customer to select one
- Update .gitignore to gen2 specific files
- Look for `Cognito` service name for grabbing the resource name since `Cognito-UserPool-Groups` can also co-exist
- Derive function names from `output` key instead of the resource name since in the case of triggers, they are different
- Remove `demandCommands` to surface top level handler errors

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Local testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
