### PR TITLE
fix Unsafe shell command constructed from library input `index`

### DIFF
--- a/packages/amplify-e2e-core/src/utils/index.ts
+++ b/packages/amplify-e2e-core/src/utils/index.ts
@@ -78,7 +78,7 @@ export const loadFunctionTestFile = (fileName: string): string => {
  */
 export const addNodeDependencies = (root: string, functionName: string, dependencies: string[]): void => {
   const indexPath = path.join(getPathToFunction(root, functionName), 'src');
-  execa.commandSync(`yarn add ${dependencies.join(' ')}`, { cwd: indexPath });
+  execa.sync('yarn', ['add', ...dependencies], { cwd: indexPath });
 };
 
 /**


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-cli/blob/c85ed14b2fe61c09a026f7bb7c82857b5227dff2/packages/amplify-e2e-core/src/utils/index.ts#L81-L81

fix the issue should avoid constructing the shell command as a single string and instead pass the command and its arguments as an array to `execa.commandSync`. This approach prevents the shell from interpreting special characters in the input, mitigating the risk of command injection. Specifically:
1. Replace the string concatenation with an array of arguments.
2. Use `execa`'s `execa.sync` method with the command and arguments passed as separate parameters.






#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
