### PR TITLE
pin amplify-category-api to 5.12.10

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@aws-amplify/amplify-app": "5.0.39",
     "@aws-amplify/amplify-category-analytics": "5.0.38",
-    "@aws-amplify/amplify-category-api": "^5.12.10",
+    "@aws-amplify/amplify-category-api": "5.12.10",
     "@aws-amplify/amplify-category-auth": "3.7.18",
     "@aws-amplify/amplify-category-custom": "3.1.26",
     "@aws-amplify/amplify-category-function": "5.7.12",

--- a/packages/amplify-container-hosting/package.json
+++ b/packages/amplify-container-hosting/package.json
@@ -26,7 +26,7 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.12.10",
+    "@aws-amplify/amplify-category-api": "5.12.10",
     "@aws-amplify/amplify-cli-core": "4.3.12",
     "@aws-amplify/amplify-environment-parameters": "1.9.17",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-util-uibuilder/package.json
+++ b/packages/amplify-util-uibuilder/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-amplify/amplify-category-api": "^5.12.10",
+    "@aws-amplify/amplify-category-api": "5.12.10",
     "@aws-amplify/amplify-cli-core": "4.3.12",
     "@aws-amplify/amplify-prompts": "2.8.6",
     "@aws-amplify/codegen-ui": "2.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,7 +151,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-amplify/amplify-category-api@npm:^5.12.10":
+"@aws-amplify/amplify-category-api@npm:5.12.10":
   version: 5.12.10
   resolution: "@aws-amplify/amplify-category-api@npm:5.12.10"
   dependencies:
@@ -504,7 +504,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-container-hosting@workspace:packages/amplify-container-hosting"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.12.10
+    "@aws-amplify/amplify-category-api": 5.12.10
     "@aws-amplify/amplify-cli-core": 4.3.12
     "@aws-amplify/amplify-environment-parameters": 1.9.17
     fs-extra: ^8.1.0
@@ -942,7 +942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-amplify/amplify-util-uibuilder@workspace:packages/amplify-util-uibuilder"
   dependencies:
-    "@aws-amplify/amplify-category-api": ^5.12.10
+    "@aws-amplify/amplify-category-api": 5.12.10
     "@aws-amplify/amplify-cli-core": 4.3.12
     "@aws-amplify/amplify-prompts": 2.8.6
     "@aws-amplify/appsync-modelgen-plugin": ^2.6.0
@@ -1078,7 +1078,7 @@ __metadata:
   dependencies:
     "@aws-amplify/amplify-app": 5.0.39
     "@aws-amplify/amplify-category-analytics": 5.0.38
-    "@aws-amplify/amplify-category-api": ^5.12.10
+    "@aws-amplify/amplify-category-api": 5.12.10
     "@aws-amplify/amplify-category-auth": 3.7.18
     "@aws-amplify/amplify-category-custom": 3.1.26
     "@aws-amplify/amplify-category-function": 5.7.12


### PR DESCRIPTION
#### Description of changes

Pin `amplify-category-api` to `5.12.10` so that API Gen1 canaries and e2e install `5.12.10` and not `5.13.0`. 

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
