### PR TITLE
fix Type confusion through parameter tampering could lead path traversal()

### DIFF
--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -50,6 +50,10 @@ export function checkFile(file: string, prefix: string, delimiter: string) {
 
 // removing chunk siognature from request payload if present
 export function stripChunkSignature(buf: Buffer) {
+  if (!Buffer.isBuffer(buf)) {
+    // If buf is not a Buffer, return it unchanged or handle the error
+    return buf;
+  }
   const str = buf.toString();
   const regex = /^[A-Fa-f0-9]+;chunk-signature=[0-9a-f]{64}/gm;
   let m;


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-cli/blob/c55512f15914856998b529bc72594f2c09e3852f/packages/amplify-storage-simulator/src/server/utils.ts#L77-L77

fix the issue need to validate that the `buf` parameter in the `stripChunkSignature` function is of type `Buffer`. If it is not, the function should either throw an error or return the input unchanged, depending on the desired behavior. This ensures that the function operates only on valid `Buffer` objects and prevents type confusion.

The changes will be made in the `stripChunkSignature` function in `packages/amplify-storage-simulator/src/server/utils.ts`. Specifically:
1. Add a type check at the beginning of the function to ensure `buf` is a `Buffer`.
2. If `buf` is not a `Buffer`, return it unchanged or handle the error appropriately.


Sanitizing untrusted HTTP request parameters is a common technique for preventing injection attacks such as SQL injection and path traversal. This is sometimes done by checking if the request parameters contain blacklisted substrings.

However, sanitizing request parameters assuming they have type `String` and using the builtin string methods such as `String.prototype.indexOf` is susceptible to type confusion attacks. In a type confusion attack, an attacker tampers with an HTTP request parameter such that it has a value of type `Array` instead of the expected type `String`. Furthermore, the content of the array has been crafted to bypass sanitizers by exploiting that some identically named methods of strings and arrays behave differently.


## POC
node server frameworks usually present request parameters as strings. But if an attacker sends multiple request parameters with the same name, then the request parameter is represented as an array instead, a sanitizer checks that a path does not contain the `".."` string, which would allow an attacker to access content outside a user-accessible directory.
```js
var app = require("express")(),
  path = require("path");

app.get("/root-files", function(req, res) {
  var file = req.param("file");
  if (file.indexOf("..") !== -1) {
    // BAD
    // we forbid relative paths that contain ..
    // as these could leave the public directory
    res.status(400).send("Bad request");
  } else {
    var absolute = path.resolve("/public/" + file);
    console.log("Sending file: %s", absolute);
    res.sendFile(absolute);
  }
});
```
As written, this sanitizer is ineffective: an array like `["../", "/../secret.txt"]` will bypass the sanitizer. The array does not contain `".."` as an element, so the call to `indexOf` returns `-1` . This is problematic since the value of the `absolute` variable then ends up being `"/secret.txt"`. This happens since the concatenation of `"/public/"` and the array results in `"/public/../,/../secret.txt"`, which the `resolve`-call converts to `"/secret.txt"`.

To fix the sanitizer, check that the request parameter is a string, and not an array:
```ts
var app = require("express")(),
  path = require("path");

app.get("/root-files", function(req, res) {
  var file = req.param("file");
  if (typeof file !== 'string' || file.indexOf("..") !== -1) {
    // GOOD
    // we forbid relative paths that contain ..
    // as these could leave the public directory
    res.status(400).send("Bad request");
  } else {
    var absolute = path.resolve("/public/" + file);
    console.log("Sending file: %s", absolute);
    res.sendFile(absolute);
  }
});
```
## References
[querystring](https://nodejs.org/api/querystring.html).
[CWE-843](https://cwe.mitre.org/data/definitions/843.html).



#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
