### PR TITLE
fix: add idp codegen and fix a couple of minor bugs

### DIFF
--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -485,6 +485,12 @@ describe('BackendRenderer', () => {
       expect(output).toContain('enableTokenRevocation: true');
       expect(output).toContain('enablePropagateAdditionalUserContextData: true');
       expect(output).toContain('generateSecret: true');
+
+      expect(output).toContain(
+        'const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;',
+      );
+      expect(output).toContain('Object.keys(providerSetupResult).forEach(provider => {');
+      expect(output).toContain('userPoolClient.node.addDependency(providerSetupPropertyValue)');
     });
     it('renders userpool and identitypool deletion policy', () => {
       const renderer = new BackendSynthesizer();

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -251,14 +251,14 @@ export class BackendSynthesizer {
       );
   }
 
-  private createProviderSetupCode(): ts.Statement[] {
-    // Create const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;
-    const providerSetupDeclaration = factory.createVariableStatement(
+  private getProviderSetupDeclaration(): ts.VariableStatement {
+    const providerSetupResult = 'providerSetupResult';
+    return factory.createVariableStatement(
       undefined,
       factory.createVariableDeclarationList(
         [
           factory.createVariableDeclaration(
-            factory.createIdentifier('providerSetupResult'),
+            factory.createIdentifier(providerSetupResult),
             undefined,
             undefined,
             factory.createPropertyAccessExpression(
@@ -288,22 +288,24 @@ export class BackendSynthesizer {
                   factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
                 ),
               ),
-              factory.createIdentifier('providerSetupResult'),
+              factory.createIdentifier(providerSetupResult),
             ),
           ),
         ],
         ts.NodeFlags.Const,
       ),
     );
+  }
 
-    // Create Object.keys(providerSetupResult).forEach(...)
-    const forEachStatement = factory.createExpressionStatement(
+  private getProviderSetupForeachStatement(): ExpressionStatement {
+    const providerSetupResult = 'providerSetupResult';
+    return factory.createExpressionStatement(
       factory.createCallExpression(
         factory.createPropertyAccessExpression(
           factory.createCallExpression(
             factory.createPropertyAccessExpression(factory.createIdentifier('Object'), factory.createIdentifier('keys')),
             undefined,
-            [factory.createIdentifier('providerSetupResult')],
+            [factory.createIdentifier(providerSetupResult)],
           ),
           factory.createIdentifier('forEach'),
         ),
@@ -327,7 +329,7 @@ export class BackendSynthesizer {
                         undefined,
                         undefined,
                         factory.createElementAccessExpression(
-                          factory.createIdentifier('providerSetupResult'),
+                          factory.createIdentifier(providerSetupResult),
                           factory.createIdentifier('provider'),
                         ),
                       ),
@@ -378,6 +380,14 @@ export class BackendSynthesizer {
         ],
       ),
     );
+  }
+
+  private createProviderSetupCode(): ts.Statement[] {
+    // Create const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;
+    const providerSetupDeclaration = this.getProviderSetupDeclaration();
+
+    // Create Object.keys(providerSetupResult).forEach(...)
+    const forEachStatement = this.getProviderSetupForeachStatement();
 
     return [providerSetupDeclaration, forEachStatement];
   }

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -201,11 +201,25 @@ export class BackendSynthesizer {
     userPoolClientAttributesMap.set('ExplicitAuthFlows', 'authFlows');
     userPoolClientAttributesMap.set('AllowedOAuthFlows', 'flows');
 
-    const nativeUserPoolClientExpressionStatement = factory.createExpressionStatement(
-      factory.createCallExpression(
-        factory.createPropertyAccessExpression(factory.createIdentifier('userPool'), factory.createIdentifier('addClient')),
-        undefined,
-        [factory.createStringLiteral('NativeAppClient'), this.createNestedObjectExpression(userPoolClient, userPoolClientAttributesMap)],
+    const userPoolClientDeclaration = factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('userPoolClient'),
+            undefined,
+            undefined,
+            factory.createCallExpression(
+              factory.createPropertyAccessExpression(factory.createIdentifier('userPool'), factory.createIdentifier('addClient')),
+              undefined,
+              [
+                factory.createStringLiteral('NativeAppClient'),
+                this.createNestedObjectExpression(userPoolClient, userPoolClientAttributesMap),
+              ],
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
       ),
     );
 
@@ -225,7 +239,147 @@ export class BackendSynthesizer {
       }
     }
 
-    return nativeUserPoolClientExpressionStatement;
+    return userPoolClientDeclaration;
+  }
+
+  private createPropertyAccessChain(identifiers: string[]): ts.Expression {
+    return identifiers
+      .slice(1)
+      .reduce<ts.Expression>(
+        (acc, curr) => factory.createPropertyAccessExpression(acc, factory.createIdentifier(curr)),
+        factory.createIdentifier(identifiers[0]),
+      );
+  }
+
+  private createProviderSetupCode(): ts.Statement[] {
+    // Create const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;
+    const providerSetupDeclaration = factory.createVariableStatement(
+      undefined,
+      factory.createVariableDeclarationList(
+        [
+          factory.createVariableDeclaration(
+            factory.createIdentifier('providerSetupResult'),
+            undefined,
+            undefined,
+            factory.createPropertyAccessExpression(
+              factory.createParenthesizedExpression(
+                factory.createAsExpression(
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      this.createPropertyAccessChain(['backend', 'auth', 'stack', 'node', 'children']),
+                      factory.createIdentifier('find'),
+                    ),
+                    undefined,
+                    [
+                      factory.createArrowFunction(
+                        undefined,
+                        undefined,
+                        [factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('child'))],
+                        undefined,
+                        factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                        factory.createBinaryExpression(
+                          this.createPropertyAccessChain(['child', 'node', 'id']),
+                          factory.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                          factory.createStringLiteral('amplifyAuth'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+                ),
+              ),
+              factory.createIdentifier('providerSetupResult'),
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    );
+
+    // Create Object.keys(providerSetupResult).forEach(...)
+    const forEachStatement = factory.createExpressionStatement(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(
+          factory.createCallExpression(
+            factory.createPropertyAccessExpression(factory.createIdentifier('Object'), factory.createIdentifier('keys')),
+            undefined,
+            [factory.createIdentifier('providerSetupResult')],
+          ),
+          factory.createIdentifier('forEach'),
+        ),
+        undefined,
+        [
+          factory.createArrowFunction(
+            undefined,
+            undefined,
+            [factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('provider'))],
+            undefined,
+            factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            factory.createBlock(
+              [
+                // const providerSetupPropertyValue = providerSetupResult[provider]
+                factory.createVariableStatement(
+                  undefined,
+                  factory.createVariableDeclarationList(
+                    [
+                      factory.createVariableDeclaration(
+                        factory.createIdentifier('providerSetupPropertyValue'),
+                        undefined,
+                        undefined,
+                        factory.createElementAccessExpression(
+                          factory.createIdentifier('providerSetupResult'),
+                          factory.createIdentifier('provider'),
+                        ),
+                      ),
+                    ],
+                    ts.NodeFlags.Const,
+                  ),
+                ),
+                // if condition
+                factory.createIfStatement(
+                  factory.createLogicalAnd(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier('providerSetupPropertyValue'),
+                      factory.createIdentifier('node'),
+                    ),
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(
+                            this.createPropertyAccessChain(['providerSetupPropertyValue', 'node', 'id']),
+                            factory.createIdentifier('toLowerCase'),
+                          ),
+                          undefined,
+                          [],
+                        ),
+                        factory.createIdentifier('endsWith'),
+                      ),
+                      undefined,
+                      [factory.createStringLiteral('idp')],
+                    ),
+                  ),
+                  factory.createBlock(
+                    [
+                      factory.createExpressionStatement(
+                        factory.createCallExpression(
+                          this.createPropertyAccessChain(['userPoolClient', 'node', 'addDependency']),
+                          undefined,
+                          [factory.createIdentifier('providerSetupPropertyValue')],
+                        ),
+                      ),
+                    ],
+                    true,
+                  ),
+                ),
+              ],
+              true,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return [providerSetupDeclaration, forEachStatement];
   }
 
   private createNestedObjectExpression(object: Record<string, any>, gen2PropertyMap: Map<string, string>): ts.ObjectLiteralExpression {
@@ -743,6 +897,9 @@ export class BackendSynthesizer {
       const userPoolVariableStatement = this.createVariableStatement(this.createVariableDeclaration('userPool', 'auth.resources.userPool'));
       nodes.push(userPoolVariableStatement);
       nodes.push(this.createUserPoolClientAssignment(renderArgs.auth?.userPoolClient, imports));
+
+      const idpStatements = this.createProviderSetupCode();
+      nodes.push(...idpStatements);
     }
 
     if (renderArgs.storage && renderArgs.storage.hasS3Bucket) {

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -107,6 +107,7 @@ export const createGen2Renderer = ({
         module: 'es2022',
         moduleResolution: 'bundler',
         resolveJsonModule: true,
+        // eslint-disable-next-line spellcheck/spell-checker
         esModuleInterop: true,
         forceConsistentCasingInFileNames: true,
         strict: true,

--- a/packages/amplify-migration/src/app_auth_definition_fetcher.ts
+++ b/packages/amplify-migration/src/app_auth_definition_fetcher.ts
@@ -40,7 +40,7 @@ export class AppAuthDefinitionFetcher {
     return JSON.parse(contents);
   };
 
-  private authCategory = async () => {
+  private getAuthCategory = async () => {
     const backendEnvironment = await this.backendEnvironmentResolver.selectBackendEnvironment();
     if (!backendEnvironment?.deploymentArtifacts) return undefined;
     const currentCloudBackendDirectory = await this.ccbFetcher.getCurrentCloudBackend(backendEnvironment.deploymentArtifacts);
@@ -123,7 +123,7 @@ export class AppAuthDefinitionFetcher {
   };
 
   getDefinition = async (): Promise<AuthDefinition | undefined> => {
-    const authCategory = await this.authCategory();
+    const authCategory = await this.getAuthCategory();
     if (!authCategory) {
       return undefined;
     }

--- a/packages/amplify-migration/src/command-handler.test.ts
+++ b/packages/amplify-migration/src/command-handler.test.ts
@@ -73,13 +73,13 @@ frontend:
     });
   });
 
-  it('should throw an error if buildSpec is not found in the app', async () => {
+  it('should not throw an error if buildSpec is not found in the app', async () => {
     (fs.readFile as jest.Mock).mockRejectedValue({ code: 'ENOENT' });
     (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({
       app: {},
     });
 
-    await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).rejects.toThrow('buildSpec not found in the app');
+    await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).resolves.not.toThrow();
   });
 
   it('should throw an error if app is not found', async () => {

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -242,6 +242,7 @@ export async function updateAmplifyYmlFile(amplifyClient: AmplifyClient, appId: 
 }
 
 async function writeToAmplifyYmlFile(amplifyYmlPath: string, content: string) {
+  // eslint-disable-next-line spellcheck/spell-checker
   // Replace 'amplifyPush --simple' with 'npx ampx pipeline-deploy'
   content = content.replace(new RegExp(GEN1_COMMAND, 'g'), GEN2_COMMAND);
   await fs.writeFile(amplifyYmlPath, content, { encoding: 'utf-8' });

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -230,9 +230,10 @@ export async function updateAmplifyYmlFile(amplifyClient: AmplifyClient, appId: 
 
       assert(getAppResponse.app, 'App not found');
       const buildSpec = getAppResponse.app.buildSpec;
-      assert(buildSpec, 'buildSpec not found in the app');
 
-      await writeToAmplifyYmlFile(amplifyYmlPath, buildSpec);
+      if (buildSpec) {
+        await writeToAmplifyYmlFile(amplifyYmlPath, buildSpec);
+      }
     } else {
       // Throw the original error if it's not related to file not found
       throw error;


### PR DESCRIPTION
#### Description of changes

1) codegen idp in backend.ts: https://app.asana.com/0/1209548398662250/1209688082354480/f

`const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;
Object.keys(providerSetupResult).forEach(provider => {
    const providerSetupPropertyValue = providerSetupResult[provider];
    if (providerSetupPropertyValue.node && providerSetupPropertyValue.node.id.toLowerCase().endsWith("idp")) {
        userPoolClient.node.addDependency(providerSetupPropertyValue);
    }
});`

2) don't throw an error if buildSpec is not found during getApp call: https://app.asana.com/0/1209548398662250/1209731110320988/f

3) don't generate auth/resource.ts if authCategory doesn't exist

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
