### PR TITLE
fix(migrate-template-gen): return early if output is not Fn:GetAtt or…

### DIFF
--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
@@ -37,6 +37,28 @@ describe('CFNOutputResolver', () => {
           'Fn::GetAtt': ['SNSRole', 'Arn'],
         },
       },
+      HostedUIDomain: {
+        Description: 'HostedUIDomain',
+        Value: {
+          'Fn::If': [
+            'ShouldNotCreateEnvResources',
+            'HostedUIDomainLogicalId',
+            {
+              'Fn::Join': [
+                '-',
+                [
+                  {
+                    Ref: 'hostedUIDomainName',
+                  },
+                  {
+                    Ref: 'env',
+                  },
+                ],
+              ],
+            },
+          ],
+        },
+      },
     },
     Resources: {
       MyS3Bucket: {
@@ -182,6 +204,10 @@ describe('CFNOutputResolver', () => {
         Description: 'role arn',
         Value: 'arn:aws:iam::12345:role/sns12345-dev',
       },
+      HostedUIDomain: {
+        Description: 'HostedUIDomain',
+        Value: 'my-hosted-UI-domain',
+      },
     },
     Resources: {
       MyS3Bucket: {
@@ -320,6 +346,10 @@ describe('CFNOutputResolver', () => {
           {
             OutputKey: 'CreatedSNSRole',
             OutputValue: 'arn:aws:iam::12345:role/sns12345-dev',
+          },
+          {
+            OutputKey: 'HostedUIDomain',
+            OutputValue: 'my-hosted-UI-domain',
           },
         ],
       ),

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
@@ -40,6 +40,8 @@ class CfnOutputResolver {
         stackTemplateResourcesString = stackTemplateResourcesString.replaceAll(outputRegexp, `"${stackOutputValue}"`);
       } else if (GET_ATT in value && Array.isArray(value[GET_ATT])) {
         logicalResourceId = value[GET_ATT][0];
+      } else {
+        return;
       }
       assert(logicalResourceId);
 

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -332,6 +332,11 @@ export async function revertGen2Migration(fromStack: string, toStack: string) {
   const usageData = await getUsageDataMetric(envName);
   if (success) {
     printer.print(format.success(`Moved resources back to Gen1 stack successfully.`));
+    const movingGen1BackendFiles = ora(`Moving your Gen1 backend files to ${format.highlight(AMPLIFY_DIR)}`).start();
+    // Move gen1 amplify from .amplify/migration/amplify to amplify
+    await fs.rm(AMPLIFY_DIR, { force: true, recursive: true });
+    await fs.rename(`${MIGRATION_DIR}/amplify`, AMPLIFY_DIR);
+    movingGen1BackendFiles.succeed(`Moved your Gen1 backend files to ${format.highlight(AMPLIFY_DIR)}`);
     await usageData.emitSuccess();
   } else {
     await usageData.emitError(new Error('Failed to run revert command'));


### PR DESCRIPTION
#### Description of changes

- Exit early in the output resolver if the template ouput is not of type `Ref` or `Fn::GetAtt`. Currently, the resources that are moved over only depend on outputs with these types. So its safe to return early. We can add additional cases if we discover its required during migration
- At the final step of revert command, delete the current `amplify` folder (Gen2) and move the backup Gen1 folder (`.amplify/migration/amplify`) to `amplify`

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

ran execute and revert command locally, unit tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
