### PR TITLE
fix: cli throws an error when `thirdPartyAuth` is enabled, but `authProvider` is not included

### DIFF
--- a/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
+++ b/packages/amplify-category-auth/src/__tests__/provider-utils/awscloudformation/index.test.ts
@@ -19,8 +19,41 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
 // mock fns
 const pluginInstanceMock = jest.fn();
 const loadResourceParametersMock = jest.fn().mockReturnValue({
-  hostedUIProviderMeta:
-    '[{"ProviderName":"Facebook","authorize_scopes":"email,public_profile","AttributeMapping":{"email":"email","username":"id"}},{"ProviderName":"LoginWithAmazon","authorize_scopes":"profile profile:user_id","AttributeMapping":{"email":"email","username":"user_id"}},{"ProviderName":"Google","authorize_scopes":"openid email profile","AttributeMapping":{"email":"email","username":"sub"}},{"ProviderName":"SignInWithApple","authorize_scopes":"openid email profile","AttributeMapping":{"email":"email","username":"sub"}}]',
+  thirdPartyAuth: true, // enable third party auth, but do not include any authProviders. Should not fail.
+  hostedUIProviderMeta: JSON.stringify([
+    {
+      ProviderName: 'Facebook',
+      authorize_scopes: 'email,public_profile',
+      AttributeMapping: {
+        email: 'email',
+        username: 'id',
+      },
+    },
+    {
+      ProviderName: 'LoginWithAmazon',
+      authorize_scopes: 'profile profile:user_id',
+      AttributeMapping: {
+        email: 'email',
+        username: 'user_id',
+      },
+    },
+    {
+      ProviderName: 'Google',
+      authorize_scopes: 'openid email profile',
+      AttributeMapping: {
+        email: 'email',
+        username: 'sub',
+      },
+    },
+    {
+      ProviderName: 'SignInWithApple',
+      authorize_scopes: 'openid email profile',
+      AttributeMapping: {
+        email: 'email',
+        username: 'sub',
+      },
+    },
+  ]),
 });
 const pluginInstance = {
   loadResourceParameters: loadResourceParametersMock,

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/index.ts
@@ -326,7 +326,8 @@ const getRequiredParamsForHeadlessInit = (projectType: any, previousValues: any)
   const requiredParams: string[] = [];
 
   if (previousValues.thirdPartyAuth) {
-    if (previousValues.authProviders.includes('accounts.google.com')) {
+    const authProviders = previousValues.authProviders ?? [];
+    if (authProviders.includes('accounts.google.com')) {
       requiredParams.push('googleClientId');
       if (projectType === 'ios') {
         requiredParams.push('googleIos');
@@ -335,14 +336,14 @@ const getRequiredParamsForHeadlessInit = (projectType: any, previousValues: any)
         requiredParams.push('googleAndroid');
       }
     }
-    if (previousValues.authProviders.includes('graph.facebook.com')) {
+    if (authProviders.includes('graph.facebook.com')) {
       requiredParams.push('facebookAppId');
     }
-    if (previousValues.authProviders.includes('www.amazon.com')) {
+    if (authProviders.includes('www.amazon.com')) {
       requiredParams.push('amazonAppId');
     }
     // eslint-disable-next-line spellcheck/spell-checker
-    if (previousValues.authProviders.includes('appleid.apple.com')) {
+    if (authProviders.includes('appleid.apple.com')) {
       requiredParams.push('appleAppId');
     }
   }


### PR DESCRIPTION
The function that loads the `awscloudformation` provider assumes that the `authProviders` property is present whenever `thirdPartyAuth` is present. This object comes from a user controlled file (`parameter.json` in the application resource dir), so there is no guarantee that this is true.

Default to an empty array if it's not present.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
