### PR TITLE
feat(gen2-migration): implement clean working directory validation for gen2 migration

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
@@ -3,6 +3,7 @@ import { $TSContext, AmplifyError } from '@aws-amplify/amplify-cli-core';
 import { printer } from '@aws-amplify/amplify-prompts';
 import { DescribeChangeSetOutput } from '@aws-sdk/client-cloudformation';
 import { STATEFUL_RESOURCES } from './stateful-resources';
+import execa from 'execa';
 
 export class AmplifyGen2MigrationValidations {
   constructor(private readonly context: $TSContext) {}
@@ -12,7 +13,28 @@ export class AmplifyGen2MigrationValidations {
   }
 
   public async validateWorkingDirectory(): Promise<void> {
-    printer.warn('Not implemented');
+    const { stdout: statusOutput } = await execa('git', ['status', '--porcelain']);
+    if (statusOutput.trim()) {
+      throw new AmplifyError('MigrationError', {
+        message: 'Working directory has uncommitted changes',
+        resolution: 'Commit or stash your changes before proceeding with migration.',
+      });
+    }
+
+    try {
+      const { stdout: unpushedOutput } = await execa('git', ['log', '@{u}..', '--oneline']);
+      if (unpushedOutput.trim()) {
+        throw new AmplifyError('MigrationError', {
+          message: 'Local branch has unpushed commits',
+          resolution: 'Push your commits before proceeding with migration.',
+        });
+      }
+    } catch (err: any) {
+      if (err instanceof AmplifyError) throw err;
+      if (!err.message?.includes('no upstream') && !err.stderr?.includes('no upstream')) {
+        throw err;
+      }
+    }
   }
 
   public async validateDeploymentStatus(): Promise<void> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR implements working directory validation to ensure the git repository is in a clean state before proceeding with Gen 1 to Gen 2 migrations. The implementation adds a validateWorkingDirectory() method that uses execa to execute git commands, checking for uncommitted changes via git status --porcelain and unpushed commits via git log @{u}.. --oneline. When validation fails, it throws MigrationError with clear messaging to guide users on resolution steps. The implementation gracefully handles cases where no upstream branch is configured, allowing migrations to proceed in such scenarios.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
