### PR TITLE
fix: codegen custom resources and added function scheduling

### DIFF
--- a/packages/amplify-gen1-codegen-function-adapter/API.md
+++ b/packages/amplify-gen1-codegen-function-adapter/API.md
@@ -19,8 +19,10 @@ export type AmplifyMetaWithFunction = {
     function: Record<string, AmplifyMetaFunction>;
 };
 
+// Warning: (ae-forgotten-export) The symbol "FunctionSchedule" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export const getFunctionDefinition: (functionConfigurations: FunctionConfiguration[], functionCategoryMap: Map<string, string>, meta: AmplifyMetaWithFunction) => FunctionDefinition[];
+export const getFunctionDefinition: (functionConfigurations: FunctionConfiguration[], functionSchedules: FunctionSchedule[], functionCategoryMap: Map<string, string>, meta: AmplifyMetaWithFunction) => FunctionDefinition[];
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.test.ts
+++ b/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.test.ts
@@ -15,7 +15,9 @@ void describe('function codegen', () => {
       functionConf1.Environment = { Variables: { ENV: 'dev', REGION: 'us-west-2' } };
       configurations.push(functionConf1);
 
-      const result = getFunctionDefinition(configurations, new Map([['function1', 'function']]), {
+      const functionSchedules = [{ functionName: 'function1', scheduleExpression: 'rate(5 minutes)' }];
+
+      const result = getFunctionDefinition(configurations, functionSchedules, new Map([['function1', 'function']]), {
         function: {
           function1: {
             providerPlugin: 'awscloudformation',
@@ -40,6 +42,7 @@ void describe('function codegen', () => {
         assert.equal(func.memoryMB, 128);
         assert.deepEqual(func.environment, { Variables: { ENV: 'dev', REGION: 'us-west-2' } });
         assert.equal(func.entry, 'index.handler');
+        assert.equal(func.schedule, 'rate(5 minutes)');
       }
     });
   });

--- a/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.ts
+++ b/packages/amplify-gen1-codegen-function-adapter/src/function_render_adapter.ts
@@ -8,12 +8,18 @@ export type AmplifyMetaFunction = {
   output: Record<string, string>;
 };
 
+type FunctionSchedule = {
+  functionName: string;
+  scheduleExpression: string | undefined;
+};
+
 export type AmplifyMetaWithFunction = {
   function: Record<string, AmplifyMetaFunction>;
 };
 
 export const getFunctionDefinition = (
   functionConfigurations: FunctionConfiguration[],
+  functionSchedules: FunctionSchedule[],
   functionCategoryMap: Map<string, string>,
   meta: AmplifyMetaWithFunction,
 ): FunctionDefinition[] => {
@@ -33,6 +39,7 @@ export const getFunctionDefinition = (
     assert(functionRecordInMeta);
     funcDef.category = functionCategoryMap.get(functionRecordInMeta[0]) ?? 'function';
     funcDef.resourceName = functionRecordInMeta[0];
+    funcDef.schedule = functionSchedules.find((schedule) => schedule.functionName === functionName)?.scheduleExpression;
 
     funcDefList.push(funcDef);
   }

--- a/packages/amplify-gen2-codegen/API.md
+++ b/packages/amplify-gen2-codegen/API.md
@@ -64,7 +64,7 @@ export type AuthLambdaTriggers = Record<AuthTriggerEvents, Lambda>;
 export type AuthTriggerEvents = 'createAuthChallenge' | 'customMessage' | 'defineAuthChallenge' | 'postAuthentication' | 'postConfirmation' | 'preAuthentication' | 'preSignUp' | 'preTokenGeneration' | 'userMigration' | 'verifyAuthChallengeResponse';
 
 // @public (undocumented)
-export const createGen2Renderer: ({ outputDir, backendEnvironmentName, auth, storage, data, functions, unsupportedCategories, fileWriter, }: Readonly<Gen2RenderingOptions>) => Renderer;
+export const createGen2Renderer: ({ outputDir, backendEnvironmentName, auth, storage, data, functions, customResources, unsupportedCategories, fileWriter, }: Readonly<Gen2RenderingOptions>) => Renderer;
 
 // @public (undocumented)
 export type CustomAttribute = {
@@ -111,6 +111,8 @@ export interface FunctionDefinition {
     // (undocumented)
     runtime?: Runtime | string;
     // (undocumented)
+    schedule?: string;
+    // (undocumented)
     timeoutSeconds?: number;
 }
 
@@ -122,6 +124,8 @@ export interface Gen2RenderingOptions {
     auth?: AuthDefinition;
     // (undocumented)
     backendEnvironmentName?: string | undefined;
+    // (undocumented)
+    customResources?: string[];
     // (undocumented)
     data?: DataDefinition;
     // (undocumented)

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -544,4 +544,33 @@ describe('BackendRenderer', () => {
       assert(output.includes('AMPLIFY_GEN_1_ENV_NAME = "sandbox"'));
     });
   });
+  describe('Custom resources are rendered()', () => {
+    it('renders custom resources', () => {
+      const renderer = new BackendSynthesizer();
+      const rendered = renderer.render({
+        customResources: ['resource1', 'resource2'],
+      });
+
+      const output = printNodeArray(rendered);
+
+      const normalizedOutput = output.replace(/\s+/g, ' ').trim();
+
+      expect(normalizedOutput).toContain(
+        `new resource1(backend.root, "resource1", undefined, { category: "custom", resourceName: "resource1" });`,
+      );
+      expect(normalizedOutput).toContain(
+        `new resource2(backend.root, "resource2", undefined, { category: "custom", resourceName: "resource2" });`,
+      );
+    });
+
+    it('does not render custom resources when none are provided', () => {
+      const renderer = new BackendSynthesizer();
+      const rendered = renderer.render({});
+
+      const output = printNodeArray(rendered);
+
+      expect(output).not.toContain('new resource1');
+      expect(output).not.toContain('category: "custom"');
+    });
+  });
 });

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -556,10 +556,10 @@ describe('BackendRenderer', () => {
       const normalizedOutput = output.replace(/\s+/g, ' ').trim();
 
       expect(normalizedOutput).toContain(
-        `new resource1(backend.root, "resource1", undefined, { category: "custom", resourceName: "resource1" });`,
+        `new resource1(backend.stack, "resource1", undefined, { category: "custom", resourceName: "resource1" });`,
       );
       expect(normalizedOutput).toContain(
-        `new resource2(backend.root, "resource2", undefined, { category: "custom", resourceName: "resource2" });`,
+        `new resource2(backend.stack, "resource2", undefined, { category: "custom", resourceName: "resource2" });`,
       );
     });
 

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -788,7 +788,7 @@ export class BackendSynthesizer {
         imports.push(importStatement);
 
         const customResourceExpression = factory.createNewExpression(factory.createIdentifier(`${resource}`), undefined, [
-          factory.createPropertyAccessExpression(factory.createIdentifier('backend'), factory.createIdentifier('root')),
+          factory.createPropertyAccessExpression(factory.createIdentifier('backend'), factory.createIdentifier('stack')),
           factory.createStringLiteral(`${resource}`),
           factory.createIdentifier('undefined'),
           factory.createObjectLiteralExpression(

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -159,7 +159,9 @@ export function createFunctionDefinition(
   if (definition?.schedule) {
     const rawScheduleExpression = definition.schedule;
     let scheduleExpression: string | undefined;
-    const scheduleValue = rawScheduleExpression.match(/\(([^)]+)\)/)?.[1];
+    const startIndex = rawScheduleExpression.indexOf('(') + 1;
+    const endIndex = rawScheduleExpression.lastIndexOf(')');
+    const scheduleValue = startIndex > 0 && endIndex > startIndex ? rawScheduleExpression.slice(startIndex, endIndex) : undefined;
     if (rawScheduleExpression?.startsWith('rate(')) {
       // Convert rate expression to a more readable format
       const rateValue = scheduleValue;

--- a/packages/amplify-gen2-codegen/src/function/source_builder.ts
+++ b/packages/amplify-gen2-codegen/src/function/source_builder.ts
@@ -175,7 +175,7 @@ export function createFunctionDefinition(
           day: 'd',
           days: 'd',
         };
-        scheduleExpression = `every ${value}${unitMap[unit] || unit}`;
+        scheduleExpression = `every ${value}${unitMap[unit]}`;
       }
     } else if (rawScheduleExpression?.startsWith('cron(')) {
       // Extract the cron expression as-is

--- a/packages/amplify-gen2-codegen/src/index.ts
+++ b/packages/amplify-gen2-codegen/src/index.ts
@@ -56,6 +56,7 @@ export interface Gen2RenderingOptions {
   storage?: StorageRenderParameters;
   data?: DataDefinition;
   functions?: FunctionDefinition[];
+  customResources?: string[];
   unsupportedCategories?: Map<string, string>;
   fileWriter?: (content: string, path: string) => Promise<void>;
 }
@@ -68,6 +69,7 @@ export const createGen2Renderer = ({
   storage,
   data,
   functions,
+  customResources,
   unsupportedCategories,
   fileWriter = (content, path) => createFileWriter(path)(content),
 }: Readonly<Gen2RenderingOptions>): Renderer => {
@@ -211,6 +213,10 @@ export const createGen2Renderer = ({
       bucketEncryptionAlgorithm: storage.bucketEncryptionAlgorithm,
       bucketName: storage.bucketName,
     };
+  }
+
+  if (customResources && customResources.length > 0) {
+    backendRenderOptions.customResources = customResources;
   }
 
   const backendRenderer = new TypescriptNodeArrayRenderer(

--- a/packages/amplify-migration/package.json
+++ b/packages/amplify-migration/package.json
@@ -54,6 +54,7 @@
     "@aws-sdk/client-amplify": "^3.592.0",
     "@aws-sdk/client-amplifybackend": "^3.592.0",
     "@aws-sdk/client-cloudformation": "^3.592.0",
+    "@aws-sdk/client-cloudwatch-events": "^3.592.0",
     "@aws-sdk/client-cognito-identity": "^3.592.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.592.0",
     "@aws-sdk/client-lambda": "^3.637.0",

--- a/packages/amplify-migration/src/command-handler.test.ts
+++ b/packages/amplify-migration/src/command-handler.test.ts
@@ -1,15 +1,38 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import { AmplifyClient, GetAppCommand } from '@aws-sdk/client-amplify';
-import { updateAmplifyYmlFile } from './command-handlers';
-import { pathManager } from '@aws-amplify/amplify-cli-core';
+import { updateAmplifyYmlFile, updateCustomResources, updateCdkStackFile, getProjectInfo } from './command-handlers';
+import { pathManager, stateManager } from '@aws-amplify/amplify-cli-core';
 
 jest.mock('node:fs/promises', () => ({
   access: jest.fn(),
   readFile: jest.fn(),
   writeFile: jest.fn(),
+  mkdir: jest.fn(),
+  cp: jest.fn(),
 }));
 
-jest.mock('@aws-amplify/amplify-cli-core');
+// jest.mock('@aws-amplify/amplify-cli-core');
+
+jest.mock('@aws-amplify/amplify-cli-core', () => ({
+  pathManager: {
+    findProjectRoot: jest.fn(),
+  },
+  stateManager: {
+    getMeta: jest.fn(),
+  },
+}));
+
+const actualUpdateCdkStackFile = jest.requireActual('./command-handlers').updateCdkStackFile;
+const actualGetProjectInfoFile = jest.requireActual('./command-handlers').getProjectInfo;
+
+// Mock the internal methods
+jest.mock('./command-handlers', () => ({
+  ...jest.requireActual('./command-handlers'),
+  updateCdkStackFile: jest.fn(),
+  getProjectInfo: jest.fn(),
+}));
 
 jest.mock('@aws-sdk/client-amplify');
 
@@ -45,11 +68,11 @@ frontend:
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (pathManager.findProjectRoot as jest.Mock).mockReturnValue('/mockRootDir');
+    jest.mocked(pathManager.findProjectRoot).mockReturnValue('/mockRootDir');
   });
 
   it('should update amplify.yml file if it exists', async () => {
-    (fs.readFile as jest.Mock).mockResolvedValue(mockBuildSpec);
+    jest.mocked(fs.readFile).mockResolvedValue(mockBuildSpec);
 
     await updateAmplifyYmlFile(amplifyClient, mockAppId);
 
@@ -60,7 +83,7 @@ frontend:
   });
 
   it('should create amplify.yml file with updated buildSpec if it does not exist', async () => {
-    (fs.readFile as jest.Mock).mockRejectedValue({ code: 'ENOENT' });
+    jest.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
     (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({
       app: { buildSpec: mockBuildSpec },
     });
@@ -74,7 +97,7 @@ frontend:
   });
 
   it('should not throw an error if buildSpec is not found in the app', async () => {
-    (fs.readFile as jest.Mock).mockRejectedValue({ code: 'ENOENT' });
+    jest.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
     (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({
       app: {},
     });
@@ -83,7 +106,7 @@ frontend:
   });
 
   it('should throw an error if app is not found', async () => {
-    (fs.readFile as jest.Mock).mockRejectedValue({ code: 'ENOENT' });
+    jest.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
     (AmplifyClient.prototype.send as jest.Mock).mockResolvedValue({});
 
     await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).rejects.toThrow('App not found');
@@ -91,8 +114,212 @@ frontend:
 
   it('should throw the original error if it is not related to file not found', async () => {
     const error = new Error('Some other error');
-    (fs.readFile as jest.Mock).mockRejectedValue(error);
+    jest.mocked(fs.readFile).mockRejectedValue(error);
 
     await expect(updateAmplifyYmlFile(amplifyClient, mockAppId)).rejects.toThrow(error);
+  });
+});
+
+describe('updateCustomResources', () => {
+  const mockRootDir = '/mock/root/dir';
+
+  const mockLocalEnvInfo = JSON.stringify({
+    projectPath: '/mock/root/dir',
+    defaultEditor: 'code',
+    envName: 'dev',
+  });
+
+  const mockProjectConfig = JSON.stringify({
+    projectName: 'testProject',
+    version: '3.1',
+    frontend: 'javascript',
+    javascript: {
+      framework: 'react',
+      config: {
+        SourceDir: 'src',
+        DistributionDir: 'build',
+        BuildCommand: 'npm run-script build',
+        StartCommand: 'npm run-script start',
+      },
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(pathManager.findProjectRoot).mockReturnValue(mockRootDir);
+    jest.mocked(stateManager.getMeta).mockReturnValue({
+      custom: {
+        resource1: {},
+        resource2: {},
+      },
+    });
+
+    jest.mocked(fs.mkdir).mockResolvedValue(undefined);
+    jest.mocked(fs.cp).mockResolvedValue(undefined);
+    jest.mocked(fs.readFile).mockImplementation((filePath) => {
+      if (typeof filePath === 'string' && filePath.includes('local-env-info.json')) {
+        return Promise.resolve(mockLocalEnvInfo);
+      }
+      if (typeof filePath === 'string' && filePath.includes('project-config.json')) {
+        return Promise.resolve(mockProjectConfig);
+      }
+      return Promise.resolve('{}');
+    });
+
+    jest.mocked(getProjectInfo).mockResolvedValue("{envName: 'dev', projectName: 'testProject'}");
+
+    jest.mocked(updateCdkStackFile).mockResolvedValue(undefined);
+  });
+
+  it('should copy custom resources and types folder and call updateCdkStackFile', async () => {
+    await updateCustomResources();
+
+    expect(fs.mkdir).toHaveBeenCalledWith('amplify-gen2/amplify/custom', { recursive: true });
+    expect(fs.mkdir).toHaveBeenCalledWith('amplify-gen2/amplify/types', { recursive: true });
+
+    expect(fs.cp).toHaveBeenCalledWith(path.join(mockRootDir, 'amplify', 'backend', 'custom'), 'amplify-gen2/amplify/custom', {
+      recursive: true,
+      filter: expect.any(Function),
+    });
+
+    expect(fs.cp).toHaveBeenCalledWith(path.join(mockRootDir, 'amplify', 'backend', 'types'), 'amplify-gen2/amplify/types', {
+      recursive: true,
+    });
+  });
+
+  it('should handle case when custom resources do not exist', async () => {
+    jest.mocked(stateManager.getMeta).mockReturnValue({});
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await updateCustomResources();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('Custom resource category does not exist in the meta');
+    expect(fs.cp).not.toHaveBeenCalled();
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should filter out package.json and yarn.lock files', async () => {
+    await updateCustomResources();
+
+    const cpCalls = (fs.cp as jest.Mock).mock.calls;
+    const filterFn = cpCalls.find((call) => call[2]?.filter)?.[2]?.filter;
+
+    expect(filterFn).toBeDefined();
+    expect(filterFn('some/path/package.json')).toBe(false);
+    expect(filterFn('some/path/yarn.lock')).toBe(false);
+    expect(filterFn('some/path/other-file.js')).toBe(true);
+  });
+
+  it('should handle file system errors gracefully', async () => {
+    const fsError = new Error('File system error');
+    jest.mocked(fs.mkdir).mockRejectedValue(fsError);
+
+    await expect(updateCustomResources()).rejects.toThrow('File system error');
+  });
+
+  it('should handle empty custom resources object', async () => {
+    jest.mocked(stateManager.getMeta).mockReturnValue({ custom: {} });
+
+    await updateCustomResources();
+
+    expect(fs.cp).not.toHaveBeenCalled();
+    expect(updateCdkStackFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateCdkStackFile', () => {
+  const mockCustomResources = ['resource1'];
+  const mockCustomResourcesPath = 'amplify-gen2/amplify/custom';
+  const mockProjectRoot = '/mockRootDir';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(updateCdkStackFile).mockImplementation(actualUpdateCdkStackFile);
+    jest.mocked(getProjectInfo).mockImplementation(actualGetProjectInfoFile);
+    jest.mocked(pathManager.findProjectRoot).mockReturnValue('/mockRootDir');
+  });
+
+  afterEach(() => {
+    // Reset to the mock after each test if needed
+    jest.mocked(updateCdkStackFile).mockReset();
+    jest.mocked(getProjectInfo).mockReset();
+  });
+
+  it('should correctly transform CDK stack file content', async () => {
+    const originalCdkContent = `
+      import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+      import * as cdk from 'aws-cdk-lib';
+      
+      export class cdkStack extends cdk.Stack {
+        constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+          super(scope, id, props);
+          
+          const projectInfo = AmplifyHelpers.getProjectInfo();
+          AmplifyHelpers.addResourceDependency(this, 
+            {
+              category: "custom",
+              resourceName: "customResource1",
+            },
+            {
+              category: "auth",
+              resourceName: "authResource1",
+            }
+          );
+        }
+      }
+    `;
+
+    const mockLocalEnvInfo = JSON.stringify({
+      projectPath: '/mock/root/dir',
+      defaultEditor: 'code',
+      envName: 'dev',
+    });
+
+    const mockProjectConfig = JSON.stringify({
+      projectName: 'testProject',
+      version: '3.1',
+      frontend: 'javascript',
+      javascript: {
+        framework: 'react',
+        config: {
+          SourceDir: 'src',
+          DistributionDir: 'build',
+          BuildCommand: 'npm run-script build',
+          StartCommand: 'npm run-script start',
+        },
+      },
+    });
+
+    // Mock readFile to return content for the correct stack file path
+    jest.mocked(fs.readFile).mockImplementation((filePath) => {
+      if (typeof filePath === 'string' && filePath.includes('local-env-info.json')) {
+        return Promise.resolve(mockLocalEnvInfo);
+      }
+      if (typeof filePath === 'string' && filePath.includes('project-config.json')) {
+        return Promise.resolve(mockProjectConfig);
+      }
+      if (filePath === path.join(mockCustomResourcesPath, 'resource1', 'cdk-stack.ts')) {
+        return Promise.resolve(originalCdkContent);
+      }
+      return Promise.resolve('{}');
+    });
+
+    jest.mocked(getProjectInfo).mockResolvedValue("{envName: 'dev', projectName: 'testProject'}");
+
+    await updateCdkStackFile(mockCustomResources, mockCustomResourcesPath, mockProjectRoot);
+
+    // Verify writeFile was called with the correct path and transformed content
+    expect(fs.writeFile).toHaveBeenCalled();
+    const writeFileCall = (fs.writeFile as jest.Mock).mock.calls[0];
+    const transformedContent = writeFileCall[1];
+
+    // Verify specific transformations
+    expect(transformedContent).not.toContain('import { AmplifyHelpers }'); // Import removed
+    expect(transformedContent).toContain(
+      "throw new Error('Follow https://docs.amplify.aws/react/start/migrate-to-gen2/ to update the resource dependency')",
+    ); // Error added
+    expect(transformedContent).toContain("const projectInfo = {envName: 'dev', projectName: 'testProject'}"); // Project info replaced
   });
 });

--- a/packages/amplify-migration/src/command-handler.test.ts
+++ b/packages/amplify-migration/src/command-handler.test.ts
@@ -13,8 +13,6 @@ jest.mock('node:fs/promises', () => ({
   cp: jest.fn(),
 }));
 
-// jest.mock('@aws-amplify/amplify-cli-core');
-
 jest.mock('@aws-amplify/amplify-cli-core', () => ({
   pathManager: {
     findProjectRoot: jest.fn(),

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -320,8 +320,6 @@ export async function updateCustomResources() {
     await fs.cp(sourceTypesPath, destinationTypesPath, { recursive: true });
 
     await updateCdkStackFile(customResources, destinationCustomResourcePath, rootDir);
-  } else {
-    console.log(`Custom resource category does not exist in the meta`);
   }
 }
 
@@ -357,7 +355,7 @@ export async function updateCdkStackFile(customResources: string[], destinationC
 
       await fs.writeFile(cdkStackFilePath, cdkStackContent, { encoding: 'utf-8' });
     } catch (error) {
-      console.error(`Error updating ${cdkStackFilePath}: ${error.message}`);
+      throw error(`Error updating the custom resource ${resource}`);
     }
   }
 }

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -52,6 +52,7 @@ const GEN2_COMMAND_GENERATION_MESSAGE_SUFFIX = 'your Gen 2 backend code';
 const CUSTOM_DIR = 'custom';
 const TYPES_DIR = 'types';
 const BACKEND_DIR = 'backend';
+const AMPLIFY_GEN_1_ENV_NAME = process.env.AMPLIFY_GEN_1_ENV_NAME;
 
 enum GEN2_AMPLIFY_GITIGNORE_FILES_OR_DIRS {
   DOT_AMPLIFY = '.amplify',
@@ -343,7 +344,7 @@ export async function updateCdkStackFile(customResources: string[], destinationC
 
       cdkStackContent = cdkStackContent.replace(
         /export class cdkStack/,
-        `const AMPLIFY_GEN_1_ENV_NAME = process.env.AMPLIFY_GEN_1_ENV_NAME ?? "sandbox";\n\nexport class cdkStack`,
+        `const AMPLIFY_GEN_1_ENV_NAME = ${AMPLIFY_GEN_1_ENV_NAME} ?? "sandbox";\n\nexport class cdkStack`,
       );
 
       cdkStackContent = cdkStackContent.replace(/extends cdk.Stack/, `extends cdk.NestedStack`);

--- a/packages/amplify-migration/src/command-handlers.ts
+++ b/packages/amplify-migration/src/command-handlers.ts
@@ -13,6 +13,7 @@ import { CognitoIdentityProviderClient, LambdaConfigType } from '@aws-sdk/client
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { S3Client } from '@aws-sdk/client-s3';
 import { LambdaClient } from '@aws-sdk/client-lambda';
+import { CloudWatchEventsClient } from '@aws-sdk/client-cloudwatch-events';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { BackendDownloader } from './backend_downloader';
@@ -48,6 +49,9 @@ const MIGRATION_DIR = '.amplify/migration';
 const GEN1_COMMAND = 'amplifyPush --simple';
 const GEN2_COMMAND = 'npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID';
 const GEN2_COMMAND_GENERATION_MESSAGE_SUFFIX = 'your Gen 2 backend code';
+const CUSTOM_DIR = 'custom';
+const TYPES_DIR = 'types';
+const BACKEND_DIR = 'backend';
 
 enum GEN2_AMPLIFY_GITIGNORE_FILES_OR_DIRS {
   DOT_AMPLIFY = '.amplify',
@@ -72,6 +76,7 @@ const generateGen2Code = async ({
     storage: await storageDefinitionFetcher.getDefinition(),
     data: await dataDefinitionFetcher.getDefinition(),
     functions: await functionsDefinitionFetcher.getDefinition(),
+    customResources: getCustomResources(),
     unsupportedCategories: unsupportedCategories(),
   };
   fetchingAWSResourceDetails.succeed('Fetched resource details from AWS');
@@ -110,7 +115,7 @@ type AmplifyMeta = {
 };
 
 const getFunctionPath = (functionName: string) => {
-  return path.join('amplify', 'backend', 'function', functionName, 'src');
+  return path.join(AMPLIFY_DIR, BACKEND_DIR, 'function', functionName, 'src');
 };
 
 const getUsageDataMetric = async (envName: string): Promise<IUsageData> => {
@@ -182,7 +187,6 @@ const unsupportedCategories = (): Map<string, string> => {
   unsupportedCategories.set('predictions', `${urlPrefix}/predictions/`);
   unsupportedCategories.set('notifications', `${urlPrefix}/in-app-messaging/`);
   unsupportedCategories.set('interactions', `${urlPrefix}/interactions/`);
-  unsupportedCategories.set('custom', `${urlPrefix}/custom-resources/`);
   unsupportedCategories.set('rest api', `${urlPrefix}/rest-api/`);
 
   const meta = stateManager.getMeta();
@@ -282,6 +286,102 @@ async function updateGitIgnoreForGen2() {
   updateGitIgnore.succeed('Updated gitignore contents');
 }
 
+const getCustomResources = (): string[] => {
+  const meta = stateManager.getMeta();
+  const customCategory = meta?.custom;
+
+  // If the custom category exists, return its resource names; otherwise, return an empty array
+  return customCategory ? Object.keys(customCategory) : [];
+};
+
+export async function updateCustomResources() {
+  const customResources = getCustomResources();
+  if (customResources.length > 0) {
+    const rootDir = pathManager.findProjectRoot();
+    assert(rootDir);
+    const amplifyGen1BackendDir = path.join(rootDir, AMPLIFY_DIR, BACKEND_DIR);
+    const amplifyGen2Dir = path.join(TEMP_GEN_2_OUTPUT_DIR, AMPLIFY_DIR);
+    const sourceCustomResourcePath = path.join(amplifyGen1BackendDir, CUSTOM_DIR);
+    const destinationCustomResourcePath = path.join(amplifyGen2Dir, CUSTOM_DIR);
+    const filterFiles = ['package.json', 'yarn.lock'];
+    await fs.mkdir(destinationCustomResourcePath, { recursive: true });
+    // Copy the custom resources, excluding package.json and yarn.lock files
+    await fs.cp(sourceCustomResourcePath, destinationCustomResourcePath, {
+      recursive: true,
+      filter: (src) => {
+        const fileName = path.basename(src);
+        return !filterFiles.includes(fileName);
+      },
+    });
+
+    const sourceTypesPath = path.join(amplifyGen1BackendDir, TYPES_DIR);
+    const destinationTypesPath = path.join(amplifyGen2Dir, TYPES_DIR);
+    await fs.mkdir(destinationTypesPath, { recursive: true });
+    await fs.cp(sourceTypesPath, destinationTypesPath, { recursive: true });
+
+    await updateCdkStackFile(customResources, destinationCustomResourcePath, rootDir);
+  } else {
+    console.log(`Custom resource category does not exist in the meta`);
+  }
+}
+
+export async function updateCdkStackFile(customResources: string[], destinationCustomResourcePath: string, rootDir: string) {
+  const projectInfo = await getProjectInfo(rootDir);
+
+  for (const resource of customResources) {
+    const cdkStackFilePath = path.join(destinationCustomResourcePath, resource, 'cdk-stack.ts');
+    const amplifyHelpersImport = /import\s+\*\s+as\s+AmplifyHelpers\s+from\s+['"]@aws-amplify\/cli-extensibility-helper['"];\n?/;
+
+    try {
+      let cdkStackContent = await fs.readFile(cdkStackFilePath, { encoding: 'utf-8' });
+
+      // Check for existence of AmplifyHelpers.addResourceDependency and throw an error if found
+      if (cdkStackContent.includes('AmplifyHelpers.addResourceDependency')) {
+        cdkStackContent = cdkStackContent.replace(
+          /export class cdkStack/,
+          `throw new Error('Follow https://docs.amplify.aws/react/start/migrate-to-gen2/ to update the resource dependency');\n\nexport class cdkStack`,
+        );
+      }
+
+      // Replace AmplifyHelpers.getProjectInfo() with {envName: 'envName', projectName: 'projectName'}
+      cdkStackContent = cdkStackContent.replace(/AmplifyHelpers\.getProjectInfo\(\)/g, projectInfo);
+
+      // Replace AmplifyHelpers.AmplifyResourceProps with {category: 'custom', resourceName: resource}
+      cdkStackContent = cdkStackContent.replace(
+        /AmplifyHelpers\.AmplifyResourceProps/g,
+        `{category: 'custom', resourceName: '${resource}' }`,
+      );
+
+      // Remove the import statement for AmplifyHelpers
+      cdkStackContent = cdkStackContent.replace(amplifyHelpersImport, '');
+
+      await fs.writeFile(cdkStackFilePath, cdkStackContent, { encoding: 'utf-8' });
+    } catch (error) {
+      console.error(`Error updating ${cdkStackFilePath}: ${error.message}`);
+    }
+  }
+}
+
+export async function getProjectInfo(rootDir: string) {
+  const configDir = path.join(rootDir, AMPLIFY_DIR, '.config');
+  const localEnvInfoFilePath = path.join(configDir, 'local-env-info.json');
+  const localEnvInfo = await fs.readFile(localEnvInfoFilePath, { encoding: 'utf-8' });
+  const envInfo = JSON.parse(localEnvInfo);
+  if (!envInfo.envName) {
+    throw new Error('Environment name not found in local-env-info.json');
+  }
+
+  const projectConfigFilePath = path.join(configDir, 'project-config.json');
+  const projectConfig = await fs.readFile(projectConfigFilePath, { encoding: 'utf-8' });
+
+  const projectConfigJson = JSON.parse(projectConfig);
+  if (!projectConfigJson.projectName) {
+    throw new Error('Project name not found in project-config.json');
+  }
+
+  return `{envName: '${envInfo.envName}', projectName: '${projectConfigJson.projectName}'}`;
+}
+
 export async function execute() {
   const appId = resolveAppId();
   const inspectApp = await ora(`Inspecting Amplify app ${appId} with current backend`).start();
@@ -299,6 +399,7 @@ export async function execute() {
   const lambdaClient = new LambdaClient({
     region: stateManager.getCurrentRegion(),
   });
+  const cloudWatchEventsClient = new CloudWatchEventsClient();
   const amplifyStackParser = new AmplifyStackParser(cloudFormationClient);
   const ccbFetcher = new BackendDownloader(s3Client);
   inspectApp.stop();
@@ -324,7 +425,12 @@ export async function execute() {
       ccbFetcher,
     ),
     dataDefinitionFetcher: new DataDefinitionFetcher(backendEnvironmentResolver, new BackendDownloader(s3Client), amplifyStackParser),
-    functionsDefinitionFetcher: new AppFunctionsDefinitionFetcher(lambdaClient, backendEnvironmentResolver, stateManager),
+    functionsDefinitionFetcher: new AppFunctionsDefinitionFetcher(
+      lambdaClient,
+      cloudWatchEventsClient,
+      backendEnvironmentResolver,
+      stateManager,
+    ),
     analytics: new AppAnalytics(appId),
     logger: new AppContextLogger(appId),
     backendEnvironmentName: backendEnvironment?.environmentName,
@@ -333,6 +439,8 @@ export async function execute() {
   await updateAmplifyYmlFile(amplifyClient, appId);
 
   await updateGitIgnoreForGen2();
+
+  await updateCustomResources();
 
   const movingGen1BackendFiles = ora(`Moving your Gen1 backend files to ${format.highlight(MIGRATION_DIR)}`).start();
   // Move gen1 amplify to .amplify/migrations and move gen2 amplify from amplify-gen2 to amplify dir to convert current app to gen2.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1928,6 +1928,7 @@ __metadata:
     "@aws-sdk/client-amplify": ^3.592.0
     "@aws-sdk/client-amplifybackend": ^3.592.0
     "@aws-sdk/client-cloudformation": ^3.592.0
+    "@aws-sdk/client-cloudwatch-events": ^3.592.0
     "@aws-sdk/client-cognito-identity": ^3.592.0
     "@aws-sdk/client-cognito-identity-provider": ^3.592.0
     "@aws-sdk/client-lambda": ^3.637.0
@@ -2673,6 +2674,53 @@ __metadata:
     tslib: ^2.6.2
     uuid: ^9.0.1
   checksum: 49fe9d0593756af5542302fbffc2de6af4d17b3c29969924671ce5f8f434d5945ddf1b260d444a3d1d59fd06dca945334eef494cac708b0d79bc7477e3030cc6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-cloudwatch-events@npm:^3.592.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/client-cloudwatch-events@npm:3.777.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/credential-provider-node": 3.777.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: ab2d2ceee8fe0a5cf8d7ded76cb7b01f0ebf3b4ca2b8e930762d3fa4bbfd58783257afd507343e07801d2accc7518d5aff165099fa3e23862524febf6bfe3aee
   languageName: node
   linkType: hard
 
@@ -4101,6 +4149,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-sso@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/client-sso@npm:3.777.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 0a14dd828ef7c46621ea564811c9055866b9775f6a13724a6dad9e195dc818367fcd182d43c92980997be6bd004b0e23e012746c1f32e5af8fca9f402582f40f
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-sts@npm:3.186.3":
   version: 3.186.3
   resolution: "@aws-sdk/client-sts@npm:3.186.3"
@@ -4379,6 +4473,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/core@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/core@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/core": ^3.2.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/signature-v4": ^5.0.2
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-middleware": ^4.0.2
+    fast-xml-parser: 4.4.1
+    tslib: ^2.6.2
+  checksum: 14fb2fb46c191d4409a1f35fc4276ec77c446e81f22d6dc5355d3d7a28575ab26253fc646e4a0deed05c2fe89e4850547096191a4ef3ec6bb775a1a4c30171d1
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-cognito-identity@npm:3.624.0":
   version: 3.624.0
   resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.624.0"
@@ -4439,6 +4552,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-env@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 461d2dba7d8dde9720b99e9d34d6b9e4e115335d3d184d15011e36124fc73d182e9c9f33fcf77682428abc7849a1b248371758be46c23fc312521f51d08054e2
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-http@npm:3.622.0":
   version: 3.622.0
   resolution: "@aws-sdk/credential-provider-http@npm:3.622.0"
@@ -4471,6 +4597,24 @@ __metadata:
     "@smithy/util-stream": ^4.1.2
     tslib: ^2.6.2
   checksum: b9c3161bb3ecfb214d537255685dec049560acd115fef89e087c5cd6f4ab294b1e5c0ca014be0040fc40cef9385c1123de39bd0870f21136cee1ca857409bc4c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-stream": ^4.2.0
+    tslib: ^2.6.2
+  checksum: f2a5939108ecdb330610b60fab61c01f0b98e972df2abaa5ac6e46102e4a2a7e877c934e28bacb32a855a431c33af53a169568ee2df6b1c4bcf6e32ed69c721a
   languageName: node
   linkType: hard
 
@@ -4568,6 +4712,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-ini@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/credential-provider-env": 3.775.0
+    "@aws-sdk/credential-provider-http": 3.775.0
+    "@aws-sdk/credential-provider-process": 3.775.0
+    "@aws-sdk/credential-provider-sso": 3.777.0
+    "@aws-sdk/credential-provider-web-identity": 3.777.0
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/credential-provider-imds": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: b905820d6591010f73bc1af5e0185d2a38590fa0722e979f9d85de46853516c353b6ccee641311e413231425b59ad9ddeb87b93a9e0ff3c301741fa79d099aef
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-node@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-node@npm:3.186.0"
@@ -4642,6 +4807,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-node@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.775.0
+    "@aws-sdk/credential-provider-http": 3.775.0
+    "@aws-sdk/credential-provider-ini": 3.777.0
+    "@aws-sdk/credential-provider-process": 3.775.0
+    "@aws-sdk/credential-provider-sso": 3.777.0
+    "@aws-sdk/credential-provider-web-identity": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/credential-provider-imds": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 4d2b3b69e24f4e64a07450caa4965cf524d3a4cd0a568c7911639230b544cfc467ed3067b84f177e6550f6b2395895346c9b393c69945fa0a56b5f2a33476294
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-process@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-process@npm:3.186.0"
@@ -4694,6 +4879,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-process@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 5e8fc389ddf91694a590adb0ee2dadf148b7279759c1a0a8b3a055a78af0b75773f9f50f6a769be1d3284c639ad037a2a8951a463020e692c5f911c8e5062402
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-sso@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-sso@npm:3.186.0"
@@ -4738,6 +4937,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/credential-provider-sso@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.777.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/token-providers": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 3df1ae333b74e9aa5ecf4e7d6dc87f778f2de11433e87e4383f46d33cacca8249dbd1b6f46ffdf720a7dd8bea25ab528cb3d4514d98bce7aa8cc30a09620ba19
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/credential-provider-web-identity@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.186.0"
@@ -4774,6 +4989,20 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: e66b08e08edb30d0b936b19c86ebf7b63a1c554cfc8328907e07a75728ef0c27cd3f9881544c7dc0c7683fba54eef6454a38cc2ed866a01355ca0754388ffc31
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 5d7fdf7d6911f06255f9d03540c1d7bdec1a74c529f91b6fb1960e473ffefcf8750d8aa8826b3e49d6bc7ec27e22b10e04888e8a9d2f6796cb262299af664e2d
   languageName: node
   linkType: hard
 
@@ -5251,6 +5480,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-host-header@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 1e7fb71bc596250c20d51a6ec5f33801746db6ca553f2baf3f3261db5abf18dc5f0c31514c81496f6efaf39643aaa90226ca801b36d9bd76943221f15256a266
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-location-constraint@npm:3.609.0":
   version: 3.609.0
   resolution: "@aws-sdk/middleware-location-constraint@npm:3.609.0"
@@ -5315,6 +5556,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-logger@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: ab46864523cd58e965bd7071781a8719dec7037aeef4c08345138ad90d6e0162ac911f79b40bd2bd3308776edbaa5dc987f9e104da0980537947227a4cddce12
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-recursion-detection@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/middleware-recursion-detection@npm:3.186.0"
@@ -5347,6 +5599,18 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: e46e5f99895a4370141b3439c58b94670fddd01d18bbda43a621cb0a5f2bb3384db66757f16da49815af52d29f2cfb8c5d12e273853ad34c919f4f71d078572f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 652ac6384034cb7219d8f44cbbc059dbc68cc6f8c9e61dbd19bc5488ff267564cc899ab52cdc45aa79d0e2d4162ce52e00c518a3eb4371f5b72465e715cd5387
   languageName: node
   linkType: hard
 
@@ -5603,6 +5867,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-user-agent@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@smithy/core": ^3.2.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: dd782955a6482df9935faec08a64b674913e8be8c58347dae32d1b5ddb2196e49c328605d864d9d85c725f92ad6eb6454d3aef8433d7ff599ad2a94545b0c2e1
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/nested-clients@npm:3.758.0":
   version: 3.758.0
   resolution: "@aws-sdk/nested-clients@npm:3.758.0"
@@ -5646,6 +5925,52 @@ __metadata:
     "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
   checksum: bcc71a7e3bee6f798e0ffee543f1ef2bdb6ce3ff07157c33cd8a95683bfeaa400d833a60d059197618cd5f630c6d35903b74faa5c3aeb109be77359867dfb620
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/nested-clients@npm:3.777.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/core": 3.775.0
+    "@aws-sdk/middleware-host-header": 3.775.0
+    "@aws-sdk/middleware-logger": 3.775.0
+    "@aws-sdk/middleware-recursion-detection": 3.775.0
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/region-config-resolver": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@aws-sdk/util-endpoints": 3.775.0
+    "@aws-sdk/util-user-agent-browser": 3.775.0
+    "@aws-sdk/util-user-agent-node": 3.775.0
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/core": ^3.2.0
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/hash-node": ^4.0.2
+    "@smithy/invalid-dependency": ^4.0.2
+    "@smithy/middleware-content-length": ^4.0.2
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-retry": ^4.1.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.8
+    "@smithy/util-defaults-mode-node": ^4.0.8
+    "@smithy/util-endpoints": ^3.0.2
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: e7fe77cc30d09ba423b518e6a4dec71402ef8b01c959c15e1c61dbbed80c997213643dc14e347e8a5a463a2020038ca0b01078ec04761f331b1359fa8acc8599
   languageName: node
   linkType: hard
 
@@ -5809,6 +6134,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/region-config-resolver@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/util-config-provider": ^4.0.0
+    "@smithy/util-middleware": ^4.0.2
+    tslib: ^2.6.2
+  checksum: 774d3e65873c725634b208604df3aac379ba9a9b8c4910a0ba54360bae8855d22e7dd1310d15f1946d9b8b16bca03b268d29984d0b25f2ba33094aeb30da6072
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/service-error-classification@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/service-error-classification@npm:3.186.0"
@@ -5948,6 +6287,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.777.0":
+  version: 3.777.0
+  resolution: "@aws-sdk/token-providers@npm:3.777.0"
+  dependencies:
+    "@aws-sdk/nested-clients": 3.777.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 744cf95c4bcda2909ff49b7fbfb784a8d8de0f0072b13acbd8706c9cf35243aecc6f0cc40cd1fd819092893a4121964d9d6194751e30bc06278be7d0e2d95d5d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/types@npm:3.186.0"
@@ -5988,6 +6341,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 74313849619b8bce9e6a52c70fcdaa212574a443503c78bccdba77cdc7bc66b8cecefe461852e0bab7376cc2ec3e1891730b1a027be63efb47394115c8ddb856
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/types@npm:3.775.0"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 106515a677a8619ecffc6a652d6866a29f9191f2f883d4a98e44ea1926a112994c4c4733e77f7d997f5f1a4cecf2ce605059a449001d5630ed73f6cd4d4d94a3
   languageName: node
   linkType: hard
 
@@ -6206,6 +6569,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-endpoints@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-endpoints": ^3.0.2
+    tslib: ^2.6.2
+  checksum: d85fbe8a1e213ac4925c9572ded852b3a26e688aa2be15918c02b3340f7493de4254fe5a2a5a4e21955a5b5b919c69004a9bfcefae834c15476dfa4ac4cb7b2d
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-format-url@npm:3.609.0":
   version: 3.609.0
   resolution: "@aws-sdk/util-format-url@npm:3.609.0"
@@ -6327,6 +6702,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/util-user-agent-browser@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/types": 3.775.0
+    "@smithy/types": ^4.2.0
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: 527f3225a28a49de6893c2a396d80cd13cfa64f9cc9d16b575a708e5d4a6006e145aaec6166071012aacdb732604c3a554d69ab6f099fb021d0d15565bb7fb4c
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-user-agent-node@npm:3.186.0":
   version: 3.186.0
   resolution: "@aws-sdk/util-user-agent-node@npm:3.186.0"
@@ -6386,6 +6773,24 @@ __metadata:
     aws-crt:
       optional: true
   checksum: 0c7609adf570da3cc7d29331fb58dec27df803ed95449debe0af5747e1b698acf7b21c67cbf9fe6e559b88422c7dc3fb4252e35cacf8f4d424f353d087db2b26
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.775.0":
+  version: 3.775.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.775.0"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": 3.775.0
+    "@aws-sdk/types": 3.775.0
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: d9dfbf657b598e673aa9d6eb793868d801bd3a0935a66f0991b3afdc790bc9a78723ed9a400a28168b61d99ae5eeb81dd644751e85ea43fda74fa093d70260d9
   languageName: node
   linkType: hard
 
@@ -10470,6 +10875,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/abort-controller@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: d5647478fa61d5d1cf3ac8fe5b91955c679ecf48e0d71638c0ce908fbcc87f166e42722d181f33ae3c37761de89e48c5eecf620f6fd0e99cd86edbb8365dd38d
+  languageName: node
+  linkType: hard
+
 "@smithy/chunked-blob-reader-native@npm:^3.0.1":
   version: 3.0.1
   resolution: "@smithy/chunked-blob-reader-native@npm:3.0.1"
@@ -10534,6 +10949,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/config-resolver@npm:4.1.0"
+  dependencies:
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/util-config-provider": ^4.0.0
+    "@smithy/util-middleware": ^4.0.2
+    tslib: ^2.6.2
+  checksum: db67064f27981452788ef8cffa3146a1896b50911379febda7315e0657e4fe3bba6c52414670b9778eb986fe06f7e50d10e7373fa644975a0491d27333e909de
+  languageName: node
+  linkType: hard
+
 "@smithy/core@npm:^2.3.2, @smithy/core@npm:^2.5.1":
   version: 2.5.1
   resolution: "@smithy/core@npm:2.5.1"
@@ -10566,6 +10994,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@smithy/core@npm:3.2.0"
+  dependencies:
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-stream": ^4.2.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: ad514aec318c4863851c8167fdade41ac3393f245038de73b546fcdc6e3ad794c12a661d5248cb56a2e893c2b236db95a93d06c91e53b04e6c2967c31e300567
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^3.2.0, @smithy/credential-provider-imds@npm:^3.2.5":
   version: 3.2.5
   resolution: "@smithy/credential-provider-imds@npm:3.2.5"
@@ -10589,6 +11033,19 @@ __metadata:
     "@smithy/url-parser": ^4.0.1
     tslib: ^2.6.2
   checksum: 76b5d82dfd2924f2b7a701fa159af54d3e9b16a644a210e3a74e5a3776bb28c2ffbdd342ed3f2bb1d2adf401e8144e84614523b1fad245b43e319e1d01fa1652
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/credential-provider-imds@npm:4.0.2"
+  dependencies:
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    tslib: ^2.6.2
+  checksum: 516482c103bd42d93de584ec75fa75d1184541816a7b430db109f8ec18abcaf8eb7bd072660fbf417f37a3df5c7438a1ba92aabd5a185ed736be1a6e885f0999
   languageName: node
   linkType: hard
 
@@ -10741,6 +11198,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/fetch-http-handler@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@smithy/fetch-http-handler@npm:5.0.2"
+  dependencies:
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/querystring-builder": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/util-base64": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 3bf84a1fe93c07558a5ba520ab0aca62518c13659d5794094764aaef95acfbcf58ba938c51b9269c485304fdbe7353eb3cd37d7e4c57863d7c50478a9e3ff4fc
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-blob-browser@npm:^3.1.2":
   version: 3.1.7
   resolution: "@smithy/hash-blob-browser@npm:3.1.7"
@@ -10789,6 +11259,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/hash-node@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/hash-node@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    "@smithy/util-buffer-from": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: aaec3fb2146d4347e97067de4dd91759de9d0254d03e234dcced1cbd52cf8b3a77067d571bd5767cb6295da7aa7261b87a789bd597cbc45a380cd90bb47f3490
+  languageName: node
+  linkType: hard
+
 "@smithy/hash-stream-node@npm:^3.1.2":
   version: 3.1.7
   resolution: "@smithy/hash-stream-node@npm:3.1.7"
@@ -10828,6 +11310,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 74bebdffb6845f6060eed482ad6e921df66af90d2f8c63f39a3bb334fa68a3e3aa8bd5cd7aa5f65628857e235e113895433895db910ba290633daa0df5725eb7
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/invalid-dependency@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: f0b884ba25c371d3d3f507aebc24e598e23edeadf0a74dfd7092fc49c496cd427ab517454ebde454b2a05916719e01aa98f34603a5396455cc2dc009ad8799e8
   languageName: node
   linkType: hard
 
@@ -10902,6 +11394,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-content-length@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/middleware-content-length@npm:4.0.2"
+  dependencies:
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 4ab343b68a15cf461f3b5996460a0730463975d9da739cf40cfb5993794023269a8bd857366f855844290fabb2b340abb6ff473cec4bfd3d6653a64f17e00c4a
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-endpoint@npm:^3.1.0, @smithy/middleware-endpoint@npm:^3.2.1":
   version: 3.2.1
   resolution: "@smithy/middleware-endpoint@npm:3.2.1"
@@ -10931,6 +11434,22 @@ __metadata:
     "@smithy/util-middleware": ^4.0.1
     tslib: ^2.6.2
   checksum: 0745d4eb28a1d0419e1f6efe9b726b5ff1389c2e9fcde407e0739a262b66b0e0eb130fe7e80e99e95e3c7472af4d597a592ec8be751f2184ca6947e77e31d0ea
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/middleware-endpoint@npm:4.1.0"
+  dependencies:
+    "@smithy/core": ^3.2.0
+    "@smithy/middleware-serde": ^4.0.3
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    "@smithy/url-parser": ^4.0.2
+    "@smithy/util-middleware": ^4.0.2
+    tslib: ^2.6.2
+  checksum: 1d38c793dbe5b32f01f96c6812935753ee14ebf5c9adf9f3782b6d3b36cf48537a7e123bfb7f7447effffa5dde0bd0d79c581cf07e8175fe1fb2b69fe158a41a
   languageName: node
   linkType: hard
 
@@ -10968,6 +11487,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-retry@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@smithy/middleware-retry@npm:4.1.0"
+  dependencies:
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/service-error-classification": ^4.0.2
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-retry": ^4.0.2
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: fe62a5be9f7e81bff08ce495792c8f5c6cffecd3a872125b8e3487b9bb2dd7341ee8804a714ab4cc8b00468f80d6d83fa19b146dfb0a8d38da9502c582655f52
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-serde@npm:^3.0.3, @smithy/middleware-serde@npm:^3.0.8":
   version: 3.0.8
   resolution: "@smithy/middleware-serde@npm:3.0.8"
@@ -10988,6 +11524,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/middleware-serde@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@smithy/middleware-serde@npm:4.0.3"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 0a3b037c8f1cade46abf9c782fe11da3f1a92d59f3c61d5806fe26a0f3c8b20d5e7e9ab919549ba33762e63fb02c60b5e436b9459647af39300b37d975acde2e
+  languageName: node
+  linkType: hard
+
 "@smithy/middleware-stack@npm:^3.0.3, @smithy/middleware-stack@npm:^3.0.8":
   version: 3.0.8
   resolution: "@smithy/middleware-stack@npm:3.0.8"
@@ -11005,6 +11551,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: b7f710e263e37a8c80c8d31c7d8fe5f66dec2955cde412054eefcc8df53905e1e2e53a01fd7930eb82c82a3a28eadd00e69f07dfc6e793b1d9272db58a982e9b
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/middleware-stack@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: ef94882966431729f7a7bddf8206b6495d67736b1f26fd88d6d6c283a96f9fffd12632ed7352e5f060f17d3ee1845a9a9da1247c26e4c46ff7011aac20b4aacc
   languageName: node
   linkType: hard
 
@@ -11029,6 +11585,18 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: f8d3b1fe91eeba41426ec57d62cfbeaed027650b5549fb2ba5bc889c1cfb7880d4fdb5a484d231b3fb2a9c9023c1f4e8907a5d18d75b3787481cde9f87c4d9cb
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/node-config-provider@npm:4.0.2"
+  dependencies:
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/shared-ini-file-loader": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 1a3b26835577e6c698a2ce59cd1dd9a3653c75e24847d35a45cd80124d72e0118b84daff47ee1ae0cdb89c134efdf7c7754d0ccf1e1c4b57467865b269b5cd0b
   languageName: node
   linkType: hard
 
@@ -11058,6 +11626,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@smithy/node-http-handler@npm:4.0.4"
+  dependencies:
+    "@smithy/abort-controller": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/querystring-builder": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: fb621c6ebcf012a99fc442d82965ca18d752f66be6f937a400e3b4e3feef1c259c028c27df9e78fc9ac7c40679b25276cbaa8d7ab82fd111bda64003ef831358
+  languageName: node
+  linkType: hard
+
 "@smithy/property-provider@npm:^3.1.3, @smithy/property-provider@npm:^3.1.8":
   version: 3.1.8
   resolution: "@smithy/property-provider@npm:3.1.8"
@@ -11078,6 +11659,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/property-provider@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/property-provider@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 6effc5ef7895eb4802c6b4c704d5616f50cd0c376da1644176d3aef71396cb65f9df20f4dd85c8301a9fa24f8ac53601e0634463f4364f0d867928efa5eb5e3d
+  languageName: node
+  linkType: hard
+
 "@smithy/protocol-http@npm:^4.1.0, @smithy/protocol-http@npm:^4.1.4, @smithy/protocol-http@npm:^4.1.5":
   version: 4.1.5
   resolution: "@smithy/protocol-http@npm:4.1.5"
@@ -11095,6 +11686,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 87b157cc86c23f7199acad237e5e0cc309b18a2a4162dfd8f99609f6cca403f832b645535e58173e2933b4d96ec71f2df16d04e1bdcf52b7b0fcbdbc0067de93
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@smithy/protocol-http@npm:5.1.0"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: bb2f600853c0282630f5f32286a07a37294a57dbbec25ea0c6fbb6be32341b1be83e37933c2e3540e513c90dcb08f492bcb05980cde0b92b083e67ade6d56eb0
   languageName: node
   linkType: hard
 
@@ -11120,6 +11721,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/querystring-builder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/querystring-builder@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    "@smithy/util-uri-escape": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 2ae27840e21982926182df809872e07d6b10b2fd93b58e02fa3f9588de23d333ddf02f0f3517de8a02a949489733bdcecb8c847980f8fb12ce1f8c3b6d127e86
+  languageName: node
+  linkType: hard
+
 "@smithy/querystring-parser@npm:^3.0.8":
   version: 3.0.8
   resolution: "@smithy/querystring-parser@npm:3.0.8"
@@ -11137,6 +11749,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 10e5aba13fbb9a602299fb92f02142e291ab5c7cd221e0ca542981414533e081abdd7442de335f2267ee4a9ff8eba4d7ba848455df50d2771f0ddb8b7d8f9d8b
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/querystring-parser@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: e6115fce0a07b1509f407cd3eca371cce1d9c09c7e3bd9156e35506b8ab1100f9864fb8779d4dbe0169501af23f062ebc2176afc012e9132e917781cd11a2f82
   languageName: node
   linkType: hard
 
@@ -11158,6 +11780,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/service-error-classification@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/service-error-classification@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+  checksum: a1f16a891cf96fad624e928d2e55d8b438b2acbb57098d615486bf01488a22f949223127a15e93b273e099a227cbe2ce7be3a3f538d1a4619fb2554dcf33d3dd
+  languageName: node
+  linkType: hard
+
 "@smithy/shared-ini-file-loader@npm:^3.1.4, @smithy/shared-ini-file-loader@npm:^3.1.9":
   version: 3.1.9
   resolution: "@smithy/shared-ini-file-loader@npm:3.1.9"
@@ -11175,6 +11806,16 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 0f0173dbe61c8dac6847cc2c5115db5f1292c956c7f0559ce7bc8e5ed196a4b102977445ee1adb72206a15226a1098cdea01e92aa8ce19f4343f1135e7d37bcf
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/shared-ini-file-loader@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 1e3d4921b6efbd1aa448a775dcb9a490d0221dd0a4fee434c5d83376de478013b3ad06d58a3d52db781124d4a53bd289fffcdb52eabffe9de152b0010332cee2
   languageName: node
   linkType: hard
 
@@ -11210,6 +11851,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/signature-v4@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@smithy/signature-v4@npm:5.0.2"
+  dependencies:
+    "@smithy/is-array-buffer": ^4.0.0
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-hex-encoding": ^4.0.0
+    "@smithy/util-middleware": ^4.0.2
+    "@smithy/util-uri-escape": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 379b2bcd535cfcf68567b8931920eefd3ec30fc734369b5a1055792377a815cb7b6c7fc3a18567e6066d771ddfd0d06da8e45334a02bf86d69985d1923a11c29
+  languageName: node
+  linkType: hard
+
 "@smithy/smithy-client@npm:^3.1.12, @smithy/smithy-client@npm:^3.4.2":
   version: 3.4.2
   resolution: "@smithy/smithy-client@npm:3.4.2"
@@ -11240,6 +11897,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/smithy-client@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/smithy-client@npm:4.2.0"
+  dependencies:
+    "@smithy/core": ^3.2.0
+    "@smithy/middleware-endpoint": ^4.1.0
+    "@smithy/middleware-stack": ^4.0.2
+    "@smithy/protocol-http": ^5.1.0
+    "@smithy/types": ^4.2.0
+    "@smithy/util-stream": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 0d7ac7549edd92a7c50abcfdb9607f729533ff1aa5f70fbe7e3f9a47a272f0f1487094fb72f421d0bbf303b335e349bfd3db3f5b9e841037c3f23f47febb0f6b
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^3.3.0, @smithy/types@npm:^3.5.0, @smithy/types@npm:^3.6.0":
   version: 3.6.0
   resolution: "@smithy/types@npm:3.6.0"
@@ -11255,6 +11927,15 @@ __metadata:
   dependencies:
     tslib: ^2.6.2
   checksum: d8817145ea043c5b29783df747ed47c3a1c584fd9d02bbdb609d38b7cb4dded1197ac214ae112744c86abe0537a314dae0edbc0e752bb639ef2d9fb84c67a9d9
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/types@npm:4.2.0"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: a8bd92c7e548bcbe7be211152de041ec164cfcc857d7574a87b1667c38827e5616563c13bd38a1d44b88bbfa3ee8f591dc597d4e2d50f3bc74e320ea82d7c49e
   languageName: node
   linkType: hard
 
@@ -11277,6 +11958,17 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: fc969b55857b3bcdc920f54bbb9b0c88b5c7695ac7100bea1c7038fd4c9a09ebe0fbb38c4839d39acea28da0d8cb4fea71ffbf362d8aec295acbb94c1b45fc86
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/url-parser@npm:4.0.2"
+  dependencies:
+    "@smithy/querystring-parser": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 3da40fc18871c145bcbbb036a3d767ae113b954e94c745770f268dc877378cbafa6fc06759ea5a5e5c159a88e7331739b35b69f4d110ba0bd04b2d0923443f32
   languageName: node
   linkType: hard
 
@@ -11412,6 +12104,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-browser@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.0.8"
+  dependencies:
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    bowser: ^2.11.0
+    tslib: ^2.6.2
+  checksum: ada59bc98f2538d189363bc8e22c7cb72b9ddd06142fbca54921efa5742cc248e8ea06f79ec679cb916683d3ac9e3a35bafb6377ee5d4cff8715e46de1445b81
+  languageName: node
+  linkType: hard
+
 "@smithy/util-defaults-mode-node@npm:^3.0.14":
   version: 3.0.25
   resolution: "@smithy/util-defaults-mode-node@npm:3.0.25"
@@ -11442,6 +12147,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-defaults-mode-node@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@smithy/util-defaults-mode-node@npm:4.0.8"
+  dependencies:
+    "@smithy/config-resolver": ^4.1.0
+    "@smithy/credential-provider-imds": ^4.0.2
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/property-provider": ^4.0.2
+    "@smithy/smithy-client": ^4.2.0
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: cbdfe00d5cd645250ca49416ebddcfc1055da3412826cf0baa75d4af6e58765ac7ea4b262a48c5bbd4e60e4329e362b76f96c319db1112b2d92b506c82bc002a
+  languageName: node
+  linkType: hard
+
 "@smithy/util-endpoints@npm:^2.0.5":
   version: 2.1.4
   resolution: "@smithy/util-endpoints@npm:2.1.4"
@@ -11461,6 +12181,17 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: fed80f300e6a6e69873e613cdd12f640d33a19fc09a41e3afd536f7ea36f7785edd96fbd0402b6980a0e5dfc9bcb8b37f503d522b4ef317f31f4fd0100c466ff
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@smithy/util-endpoints@npm:3.0.2"
+  dependencies:
+    "@smithy/node-config-provider": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 5d2fe3956dc528842c071329bc69bd6567462858c1fbb1cc7ca19622227a803b54d95f44f3ac703852bce6349f455bfec599aea51df56d02e3c8b12e6481c27a
   languageName: node
   linkType: hard
 
@@ -11502,6 +12233,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-middleware@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/util-middleware@npm:4.0.2"
+  dependencies:
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: 18c3882c94f1b1bbb3825c30d1e41ae77a8da3dcd93ebbf1c486f34d5db9e06431789aef54d1b1fbb0424b115fc1e1ae17d27efe4af4277173d901a76147fef8
+  languageName: node
+  linkType: hard
+
 "@smithy/util-retry@npm:^3.0.3, @smithy/util-retry@npm:^3.0.8":
   version: 3.0.8
   resolution: "@smithy/util-retry@npm:3.0.8"
@@ -11521,6 +12262,17 @@ __metadata:
     "@smithy/types": ^4.1.0
     tslib: ^2.6.2
   checksum: 93ef89572651b8a30b9a648292660ae9532508ec6d2577afc62e1d9125fe6d14086e0f70a2981bf9f12256b41a57152368b5ed839cdd2df47ba78dd005615173
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@smithy/util-retry@npm:4.0.2"
+  dependencies:
+    "@smithy/service-error-classification": ^4.0.2
+    "@smithy/types": ^4.2.0
+    tslib: ^2.6.2
+  checksum: c2b98faa4171f620aa17a0f0a91dff9215a4729242a040ad25aee4c716752a64944cc58031ae71bcf3fc320b3e84cb3da4648e5bbccd782126a721e588d98b87
   languageName: node
   linkType: hard
 
@@ -11553,6 +12305,22 @@ __metadata:
     "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
   checksum: 639328ec53d44f703b1e3cb9363397f6b506626584b22c68897133831b25026359f99f2b89c6d6c597e72773ff3508a374ae13cc266f1d1f761bcfbe9e4318d5
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@smithy/util-stream@npm:4.2.0"
+  dependencies:
+    "@smithy/fetch-http-handler": ^5.0.2
+    "@smithy/node-http-handler": ^4.0.4
+    "@smithy/types": ^4.2.0
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-buffer-from": ^4.0.0
+    "@smithy/util-hex-encoding": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    tslib: ^2.6.2
+  checksum: 52449a6ec68a483fdeef816128c923c744e278f6cf4d5b6fbe50e29fa8b6e5813df26221389f22bce143deb91f047ac56f87db85306908c5d0b87460e162bf63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes

**Codegen custom resource**

Copy custom/ folder from gen1 -> gen2
Update cdk-stack.ts file to remove @aws-amplify/cli-extensibility-helper dependency
-- Check for existence of AmplifyHelpers.addResourceDependency and throw an error if found (errorMessage to be updated)
-- Replace AmplifyHelpers.getProjectInfo() with {envName: 'envName', projectName: 'projectName'}
-- Replace AmplifyHelpers.AmplifyResourceProps with {category: 'custom', resourceName: resource}
-- Remove the import statement import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';

**Add scheduling in functions**
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
