### PR TITLE
fix: Graphql API error message changed

### DIFF
--- a/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/api_3.test.ts
@@ -185,7 +185,7 @@ describe('amplify add api (GraphQL)', () => {
       await getAppSyncApi(GraphQLAPIIdOutput, meta.providers.awscloudformation.Region);
       expect(true).toBe(false); // expecting failure
     } catch (err) {
-      expect(err.message).toBe(`GraphQL API ${GraphQLAPIIdOutput} not found.`);
+      expect(err.message).toBe('API not found.');
     }
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
A Graphql API error message seems to have changed from `GraphQL API ${GraphQLAPIIdOutput} not found.` to `API not found.`. This started causing one of our e2e tests to fail, updated the expected error message. 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
