### PR TITLE
fix(migrate): set CLI_ENV to production for usage metrics

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -139,10 +139,10 @@ function verifyPkgCli {
       fi
     }
 
-    verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((1000 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((1000 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((1000 * 1024 * 1024))
-    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((1000 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-x64" "amplify-pkg-linux-x64.tgz" $((900 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-macos-x64" "amplify-pkg-macos-x64.tgz" $((900 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-win-x64.exe" "amplify-pkg-win-x64.tgz" $((890 * 1024 * 1024))
+    verifySinglePkg "amplify-pkg-linux-arm64" "amplify-pkg-linux-arm64.tgz" $((750 * 1024 * 1024))
 }
 
 function unsetNpmRegistryUrl {

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -297,6 +297,7 @@ export async function execute() {
   const movingGen1BackendFiles = ora(`Moving your Gen1 backend files to ${format.highlight(MIGRATION_DIR)}`).start();
   // Move gen1 amplify to .amplify/migrations and move gen2 amplify from amplify-gen2 to amplify dir to convert current app to gen2.
   const cwd = process.cwd();
+  await fs.rm(MIGRATION_DIR, { recursive: true });
   await fs.mkdir(MIGRATION_DIR, { recursive: true });
   await fs.rename(AMPLIFY_DIR, `${MIGRATION_DIR}/amplify`);
   await fs.rename(`${TEMP_GEN_2_OUTPUT_DIR}/amplify`, `${cwd}/amplify`);

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -338,6 +338,8 @@ export async function executeStackRefactor(fromStack: string, toStack: string) {
   const success = await templateGenerator.generate();
   if (success) {
     printer.print(format.success(`Generated .README file(s) successfully under ${MIGRATION_DIR}/<category>/templates directory.`));
+    await usageData.emitSuccess();
+  } else {
+    await usageData.emitError(new Error('Failed to run execute command'));
   }
-  await usageData.emitSuccess();
 }

--- a/packages/amplify-migration/src/main_parser_factory.test.ts
+++ b/packages/amplify-migration/src/main_parser_factory.test.ts
@@ -26,4 +26,9 @@ describe('main parser', () => {
       },
     );
   });
+
+  it('sets CLI_ENV to production', async () => {
+    await runCommandAsync(parser, '--version');
+    assert(process.env.CLI_ENV === 'production');
+  });
 });

--- a/packages/amplify-migration/src/main_parser_factory.ts
+++ b/packages/amplify-migration/src/main_parser_factory.ts
@@ -1,6 +1,11 @@
 import { createGen2Command } from './commands/gen2/gen2_command_factory';
 import yargs, { Argv } from 'yargs';
 
+// Set CLI_ENV to production to always stream usage data metrics to production
+// This tool is not part of CLI binary and doesn't have preprod stages,
+// so will always default to production.
+process.env.CLI_ENV = 'production';
+
 export const createMainParser = (libraryVersion: string): Argv => {
   const parser = yargs()
     .version(libraryVersion)


### PR DESCRIPTION
#### Description of changes

- Set CLI_ENV to production for usage metrics. The migration tool is not part of CLI and does not have preprod stages.
- Emit usage error metrics when execute fails. The error message we are emitting is a generic one at this point.  If needed, we can sanitize the errors from execute command and pass it here
- Revert package size checks back to the ones in `dev` branch. Sizes are back to below threshold. There was only instance of the size increase and we are not able to figure out the root cause
- Remove `.amplify/migration` dir prior if already exists, prior to creation and moving of the directory

#### Description of how you validated changes
unit tests, ran command locally without env variable set (`AMPLIFY_CLI_BETA_USAGE_TRACKING_URL`):

```
unset AMPLIFY_CLI_BETA_USAGE_TRACKING_URL
../amplify-cli/node_modules/.bin/migrate to-gen-2 prepare
✔ Fetched resource details from AWS
✔ Generated your Gen 2 backend code
✔ Updated gitignore contents
✔ Moved your Gen1 backend files to .amplify/migration

```


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
