### PR TITLE
Gen2 migrations QA fixes

### DIFF
--- a/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
+++ b/packages/amplify-gen1-codegen-auth-adapter/src/auth_render_adapter.test.ts
@@ -462,6 +462,7 @@ void describe('auth codegen', () => {
       ['DefineAuthChallenge', 'defineAuthChallenge'],
       ['CreateAuthChallenge', 'createAuthChallenge'],
       ['VerifyAuthChallengeResponse', 'verifyAuthChallengeResponse'],
+      ['PreTokenGenerationConfig', 'preTokenGeneration'],
     ];
     for (const [lambdaConfigKey, authEventKey] of testCases) {
       void it(`adapts user pool lambda config key ${lambdaConfigKey} to triggers ${authEventKey}`, () => {
@@ -469,7 +470,11 @@ void describe('auth codegen', () => {
           userPool: { LambdaConfig: { [lambdaConfigKey]: {} } },
         });
         assert(result.lambdaTriggers);
-        assert.deepEqual(result.lambdaTriggers[authEventKey], { source: '' });
+        if (lambdaConfigKey === 'PreTokenGenerationConfig') {
+          expect(result.lambdaTriggers[authEventKey]).toBeUndefined();
+        } else {
+          assert.deepEqual(result.lambdaTriggers[authEventKey], { source: '' });
+        }
       });
     }
   });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -855,7 +855,7 @@ export class BackendSynthesizer {
     }
 
     return factory.createNodeArray(
-      [...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, newLineIdentifier, ...nodes],
+      [...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, ...nodes],
       true,
     );
   }

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -14,6 +14,7 @@ import { BucketAccelerateStatus, BucketVersioningStatus } from '@aws-sdk/client-
 import { AccessPatterns, ServerSideEncryptionConfiguration } from '../storage/source_builder.js';
 import { ExplicitAuthFlowsType, OAuthFlowType, UserPoolClientType } from '@aws-sdk/client-cognito-identity-provider';
 import assert from 'assert';
+import { newLineIdentifier } from '../ts_factory_utils';
 
 const factory = ts.factory;
 export interface BackendRenderParameters {
@@ -570,10 +571,8 @@ export class BackendSynthesizer {
     }
 
     if (renderArgs.function) {
-      const functionIdentifiers: Identifier[] = [];
       const functionNameCategories = renderArgs.function.functionNamesAndCategories;
       for (const [functionName, category] of functionNameCategories) {
-        functionIdentifiers.push(factory.createIdentifier(functionName));
         const functionProperty = factory.createShorthandPropertyAssignment(factory.createIdentifier(functionName));
         defineBackendProperties.push(functionProperty);
         imports.push(this.createImportStatement([factory.createIdentifier(functionName)], `./${category}/${functionName}/resource`));
@@ -855,6 +854,9 @@ export class BackendSynthesizer {
       nodes.push(tagAssignment);
     }
 
-    return factory.createNodeArray([...imports, ...errors, backendStatement, ...nodes], true);
+    return factory.createNodeArray(
+      [...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, newLineIdentifier, ...nodes],
+      true,
+    );
   }
 }

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -854,9 +854,6 @@ export class BackendSynthesizer {
       nodes.push(tagAssignment);
     }
 
-    return factory.createNodeArray(
-      [...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, ...nodes],
-      true,
-    );
+    return factory.createNodeArray([...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, ...nodes], true);
   }
 }

--- a/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
+++ b/packages/amplify-gen2-codegen/src/data/source_builder.test.ts
@@ -41,7 +41,7 @@ describe('Data Category code generation', () => {
       const source = printNodeArray(generateDataSource({ tableMappings, schema: 'schema' }));
       assert.match(
         source,
-        /const schema \= \`schema\`\;\nexport const data \= defineData\({\n\s+migratedAmplifyGen1DynamoDbTableMappings: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelNameToTableNameMapping: { Todo: ['"]my-todo-mapping['"] }\n\s+}],\n\s+schema\n}\)/,
+        /const schema \= \`schema\`\;\n\nexport const data \= defineData\({\n\s+migratedAmplifyGen1DynamoDbTableMappings: \[\{\n\s+\/\/ Replace the environment name \(dev\) with the corresponding branch name. Use ['"]sandbox['"] for your sandbox environment.\n\s+branchName: ['"]dev['"],\n\s+modelNameToTableNameMapping: { Todo: ['"]my-todo-mapping['"] }\n\s+}],\n\s+schema\n}\)/,
       );
     });
   });

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -39,11 +39,13 @@ export function renderFunctions(definition: FunctionDefinition, appId?: string, 
   namedImports['@aws-amplify/backend'].add('defineFunction');
 
   postImportStatements.push(
-    factory.createCallExpression(factory.createIdentifier('throw new Error'), undefined, [
-      factory.createStringLiteral(
-        `Source code for this function can be found in your Amplify Gen 1 Directory. See .amplify/migration/amplify/backend/function/${definition.resourceName}/src`,
-      ),
-    ]),
+    factory.createExpressionStatement(
+      factory.createCallExpression(factory.createIdentifier('throw new Error'), undefined, [
+        factory.createStringLiteral(
+          `Source code for this function can be found in your Amplify Gen 1 Directory. See .amplify/migration/amplify/backend/function/${definition.resourceName}/src`,
+        ),
+      ]),
+    ),
   );
 
   const defineFunctionProperty = createFunctionDefinition(definition, postImportStatements, namedImports, appId, backendEnvironmentName);
@@ -69,7 +71,7 @@ export function renderFunctions(definition: FunctionDefinition, appId?: string, 
 
 export function createFunctionDefinition(
   definition?: FunctionDefinition,
-  postImportStatements?: (ts.CallExpression | ts.JSDoc)[],
+  postImportStatements?: (ts.CallExpression | ts.JSDoc | ts.ExpressionStatement)[],
   namedImports?: Record<string, Set<string>>,
   appId?: string,
   backendEnvironmentName?: string,

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -96,7 +96,7 @@ export const createGen2Renderer = ({
         'ci-info': '^3.8.0',
         constructs: '^10.0.0',
         typescript: '^5.0.0',
-        '@types/node': '*'
+        '@types/node': '*',
       });
     },
     (content) => fileWriter(content, path.join(outputDir, 'package.json')),

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -96,6 +96,7 @@ export const createGen2Renderer = ({
         'ci-info': '^3.8.0',
         constructs: '^10.0.0',
         typescript: '^5.0.0',
+        '@types/node': '*'
       });
     },
     (content) => fileWriter(content, path.join(outputDir, 'package.json')),
@@ -142,9 +143,7 @@ export const createGen2Renderer = ({
           new TypescriptNodeArrayRenderer(
             async () => renderFunctions(func),
             (content) => {
-              return fileWriter(content, path.join(dirPath, 'resource.ts'))
-                .then(() => fileWriter('', path.join(dirPath, 'handler.ts')))
-                .catch(console.error);
+              return fileWriter(content, path.join(dirPath, 'resource.ts')).then(() => fileWriter('', path.join(dirPath, 'handler.ts')));
             },
           ),
         );

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
@@ -24,7 +24,7 @@ const installedDependencies: Record<keyof AmplifyPackageVersions, IsDevDependenc
   '@aws-amplify/backend': true,
   '@aws-amplify/backend-cli': true,
   'ci-info': true,
-  '@types/node': true
+  '@types/node': true,
 };
 
 describe('package.json renderer', () => {

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.test.ts
@@ -24,6 +24,7 @@ const installedDependencies: Record<keyof AmplifyPackageVersions, IsDevDependenc
   '@aws-amplify/backend': true,
   '@aws-amplify/backend-cli': true,
   'ci-info': true,
+  '@types/node': true
 };
 
 describe('package.json renderer', () => {

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
@@ -8,6 +8,7 @@ export type AmplifyDevDependencies = {
   esbuild: string;
   tsx: string;
   typescript: string;
+  '@types/node': string;
 };
 export type AmplifyDependencies = {
   'aws-amplify': string;
@@ -40,6 +41,7 @@ export const patchNpmPackageJson = (packageJson: PackageJson, packageVersions: P
       esbuild: withDefault(packageVersions.esbuild),
       tsx: withDefault(packageVersions.tsx),
       typescript: withDefault(packageVersions.typescript),
+      '@types/node': withDefault(packageVersions['@types/node'])
     },
     dependencies: {
       ...(packageJson.dependencies ?? {}),

--- a/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
+++ b/packages/amplify-gen2-codegen/src/npm_package/renderer.ts
@@ -41,7 +41,7 @@ export const patchNpmPackageJson = (packageJson: PackageJson, packageVersions: P
       esbuild: withDefault(packageVersions.esbuild),
       tsx: withDefault(packageVersions.tsx),
       typescript: withDefault(packageVersions.typescript),
-      '@types/node': withDefault(packageVersions['@types/node'])
+      '@types/node': withDefault(packageVersions['@types/node']),
     },
     dependencies: {
       ...(packageJson.dependencies ?? {}),

--- a/packages/amplify-gen2-codegen/src/resource/resource.ts
+++ b/packages/amplify-gen2-codegen/src/resource/resource.ts
@@ -28,11 +28,10 @@ export function renderResourceTsFile({
 
   return factory.createNodeArray([
     ...importStatements,
+    ...(postImportStatements !== undefined && postImportStatements.length > 0 ? [newLineIdentifier, ...postImportStatements] : []),
     newLineIdentifier,
-    ...(postImportStatements ?? []),
     exportStatement,
-    newLineIdentifier,
-    ...(postExportStatements ?? []),
+    ...(postExportStatements !== undefined && postExportStatements.length > 0 ? [newLineIdentifier, ...postExportStatements] : []),
   ]);
 }
 
@@ -58,12 +57,9 @@ export function renderResourceTsFilesForFunction({
 
   return factory.createNodeArray([
     ...importStatements,
-    newLineIdentifier,
-    ...(postImportStatements ?? []),
-    newLineIdentifier,
-    ...(exportStatements ?? []),
-    newLineIdentifier,
-    ...(postExportStatements ?? []),
+    ...(postImportStatements !== undefined && postImportStatements.length > 0 ? [newLineIdentifier, ...postImportStatements] : []),
+    ...(exportStatements ? [newLineIdentifier, ...exportStatements] : []),
+    ...(postExportStatements !== undefined && postExportStatements.length > 0 ? [newLineIdentifier, ...postExportStatements] : []),
   ]);
 }
 

--- a/packages/amplify-gen2-codegen/src/resource/resource.ts
+++ b/packages/amplify-gen2-codegen/src/resource/resource.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { newLineIdentifier } from '../ts_factory_utils';
 const factory = ts.factory;
 export type ResourceTsParameters = {
   additionalImportedBackendIdentifiers?: Record<string, Set<string>>;
@@ -25,7 +26,14 @@ export function renderResourceTsFile({
     factory.createVariableDeclarationList([exportedVariable], ts.NodeFlags.Const),
   );
 
-  return factory.createNodeArray([...importStatements, ...(postImportStatements ?? []), exportStatement, ...(postExportStatements ?? [])]);
+  return factory.createNodeArray([
+    ...importStatements,
+    newLineIdentifier,
+    ...(postImportStatements ?? []),
+    exportStatement,
+    newLineIdentifier,
+    ...(postExportStatements ?? []),
+  ]);
 }
 
 export type ResourceTsParametersList = {
@@ -50,8 +58,11 @@ export function renderResourceTsFilesForFunction({
 
   return factory.createNodeArray([
     ...importStatements,
+    newLineIdentifier,
     ...(postImportStatements ?? []),
+    newLineIdentifier,
     ...(exportStatements ?? []),
+    newLineIdentifier,
     ...(postExportStatements ?? []),
   ]);
 }

--- a/packages/amplify-gen2-codegen/src/ts_factory_utils.ts
+++ b/packages/amplify-gen2-codegen/src/ts_factory_utils.ts
@@ -3,4 +3,3 @@ import ts from 'typescript';
 const factory = ts.factory;
 
 export const newLineIdentifier = factory.createIdentifier('\n');
-

--- a/packages/amplify-gen2-codegen/src/ts_factory_utils.ts
+++ b/packages/amplify-gen2-codegen/src/ts_factory_utils.ts
@@ -1,0 +1,6 @@
+import ts from 'typescript';
+
+const factory = ts.factory;
+
+export const newLineIdentifier = factory.createIdentifier('\n');
+

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -27,6 +27,7 @@ import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-
 import { tryRefactorStack } from './cfn-stack-refactor-updater';
 import CfnOutputResolver from './resolvers/cfn-output-resolver';
 import CfnDependencyResolver from './resolvers/cfn-dependency-resolver';
+import CfnParameterResolver from './resolvers/cfn-parameter-resolver';
 
 const CFN_RESOURCE_STACK_TYPE = 'AWS::CloudFormation::Stack';
 const GEN2_AMPLIFY_AUTH_LOGICAL_ID_PREFIX = 'amplifyAuth';
@@ -482,10 +483,11 @@ class TemplateGenerator {
     const describeStackResponseForSourceTemplate = await categoryTemplateGenerator.describeStack(sourceCategoryStackId);
     assert(describeStackResponseForSourceTemplate);
     const sourceLogicalIds = [...sourceResourcesToRemove.keys()];
-    const { Outputs } = describeStackResponseForSourceTemplate;
+    const { Outputs, Parameters } = describeStackResponseForSourceTemplate;
     assert(Outputs);
     assert(this.region);
-    const newSourceTemplateWithOutputsResolved = new CfnOutputResolver(newSourceTemplate, this.region, this.accountId).resolve(
+    const newSourceTemplateWithParametersResolved = new CfnParameterResolver(newSourceTemplate).resolve(Parameters ?? []);
+    const newSourceTemplateWithOutputsResolved = new CfnOutputResolver(newSourceTemplateWithParametersResolved, this.region, this.accountId).resolve(
       sourceLogicalIds,
       Outputs,
     );

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -487,10 +487,11 @@ class TemplateGenerator {
     assert(Outputs);
     assert(this.region);
     const newSourceTemplateWithParametersResolved = new CfnParameterResolver(newSourceTemplate).resolve(Parameters ?? []);
-    const newSourceTemplateWithOutputsResolved = new CfnOutputResolver(newSourceTemplateWithParametersResolved, this.region, this.accountId).resolve(
-      sourceLogicalIds,
-      Outputs,
-    );
+    const newSourceTemplateWithOutputsResolved = new CfnOutputResolver(
+      newSourceTemplateWithParametersResolved,
+      this.region,
+      this.accountId,
+    ).resolve(sourceLogicalIds, Outputs);
     const newSourceTemplateWithDepsResolved = new CfnDependencyResolver(newSourceTemplateWithOutputsResolved).resolve(sourceLogicalIds);
     if (category === 'auth' || category === 'auth-user-pool-group') {
       const { StackResources: AuthStackResources } = await this.cfnClient.send(

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -1,7 +1,8 @@
 import { Parameter, StackRefactorExecutionStatus, StackRefactorStatus } from '@aws-sdk/client-cloudformation';
 
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
 export interface CFNOutput {
-  Description: string;
+  Description?: string;
   Value: string | object;
 }
 

--- a/packages/amplify-migration/src/error_handler.test.ts
+++ b/packages/amplify-migration/src/error_handler.test.ts
@@ -9,8 +9,8 @@ jest.mock('./format', () => ({
     error: jest.fn((message) => message),
     command: jest.fn((command) => command),
     highlight: jest.fn((command) => command),
-    success: jest.fn((message) => message)
-  }
+    success: jest.fn((message) => message),
+  },
 }));
 
 jest.mock('yargs', () => {

--- a/packages/amplify-migration/src/error_handler.test.ts
+++ b/packages/amplify-migration/src/error_handler.test.ts
@@ -1,0 +1,72 @@
+import { generateCommandFailureHandler } from './error_handler';
+import { createMainParser } from './main_parser_factory';
+import { version } from '../package.json';
+import { printer } from './printer';
+
+jest.mock('./printer.ts');
+jest.mock('./format', () => ({
+  format: {
+    error: jest.fn((message) => message),
+    command: jest.fn((command) => command),
+    highlight: jest.fn((command) => command),
+    success: jest.fn((message) => message)
+  }
+}));
+
+jest.mock('yargs', () => {
+  const mockYargsInstance = {
+    version: jest.fn().mockReturnThis(),
+    options: jest.fn().mockReturnThis(),
+    strict: jest.fn().mockReturnThis(),
+    command: jest.fn().mockReturnThis(),
+    help: jest.fn().mockReturnThis(),
+    demandCommand: jest.fn().mockReturnThis(),
+    strictCommands: jest.fn().mockReturnThis(),
+    recommendCommands: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+    showHelp: jest.fn(),
+  };
+
+  return jest.fn(() => mockYargsInstance);
+});
+
+describe('Error handler tests', () => {
+  let errorHandler: (message: string, error: Error, debug?: boolean) => Promise<void>;
+  beforeAll(() => {
+    const parser = createMainParser(version);
+    errorHandler = generateCommandFailureHandler(parser);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should print error without debug flag', async () => {
+    const printSpy = jest.spyOn(printer, 'print');
+    const message = 'Unauthorized';
+    const error = new Error('Unauthorized');
+    expect.assertions(3);
+    try {
+      await errorHandler(message, error);
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(printSpy).toBeCalledTimes(1);
+      expect(printSpy).toBeCalledWith(message);
+    }
+  });
+
+  it('should print error with debug flag', async () => {
+    const printSpy = jest.spyOn(printer, 'print');
+    const message = 'Unauthorized';
+    const error = new Error('Unauthorized');
+    expect.assertions(4);
+    try {
+      await errorHandler(message, error, true);
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(printSpy).toBeCalledTimes(2);
+      expect(printSpy).toHaveBeenNthCalledWith(1, message);
+      expect(printSpy.mock.calls[1][0]).toContain('at Promise');
+    }
+  });
+});

--- a/packages/amplify-migration/src/error_handler.ts
+++ b/packages/amplify-migration/src/error_handler.ts
@@ -37,7 +37,7 @@ export const generateCommandFailureHandler = (parser: Argv): ((message: string, 
       preambleMessage: printHelp,
       error,
       message,
-      debug
+      debug,
     });
     parser.exit(1, error || new Error(message));
   };

--- a/packages/amplify-migration/src/migrate.ts
+++ b/packages/amplify-migration/src/migrate.ts
@@ -9,6 +9,8 @@ const parser = createMainParser(libraryVersion);
 const errorHandler = generateCommandFailureHandler(parser);
 parser.parseAsync(hideBin(process.argv)).catch(async (e) => {
   if (e instanceof Error) {
-    await errorHandler(e.message, e);
+    await errorHandler(e.message, e, isDebugFlagEnabled());
   }
 });
+
+const isDebugFlagEnabled = (): boolean => process.argv.includes('--debug');


### PR DESCRIPTION
#### Description of changes

- Skip `PreTokenGenerationConfig` key from Cognito during `prepare`
- Add new line to separate import, body and export statements in codegen
- Wrap `throw new Error` call expression in a statement. This adds a semicolon at the end
- Add `@types/node` to fix `process.env` type errors
- Resolve CFN parameters in Gen2 stack during revert
- Surface errors during  Gen2 codegen in `prepare` command
- Add support for `--debug` flag for `prepare` command to output the stack trace


#### Description of how you validated changes

local testing with `prepare`, `execute` and `revert` commands

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
