### PR TITLE
fix: temporary increase to binary size to unblock migrations testing

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -140,9 +140,9 @@ function verifyPkgCli {
     }
 
     verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((1000 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((900 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((890 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((750 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((1000 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((1000 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((1000 * 1024 * 1024))
 }
 
 function unsetNpmRegistryUrl {

--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -139,7 +139,7 @@ function verifyPkgCli {
       fi
     }
 
-    verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((900 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((1000 * 1024 * 1024))
     verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((900 * 1024 * 1024))
     verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((890 * 1024 * 1024))
     verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((750 * 1024 * 1024))


### PR DESCRIPTION
#### Description of changes

When building a tagged release, the size of the binary seems to increase to 970 MB, while the cloud pr on the same branch is 880 MB. While this is being investigated, to unblock migration testing, we are temporarily increasing the size of threshold to 1000 MB.


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
