### PR TITLE
Add warnings for Pinpoint categories

### DIFF
--- a/packages/amplify-category-analytics/src/commands/analytics/add.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/add.ts
@@ -17,7 +17,7 @@ export const run = async (context: $TSContext): Promise<$TSAny> => {
   const { amplify } = context;
   const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
-    It is recommended you use Kinesis for event collection and mobile analytics instead.`);
+    It is recommended you use Kinesis for event collection and mobile analytics instead.\n`);
 
   return amplify
     .serviceSelectionPrompt(context, category, servicesMetadata, 'Select an Analytics provider')

--- a/packages/amplify-category-analytics/src/commands/analytics/add.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/add.ts
@@ -16,6 +16,9 @@ let options: $TSAny;
 export const run = async (context: $TSContext): Promise<$TSAny> => {
   const { amplify } = context;
   const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+    It is recommended you use Kinesis for event collection and mobile analytics instead.`);
+
   return amplify
     .serviceSelectionPrompt(context, category, servicesMetadata, 'Select an Analytics provider')
     .then((result) => {

--- a/packages/amplify-category-analytics/src/commands/analytics/push.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/push.ts
@@ -13,7 +13,7 @@ export const run = async (context: $TSContext): Promise<$TSAny> => {
   const resourceName = parameters.first;
   context.amplify.constructExeInfo(context);
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
-      If you are using Pinpoint, we recommended you use Kinesis for event collection and mobile analytics instead.`);
+      If you are using Pinpoint, it is recommended you use Kinesis for event collection and mobile analytics instead.\n`);
   return amplify.pushResources(context, category, resourceName);
 };
 

--- a/packages/amplify-category-analytics/src/commands/analytics/push.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/push.ts
@@ -1,4 +1,5 @@
 import { $TSAny, $TSContext } from '@aws-amplify/amplify-cli-core';
+import { printer } from '@aws-amplify/amplify-prompts';
 
 const subcommand = 'push';
 const category = 'analytics';
@@ -11,6 +12,8 @@ export const run = async (context: $TSContext): Promise<$TSAny> => {
   const { amplify, parameters } = context;
   const resourceName = parameters.first;
   context.amplify.constructExeInfo(context);
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+      If you are using Pinpoint, we recommended you use Kinesis for event collection and mobile analytics instead.`);
   return amplify.pushResources(context, category, resourceName);
 };
 

--- a/packages/amplify-category-analytics/src/commands/analytics/update.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/update.ts
@@ -12,6 +12,8 @@ const category = 'analytics';
 export const run = async (context: $TSContext): Promise<$TSAny> => {
   const { amplify } = context;
   const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+    If you are using Pinpoint, we recommended you use Kinesis for event collection and mobile analytics instead.`);
 
   return amplify
     .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-category-analytics/src/commands/analytics/update.ts
+++ b/packages/amplify-category-analytics/src/commands/analytics/update.ts
@@ -13,7 +13,7 @@ export const run = async (context: $TSContext): Promise<$TSAny> => {
   const { amplify } = context;
   const servicesMetadata = amplify.readJsonFile(`${__dirname}/../../provider-utils/supported-services.json`);
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
-    If you are using Pinpoint, we recommended you use Kinesis for event collection and mobile analytics instead.`);
+    If you are using Pinpoint, it is recommended you use Kinesis for event collection and mobile analytics instead.\n`);
 
   return amplify
     .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-category-interactions/src/commands/interactions/push.js
+++ b/packages/amplify-category-interactions/src/commands/interactions/push.js
@@ -9,7 +9,7 @@ module.exports = {
     context.amplify.constructExeInfo(context);
     context.print
       .warning(`Amazon Lex V1 is reaching end of life on September 15, 2025 and no longer allows creation of new bots as of March 31, 2025. 
-      It is recommended that you migrate your bot to Amazon Lex V2 before September 15.`);
+      It is recommended that you migrate your bot to Amazon Lex V2 before September 15. \n`);
     return amplify.pushResources(context, category, resourceName).catch((err) => {
       context.print.info(err.stack);
       context.print.error('There was an error pushing the interactions resource');

--- a/packages/amplify-category-interactions/src/commands/interactions/push.js
+++ b/packages/amplify-category-interactions/src/commands/interactions/push.js
@@ -7,6 +7,9 @@ module.exports = {
     const { amplify, parameters } = context;
     const resourceName = parameters.first;
     context.amplify.constructExeInfo(context);
+    context.print
+      .warning(`Amazon Lex V1 is reaching end of life on September 15, 2025 and no longer allows creation of new bots as of March 31, 2025. 
+      It is recommended that you migrate your bot to Amazon Lex V2 before September 15.`);
     return amplify.pushResources(context, category, resourceName).catch((err) => {
       context.print.info(err.stack);
       context.print.error('There was an error pushing the interactions resource');

--- a/packages/amplify-category-interactions/src/commands/interactions/update.js
+++ b/packages/amplify-category-interactions/src/commands/interactions/update.js
@@ -7,6 +7,9 @@ module.exports = {
   alias: ['configure'],
   run: async (context) => {
     const { amplify } = context;
+    context.print
+      .warning(`Amazon Lex V1 is reaching end of life on September 15, 2025 and no longer allows creation of new bots as of March 31, 2025. 
+      It is recommended that you migrate your bot to Amazon Lex V2 before September 15.`);
 
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-category-interactions/src/commands/interactions/update.js
+++ b/packages/amplify-category-interactions/src/commands/interactions/update.js
@@ -9,7 +9,7 @@ module.exports = {
     const { amplify } = context;
     context.print
       .warning(`Amazon Lex V1 is reaching end of life on September 15, 2025 and no longer allows creation of new bots as of March 31, 2025. 
-      It is recommended that you migrate your bot to Amazon Lex V2 before September 15.`);
+      It is recommended that you migrate your bot to Amazon Lex V2 before September 15. \n`);
 
     return amplify
       .serviceSelectionPrompt(context, category, servicesMetadata)

--- a/packages/amplify-category-notifications/src/commands/notifications/add.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/add.ts
@@ -59,7 +59,7 @@ export const run = async (context: $TSContext): Promise<$TSContext> => {
 
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
     It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
-    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html \n`);
 
   const availableChannels: Array<string> = getAvailableChannels();
   const disabledChannels: Array<string> = await getDisabledChannelsFromAmplifyMeta();

--- a/packages/amplify-category-notifications/src/commands/notifications/add.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/add.ts
@@ -57,6 +57,10 @@ export const run = async (context: $TSContext): Promise<$TSContext> => {
     });
   }
 
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+    It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
+    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+
   const availableChannels: Array<string> = getAvailableChannels();
   const disabledChannels: Array<string> = await getDisabledChannelsFromAmplifyMeta();
 

--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -1,5 +1,5 @@
 import { $TSContext, AmplifyError } from '@aws-amplify/amplify-cli-core';
-import { prompter } from '@aws-amplify/amplify-prompts';
+import { prompter, printer } from '@aws-amplify/amplify-prompts';
 import * as pinpointHelper from '../../pinpoint-helper';
 import * as notificationManager from '../../notifications-manager';
 import { IChannelAPIResponse } from '../../channel-types';
@@ -25,6 +25,10 @@ export const alias = 'update';
  * @returns context with notifications metadata updated
  */
 export const run = async (context: $TSContext): Promise<$TSContext> => {
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+      It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
+      For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+
   const availableChannelViewNames = getAvailableChannelViewNames();
   let channelViewName = context.parameters.first ? getChannelViewName(context.parameters.first) : undefined;
 

--- a/packages/amplify-category-notifications/src/commands/notifications/configure.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/configure.ts
@@ -27,7 +27,7 @@ export const alias = 'update';
 export const run = async (context: $TSContext): Promise<$TSContext> => {
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
       It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
-      For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+      For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html \n`);
 
   const availableChannelViewNames = getAvailableChannelViewNames();
   let channelViewName = context.parameters.first ? getChannelViewName(context.parameters.first) : undefined;

--- a/packages/amplify-category-notifications/src/commands/notifications/status.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/status.ts
@@ -23,7 +23,7 @@ const viewStyles = {
 const getDeployedStyledStatus = (deployedChannel: string, deployedChannels: IChannelAvailability, configuredState: string): string => {
   printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
     It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
-    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html \n`);
 
   if (deployedChannels.enabledChannels.includes(deployedChannel)) {
     if (configuredState === 'Enabled') {

--- a/packages/amplify-category-notifications/src/commands/notifications/status.ts
+++ b/packages/amplify-category-notifications/src/commands/notifications/status.ts
@@ -21,6 +21,10 @@ const viewStyles = {
 };
 
 const getDeployedStyledStatus = (deployedChannel: string, deployedChannels: IChannelAvailability, configuredState: string): string => {
+  printer.warn(`Amazon Pinpoint is reaching end of life on October 30, 2026 and no longer accepts new customers as of May 20, 2025.
+    It is recommended you use use AWS End User Messaging for push notifications and SMS, Amazon Simple Email Service for sending emails, Amazon Connect for campaigns, journeys, endpoints, and engagement analytics.
+    For more information see: https://docs.aws.amazon.com/pinpoint/latest/userguide/migrate.html`);
+
   if (deployedChannels.enabledChannels.includes(deployedChannel)) {
     if (configuredState === 'Enabled') {
       return viewStyles.deployed('Deployed');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Pinpoint is reaching end of life on October 30,2026 and stop accepting new customers May 20, 2025. Currently Analytics and Notifications use Pinpoint and will become unusable after October 30, 2026. 
This PR adds warnings to commands in the notifications and analytics categories to warn customers about Pinpoint's looming end of life. 
Removing the ability to use Analytics with Pinpoint will be in a separate PR since it will involve a lot of e2e test changes (and may result in our notifications e2e tests no longer being functional).
Additionally, some warnings are added to interactions commands about Lex V1 reaching end of life. 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Ensured the warnings appeared when running the commands. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
