### PR TITLE
Initialize non-custom category generator without custom predicate

### DIFF
--- a/packages/amplify-migration-e2e/package.json
+++ b/packages/amplify-migration-e2e/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.4.0",
     "@aws-amplify/amplify-e2e-core": "5.7.3",
-    "@aws-amplify/amplify-gen2-codegen": "0.1.0-next-7.0",
+    "@aws-amplify/amplify-gen2-codegen": "0.1.0-next-6.0",
     "@aws-sdk/client-appsync": "^3.666.0",
     "@aws-sdk/client-cloudcontrol": "^3.658.1",
     "@aws-sdk/client-cognito-identity": "^3.670.0",

--- a/packages/amplify-migration-e2e/package.json
+++ b/packages/amplify-migration-e2e/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-amplify/amplify-cli-core": "4.4.0",
     "@aws-amplify/amplify-e2e-core": "5.7.3",
-    "@aws-amplify/amplify-gen2-codegen": "0.1.0-next-6.0",
+    "@aws-amplify/amplify-gen2-codegen": "0.1.0-next-7.0",
     "@aws-sdk/client-appsync": "^3.666.0",
     "@aws-sdk/client-cloudcontrol": "^3.658.1",
     "@aws-sdk/client-cognito-identity": "^3.670.0",

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.test.ts
@@ -199,6 +199,28 @@ describe('CFNOutputResolver', () => {
           TopicName: 'snsTopic',
         },
       },
+      CustomS3AutoDeleteObjectsCustomResourceProviderHandler: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          FunctionName: 'CustomS3AutoDeleteObjectsCustomResourceProviderHandler',
+          Handler: 'index.handler',
+          Code: {
+            ZipFile: 'exports.handler = function() {}',
+          },
+          Runtime: 'nodejs14.x',
+        },
+      },
+      CustomS3AutoDeleteObjects: {
+        Type: 'Custom::S3AutoDeleteObjects',
+        Properties: {
+          ServiceToken: {
+            'Fn::GetAtt': ['CustomS3AutoDeleteObjectsCustomResourceProviderHandler', 'Arn'],
+          },
+          BucketName: {
+            Ref: 'MyS3Bucket',
+          },
+        },
+      },
     },
   };
   const expectedTemplate: CFNTemplate = {
@@ -372,8 +394,27 @@ describe('CFNOutputResolver', () => {
           TopicName: 'snsTopic',
         },
       },
+      CustomS3AutoDeleteObjectsCustomResourceProviderHandler: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          FunctionName: 'CustomS3AutoDeleteObjectsCustomResourceProviderHandler',
+          Handler: 'index.handler',
+          Code: {
+            ZipFile: 'exports.handler = function() {}',
+          },
+          Runtime: 'nodejs14.x',
+        },
+      },
+      CustomS3AutoDeleteObjects: {
+        Type: 'Custom::S3AutoDeleteObjects',
+        Properties: {
+          ServiceToken: 'arn:aws:lambda:us-east-1:12345:function:mycustomS3AutoDeleteObjectsLambdaFunction',
+          BucketName: 'test-bucket',
+        },
+      },
     },
   };
+
   it('should resolve output references', () => {
     expect(
       new CfnOutputResolver(template, 'us-east-1', '12345').resolve(
@@ -428,6 +469,15 @@ describe('CFNOutputResolver', () => {
             LogicalResourceId: 'snsSubscription',
             PhysicalResourceId: 'physicalIdSns',
             ResourceType: 'AWS::SNS::Subscription',
+            Timestamp: new Date('2025-04-02T22:27:41.603000+00:00'),
+            ResourceStatus: 'CREATE_COMPLETE',
+          },
+          {
+            StackName: 'amplify-amplifycodegen-dev',
+            StackId: 'arn:aws:cloudformation:us-west-2:123456789:stack/amplify-amplifycodegen-dev',
+            LogicalResourceId: 'CustomS3AutoDeleteObjectsCustomResourceProviderHandler',
+            PhysicalResourceId: 'mycustomS3AutoDeleteObjectsLambdaFunction',
+            ResourceType: 'AWS::Lambda::Function',
             Timestamp: new Date('2025-04-02T22:27:41.603000+00:00'),
             ResourceStatus: 'CREATE_COMPLETE',
           },

--- a/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
+++ b/packages/amplify-migration-template-gen/src/resolvers/cfn-output-resolver.ts
@@ -157,6 +157,10 @@ class CfnOutputResolver {
             return {
               Arn: `arn:aws:sqs:${this.region}:${this.accountId}:${resourceIdentifier}`,
             };
+          case 'AWS::Lambda::Function':
+            return {
+              Arn: `arn:aws:lambda:${this.region}:${this.accountId}:function:${resourceIdentifier}`,
+            };
           default:
             return undefined;
         }

--- a/packages/amplify-migration-template-gen/src/template-generator.test.ts
+++ b/packages/amplify-migration-template-gen/src/template-generator.test.ts
@@ -834,7 +834,7 @@ describe('TemplateGenerator', () => {
         CFN_AUTH_TYPE.IdentityPoolRoleAttachment,
         CFN_AUTH_TYPE.UserPoolDomain,
       ],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       2,
@@ -848,7 +848,7 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_AUTH_TYPE.UserPoolGroup],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       3,
@@ -862,7 +862,7 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_S3_TYPE.Bucket],
-      expect.any(Function),
+      undefined,
     );
   }
 
@@ -892,7 +892,7 @@ describe('TemplateGenerator', () => {
         CFN_AUTH_TYPE.IdentityPoolRoleAttachment,
         CFN_AUTH_TYPE.UserPoolDomain,
       ],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       2,
@@ -906,7 +906,7 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_AUTH_TYPE.UserPoolGroup],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       3,
@@ -920,7 +920,7 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_S3_TYPE.Bucket],
-      expect.any(Function),
+      undefined,
     );
   }
 
@@ -950,7 +950,7 @@ describe('TemplateGenerator', () => {
         CFN_AUTH_TYPE.IdentityPoolRoleAttachment,
         CFN_AUTH_TYPE.UserPoolDomain,
       ],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       2,
@@ -964,7 +964,7 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_AUTH_TYPE.UserPoolGroup],
-      expect.any(Function),
+      undefined,
     );
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       3,
@@ -978,8 +978,9 @@ describe('TemplateGenerator', () => {
       APP_ID,
       ENV_NAME,
       [CFN_S3_TYPE.Bucket],
-      expect.any(Function),
+      undefined,
     );
+    // custom resource category
     expect(CategoryTemplateGenerator).toHaveBeenNthCalledWith(
       4,
       GEN1_ROOT_STACK_NAME,

--- a/packages/amplify-migration-template-gen/src/types.ts
+++ b/packages/amplify-migration-template-gen/src/types.ts
@@ -109,7 +109,11 @@ export enum CFN_SQS_TYPE {
   Queue = 'AWS::SQS::Queue',
 }
 
-export type CFN_RESOURCE_TYPES = CFN_AUTH_TYPE | CFN_S3_TYPE | CFN_IAM_TYPE | CFN_SQS_TYPE;
+export enum CFN_LAMBDA_TYPE {
+  Function = 'AWS::Lambda::Function',
+}
+
+export type CFN_RESOURCE_TYPES = CFN_AUTH_TYPE | CFN_S3_TYPE | CFN_IAM_TYPE | CFN_SQS_TYPE | CFN_LAMBDA_TYPE;
 
 export type AWS_RESOURCE_ATTRIBUTES = 'Arn';
 


### PR DESCRIPTION
#### Description of changes

- Initialize non-custom category generator without custom predicate
- Support Lambda function ARN replace in output resolver (needed for S3 auto delete objects in `storage` category)

#### Description of how you validated changes

ran `execute` command locally, unit tests.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
