### PR TITLE
fix: update amplify.yml file with the gen2 command

### DIFF
--- a/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.ts
+++ b/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.ts
@@ -29,7 +29,7 @@ export const getFunctionDefinition = (
     funcDef.runtime = configuration?.Runtime;
     const functionName = configuration?.FunctionName;
     assert(functionName);
-    const functionRecordInMeta = Object.entries(meta.function).find(([_, value]) => value.output.Name === functionName);
+    const functionRecordInMeta = Object.entries(meta.function).find(([, value]) => value.output.Name === functionName);
     assert(functionRecordInMeta);
     funcDef.category = functionCategoryMap.get(functionRecordInMeta[0]) ?? 'function';
     funcDef.resourceName = functionRecordInMeta[0];

--- a/packages/amplify-gen2-codegen/API.md
+++ b/packages/amplify-gen2-codegen/API.md
@@ -64,7 +64,7 @@ export type AuthLambdaTriggers = Record<AuthTriggerEvents, Lambda>;
 export type AuthTriggerEvents = 'createAuthChallenge' | 'customMessage' | 'defineAuthChallenge' | 'postAuthentication' | 'postConfirmation' | 'preAuthentication' | 'preSignUp' | 'preTokenGeneration' | 'userMigration' | 'verifyAuthChallengeResponse';
 
 // @public (undocumented)
-export const createGen2Renderer: ({ outputDir, appId, backendEnvironmentName, auth, storage, data, functions, unsupportedCategories, fileWriter, }: Readonly<Gen2RenderingOptions>) => Renderer;
+export const createGen2Renderer: ({ outputDir, backendEnvironmentName, auth, storage, data, functions, unsupportedCategories, fileWriter, }: Readonly<Gen2RenderingOptions>) => Renderer;
 
 // @public (undocumented)
 export type CustomAttribute = {

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -63,7 +63,6 @@ const createFileWriter = (path: string) => async (content: string) => fs.writeFi
 
 export const createGen2Renderer = ({
   outputDir,
-  appId,
   backendEnvironmentName,
   auth,
   storage,

--- a/packages/amplify-migration/src/command-handler.test.ts
+++ b/packages/amplify-migration/src/command-handler.test.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs/promises';
+import { AmplifyClient, GetAppCommand } from '@aws-sdk/client-amplify';
+import { updateAmplifyYmlFile } from './command-handlers';
+import { pathManager } from '@aws-amplify/amplify-cli-core';
+
+jest.mock('node:fs/promises', () => ({
+  access: jest.fn(),
+  readFile: jest.fn(),
+  writeFile: jest.fn(),
+}));
+
+jest.mock('@aws-amplify/amplify-cli-core');
+
+jest.mock('@aws-sdk/client-amplify');
+
+describe('updateAmplifyYmlFile', () => {
+  const amplifyClient = new AmplifyClient();
+  const mockAppId = 'testAppId';
+  const amplifyYmlPath = '/mockRootDir/amplify.yml';
+  const mockBuildSpec = `version: 1
+backend:
+  phases:
+    build:
+      commands:
+        - '# Execute Amplify CLI with the helper script'
+        - amplifyPush --simple
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci --cache .npm --prefer-offline
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    baseDirectory: build
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .npm/**/*`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (pathManager.findProjectRoot as jest.Mock).mockReturnValue('/mockRootDir');
+  });
+
+  it('should update amplify.yml file if it exists', async () => {
+    (fs.access as jest.Mock).mockResolvedValue(undefined);
+    (fs.readFile as jest.Mock).mockResolvedValue(mockBuildSpec);
+
+    await updateAmplifyYmlFile(amplifyClient, mockAppId);
+
+    expect(fs.readFile).toHaveBeenCalledWith(amplifyYmlPath, 'utf-8');
+    expect(fs.writeFile).toHaveBeenCalledWith(amplifyYmlPath, mockBuildSpec.replace(/amplifyPush --simple/g, 'npx ampx pipeline-deploy'), {
+      encoding: 'utf-8',
+    });
+  });
+
+  it('should create amplify.yml file with updated buildSpec if it does not exist', async () => {
+    (fs.access as jest.Mock).mockRejectedValue(new Error('File not found'));
+    (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({
+      app: { buildSpec: mockBuildSpec },
+    });
+
+    await updateAmplifyYmlFile(amplifyClient, mockAppId);
+
+    expect(AmplifyClient.prototype.send).toHaveBeenCalledWith(expect.any(GetAppCommand));
+    expect(fs.writeFile).toHaveBeenCalledWith(amplifyYmlPath, mockBuildSpec.replace(/amplifyPush --simple/g, 'npx ampx pipeline-deploy'), {
+      encoding: 'utf-8',
+    });
+  });
+
+  it('should throw an error if buildSpec is not found in the app', async () => {
+    (fs.access as jest.Mock).mockRejectedValue(new Error('File not found'));
+    (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({
+      app: {},
+    });
+
+    await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).rejects.toThrow('buildSpec not found in the app');
+  });
+
+  it('should throw an error if app is not found', async () => {
+    (fs.access as jest.Mock).mockRejectedValue(new Error('File not found'));
+    (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({});
+
+    await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).rejects.toThrow('App not found');
+  });
+});

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -36,7 +36,6 @@ interface CodegenCommandParameters {
   logger: AppContextLogger;
   outputDirectory: string;
   backendEnvironmentName: string | undefined;
-  appId: string;
   dataDefinitionFetcher: DataDefinitionFetcher;
   authDefinitionFetcher: AppAuthDefinitionFetcher;
   storageDefinitionFetcher: AppStorageDefinitionFetcher;
@@ -59,7 +58,6 @@ enum GEN2_AMPLIFY_GITIGNORE_FILES_OR_DIRS {
 const generateGen2Code = async ({
   outputDirectory,
   backendEnvironmentName,
-  appId,
   authDefinitionFetcher,
   dataDefinitionFetcher,
   storageDefinitionFetcher,
@@ -68,7 +66,6 @@ const generateGen2Code = async ({
   const fetchingAWSResourceDetails = ora('Fetching resource details from AWS').start();
   const gen2RenderOptions = {
     outputDir: outputDirectory,
-    appId: appId,
     backendEnvironmentName: backendEnvironmentName,
     auth: await authDefinitionFetcher.getDefinition(),
     storage: await storageDefinitionFetcher.getDefinition(),
@@ -322,12 +319,11 @@ export async function execute() {
       () => getAuthTriggersConnections(),
       ccbFetcher,
     ),
-    dataDefinitionFetcher: new DataDefinitionFetcher(backendEnvironmentResolver, amplifyStackParser),
+    dataDefinitionFetcher: new DataDefinitionFetcher(backendEnvironmentResolver, new BackendDownloader(s3Client), amplifyStackParser),
     functionsDefinitionFetcher: new AppFunctionsDefinitionFetcher(lambdaClient, backendEnvironmentResolver, stateManager),
     analytics: new AppAnalytics(appId),
     logger: new AppContextLogger(appId),
     backendEnvironmentName: backendEnvironment?.environmentName,
-    appId: appId,
   });
 
   await updateAmplifyYmlFile(amplifyClient, appId);

--- a/packages/amplify-migration/src/data_definition_fetcher.ts
+++ b/packages/amplify-migration/src/data_definition_fetcher.ts
@@ -89,7 +89,7 @@ export class DataDefinitionFetcher {
 
     const amplifyMeta = (await this.readJsonFile(amplifyMetaPath)) ?? {};
 
-    if ('api' in amplifyMeta && Object.keys(amplifyMeta.api).length) {
+    if ('api' in amplifyMeta && Object.keys(amplifyMeta.api).length > 0) {
       const tableMappings = await Promise.all(
         backendEnvironments.map(async (backendEnvironment) => {
           if (!backendEnvironment?.stackName) {


### PR DESCRIPTION
#### Description of changes
If amplify.yml does not exist at the root of their project, get the buildSpec by making the getApp call, update the Gen1 command and create amplify.yml file with the updated buildspec
if amplify.yml exists at the root, update the buildspec by replacing Gen1 command to Gen2 command
Gen1 command: amplifyPush --simple
Gen2 command: npx ampx pipeline-deploy

#### Issue #, if available
https://app.asana.com/0/1209548398662247/1209172037882456

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
