### PR TITLE
fix: update throttling retry

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
+++ b/packages/amplify-provider-awscloudformation/src/iterative-deployment/stack-event-monitor.ts
@@ -146,7 +146,7 @@ export class StackEventMonitor {
       if (e.name === 'ValidationError' && e.message === `Stack [${this.stackName}] does not exist`) {
         return;
       }
-      if (e.name !== 'Throttling' || e.name === 'ThrottlingException') {
+      if (e.name !== 'Throttling') {
         throw new AmplifyFault(
           'NotImplementedFault',
           {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

AWS SDK V3 no longer has `retryable` as a property on the errors that are thrown when throttling happens. This lead to the custom retry configuration we had set up in `describeStacks` not properly activating, which caused an increase in throttling errors with customers who had large/complicated applications. 

#### Description of how you validated changes

Created a script that ran a large number (1000) of `describeStacks` operations and observed how it ran with and without the custom retry configuration set up. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
