### PR TITLE
fix(amplify-cli-core): use build script properly for overrides

### DIFF
--- a/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
+++ b/packages/amplify-cli-core/src/overrides-manager/override-skeleton-generator.ts
@@ -93,17 +93,8 @@ export const buildOverrideDir = async (cwd: string, destDirPath: string): Promis
     const tsConfigSampleFilePath = path.join(__dirname, '..', '..', 'resources', 'overrides-resource', 'tsconfig.resource.json');
     fs.writeFileSync(tsConfigDestFilePath, fs.readFileSync(tsConfigSampleFilePath));
 
-    // get locally installed tsc executable
-
-    const localTscExecutablePath = path.join(cwd, 'node_modules', '.bin', 'tsc');
-
-    if (!fs.existsSync(localTscExecutablePath)) {
-      throw new AmplifyError('MissingOverridesInstallationRequirementsError', {
-        message: 'TypeScript executable not found.',
-        resolution: 'Please add it as a dev-dependency in the package.json file for this resource.',
-      });
-    }
-    execa.sync(localTscExecutablePath, [`--project`, `${tsConfigDestFilePath}`], {
+    // ensure the --project and specific tsconfig.json file get passed through to tsc by using --
+    execa.sync(packageManager.executable, [`run`, `build`, '--', `--project`, `${tsConfigDestFilePath}`], {
       cwd: tsConfigDir,
       stdio: 'pipe',
       encoding: 'utf-8',


### PR DESCRIPTION
Updated the TypeScript compilation of overrides so that it doesn't require `node_modules/.bin/tsc`. Instead, it simply relies on the `build` script to execute `tsc`. This is more flexible and can support alternative setups w/ hoisting (e.g. via Yarn workspaces).

This is an override corollary fix to #11854, which is for custom resources.

This is an improvement over my previous PR in #13858 in that it works with any package manager by ensuring the `--project` and `tsconfig.json` files are passed through to the `tsc` script. The previous implementation didn't work with `npm` because it doesn't pass through additional args like `yarn` does. The fix was easy: simply separate the build run with `--` so that the remaining args are treated as positional for the `tsc` script.

I've confirmed the fix works with both `yarn` and `npm` 💪

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Remove hard-coded dependency on `node_modules/.bin/tsc` for overrides to instead use the `build` script from `package.json`, which is more flexible.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #11889

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran `yarn test` and all pre-commit hooks without issue.
Tested `amplify build --debug` and `amplify push` locally _with both `yarn` and `npm`_. The commands were failing with `yarn` prior to these changes, and it succeeds with these changes in place (via `amplify-dev`).

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
