### PR TITLE
fix Type confusion through parameter tampering

### DIFF
--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -50,6 +50,10 @@ export function checkFile(file: string, prefix: string, delimiter: string) {
 
 // removing chunk siognature from request payload if present
 export function stripChunkSignature(buf: Buffer) {
+  if (!Buffer.isBuffer(buf)) {
+    // If buf is not a Buffer, return it unchanged or handle the error
+    return buf;
+  }
   const str = buf.toString();
   const regex = /^[A-Fa-f0-9]+;chunk-signature=[0-9a-f]{64}/gm;
   let m;


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-cli/blob/aaef95c5a46232fac5105201c490210ac67c93b7/packages/amplify-storage-simulator/src/server/utils.ts#L77-L77

fix the issue need to ensure that the `buf` parameter in the `stripChunkSignature` function is of the expected type (`Buffer`). If `buf` is not a `Buffer`, the function should either throw an error or return the input unchanged, depending on the desired behavior. This can be achieved by adding a runtime type check at the beginning of the function.

1. Add a type check to verify that `buf` is a `Buffer` using `Buffer.isBuffer(buf)`.
2. If the check fails, return the input unchanged or handle the error appropriately.
3. This change ensures that the function behaves predictably even if `buf` is tampered with.

---




#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
