### PR TITLE
chore: remove migration package from cli tsconfig as its a standalone executable

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -306,14 +306,14 @@ function runGen2MigrationsE2ETestCb {
         failedTests=$(<$FAILED_TEST_REGEX_FILE)
         if [[ ! -z "$DISABLE_COVERAGE" ]]; then
             echo Running WITHOUT coverage
-            yarn e2e --forceExit --no-cache --maxWorkers=4 $TEST_SUITE -t "$failedTests"
+            yarn e2e-migration --forceExit --no-cache --maxWorkers=4 $TEST_SUITE -t "$failedTests"
         else
             NODE_V8_COVERAGE=$E2E_TEST_COVERAGE_DIR yarn e2e-migration --forceExit --no-cache --maxWorkers=4 $TEST_SUITE -t "$failedTests"
         fi
     else
         if [[ ! -z "$DISABLE_COVERAGE" ]]; then
             echo Running WITHOUT coverage
-            yarn e2e --forceExit --no-cache --maxWorkers=4 $TEST_SUITE
+            yarn e2e-migration --forceExit --no-cache --maxWorkers=4 $TEST_SUITE
         else
             NODE_V8_COVERAGE=$E2E_TEST_COVERAGE_DIR yarn e2e-migration --forceExit --no-cache --maxWorkers=4 $TEST_SUITE
         fi

--- a/codebuild_specs/e2e_workflow_base.yml
+++ b/codebuild_specs/e2e_workflow_base.yml
@@ -139,7 +139,7 @@ batch:
     - identifier: gen2_migrations_e2e_test
       buildspec: codebuild_specs/run_gen2_migrations_e2e_tests_linux.yml
       depend-on:
-        - build_linux
+        - upb
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: cleanup_resources

--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -139,7 +139,7 @@ batch:
     - identifier: gen2_migrations_e2e_test
       buildspec: codebuild_specs/run_gen2_migrations_e2e_tests_linux.yml
       depend-on:
-        - build_linux
+        - upb
       env:
         compute-type: BUILD_GENERAL1_LARGE
     - identifier: cleanup_resources

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -10,9 +10,6 @@
   "include": ["src/**/*"],
   "references": [
     {
-      "path": "../amplify-migration"
-    },
-    {
       "path": "../amplify-category-function"
     },
     {

--- a/packages/amplify-migration/src/command-handler.test.ts
+++ b/packages/amplify-migration/src/command-handler.test.ts
@@ -731,7 +731,6 @@ describe('revertGen2Migration', () => {
   });
 });
 
-// add tests for updateGitIgnoreForGen2
 describe('updateGitIgnoreForGen2', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
#### Description of changes

- remove migration package from cli tsconfig as its a standalone executable
-  Add depends on to `upb` instead of `build_linux`.  I checked the s3 verdaccio cache for the failed run and it was created at `18:04 UTC` while this run was started at `18:03 UTC`. When I traced the `depend-on`  for the migration test it was set to `build_linux` instead of `upb` (upload package binaries). `upb` transitively depends on `build_linux`. So we should be good.

#### Description of how you validated changes
`yarn build`, `yarn test`

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
