### PR TITLE
feat(gen2-migration): add deployment status validation and unit tests for safe migrations

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_validations.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_validations.test.ts
@@ -1,8 +1,14 @@
 import { AmplifyGen2MigrationValidations } from '../../../commands/gen2-migration/_validations';
-import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, stateManager } from '@aws-amplify/amplify-cli-core';
 import { CloudFormationClient, DescribeChangeSetOutput } from '@aws-sdk/client-cloudformation';
 
 jest.mock('@aws-sdk/client-cloudformation');
+jest.mock('@aws-amplify/amplify-cli-core', () => ({
+  ...jest.requireActual('@aws-amplify/amplify-cli-core'),
+  stateManager: {
+    getMeta: jest.fn(),
+  },
+}));
 
 describe('AmplifyGen2MigrationValidations', () => {
   let mockContext: $TSContext;
@@ -488,6 +494,125 @@ describe('AmplifyGen2MigrationValidations', () => {
       await expect(validations.validateStatefulResources(changeSet)).rejects.toMatchObject({
         name: 'DestructiveMigrationError',
         message: expect.stringContaining('DirectTable'),
+      });
+    });
+  });
+
+  describe('validateDeploymentStatus', () => {
+    let mockSend: jest.Mock;
+
+    beforeEach(() => {
+      mockSend = jest.fn();
+      (CloudFormationClient as jest.Mock).mockImplementation(() => ({
+        send: mockSend,
+      }));
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw StackNotFoundError when stackName is missing', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {},
+        },
+      });
+
+      await expect(validations.validateDeploymentStatus()).rejects.toMatchObject({
+        name: 'StackNotFoundError',
+        message: 'Root stack not found',
+        resolution: 'Ensure the project is initialized and deployed.',
+      });
+    });
+
+    it('should throw StackNotFoundError when stack not found in CloudFormation', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValue({ Stacks: [] });
+
+      await expect(validations.validateDeploymentStatus()).rejects.toMatchObject({
+        name: 'StackNotFoundError',
+        message: 'Stack test-stack not found in CloudFormation',
+        resolution: 'Ensure the project is deployed.',
+      });
+    });
+
+    it('should pass when stack status is UPDATE_COMPLETE', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValue({
+        Stacks: [{ StackStatus: 'UPDATE_COMPLETE' }],
+      });
+
+      await expect(validations.validateDeploymentStatus()).resolves.not.toThrow();
+    });
+
+    it('should pass when stack status is CREATE_COMPLETE', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValue({
+        Stacks: [{ StackStatus: 'CREATE_COMPLETE' }],
+      });
+
+      await expect(validations.validateDeploymentStatus()).resolves.not.toThrow();
+    });
+
+    it('should throw StackStateError when status is UPDATE_IN_PROGRESS', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValue({
+        Stacks: [{ StackStatus: 'UPDATE_IN_PROGRESS' }],
+      });
+
+      await expect(validations.validateDeploymentStatus()).rejects.toMatchObject({
+        name: 'StackStateError',
+        message: 'Root stack status is UPDATE_IN_PROGRESS, expected UPDATE_COMPLETE or CREATE_COMPLETE',
+        resolution: 'Complete the deployment before proceeding.',
+      });
+    });
+
+    it('should throw StackStateError when status is ROLLBACK_COMPLETE', async () => {
+      jest.spyOn(stateManager, 'getMeta').mockReturnValue({
+        providers: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValue({
+        Stacks: [{ StackStatus: 'ROLLBACK_COMPLETE' }],
+      });
+
+      await expect(validations.validateDeploymentStatus()).rejects.toMatchObject({
+        name: 'StackStateError',
+        message: 'Root stack status is ROLLBACK_COMPLETE, expected UPDATE_COMPLETE or CREATE_COMPLETE',
+        resolution: 'Complete the deployment before proceeding.',
       });
     });
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR implements deployment status validation to ensure CloudFormation root stack for amplify app is in a stable state before proceeding with Gen 1 to Gen 2 migrations. The implementation adds a validateDeploymentStatus() method that queries the CloudFormation root stack status using AWS SDK v3 and validates that the stack exists and is in either CREATE_COMPLETE or UPDATE_COMPLETE state. When validation fails, it throws appropriate AmplifyError instances (StackNotFoundError or StackStateError) with clear messaging to guide users on resolution steps.
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Added unit tests covering multiple scenarios:
- Missing stack validation: Stack name not found in amplify-meta
- Stack not found in CloudFormation: Stack doesn't exist in AWS
- Valid stable states: CREATE_COMPLETE and UPDATE_COMPLETE statuses pass validation
- Invalid states: UPDATE_IN_PROGRESS and ROLLBACK_COMPLETE statuses throw errors

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
