### PR TITLE
feat(gen2-migration): implement stateful resources validation for decommission command

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/decommission.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/decommission.ts
@@ -1,12 +1,25 @@
 import { AmplifyMigrationStep } from './_step';
 import { printer } from '@aws-amplify/amplify-prompts';
+import { AmplifyGen2MigrationValidations } from './_validations';
+import {
+  CloudFormationClient,
+  CreateChangeSetCommand,
+  DescribeChangeSetCommand,
+  DeleteChangeSetCommand,
+  DescribeChangeSetOutput,
+  waitUntilChangeSetCreateComplete,
+} from '@aws-sdk/client-cloudformation';
+import { stateManager } from '@aws-amplify/amplify-cli-core';
 
 export class AmplifyMigrationDecommissionStep extends AmplifyMigrationStep {
   readonly command = 'decommission';
-  readonly describe = 'Decommission Gen1 resources';
+  readonly describe = 'Decommission Gen1 resources after migration';
 
   public async validate(): Promise<void> {
-    printer.warn('Not implemented');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const validations = new AmplifyGen2MigrationValidations({} as any);
+    // eslint-disable-next-line spellcheck/spell-checker
+    await validations.validateStatefulResources(await this.createChangeSet());
   }
 
   public async execute(): Promise<void> {
@@ -15,5 +28,45 @@ export class AmplifyMigrationDecommissionStep extends AmplifyMigrationStep {
 
   public async rollback(): Promise<void> {
     printer.warn('Not implemented');
+  }
+
+  private async createChangeSet(): Promise<DescribeChangeSetOutput> {
+    const meta = stateManager.getMeta();
+    const stackName = meta.providers.awscloudformation.StackName;
+
+    const cfn = new CloudFormationClient({});
+    const changeSetName = `decommission-${Date.now()}`;
+
+    await cfn.send(
+      new CreateChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: changeSetName,
+        TemplateBody: JSON.stringify({
+          Resources: {
+            DummyResource: {
+              Type: 'AWS::CloudFormation::WaitConditionHandle',
+            },
+          },
+        }),
+      }),
+    );
+
+    await waitUntilChangeSetCreateComplete({ client: cfn, maxWaitTime: 120 }, { StackName: stackName, ChangeSetName: changeSetName });
+
+    const changeSet = await cfn.send(
+      new DescribeChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: changeSetName,
+      }),
+    );
+
+    await cfn.send(
+      new DeleteChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: changeSetName,
+      }),
+    );
+
+    return changeSet;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
---

This PR implements the `validate()` method for `decommission` command to ensure decommissioning won't accidentally delete stateful resources. The implementation uses CloudFormation change sets to preview what resources would be deleted during decommissioning without actually performing the deletion. The change set is created with an empty template ( { Resources: {} }), which simulates deleting all stack resources, allowing us to validate the impact before execution.

Flow:

1. Get Stack Name - Retrieves from stateManager.getMeta(). Stack name format is amplify-{appId}-{envName}, which CloudFormation uses as the unique identifier.
2. Create Change Set - Uses Date.now() for unique naming. Empty template simulates deleting all resources.
3. Wait for Completion - waitUntilChangeSetCreateComplete with maxWaitTime: 120 secs (SDK default) polls until CloudFormation computes all changes.
4. Describe & Store - Retrieves change set details into local variable for validation.
5. Cleanup - Deletes change set from AWS.

Lint Suppressions:
@typescript-eslint/no-explicit-any (line 17): validateStatefulResources() doesn't use context, so {} as any is acceptable.
spellcheck/spell-checker (line 19): "Stateful" is valid technical terminology.
 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->
PR #14297  

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
