### PR TITLE
fix(migrate-template-gen): replace console logs with ora for async tasks

### DIFF
--- a/packages/amplify-migration-template-gen/package.json
+++ b/packages/amplify-migration-template-gen/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.744.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.592.0",
-    "@aws-sdk/client-ssm": "^3.592.0"
+    "@aws-sdk/client-ssm": "^3.592.0",
+    "ora": "^4.0.3"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/packages/amplify-migration-template-gen/src/template-generator.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.ts
@@ -248,7 +248,7 @@ class TemplateGenerator {
       const { newTemplate, parameters: gen1StackParameters } = await categoryTemplateGenerator.generateGen1PreProcessTemplate();
 
       assert(gen1StackParameters);
-      updatingGen1CategoryStack = ora(`Updating Gen1 ${category} stack...`);
+      updatingGen1CategoryStack = ora(`Updating Gen1 ${category} stack...`).start();
 
       const gen1StackUpdateStatus = await tryUpdateStack(this.cfnClient, sourceCategoryStackId, gen1StackParameters, newTemplate);
 
@@ -276,7 +276,7 @@ class TemplateGenerator {
   }> {
     const { newTemplate, oldTemplate, parameters } = await categoryTemplateGenerator.generateGen2ResourceRemovalTemplate();
 
-    const updatingGen2CategoryStack = ora(`Updating Gen2 ${category} stack...`);
+    const updatingGen2CategoryStack = ora(`Updating Gen2 ${category} stack...`).start();
 
     const gen2StackUpdateStatus = await tryUpdateStack(this.cfnClient, destinationCategoryStackId, parameters ?? [], newTemplate);
 
@@ -379,7 +379,7 @@ class TemplateGenerator {
 
       assert(newSourceTemplate);
       assert(newDestinationTemplate);
-      const refactorResources = ora(`Moving ${category} resources from ${this.getSourceToDestinationMessage(isRevert)} stack...`);
+      const refactorResources = ora(`Moving ${category} resources from ${this.getSourceToDestinationMessage(isRevert)} stack...`).start();
       const { success, failedRefactorMetadata } = await this.refactorResources(
         logicalIdMappingForRefactor,
         sourceCategoryStackId,
@@ -459,7 +459,7 @@ class TemplateGenerator {
     gen2StackParameters: Parameter[] | undefined,
     oldGen2Template: CFNTemplate,
   ) {
-    const rollingBackGen2Stack = ora(`Rolling back Gen2 ${category} stack...`);
+    const rollingBackGen2Stack = ora(`Rolling back Gen2 ${category} stack...`).start();
     const gen2StackUpdateStatus = await tryUpdateStack(this.cfnClient, gen2CategoryStackId, gen2StackParameters ?? [], oldGen2Template);
     assert(gen2StackUpdateStatus === CFNStackStatus.UPDATE_COMPLETE, `Gen2 Stack in a failed state: ${gen2StackUpdateStatus}.`);
     rollingBackGen2Stack.succeed(`Rolled back Gen2 ${category} stack successfully`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,7 @@ __metadata:
     "@aws-sdk/client-ssm": ^3.592.0
     "@jest/globals": ^29.7.0
     jest: ^29.5.0
+    ora: ^4.0.3
     typescript: ^5.4.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
#### Description of changes

Replace console logs with ora for async tasks in template gen flow.


#### Description of how you validated changes

Local testing

```
../amplify-cli/node_modules/.bin/migrate to-gen-2 revert --to amplify-testora-dev-8fb33 --from amplify-mygen2app-ora-sandbox-2681f0acba --debug
✔ Moved auth resources from Gen2 to Gen1 stack successfully
Moved resources back to Gen1 stack successfully.
✔ Moved your Gen1 backend files to amplify
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
