### PR TITLE
fix: added dynamic reference to the env name in backend.ts and fixed a couple of bugs

### DIFF
--- a/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.test.ts
+++ b/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.test.ts
@@ -43,6 +43,13 @@ void describe('getStorageAccess', () => {
           assert.deepEqual(access?.groups?.[group].sort(), gen2[group].sort());
         }
       });
+
+      void it('returns empty group permissions', () => {
+        const input = getCLIInput();
+        input.groupAccess = {};
+        const access = getStorageAccess(input);
+        assert.deepEqual(access?.groups, undefined);
+      });
     }
   });
   void describe('auth and unauth', () => {

--- a/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.test.ts
+++ b/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.test.ts
@@ -48,6 +48,7 @@ void describe('getStorageAccess', () => {
         const input = getCLIInput();
         input.groupAccess = {};
         const access = getStorageAccess(input);
+        assert.notEqual(access, undefined);
         assert.deepEqual(access?.groups, undefined);
       });
     }

--- a/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.ts
+++ b/packages/amplify-gen1-codegen-storage-adapter/src/storage_access.ts
@@ -22,7 +22,7 @@ const getGen2Permissions = (permissions: CLIV1Permission[]): Permission[] => {
 };
 export const getStorageAccess = (input: StorageCLIInputsJSON): AccessPatterns => {
   let groups: AccessPatterns['groups'] | undefined;
-  if (input.groupAccess) {
+  if (input.groupAccess && Object.keys(input.groupAccess).length > 0) {
     groups = Object.entries(input.groupAccess).reduce((acc, [key, value]) => {
       acc[key] = getGen2Permissions(value);
       return acc;

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -26,7 +26,7 @@ describe('BackendRenderer', () => {
         'Policies.PasswordPolicy.RequireLowercase': true,
         'Policies.PasswordPolicy.RequireUppercase': false,
         'Policies.PasswordPolicy.TemporaryPasswordValidityDays': 10,
-        userPoolName: 'Test_Name',
+        userPoolName: 'Test_Name-dev',
         userNameAttributes: undefined,
       };
       const mappedPolicyType: Record<string, string> = {
@@ -50,7 +50,11 @@ describe('BackendRenderer', () => {
             },
           });
           const output = printNodeArray(rendered);
-          if (key.includes('PasswordPolicy')) {
+          if (key.includes('userPoolName')) {
+            assert(value);
+            assert(typeof value === 'string');
+            assert(output.includes('cfnUserPool.userPoolName = `Test_Name-${AMPLIFY_GEN_1_ENV_NAME}`'));
+          } else if (key.includes('PasswordPolicy')) {
             const policyKey = key.split('.')[2];
             if (value !== undefined && policyKey in mappedPolicyType) {
               if (typeof value === 'string') assert(output.includes(`cfnUserPool.policies = {passwordPolicy:{${policyKey}:"${value}"}}`));
@@ -76,7 +80,11 @@ describe('BackendRenderer', () => {
         });
         const output = printNodeArray(rendered);
         for (const [key, value] of Object.entries(testCases)) {
-          if (key.includes('PasswordPolicy')) {
+          if (key.includes('userPoolName')) {
+            assert(value);
+            assert(typeof value === 'string');
+            assert(output.includes('cfnUserPool.userPoolName = `Test_Name-${AMPLIFY_GEN_1_ENV_NAME}`'));
+          } else if (key.includes('PasswordPolicy')) {
             const policyKey = key.split('.')[2];
             if (value !== undefined && policyKey in mappedPolicyType) {
               if (typeof value === 'string') assert(output.includes(`cfnUserPool.policies = {passwordPolicy:{${policyKey}:"${value}"}}`));
@@ -122,12 +130,12 @@ describe('BackendRenderer', () => {
       const rendered = renderer.render({
         auth: {
           importFrom: './auth/resource.ts',
-          identityPoolName: 'Test_Name',
+          identityPoolName: 'Test_Name_dev',
           guestLogin: true,
         },
       });
       const output = printNodeArray(rendered);
-      assert(output.includes('cfnIdentityPool'));
+      assert(output.includes('cfnIdentityPool.identityPoolName = `Test_Name_${AMPLIFY_GEN_1_ENV_NAME}`'));
     });
     it('Does not render cfnIdentityPool accessor if identityPoolName is undefined and guestLogin is true', () => {
       const renderer = new BackendSynthesizer();
@@ -410,7 +418,7 @@ describe('BackendRenderer', () => {
             CallbackURLs: ['XXXXXXXXXXXXXXXXXX', 'XXXXXXXXXXXXXXXXXXXXXX'],
             LogoutURLs: ['XXXXXXXXXXXXXXXXXX', 'XXXXXXXXXXXXXXXXXXXXXX'],
             DefaultRedirectURI: 'XXXXXXXXXXXXXXXXXX',
-            SupportedIdentityProviders: ['COGNITO', 'Facebook'],
+            SupportedIdentityProviders: ['COGNITO', 'Facebook', 'LoginWithAmazon'],
             AuthSessionValidity: 3,
             EnableTokenRevocation: true,
             EnablePropagateAdditionalUserContextData: true,
@@ -458,6 +466,7 @@ describe('BackendRenderer', () => {
       expect(output).toContain(`supportedIdentityProviders`);
       expect(output).toContain(`UserPoolClientIdentityProvider.COGNITO`);
       expect(output).toContain(`UserPoolClientIdentityProvider.FACEBOOK`);
+      expect(output).toContain(`UserPoolClientIdentityProvider.AMAZON`);
       expect(output).toContain('authSessionValidity: Duration.minutes(3)');
       expect(output).toContain('enableTokenRevocation: true');
       expect(output).toContain('enablePropagateAdditionalUserContextData: true');

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -48,6 +48,8 @@ export interface BackendRenderParameters {
   unsupportedCategories?: Map<string, string>;
 }
 
+const amplifyGen1EnvName = 'AMPLIFY_GEN_1_ENV_NAME';
+
 export class BackendSynthesizer {
   private importDurationFlag = false;
   private oAuthFlag = false;
@@ -448,12 +450,13 @@ export class BackendSynthesizer {
     ]);
   }
 
-  private createTemplateLiteralExpression(id1: string, id2: string, templateHead: string) {
+  // id1.id2 = `templateHead-${templateSpan}templateTail`;
+  private createTemplateLiteralExpression(id1: string, id2: string, templateHead: string, templateSpan: string, templateTail: string) {
     return factory.createExpressionStatement(
       factory.createAssignment(
         factory.createPropertyAccessExpression(factory.createIdentifier(id1), factory.createIdentifier(id2)),
         factory.createTemplateExpression(factory.createTemplateHead(templateHead), [
-          factory.createTemplateSpan(factory.createIdentifier('AMPLIFY_GEN_1_ENV_NAME'), factory.createTemplateTail('')),
+          factory.createTemplateSpan(factory.createIdentifier(templateSpan), factory.createTemplateTail(templateTail)),
         ]),
       ),
     );
@@ -583,6 +586,8 @@ export class BackendSynthesizer {
             'cfnUserPool',
             'userPoolName',
             `${userPoolWithoutBackendEnvName}-`,
+            amplifyGen1EnvName,
+            '',
           );
 
           nodes.push(userPoolAssignment);
@@ -618,6 +623,8 @@ export class BackendSynthesizer {
           'cfnIdentityPool',
           'identityPoolName',
           `${identityPoolWithoutBackendEnvName}_`,
+          amplifyGen1EnvName,
+          '',
         );
 
         nodes.push(identityPoolAssignment);
@@ -684,7 +691,13 @@ export class BackendSynthesizer {
       const splitBucketName = renderArgs.storage.bucketName.split('-');
       const bucketNameWithoutBackendEnvName = splitBucketName.slice(0, -1).join('-');
 
-      const bucketNameAssignment = this.createTemplateLiteralExpression('// s3Bucket', 'bucketName', `${bucketNameWithoutBackendEnvName}-`);
+      const bucketNameAssignment = this.createTemplateLiteralExpression(
+        '// s3Bucket',
+        'bucketName',
+        `${bucketNameWithoutBackendEnvName}-`,
+        amplifyGen1EnvName,
+        '',
+      );
       nodes.push(bucketNameAssignment);
       nodes.push(this.addRemovalPolicyAssignment('s3Bucket'));
     }

--- a/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
@@ -19,6 +19,7 @@ describe('render function', () => {
       const rendered = renderFunctions({});
       const source = printNodeArray(rendered);
       assert.doesNotMatch(source, new RegExp(`entry:`));
+      assert.match(source, /throw new Error/);
     });
   });
   describe('render properties', () => {

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -24,13 +24,12 @@ export function renderFunctions(definition: FunctionDefinition, appId?: string, 
   namedImports['@aws-amplify/backend'].add('defineFunction');
 
   groupsComment.push(
-    factory.createJSDocComment(
-      factory.createNodeArray([
-        factory.createJSDocText(
-          `Source code for this function can be found in your Amplify Gen 1 Directory.\nSee .amplify/migration/amplify/backend/function/${definition.resourceName}/src \n`,
-        ),
-      ]),
-    ),
+    factory.createCallExpression(factory.createIdentifier('throw new Error'), undefined, [
+      // eslint-disable-next-line spellcheck/spell-checker
+      factory.createStringLiteral(
+        `Source code for this function can be found in your Amplify Gen 1 Directory. See .amplify/migration/amplify/backend/function/${definition.resourceName}/src`,
+      ),
+    ]),
   );
 
   const defineFunctionProperty = createFunctionDefinition(definition, groupsComment, namedImports, appId, backendEnvironmentName);

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -25,7 +25,6 @@ export function renderFunctions(definition: FunctionDefinition, appId?: string, 
 
   groupsComment.push(
     factory.createCallExpression(factory.createIdentifier('throw new Error'), undefined, [
-      // eslint-disable-next-line spellcheck/spell-checker
       factory.createStringLiteral(
         `Source code for this function can be found in your Amplify Gen 1 Directory. See .amplify/migration/amplify/backend/function/${definition.resourceName}/src`,
       ),

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -266,7 +266,7 @@ export async function execute() {
 
   await amplifyClient.send(
     new UpdateAppCommand({
-      appId: appId,
+      appId,
       environmentVariables: {
         AMPLIFY_GEN_1_ENV_NAME: backendEnvironment.environmentName,
       },

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -7,7 +7,7 @@ import { v4 as uuid } from 'uuid';
 import { createGen2Renderer, Gen2RenderingOptions } from '@aws-amplify/amplify-gen2-codegen';
 
 import { getProjectSettings, UsageData } from '@aws-amplify/cli-internal';
-import { AmplifyClient } from '@aws-sdk/client-amplify';
+import { AmplifyClient, UpdateAppCommand } from '@aws-sdk/client-amplify';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { CognitoIdentityProviderClient, LambdaConfigType } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
@@ -251,6 +251,7 @@ export async function execute() {
   const backendEnvironment = await backendEnvironmentResolver.selectBackendEnvironment();
   assert(backendEnvironment);
   assert(backendEnvironmentResolver);
+  assert(backendEnvironment.environmentName);
 
   const s3Client = new S3Client();
   const cloudFormationClient = new CloudFormationClient();
@@ -262,6 +263,15 @@ export async function execute() {
   const amplifyStackParser = new AmplifyStackParser(cloudFormationClient);
   const ccbFetcher = new BackendDownloader(s3Client);
   inspectApp.stop();
+
+  await amplifyClient.send(
+    new UpdateAppCommand({
+      appId: appId,
+      environmentVariables: {
+        AMPLIFY_GEN_1_ENV_NAME: backendEnvironment.environmentName,
+      },
+    }),
+  );
 
   await generateGen2Code({
     outputDirectory: TEMP_GEN_2_OUTPUT_DIR,


### PR DESCRIPTION
#### Description of changes

- During `prepare` phase, add an environment variable to customers Amplify Hosting build for their gen 1 backend name - https://app.asana.com/0/1206146466379945/1209214806262350
- Throw new error in function resource.ts - https://app.asana.com/0/1209297236712871/1209207544854343
- Fix the identity provider type for LoginWithAmazon - https://app.asana.com/0/1209297236712871/1209313621506855
- Fix the storage access groups

#### Description of how you validated changes
Unit tests

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
