### PR TITLE
fix: custom resource error handling, formatting messages

### DIFF
--- a/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
+++ b/packages/amplify-migration-template-gen/src/migration-readme-generator.ts
@@ -31,9 +31,13 @@ s3Bucket.bucketName = YOUR_GEN1_BUCKET_NAME;
       `## REDEPLOY GEN2 APPLICATION
 1.a) Uncomment the following lines in \`amplify/backend.ts\` file
 ${this.categories.includes('storage') ? s3BucketChanges : ''}
-\`\`\`
+${
+  this.categories.includes('auth')
+    ? `\`\`\`
 backend.auth.resources.userPool.node.tryRemoveChild('UserPoolDomain');
-\`\`\`
+\`\`\``
+    : ''
+}
 
 \`\`\`
 Tags.of(backend.stack).add("gen1-migrated-app", "true");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

- Formatting changes: 
  -  Add space between Gen1 and Gen2 in outputs
  - Use `custom` to depict moving custom resources instead of the resource logical ids
- Custom resource conditional error handling based on presence/absence of comments
-  Use single or double quotes in `env` parameter regex in custom resource file to add default value 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
ran the prepare and execute commands locally, unit tests

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
