### PR TITLE
chore: Upgrade baseline python function version to 3.13

### DIFF
--- a/packages/amplify-e2e-tests/functions/titlecase.pipfile
+++ b/packages/amplify-e2e-tests/functions/titlecase.pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 titlecase = "==0.12.0"
 
 [requires]
-python_version = "3.8"
+python_version = "3.13"

--- a/packages/amplify-e2e-tests/src/__tests__/layer-2.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/layer-2.test.ts
@@ -371,13 +371,13 @@ describe('amplify add lambda layer with changes', () => {
     add python layer
     add files in opt
     push
-    remove lib/python3.8/site-packages (simulate gitignore),
+    remove lib/python3.13/site-packages (simulate gitignore),
     amplify status -> no change
     delete Pipfile.lock
     amplify status -> update
     push
     -> should not create layer version, (it should force a pip install),
-    lib/python3.8/site-packages should exist with content, push should succeed
+    lib/python3.13/site-packages should exist with content, push should succeed
   */
 
   it('add python layer, remove lock file, site-packages, verify status, push', async () => {
@@ -405,7 +405,7 @@ describe('amplify add lambda layer with changes', () => {
 
     const firstArn = getCurrentLayerArnFromMeta(projRoot, { layerName, projName });
 
-    // 1. Remove lib/python3.8/site-packages
+    // 1. Remove lib/python3.13/site-packages
     // 2. Check status: No Change
     const layerPath = path.join(
       projRoot,

--- a/packages/amplify-python-function-runtime-provider/resources/Pipfile
+++ b/packages/amplify-python-function-runtime-provider/resources/Pipfile
@@ -8,4 +8,4 @@ verify_ssl = true
 [packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.13"

--- a/packages/amplify-python-function-runtime-provider/src/index.ts
+++ b/packages/amplify-python-function-runtime-provider/src/index.ts
@@ -18,7 +18,7 @@ export const functionRuntimeContributorFactory: FunctionRuntimeContributorFactor
         runtime: {
           name: 'Python',
           value: 'python',
-          cloudTemplateValue: 'python3.8',
+          cloudTemplateValue: 'python3.13',
           defaultHandler: 'index.handler',
           layerExecutablePath: 'python',
           layerDefaultFiles: [

--- a/packages/amplify-python-function-template-provider/resources/hello-world/Pipfile
+++ b/packages/amplify-python-function-template-provider/resources/hello-world/Pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 src = {editable = true, path = "./src"}
 
 [requires]
-python_version = "3.8"
+python_version = "3.13"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Upgrades baseline python version used for the function category to 3.13. 
This should not affect existing customers, but new customers who create python lambda functions with amplify will be using 3.13 as a baseline version instead of 3.8. 

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
