### PR TITLE
refactor: use array table map and change property name

### DIFF
--- a/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
@@ -20,7 +20,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}]/,
+        /migratedAmplifyGen1DynamoDbTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}]/,
       );
     });
     it('includes multiple table mappings', () => {
@@ -31,7 +31,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}, {\n\s+\/\/ Replace the environment name \(prod\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]prod['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping-prod['"] }\n\s+}]/,
+        /migratedAmplifyGen1DynamoDbTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}, {\n\s+\/\/ Replace the environment name \(prod\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]prod['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping-prod['"] }\n\s+}]/,
       );
     });
     it('includes a comment for missing table mappings', () => {
@@ -49,7 +49,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /defineData\({\n\s+importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}],\n\s+schema: "TODO: Add your existing graphql schema here"\n}\)/,
+        /defineData\({\n\s+migratedAmplifyGen1DynamoDbTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}],\n\s+schema: "TODO: Add your existing graphql schema here"\n}\)/,
       );
     });
   });

--- a/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
@@ -20,7 +20,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /\/\/ Replace each environment name with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+importedAmplifyDynamoDBTableMap: \{\s+dev: { Todo: ['"]my-todo-mapping['"] } }/,
+        /importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}]/,
       );
     });
     it('includes multiple table mappings', () => {
@@ -31,7 +31,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /importedAmplifyDynamoDBTableMap: \{\s+dev: { Todo: ['"]my-todo-mapping['"] }, prod: { Todo: ['"]my-todo-mapping-prod['"] } }/,
+        /importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}, {\n\s+\/\/ Replace the environment name \(prod\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]prod['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping-prod['"] }\n\s+}]/,
       );
     });
     it('includes a comment for missing table mappings', () => {
@@ -41,15 +41,15 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /\/\*\*\n\s+\* Unable to find the table mapping for this environment.\n\s+\* This could be due the enableGen2Migration feature flag not being set to true for this environment.\n\s+\* Please enable the feature flag and push the backend resources.\n\s+\* If you are not planning to migrate this environment, you can remove this key.\n\s+\*\/\n\s+dev: {}/,
-      ); //\s+dev: {}/);
+        /\/\*\*\n\s+\* Unable to find the table mapping for this environment.\n\s+\* This could be due the enableGen2Migration feature flag not being set to true for this environment.\n\s+\* Please enable the feature flag and push the backend resources.\n\s+\* If you are not planning to migrate this environment, you can remove this key.\n\s+\*\/\n\s+modelTableNameMap: {}/,
+      );
     });
     it('has each each key in defineData', () => {
       const tableMappings = { dev: { Todo: 'my-todo-mapping' } };
       const source = printNodeArray(generateDataSource({ tableMappings }));
       assert.match(
         source,
-        /defineData\({\n\s+\/\/ Replace each environment name with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+importedAmplifyDynamoDBTableMap: \{\s+dev: { Todo: ['"]my-todo-mapping['"] } },\n\s+schema: "TODO: Add your existing graphql schema here"\n}\)/,
+        /defineData\({\n\s+importedAmplifyDynamoDBTableMap: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelTableNameMap: { Todo: ['"]my-todo-mapping['"] }\n\s+}],\n\s+schema: "TODO: Add your existing graphql schema here"\n}\)/,
       );
     });
   });

--- a/packages/amplify-gen2-codegen/src/data/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.ts
@@ -8,7 +8,7 @@ export type DataDefinition = {
   tableMappings: Record<string, DataTableMapping | undefined>;
 };
 
-const importedAmplifyDynamoDBTableMapKeyName = 'importedAmplifyDynamoDBTableMap';
+const migratedAmplifyGen1DynamoDbTableMapKeyName = 'migratedAmplifyGen1DynamoDbTableMap';
 
 export const schemaPlaceholderComment = 'TODO: Add your existing graphql schema here';
 
@@ -56,7 +56,7 @@ export const generateDataSource = (dataDefinition?: DataDefinition): ts.NodeArra
     }
     dataRenderProperties.push(
       factory.createPropertyAssignment(
-        importedAmplifyDynamoDBTableMapKeyName,
+        migratedAmplifyGen1DynamoDbTableMapKeyName,
         factory.createArrayLiteralExpression(tableMappingEnvironments),
       ),
     );


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Change table map to array of mappings and change top level property name to `migratedAmplifyGen1DynamoDbTableMap`.


```typescript
defineData({
  schema,
  migratedAmplifyGen1DynamoDbTableMap: [{
    branchName: 'dev',
    modelTableNameMap: {
      ImportedModel: 'ImportedModel-1234-dev',
    },
  }],
});
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
