### PR TITLE
Revert "fix(amplify-cli-core): use build script for overrides (#13858)"

### DIFF
--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -93,7 +93,17 @@ export const buildOverrideDir = async (cwd: string, destDirPath: string): Promis
     const tsConfigSampleFilePath = path.join(__dirname, '..', '..', 'resources', 'overrides-resource', 'tsconfig.resource.json');
     fs.writeFileSync(tsConfigDestFilePath, fs.readFileSync(tsConfigSampleFilePath));
 
-    execa.sync(packageManager.executable, [`run`, `build`, `--project`, `${tsConfigDestFilePath}`], {
+    // get locally installed tsc executable
+
+    const localTscExecutablePath = path.join(cwd, 'node_modules', '.bin', 'tsc');
+
+    if (!fs.existsSync(localTscExecutablePath)) {
+      throw new AmplifyError('MissingOverridesInstallationRequirementsError', {
+        message: 'TypeScript executable not found.',
+        resolution: 'Please add it as a dev-dependency in the package.json file for this resource.',
+      });
+    }
+    execa.sync(localTscExecutablePath, [`--project`, `${tsConfigDestFilePath}`], {
       cwd: tsConfigDir,
       stdio: 'pipe',
       encoding: 'utf-8',


### PR DESCRIPTION
This reverts commit 30c9f0ce2935c3b3871baa2bb01007638b3ffcc9.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

@brianlenz  I'm sorry but I have to revert https://github.com/aws-amplify/amplify-cli/pull/13858 .

Upon further verification it turned out that it doesn't work with `npm`. I haven't checked `pnpm` but this is enough signal to revert.

Repro steps:
1. Create amplify project
2. Add auth and data
3. Override auth and data.
4. `cd amplify/backend/ && rm yarn.lock && rm -rf node_modules && npm install && cd .. && cd ..`
5. `amplify build`

![image](https://github.com/user-attachments/assets/f981197d-fa26-42ba-aa39-f379c261a97b)


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
