### PR TITLE
Fix mac smoke tests

### DIFF
--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -57,7 +57,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        sudo xcode-select -s "/Applications/Xcode_14.1.app"
+        sudo xcode-select -s "/Applications/Xcode_15.1.app"
         xcodebuild -version
 
     - name: Run Smoke Tests

--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -47,7 +47,7 @@ runs:
 
       # For iOS tests
     - name: Setup Ruby
-      uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+      uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
       if: runner.os == 'macOS'
       with:
         ruby-version: '3.2.1'

--- a/.github/workflows/smoke-tests-manual.yml
+++ b/.github/workflows/smoke-tests-manual.yml
@@ -11,7 +11,7 @@ on:
       os:
         required: false
         type: string
-        default: '["macos-latest-xl", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
+        default: '["macos-latest-xlarge", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
       versions:
         required: false
         type: string

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -11,7 +11,7 @@ on:
       os:
         required: false
         type: string
-        default: '["macos-latest-xl", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
+        default: '["macos-latest-xlarge", "ubuntu-latest", "amplify-cli_windows-latest_8-core"]'
       versions:
         required: false
         type: string


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The runners we were previously using for smoke tests on mac have gone out of support. Updating to the new runners requires that we update Ruby as well (see: https://github.com/ruby/setup-ruby/issues/568). 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

See successful smoke test run: https://github.com/aws-amplify/amplify-cli/actions/runs/13426677491

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
