### PR TITLE
Upgrade Node to 22.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,9 +203,9 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_18_VERSION="18.15.0"
+ENV NODE_VERSION="22.12.0"
 
-RUN  n $NODE_18_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
+RUN  n $NODE_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
      && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
      && apt-get update && apt-get install -y -qq --no-install-recommends yarn \
@@ -374,7 +374,7 @@ VOLUME /var/lib/docker
 FROM runtimes_n_corretto AS std_v6
 
 # Activate runtime versions specific to image version.
-RUN n $NODE_18_VERSION
+RUN n $NODE_VERSION
 RUN pyenv  global $PYTHON_38_VERSION
 RUN goenv global  $GOLANG_18_VERSION
 

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
       # increment DEFAULT_TAG version to a unique consecutive version whenever you make changes to the dockerfile or image settings
-      - export DEFAULT_TAG=1.0.4-node-22-rc
+      - export DEFAULT_TAG=2.0.0
       - export IMAGE_TAG=${CUSTOM_TAG:=$DEFAULT_TAG}
       - echo $IMAGE_TAG
       - echo $PKG_BINARY_CACHE_BUCKET_NAME

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
       # increment DEFAULT_TAG version to a unique consecutive version whenever you make changes to the dockerfile or image settings
-      - export DEFAULT_TAG=1.0.3
+      - export DEFAULT_TAG=1.0.4-node-22-rc
       - export IMAGE_TAG=${CUSTOM_TAG:=$DEFAULT_TAG}
       - echo $IMAGE_TAG
       - echo $PKG_BINARY_CACHE_BUCKET_NAME


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR bumps node version to 22.

Companion PR https://github.com/aws-amplify/amplify-cli/pull/14079 .

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

I got passing E2E run using image override.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
