### PR TITLE
fix: load region from AWS client if the credentials are managed by AWS-SDK

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/deployment-manager.ts
@@ -88,8 +88,9 @@ export class DeploymentManager {
   ): Promise<DeploymentManager> => {
     try {
       const cred = await loadConfiguration(context);
-      assert(cred.region);
-      return new DeploymentManager(cred, cred.region, deploymentBucket, eventMap, options);
+      // this is the "general" config level case, aws sdk will resolve creds and region from env variables etc.
+      const region = cred?.region ?? new aws.S3().config.region;
+      return new DeploymentManager(cred, region, deploymentBucket, eventMap, options);
     } catch (e) {
       throw new AmplifyError(
         'DeploymentError',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

When using `general` configLevel for aws credentials, deployment manager was failing because it expected amplify-cli to resolve credentials (and hence region) whereas `general` config implies that credentials are managed by customers and resolved by aws-sdk automatically without cli doing anything. This change removes the validation and instead defaults to AWS client's `region` instead of taking it away completely to reduce the scope of this change.

Reference: https://docs.amplify.aws/gen1/react/tools/cli/usage/headless/#--providers-1

See [this](https://github.com/aws-amplify/amplify-cli/blob/aab715db07578b7790498b9ad791db7d3a0b4d5c/packages/amplify-provider-awscloudformation/src/aws-utils/aws-amplify.js#L34-L42) for a similar example.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manually tested before and after and confirmed that it fixes the issue.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
