### PR TITLE
feat: replace AmplifyHelpers.getProjectInfo().projectName with projectName

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-custom-resources/transformer/amplify-helper-transformer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-custom-resources/transformer/amplify-helper-transformer.ts
@@ -1,20 +1,27 @@
 import * as ts from 'typescript';
 
 export class AmplifyHelperTransformer {
-  static transform(sourceFile: ts.SourceFile): ts.SourceFile {
+  static transform(sourceFile: ts.SourceFile, projectName?: string): ts.SourceFile {
+    // Track variable names that hold AmplifyHelpers.getProjectInfo() result
+    const projectInfoVariables = new Set<string>();
+
     const transformer = <T extends ts.Node>(context: ts.TransformationContext) => {
       return (node: T) => {
         function visit(node: ts.Node): ts.Node {
+          // Remove AmplifyHelpers import statements
           if (ts.isImportDeclaration(node)) {
             const moduleSpecifier = node.moduleSpecifier;
             if (ts.isStringLiteral(moduleSpecifier) && moduleSpecifier.text === '@aws-amplify/cli-extensibility-helper') {
+              // Return undefined to remove this import
               return undefined;
             }
           }
 
+          // Transform cdk.Fn.ref('env') and Fn.ref('env') calls
           if (ts.isCallExpression(node)) {
             const expression = node.expression;
             if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.name) && expression.name.text === 'ref') {
+              // Check if it's cdk.Fn.ref or Fn.ref
               const isCdkFnRef =
                 ts.isPropertyAccessExpression(expression.expression) &&
                 ts.isIdentifier(expression.expression.expression) &&
@@ -35,8 +42,30 @@ export class AmplifyHelperTransformer {
             }
           }
 
+          // Track and remove variable statements assigned from AmplifyHelpers.getProjectInfo()
+          if (ts.isVariableStatement(node)) {
+            const declaration = node.declarationList.declarations[0];
+            if (
+              declaration &&
+              declaration.initializer &&
+              ts.isCallExpression(declaration.initializer) &&
+              ts.isPropertyAccessExpression(declaration.initializer.expression) &&
+              ts.isIdentifier(declaration.initializer.expression.expression) &&
+              declaration.initializer.expression.expression.text === 'AmplifyHelpers' &&
+              declaration.initializer.expression.name.text === 'getProjectInfo' &&
+              ts.isIdentifier(declaration.name)
+            ) {
+              projectInfoVariables.add(declaration.name.text);
+              // Remove this entire variable statement
+              return undefined;
+            }
+          }
+
+          // Transform property access to AmplifyHelpers.getProjectInfo().envName or .projectName
           if (ts.isPropertyAccessExpression(node)) {
             const expression = node.expression;
+
+            // Handle direct call: AmplifyHelpers.getProjectInfo().propertyName
             if (
               ts.isCallExpression(expression) &&
               ts.isPropertyAccessExpression(expression.expression) &&
@@ -48,6 +77,21 @@ export class AmplifyHelperTransformer {
 
               if (propertyName === 'envName') {
                 return ts.factory.createIdentifier('branchName');
+              }
+              if (propertyName === 'projectName') {
+                return ts.factory.createIdentifier('projectName');
+              }
+            }
+
+            // Handle variable access: amplifyProjectInfo.propertyName
+            if (ts.isIdentifier(expression) && projectInfoVariables.has(expression.text)) {
+              const propertyName = node.name.text;
+
+              if (propertyName === 'envName') {
+                return ts.factory.createIdentifier('branchName');
+              }
+              if (propertyName === 'projectName') {
+                return ts.factory.createIdentifier('projectName');
               }
             }
           }
@@ -62,12 +106,19 @@ export class AmplifyHelperTransformer {
     return result.transformed[0] as ts.SourceFile;
   }
 
-  static addBranchNameVariable(sourceFile: ts.SourceFile): ts.SourceFile {
+  static addBranchNameVariable(sourceFile: ts.SourceFile, projectName?: string): ts.SourceFile {
     // Check if branchName declaration already exists
     const hasBranchName = sourceFile.statements.some(
       (stmt) =>
         ts.isVariableStatement(stmt) &&
         stmt.declarationList.declarations.some((decl) => ts.isIdentifier(decl.name) && decl.name.text === 'branchName'),
+    );
+
+    // Check if projectName declaration already exists
+    const hasProjectName = sourceFile.statements.some(
+      (stmt) =>
+        ts.isVariableStatement(stmt) &&
+        stmt.declarationList.declarations.some((decl) => ts.isIdentifier(decl.name) && decl.name.text === 'projectName'),
     );
 
     // Create branchName declaration: const branchName = process.env.AWS_BRANCH ?? "sandbox";
@@ -93,22 +144,34 @@ export class AmplifyHelperTransformer {
       ),
     );
 
-    const newStatements = [];
-    let importsAdded = false;
+    // Create projectName declaration: const projectName = "project-name";
+    const projectNameDeclaration = projectName
+      ? ts.factory.createVariableStatement(
+          undefined,
+          ts.factory.createVariableDeclarationList(
+            [ts.factory.createVariableDeclaration('projectName', undefined, undefined, ts.factory.createStringLiteral(projectName))],
+            ts.NodeFlags.Const,
+          ),
+        )
+      : undefined;
 
-    for (const stmt of sourceFile.statements) {
-      if (ts.isImportDeclaration(stmt)) {
-        newStatements.push(stmt);
-      } else {
-        if (!importsAdded) {
-          if (!hasBranchName) {
-            newStatements.push(branchNameDeclaration);
-          }
-          importsAdded = true;
-        }
-        newStatements.push(stmt);
-      }
+    const newStatements = [];
+
+    // Add imports
+    newStatements.push(...sourceFile.statements.filter((stmt) => ts.isImportDeclaration(stmt)));
+
+    // Add branchName declaration if needed
+    if (!hasBranchName) {
+      newStatements.push(branchNameDeclaration);
     }
+
+    // Add projectName declaration if needed
+    if (!hasProjectName && projectNameDeclaration) {
+      newStatements.push(projectNameDeclaration);
+    }
+
+    // Add remaining statements (classes, etc.)
+    newStatements.push(...sourceFile.statements.filter((stmt) => !ts.isImportDeclaration(stmt)));
 
     return ts.factory.updateSourceFile(sourceFile, newStatements);
   }


### PR DESCRIPTION
Added support for transforming AmplifyHelpers.getProjectInfo().projectName from Gen1 to Gen2 during custom resource migration.

**1. amplify-helper-transformer.ts**
Enhanced the AST transformer to handle projectName transformations:

Added:

- Optional projectName parameter to transform() 

- Tracking of variables assigned from AmplifyHelpers.getProjectInfo()

- Removal of entire variable statements like const amplifyProjectInfo = AmplifyHelpers.getProjectInfo();

Transformations:

- AmplifyHelpers.getProjectInfo().projectName → projectName

- amplifyProjectInfo.projectName → projectName


**2. command-handlers.ts**
Integrated the transformer into the migration pipeline:

Added:

- Logic to read projectName from amplify/.config/project-config.json

- Passes projectName to transformer methods

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.