### PR TITLE
Gen2 migrations - support node 20 and 22 in functions

### DIFF
--- a/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { FunctionDefinition, renderFunctions } from './source_builder';
 import { printNodeArray } from '../test_utils/ts_node_printer';
+import { Runtime } from '@aws-sdk/client-lambda';
 
 describe('render function', () => {
   describe('import', () => {
@@ -40,13 +41,15 @@ describe('render function', () => {
       const source = printNodeArray(rendered);
       assert.match(source, /name: /);
     });
-    it('does render runtime property', () => {
+    test.each([[Runtime.nodejs16x], [Runtime.nodejs18x], [Runtime.nodejs20x], [Runtime.nodejs22x]])('does render runtime property for %s nodejs.', (nodejsRuntime: Runtime) => {
       const definition: FunctionDefinition = {};
-      definition.runtime = 'nodejs18.x';
+      definition.runtime = nodejsRuntime;
 
       const rendered = renderFunctions(definition);
       const source = printNodeArray(rendered);
-      assert.match(source, /runtime: 18/);
+      const expectedRuntime = nodejsRuntime.split('nodejs')[1].split('.')[0];
+      assert(expectedRuntime);
+      assert.match(source, new RegExp(`runtime: ${expectedRuntime}`));
     });
     it('does render timeoutSeconds property', () => {
       const definition: FunctionDefinition = {};

--- a/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
@@ -51,6 +51,13 @@ describe('render function', () => {
       assert(expectedRuntime);
       assert.match(source, new RegExp(`runtime: ${expectedRuntime}`));
     });
+
+    it('throws error for unsupported nodejs runtime', () => {
+      const definition: FunctionDefinition = {};
+      definition.runtime = Runtime.nodejs14x;
+
+      assert.throws(() => renderFunctions(definition), /Unsupported nodejs runtime/);
+    });
     it('does render timeoutSeconds property', () => {
       const definition: FunctionDefinition = {};
       definition.timeoutSeconds = 3;

--- a/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.test.ts
@@ -41,22 +41,33 @@ describe('render function', () => {
       const source = printNodeArray(rendered);
       assert.match(source, /name: /);
     });
-    test.each([[Runtime.nodejs16x], [Runtime.nodejs18x], [Runtime.nodejs20x], [Runtime.nodejs22x]])('does render runtime property for %s nodejs.', (nodejsRuntime: Runtime) => {
-      const definition: FunctionDefinition = {};
-      definition.runtime = nodejsRuntime;
+    test.each([[Runtime.nodejs16x], [Runtime.nodejs18x], [Runtime.nodejs20x], [Runtime.nodejs22x]])(
+      'does render runtime property for %s nodejs.',
+      (nodejsRuntime: Runtime) => {
+        const definition: FunctionDefinition = {};
+        definition.runtime = nodejsRuntime;
 
-      const rendered = renderFunctions(definition);
-      const source = printNodeArray(rendered);
-      const expectedRuntime = nodejsRuntime.split('nodejs')[1].split('.')[0];
-      assert(expectedRuntime);
-      assert.match(source, new RegExp(`runtime: ${expectedRuntime}`));
-    });
+        const rendered = renderFunctions(definition);
+        const source = printNodeArray(rendered);
+        const expectedRuntime = nodejsRuntime.split('nodejs')[1].split('.')[0];
+        assert(expectedRuntime);
+        assert.match(source, new RegExp(`runtime: ${expectedRuntime}`));
+      },
+    );
 
     it('throws error for unsupported nodejs runtime', () => {
       const definition: FunctionDefinition = {};
       definition.runtime = Runtime.nodejs14x;
 
       assert.throws(() => renderFunctions(definition), /Unsupported nodejs runtime/);
+    });
+    it('does not render runtime property for unsupported runtimes', () => {
+      const definition: FunctionDefinition = {};
+      definition.runtime = Runtime.dotnet8;
+
+      const rendered = renderFunctions(definition);
+      const source = printNodeArray(rendered);
+      assert.doesNotMatch(source, /runtime: /);
     });
     it('does render timeoutSeconds property', () => {
       const definition: FunctionDefinition = {};

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -97,9 +97,9 @@ export function createFunctionDefinition(
     );
   }
 
-  let nodeRuntime = 0;
   const runtime = definition?.runtime;
-  if (runtime) {
+  if (runtime && runtime.includes('nodejs')) {
+    let nodeRuntime: number | undefined;
     switch (runtime) {
       case Runtime.nodejs16x:
         nodeRuntime = 16;
@@ -116,6 +116,7 @@ export function createFunctionDefinition(
       default:
         throw new Error(`Unsupported nodejs runtime for function: ${runtime}`);
     }
+    assert(nodeRuntime, 'Expected nodejs version to be set');
 
     defineFunctionProperties.push(createParameter('runtime', factory.createNumericLiteral(nodeRuntime)));
   }

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -1,6 +1,7 @@
 import ts, { ObjectLiteralElementLike } from 'typescript';
 import { EnvironmentResponse, Runtime } from '@aws-sdk/client-lambda';
 import { renderResourceTsFile } from '../resource/resource';
+import assert from 'node:assert';
 
 export interface FunctionDefinition {
   category?: string;
@@ -97,12 +98,23 @@ export function createFunctionDefinition(
   }
 
   let nodeRuntime = 0;
-  if (definition?.runtime) {
-    const runtime = definition?.runtime;
-    if (runtime === Runtime.nodejs16x) {
-      nodeRuntime = 16;
-    } else if (runtime === Runtime.nodejs18x) {
-      nodeRuntime = 18;
+  const runtime = definition?.runtime;
+  if (runtime) {
+    switch (runtime) {
+      case Runtime.nodejs16x:
+        nodeRuntime = 16;
+        break;
+      case Runtime.nodejs18x:
+        nodeRuntime = 18;
+        break;
+      case Runtime.nodejs20x:
+        nodeRuntime = 20;
+        break;
+      case Runtime.nodejs22x:
+        nodeRuntime = 22;
+        break;
+      default:
+        throw new Error(`Unsupported nodejs runtime for function: ${runtime}`);
     }
 
     defineFunctionProperties.push(createParameter('runtime', factory.createNumericLiteral(nodeRuntime)));


### PR DESCRIPTION
#### Description of changes

add node 20 and 22 version support for functions.

#### Description of how you validated changes
unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
