### PR TITLE
fix Unsafe shell command constructed from library input shell-quote() OS Command Injection

### DIFF
--- a/packages/amplify-go-function-runtime-provider/src/localinvoke.ts
+++ b/packages/amplify-go-function-runtime-provider/src/localinvoke.ts
@@ -39,7 +39,7 @@ const startLambda = (request: InvocationRequest, portNumber: number, lambda: { e
 
   envVars['_LAMBDA_SERVER_PORT'] = portNumber.toString();
 
-  const lambdaProcess: ExecaChildProcess = execa.command(lambda.executable, {
+  const lambdaProcess: ExecaChildProcess = execa(lambda.executable, [], {
     env: envVars,
     extendEnv: false,
     cwd: lambda.cwd,


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-cli/blob/e936bfd8a4527eba1576548301fe460dc1250005/packages/amplify-go-function-runtime-provider/src/localinvoke.ts#L73-L73


To fix the problem, we should avoid using `execa.command` with a dynamically constructed command string. Instead, we can use `execa` with an array of arguments to safely pass the executable and its arguments without shell interpretation. This approach ensures that the input is not interpreted by the shell, preventing command injection.

1. Replace the use of `execa.command` with `execa` and pass the executable and arguments as an array.
2. Ensure that the `lambdaExecutablePath` and `lambdaExecutableDir` are passed as separate arguments to avoid shell interpretation.

Dynamically constructing a shell command with inputs from exported functions may inadvertently change the meaning of the shell command. Clients using the exported function may use inputs containing characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

## POC
The following shows a dynamically constructed shell command that downloads a file from a remote URL.
```ts
var cp = require("child_process");

module.exports = function download(path, callback) {
  cp.exec("wget " + path, callback);
}
```
The shell command will, however, fail to work as intended if the input contains spaces or other special characters interpreted in a special way by the shell. Even worse, a client might pass in user-controlled data, not knowing that the input is interpreted as a shell command. This could allow a malicious user to provide the input `http://redactedaws.org; cat /etc/passwd` in order to execute the command `cat /etc/passwd`. To avoid such potentially catastrophic behaviors, provide the inputs from exported functions as an argument that does not get interpreted by a shell:

```ts
var cp = require("child_process");

module.exports = function download(path, callback) {
  cp.execFile("wget", [path], callback);
}
```
As another example, consider the following code which is similar to the preceding, but pipes the output of `wget` into `wc -l` to count the number of lines in the downloaded file.
```ts
var cp = require("child_process");

module.exports = function download(path, callback) {
  cp.exec("wget " + path + " | wc -l", callback);
};
```
In this case, using `child_process.execFile` is not an option because the shell is needed to interpret the pipe operator. Instead, you can use `shell-quote` to escape the input before embedding it in the command:
```ts
var cp = require("child_process");

module.exports = function download(path, callback) {
  cp.exec("wget " + shellQuote.quote([path]) + " | wc -l", callback);
};
```
## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[shell-quote](https://www.npmjs.com/package/shell-quote)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)





#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
