### PR TITLE
Gen2 migrations execute

### DIFF
--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -477,6 +477,7 @@ describe('BackendRenderer', () => {
       );
       expect(output).toContain('Object.keys(providerSetupResult).forEach(provider => {');
       expect(output).toContain('userPoolClient.node.addDependency(providerSetupPropertyValue)');
+      expect(output).toContain('// backend.auth.resources.userPool.node.tryRemoveChild("UserPoolDomain");');
     });
     it('renders user pool client configuration with default value for generateSecrets', () => {
       const renderer = new BackendSynthesizer();

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -485,20 +485,13 @@ describe('BackendRenderer', () => {
       expect(output).toContain('enableTokenRevocation: true');
       expect(output).toContain('enablePropagateAdditionalUserContextData: true');
       expect(output).toContain('generateSecret: true');
-    });
-    it('renders userpool and identitypool deletion policy', () => {
-      const renderer = new BackendSynthesizer();
-      const rendered = renderer.render({
-        auth: {
-          importFrom: 'auth/resource.ts',
-          identityPoolName: 'testIdentityPool',
-          userPoolOverrides: {},
-        },
-      });
-      const output = printNodeArray(rendered);
-      assert(output.includes('// cfnUserPool.applyRemovalPolicy'));
-      assert(output.includes('// cfnIdentityPool.applyRemovalPolicy'));
-      assert(output.includes('import { RemovalPolicy, Tags } from "aws-cdk-lib";'));
+
+      expect(output).toContain(
+        'const providerSetupResult = (backend.auth.stack.node.children.find(child => child.node.id === "amplifyAuth") as any).providerSetupResult;',
+      );
+      expect(output).toContain('Object.keys(providerSetupResult).forEach(provider => {');
+      expect(output).toContain('userPoolClient.node.addDependency(providerSetupPropertyValue)');
+      expect(output).toContain('// backend.auth.resources.userPool.node.tryRemoveChild("UserPoolDomain");');
     });
     it('renders user pool client configuration with default value for generateSecrets', () => {
       const renderer = new BackendSynthesizer();

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.test.ts
@@ -345,20 +345,6 @@ describe('BackendRenderer', () => {
       assert(output.includes('bucketEncryption'));
       assert(output.includes('sseAlgorithm'));
     });
-    it('renders s3 deletion policy', () => {
-      const renderer = new BackendSynthesizer();
-      const rendered = renderer.render({
-        storage: {
-          importFrom: 'my-storage',
-          bucketName: 'testBucket',
-          hasS3Bucket: 'bucket-name',
-        },
-      });
-      const output = printNodeArray(rendered);
-      assert(output.includes('// s3Bucket.applyRemovalPolicy'));
-      assert(output.includes('import { RemovalPolicy, Tags } from "aws-cdk-lib";'));
-      assert(output.includes('// Tags.of(backend.stack).add("gen1-migrated-app", "true")'));
-    });
   });
   describe('UserPoolClient Configuration using render()', () => {
     it('renders complete user pool client configuration', () => {
@@ -491,20 +477,6 @@ describe('BackendRenderer', () => {
       );
       expect(output).toContain('Object.keys(providerSetupResult).forEach(provider => {');
       expect(output).toContain('userPoolClient.node.addDependency(providerSetupPropertyValue)');
-    });
-    it('renders userpool and identitypool deletion policy', () => {
-      const renderer = new BackendSynthesizer();
-      const rendered = renderer.render({
-        auth: {
-          importFrom: 'auth/resource.ts',
-          identityPoolName: 'testIdentityPool',
-          userPoolOverrides: {},
-        },
-      });
-      const output = printNodeArray(rendered);
-      assert(output.includes('// cfnUserPool.applyRemovalPolicy'));
-      assert(output.includes('// cfnIdentityPool.applyRemovalPolicy'));
-      assert(output.includes('import { RemovalPolicy, Tags } from "aws-cdk-lib";'));
     });
     it('renders user pool client configuration with default value for generateSecrets', () => {
       const renderer = new BackendSynthesizer();

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -890,9 +890,6 @@ export class BackendSynthesizer {
       const userPoolVariableStatement = this.createVariableStatement(this.createVariableDeclaration('userPool', 'auth.resources.userPool'));
       nodes.push(userPoolVariableStatement);
       nodes.push(this.createUserPoolClientAssignment(renderArgs.auth?.userPoolClient, imports));
-
-      const idpStatements = this.createProviderSetupCode();
-      nodes.push(...idpStatements);
     }
 
     if (renderArgs.storage && renderArgs.storage.hasS3Bucket) {

--- a/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
+++ b/packages/amplify-gen2-codegen/src/backend/synthesizer.ts
@@ -164,20 +164,6 @@ export class BackendSynthesizer {
     return factory.createPropertyAssignment(factory.createIdentifier(identifier), factory.createStringLiteral(stringLiteral));
   }
 
-  private addRemovalPolicyAssignment(identifier: string) {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(factory.createIdentifier(`// ${identifier}`), factory.createIdentifier('applyRemovalPolicy')),
-      undefined,
-      [
-        factory.createIdentifier('RemovalPolicy.RETAIN'),
-        factory.createObjectLiteralExpression(
-          [factory.createPropertyAssignment(factory.createIdentifier('applyToUpdateReplacePolicy'), factory.createTrue())],
-          false,
-        ),
-      ],
-    );
-  }
-
   private createUserPoolClientAssignment(userPoolClient: UserPoolClientType, imports: ts.ImportDeclaration[]) {
     const userPoolClientAttributesMap = new Map<string, string>();
     userPoolClientAttributesMap.set('ClientName', 'userPoolClientName');
@@ -927,7 +913,6 @@ export class BackendSynthesizer {
         '',
       );
       nodes.push(bucketNameAssignment);
-      nodes.push(this.addRemovalPolicyAssignment('s3Bucket'));
     }
 
     if (

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
@@ -28,10 +28,6 @@ s3Bucket.bucketName = YOUR_GEN1_BUCKET_NAME;
 \`\`\`
 
 \`\`\`
-s3Bucket.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
-\`\`\`
-
-\`\`\`
 backend.auth.resources.userPool.node.tryRemoveChild('UserPoolDomain');
 \`\`\`
 

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.test.ts
@@ -32,11 +32,7 @@ s3Bucket.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: 
 \`\`\`
 
 \`\`\`
-cfnUserPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
-\`\`\`
-
-\`\`\`
-cfnIdentityPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
+backend.auth.resources.userPool.node.tryRemoveChild('UserPoolDomain');
 \`\`\`
 
 \`\`\`
@@ -64,11 +60,7 @@ npx ampx sandbox
 1.a) Uncomment the following lines in \`amplify/backend.ts\` file
 
 \`\`\`
-cfnUserPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
-\`\`\`
-
-\`\`\`
-cfnIdentityPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
+backend.auth.resources.userPool.node.tryRemoveChild('UserPoolDomain');
 \`\`\`
 
 \`\`\`

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -36,11 +36,7 @@ s3Bucket.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: 
 1.a) Uncomment the following lines in \`amplify/backend.ts\` file
 ${this.categories.includes('storage') ? s3BucketChanges : ''}
 \`\`\`
-cfnUserPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
-\`\`\`
-
-\`\`\`
-cfnIdentityPool.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
+backend.auth.resources.userPool.node.tryRemoveChild('UserPoolDomain');
 \`\`\`
 
 \`\`\`

--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -25,10 +25,6 @@ class MigrationReadmeGenerator {
     const s3BucketChanges = `\`\`\`
 s3Bucket.bucketName = YOUR_GEN1_BUCKET_NAME;
 \`\`\`
-
-\`\`\`
-s3Bucket.applyRemovalPolicy(RemovalPolicy.RETAIN, { applyToUpdateReplacePolicy: true });
-\`\`\`
 `;
     await fs.appendFile(
       this.migrationReadMePath,


### PR DESCRIPTION
#### Description of changes

- Remove commented out codegen for adding RETAIN policies to User pool, Identity Pool, S3 bucket as its already handled by Gen2 CDK code for CI deployments. Sandbox deployments are intentionally overriden to be deleted
- Add a Commented out line for deleting User pool domain from Gen2 stack. This is because Gen1 did not have User Pool Domains as part of CFN but had a custom resource adding them. Post refactor, if we don't add this line the deploy would fail saying Invalid request for OAuth apps.

#### Description of how you validated changes
Local testing, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
