### PR TITLE
fix: conditional data codegen, phone attribute, add support for native userpool client refactor

### DIFF
--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
@@ -331,9 +331,14 @@ void describe('auth codegen', () => {
     });
   });
   void describe('`Enable users to login with phone` is selected', () => {
-    void it('loginWith contains `phone: true`', () => {
+    // gen1 oddities: In order to match the gen1 template,
+    // we can't add phone to loginOptions as it changes the Schema & AutoVerifiedAttributes section.
+    // It just needs to be present as part of usernameAttributes
+    void it('loginWith does not contains `phone: true`', () => {
       const result = getAuthDefinition({ userPool: { UsernameAttributes: ['phone_number'] } });
-      assert(result.loginOptions?.phone);
+      expect(result.loginOptions).toBeDefined();
+      expect(result.loginOptions?.phone).not.toBeDefined();
+      assert.deepEqual(result.userPoolOverrides, { usernameAttributes: ['phone_number'] });
     });
   });
   void describe('Password policy', () => {

--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.ts
@@ -84,6 +84,8 @@ const getUserPoolOverrides = (userPool: UserPoolType): Partial<PolicyOverrides> 
   }
   if (userPool.UsernameAttributes === undefined || userPool.UsernameAttributes.length === 0) {
     userPoolOverrides.usernameAttributes = undefined;
+  } else {
+    userPoolOverrides.usernameAttributes = userPool.UsernameAttributes;
   }
   return userPoolOverrides;
 };
@@ -334,9 +336,6 @@ export const getAuthDefinition = ({
     loginWith.samlLogin = samlOptions;
   }
 
-  if (userPool.UsernameAttributes?.includes('phone_number')) {
-    loginWith.phone = true;
-  }
   if (userPool.EmailVerificationMessage || userPool.EmailVerificationSubject) {
     loginWith.emailOptions = getEmailConfig(userPool);
   }

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -178,7 +178,7 @@ export const createGen2Renderer = ({
     };
   }
 
-  if (data) {
+  if (data && data.tableMappings && backendEnvironmentName && data.tableMappings[backendEnvironmentName] !== undefined) {
     renderers.push(new EnsureDirectory(path.join(outputDir, 'amplify', 'data')));
     renderers.push(
       new TypescriptNodeArrayRenderer(

--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -369,7 +369,7 @@ const refactoredGen2Template: CFNTemplate = {
     [GEN2_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-storage-ABCDE']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', GEN1_STORAGE_CATEGORY_STACK_NAME]] },
       },
     },
     [GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID]: {

--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -1,5 +1,5 @@
 import CategoryTemplateGenerator from './category-template-generator';
-import { CFN_PSEUDO_PARAMETERS_REF, CFN_S3_TYPE, CFNTemplate } from './types';
+import { CFN_AUTH_TYPE, CFN_PSEUDO_PARAMETERS_REF, CFN_S3_TYPE, CFNTemplate } from './types';
 import {
   CloudFormationClient,
   DescribeStacksCommand,
@@ -21,14 +21,26 @@ const stubCfnClientSend = jest.fn();
 const stubSsmClientSend = jest.fn();
 const stubCognitoClientSend = jest.fn();
 
-const GEN1_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-testauth-dev-12345-auth-ABCDE/12345';
-const GEN2_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
+const GEN1_STORAGE_CATEGORY_STACK_NAME = 'amplify-testauth-dev-12345-storage-ABCDE';
+const GEN1_CATEGORY_STACK_ID = `arn:aws:cloudformation:us-east-1:1234567890:stack/${GEN1_STORAGE_CATEGORY_STACK_NAME}/12345`;
+const GEN2_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-storage-ABCDE/12345';
+const GEN1_AUTH_CATEGORY_STACK_NAME = 'amplify-testauth-dev-12345-auth-ABCDE';
+const GEN1_AUTH_CATEGORY_STACK_ID = `arn:aws:cloudformation:us-east-1:1234567890:stack/${GEN1_AUTH_CATEGORY_STACK_NAME}/12345`;
+const GEN2_AUTH_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
 const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
 const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
 const GEN1_ANOTHER_S3_BUCKET_LOGICAL_ID = 'MyOtherS3Bucket';
 const GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID = 'MyOtherGen2S3Bucket';
 const MOCK_APP_ID = 'd123456';
 const ENV_NAME = 'test';
+const GEN1_AUTH_USER_POOL_LOGICAL_ID = 'UserPool';
+const GEN1_AUTH_IDENTITY_POOL_LOGICAL_ID = 'IdentityPool';
+const GEN1_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID = 'UserPoolClient';
+const GEN1_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID = 'UserPoolClientWeb';
+const GEN2_AUTH_USER_POOL_LOGICAL_ID = 'Gen2UserPool';
+const GEN2_AUTH_IDENTITY_POOL_LOGICAL_ID = 'Gen2IdentityPool';
+const GEN2_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID = 'UserPoolAppClient';
+const GEN2_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID = 'UserPoolNativeAppClient';
 
 const oldGen1Template: CFNTemplate = {
   AWSTemplateFormatVersion: '2010-09-09',
@@ -122,7 +134,7 @@ const newGen1Template: CFNTemplate = {
     [GEN1_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', GEN1_STORAGE_CATEGORY_STACK_NAME]] },
       },
     },
     MyS3BucketPolicy: {
@@ -182,7 +194,7 @@ const newGen1TemplateWithPredicate: CFNTemplate = {
     [GEN1_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', GEN1_STORAGE_CATEGORY_STACK_NAME]] },
       },
     },
     MyS3BucketPolicy: {
@@ -356,7 +368,7 @@ const refactoredGen2Template: CFNTemplate = {
     [GEN2_S3_BUCKET_LOGICAL_ID]: {
       Type: CFN_S3_TYPE.Bucket,
       Properties: {
-        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-auth-ABCDE']] },
+        BucketName: { 'Fn::Join': ['-', ['my-test-bucket', 'dev', 'amplify-testauth-dev-12345-storage-ABCDE']] },
       },
     },
     [GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID]: {
@@ -377,6 +389,184 @@ const oldGen2TemplateWithoutS3Bucket = JSON.parse(JSON.stringify(oldGen2Template
 delete oldGen2TemplateWithoutS3Bucket.Resources[GEN2_S3_BUCKET_LOGICAL_ID];
 delete oldGen2TemplateWithoutS3Bucket.Resources[GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID];
 
+const oldGen1AuthTemplate: CFNTemplate = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'Test template',
+  Parameters: {
+    Environment: {
+      Type: 'String',
+      Description: 'Environment',
+    },
+    hostedUIProviderMeta: {
+      Type: 'String',
+      Description: 'HostedUIProviderMeta',
+    },
+    hostedUIProviderCreds: {
+      Type: 'String',
+      Description: 'HostedUIProviderCreds',
+      NoEcho: true,
+    },
+  },
+  Outputs: {
+    UserPoolId: {
+      Description: 'User pool id',
+      Value: 'userPoolId',
+    },
+  },
+  Resources: {
+    [GEN1_AUTH_USER_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPool,
+      Properties: {
+        UserPoolName: { 'Fn::Join': ['-', 'my-user-pool', { Ref: 'Environment' }] },
+      },
+    },
+    [GEN1_AUTH_IDENTITY_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.IdentityPool,
+      Properties: {
+        IdentityPoolName: { 'Fn::Join': ['-', 'my-identity-pool', { Ref: 'Environment' }] },
+      },
+    },
+    [GEN1_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'WebClient',
+      },
+    },
+    [GEN1_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'NativeClient',
+      },
+    },
+    DummyResource: {
+      Type: 'AWS::CloudFormation::WaitConditionHandle',
+      Properties: {},
+    },
+  },
+};
+
+const oldGen2AuthTemplate: CFNTemplate = {
+  AWSTemplateFormatVersion: '2010-09-09',
+  Description: 'Test template',
+  Outputs: {
+    UserPoolId: {
+      Description: 'User pool id',
+      Value: 'userPoolId',
+    },
+  },
+  Resources: {
+    [GEN2_AUTH_USER_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPool,
+      Properties: {
+        UserPoolName: 'my-gen2-user-pool',
+      },
+    },
+    [GEN2_AUTH_IDENTITY_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.IdentityPool,
+      Properties: {
+        IdentityPoolName: 'my-gen2-identity-pool',
+      },
+    },
+    [GEN2_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'Gen2WebClient',
+      },
+    },
+    [GEN2_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'Gen2NativeClient',
+      },
+    },
+    AuthRole: {
+      Type: 'AWS::IAM::Role',
+      Properties: {},
+    },
+  },
+};
+
+const newGen1AuthTemplate: CFNTemplate = {
+  ...oldGen1AuthTemplate,
+  Resources: {
+    [GEN1_AUTH_USER_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPool,
+      Properties: {
+        UserPoolName: 'my-user-pool-dev',
+      },
+    },
+    [GEN1_AUTH_IDENTITY_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.IdentityPool,
+      Properties: {
+        IdentityPoolName: 'my-identity-pool-dev',
+      },
+    },
+    [GEN1_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'WebClient',
+      },
+    },
+    [GEN1_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'NativeClient',
+      },
+    },
+  },
+};
+
+const newGen2AuthTemplate: CFNTemplate = {
+  ...oldGen2AuthTemplate,
+  Resources: {
+    AuthRole: {
+      Type: 'AWS::IAM::Role',
+      Properties: {},
+    },
+  },
+};
+
+const refactoredGen1AuthTemplate: CFNTemplate = {
+  ...newGen1AuthTemplate,
+  Resources: {
+    DummyResource: {
+      Type: 'AWS::CloudFormation::WaitConditionHandle',
+      Properties: {},
+    },
+  },
+};
+
+const refactoredGen2AuthTemplate: CFNTemplate = {
+  ...newGen2AuthTemplate,
+  Resources: {
+    ...oldGen2AuthTemplate.Resources,
+    [GEN2_AUTH_USER_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPool,
+      Properties: {
+        UserPoolName: { 'Fn::Join': ['-', 'my-user-pool', 'dev'] },
+      },
+    },
+    [GEN2_AUTH_IDENTITY_POOL_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.IdentityPool,
+      Properties: {
+        IdentityPoolName: { 'Fn::Join': ['-', 'my-identity-pool', 'dev'] },
+      },
+    },
+    [GEN2_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'WebClient',
+      },
+    },
+    [GEN2_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID]: {
+      Type: CFN_AUTH_TYPE.UserPoolClient,
+      Properties: {
+        ClientName: 'NativeClient',
+      },
+    },
+  },
+};
+
 const generateDescribeStacksResponse = (command: DescribeStacksCommand): DescribeStacksOutput => ({
   Stacks: [
     {
@@ -386,7 +576,7 @@ const generateDescribeStacksResponse = (command: DescribeStacksCommand): Describ
       Tags: [
         {
           Key: 'amplify:category-stack',
-          Value: 'amplify-testauth-dev-12345-auth-ABCDE',
+          Value: GEN1_AUTH_CATEGORY_STACK_NAME,
         },
       ],
       CreationTime: new Date(),
@@ -409,9 +599,33 @@ const generateDescribeStacksResponse = (command: DescribeStacksCommand): Describ
   ],
 });
 
-const generateGetTemplateResponse = (command: GetTemplateCommand): GetTemplateOutput => ({
-  TemplateBody: command.input.StackName === GEN1_CATEGORY_STACK_ID ? JSON.stringify(oldGen1Template) : JSON.stringify(oldGen2Template),
-});
+const generateGetTemplateResponse = (command: GetTemplateCommand): GetTemplateOutput => {
+  const stackName = command.input.StackName;
+  let templateBody;
+  switch (stackName) {
+    case GEN1_CATEGORY_STACK_ID: {
+      templateBody = JSON.stringify(oldGen1Template);
+      break;
+    }
+    case GEN2_CATEGORY_STACK_ID: {
+      templateBody = JSON.stringify(oldGen2Template);
+      break;
+    }
+    case GEN1_AUTH_CATEGORY_STACK_ID: {
+      templateBody = JSON.stringify(oldGen1AuthTemplate);
+      break;
+    }
+    case GEN2_AUTH_CATEGORY_STACK_ID: {
+      templateBody = JSON.stringify(oldGen2AuthTemplate);
+      break;
+    }
+    default:
+      throw new Error(`Unknown stack name: ${stackName}`);
+  }
+  return {
+    TemplateBody: templateBody,
+  };
+};
 
 const generateDescribeIdentityProviderResponse = ({ input }: DescribeIdentityProviderCommand): DescribeIdentityProviderResponse => ({
   IdentityProvider: {
@@ -526,6 +740,19 @@ describe('CategoryTemplateGenerator', () => {
     [CFN_S3_TYPE.Bucket],
   );
 
+  const authTemplateGenerator = new CategoryTemplateGenerator(
+    GEN1_AUTH_CATEGORY_STACK_ID,
+    GEN2_AUTH_CATEGORY_STACK_ID,
+    'us-east-1',
+    '12345',
+    new CloudFormationClient(),
+    new SSMClient(),
+    new CognitoIdentityProviderClient(),
+    MOCK_APP_ID,
+    ENV_NAME,
+    [CFN_AUTH_TYPE.UserPoolClient, CFN_AUTH_TYPE.UserPool, CFN_AUTH_TYPE.IdentityPool, CFN_AUTH_TYPE.UserPoolDomain],
+  );
+
   it('should preprocess gen1 template prior to refactor', async () => {
     await expect(s3TemplateGenerator.generateGen1PreProcessTemplate()).resolves.toEqual({
       oldTemplate: oldGen1Template,
@@ -563,6 +790,25 @@ describe('CategoryTemplateGenerator', () => {
       new Map<string, string>([
         [GEN1_S3_BUCKET_LOGICAL_ID, GEN2_S3_BUCKET_LOGICAL_ID],
         [GEN1_ANOTHER_S3_BUCKET_LOGICAL_ID, GEN2_ANOTHER_S3_BUCKET_LOGICAL_ID],
+      ]),
+    );
+  });
+
+  it('should refactor auth gen1 resources into gen2 stack', async () => {
+    const { newTemplate: newGen1Template } = await authTemplateGenerator.generateGen1PreProcessTemplate();
+    const { newTemplate: newGen2Template } = await authTemplateGenerator.generateGen2ResourceRemovalTemplate();
+    const { sourceTemplate, destinationTemplate, logicalIdMapping } = authTemplateGenerator.generateStackRefactorTemplates(
+      newGen1Template,
+      newGen2Template,
+    );
+    expect(sourceTemplate).toEqual<CFNTemplate>(refactoredGen1AuthTemplate);
+    expect(destinationTemplate).toEqual<CFNTemplate>(refactoredGen2AuthTemplate);
+    expect(logicalIdMapping).toEqual(
+      new Map<string, string>([
+        [GEN1_AUTH_USER_POOL_LOGICAL_ID, GEN2_AUTH_USER_POOL_LOGICAL_ID],
+        [GEN1_AUTH_IDENTITY_POOL_LOGICAL_ID, GEN2_AUTH_IDENTITY_POOL_LOGICAL_ID],
+        [GEN1_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID, GEN2_AUTH_USER_POOL_CLIENT_WEB_LOGICAL_ID],
+        [GEN1_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID, GEN2_AUTH_USER_POOL_CLIENT_NATIVE_LOGICAL_ID],
       ]),
     );
   });

--- a/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.test.ts
@@ -26,7 +26,8 @@ const GEN1_CATEGORY_STACK_ID = `arn:aws:cloudformation:us-east-1:1234567890:stac
 const GEN2_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-storage-ABCDE/12345';
 const GEN1_AUTH_CATEGORY_STACK_NAME = 'amplify-testauth-dev-12345-auth-ABCDE';
 const GEN1_AUTH_CATEGORY_STACK_ID = `arn:aws:cloudformation:us-east-1:1234567890:stack/${GEN1_AUTH_CATEGORY_STACK_NAME}/12345`;
-const GEN2_AUTH_CATEGORY_STACK_ID = 'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
+const GEN2_AUTH_CATEGORY_STACK_ID =
+  'arn:aws:cloudformation:us-east-1:1234567890:stack/amplify-mygen2app-test-sandbox-12345-auth-ABCDE/12345';
 const GEN1_S3_BUCKET_LOGICAL_ID = 'S3Bucket';
 const GEN2_S3_BUCKET_LOGICAL_ID = 'Gen2S3Bucket';
 const GEN1_ANOTHER_S3_BUCKET_LOGICAL_ID = 'MyOtherS3Bucket';

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -189,11 +189,11 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
         }
         // Since we have 2 app clients, we want to map the corresponding app clients (Web->Web, Native->Native)
         // In gen1, we differentiate clients with Web. In gen2, we differentiate with Native.
+        const isWebClient = gen1ResourceLogicalId === GEN1_WEB_APP_CLIENT && !gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT);
+        const isNativeClient = gen1ResourceLogicalId !== GEN1_WEB_APP_CLIENT && gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT);
         if (
           gen1Resource.Type !== CFN_AUTH_TYPE.UserPoolClient ||
-          (gen1Resource.Type === CFN_AUTH_TYPE.UserPoolClient &&
-            ((gen1ResourceLogicalId === GEN1_WEB_APP_CLIENT && !gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT)) ||
-              (gen1ResourceLogicalId !== GEN1_WEB_APP_CLIENT && gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT))))
+          (gen1Resource.Type === CFN_AUTH_TYPE.UserPoolClient && (isWebClient || isNativeClient))
         ) {
           gen1ToGen2ResourceLogicalIdMapping.set(gen1ResourceLogicalId, gen2ResourceLogicalId);
           clonedGen1ResourceMap.delete(gen1ResourceLogicalId);

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -109,7 +109,6 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
     // validate empty resources
     if (this.gen2ResourcesToRemove.size === 0) throw new Error('No resources to remove in Gen2 stack.');
     const logicalResourceIds = [...this.gen2ResourcesToRemove.keys()];
-    // const gen2TemplateWithDepsResolved = new CfnDependencyResolver(oldGen2Template).resolve(logicalResourceIds);
     const updatedGen2Template = this.removeGen2ResourcesFromGen2Stack(oldGen2Template, logicalResourceIds);
     return {
       oldTemplate: oldGen2Template,

--- a/packages/amplify-migration-template-gen/src/category-template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/category-template-generator.ts
@@ -1,7 +1,14 @@
 import { CloudFormationClient, DescribeStacksCommand, GetTemplateCommand, Stack } from '@aws-sdk/client-cloudformation';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import assert from 'node:assert';
-import { CFN_CATEGORY_TYPE, CFNChangeTemplateWithParams, CFNResource, CFNStackRefactorTemplates, CFNTemplate } from './types';
+import {
+  CFN_AUTH_TYPE,
+  CFN_CATEGORY_TYPE,
+  CFNChangeTemplateWithParams,
+  CFNResource,
+  CFNStackRefactorTemplates,
+  CFNTemplate,
+} from './types';
 import CFNConditionResolver from './resolvers/cfn-condition-resolver';
 import CfnParameterResolver from './resolvers/cfn-parameter-resolver';
 import CfnOutputResolver from './resolvers/cfn-output-resolver';
@@ -13,6 +20,8 @@ import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-
 const HOSTED_PROVIDER_META_PARAMETER_NAME = 'hostedUIProviderMeta';
 const HOSTED_PROVIDER_CREDENTIALS_PARAMETER_NAME = 'hostedUIProviderCreds';
 const USER_POOL_ID_OUTPUT_KEY_NAME = 'UserPoolId';
+const GEN1_WEB_APP_CLIENT = 'UserPoolClientWeb';
+const GEN2_NATIVE_APP_CLIENT = 'UserPoolNativeAppClient';
 
 class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
   private gen1DescribeStacksResponse: Stack | undefined;
@@ -99,7 +108,9 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
     );
     // validate empty resources
     if (this.gen2ResourcesToRemove.size === 0) throw new Error('No resources to remove in Gen2 stack.');
-    const updatedGen2Template = this.removeGen2ResourcesFromGen2Stack(oldGen2Template, [...this.gen2ResourcesToRemove.keys()]);
+    const logicalResourceIds = [...this.gen2ResourcesToRemove.keys()];
+    // const gen2TemplateWithDepsResolved = new CfnDependencyResolver(oldGen2Template).resolve(logicalResourceIds);
+    const updatedGen2Template = this.removeGen2ResourcesFromGen2Stack(oldGen2Template, logicalResourceIds);
     return {
       oldTemplate: oldGen2Template,
       newTemplate: updatedGen2Template,
@@ -177,10 +188,19 @@ class CategoryTemplateGenerator<CFNCategoryType extends CFN_CATEGORY_TYPE> {
         if (gen2Resource.Type !== gen1Resource.Type) {
           continue;
         }
-        gen1ToGen2ResourceLogicalIdMapping.set(gen1ResourceLogicalId, gen2ResourceLogicalId);
-        clonedGen1ResourceMap.delete(gen1ResourceLogicalId);
-        clonedGen2ResourceMap.delete(gen2ResourceLogicalId);
-        break;
+        // Since we have 2 app clients, we want to map the corresponding app clients (Web->Web, Native->Native)
+        // In gen1, we differentiate clients with Web. In gen2, we differentiate with Native.
+        if (
+          gen1Resource.Type !== CFN_AUTH_TYPE.UserPoolClient ||
+          (gen1Resource.Type === CFN_AUTH_TYPE.UserPoolClient &&
+            ((gen1ResourceLogicalId === GEN1_WEB_APP_CLIENT && !gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT)) ||
+              (gen1ResourceLogicalId !== GEN1_WEB_APP_CLIENT && gen2ResourceLogicalId.includes(GEN2_NATIVE_APP_CLIENT))))
+        ) {
+          gen1ToGen2ResourceLogicalIdMapping.set(gen1ResourceLogicalId, gen2ResourceLogicalId);
+          clonedGen1ResourceMap.delete(gen1ResourceLogicalId);
+          clonedGen2ResourceMap.delete(gen2ResourceLogicalId);
+          break;
+        }
       }
     }
     return gen1ToGen2ResourceLogicalIdMapping;

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -46,7 +46,7 @@ export interface CFNTemplate {
   AWSTemplateFormatVersion: string;
   Conditions?: Record<string, CFNConditionFunction>;
   Resources: Record<string, CFNResource>;
-  Parameters: Record<string, CFNParameter>;
+  Parameters?: Record<string, CFNParameter>;
   Outputs: Record<string, CFNOutput>;
 }
 

--- a/packages/amplify-migration/README.md
+++ b/packages/amplify-migration/README.md
@@ -4,6 +4,10 @@
 
 In Gen1 root directory run the following to generate Gen2 code based on Gen1 configuration:
 
-`npx @aws-amplify/migrate to-gen-2 generate-code`
+`npx @aws-amplify/migrate to-gen-2 prepare`
 
 Once this command runs successfully, the Gen1 project is converted to Gen2 with `amplify` directory containing Gen2 code and `.amplify/migration/amplify` containing Gen1 configuration as a backup.
+
+For executing the migration of resources from Gen1 to Gen2, run the following command:
+
+`npx @aws-amplify/migrate to-gen-2 execute --from <GEN1_ROOT_STACK_NAME> --to <GEN2_ROOT_STACK_NAME>`


### PR DESCRIPTION
#### Description of changes

#### Bug fixes

- Generate data code conditionally
- Set username attributes explicitly if present
- Don't set `phone` in `loginWith` object  in order to match the gen1 template
- Add support for native userpool client refactor

#### Description of how you validated changes
test locally with the codegen command, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
