### PR TITLE
chore: add lock validation for refactor and generate commands

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/generate.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate.ts
@@ -1,9 +1,12 @@
 import { AmplifyMigrationStep } from './_step';
 import { prepare } from './codegen-generate/src/codegen-head/command-handlers';
+import { AmplifyGen2MigrationValidations } from './_validations';
 
 export class AmplifyMigrationGenerateStep extends AmplifyMigrationStep {
   public async validate(): Promise<void> {
-    // Validation logic can be added here if needed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const validations = new AmplifyGen2MigrationValidations({} as any);
+    await validations.validateLockStatus();
   }
 
   public async execute(): Promise<void> {

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor/refactor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor/refactor.ts
@@ -9,6 +9,7 @@ import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { SSMClient } from '@aws-sdk/client-ssm';
 import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { AmplifyGen2MigrationValidations } from '../_validations';
 
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { TemplateGenerator } from './generators/template-generator';
@@ -48,6 +49,10 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
 
       // Check prerequisites
       await this.checkPrerequisites();
+
+      // Validate lock status
+      const validations = new AmplifyGen2MigrationValidations(this.getContext());
+      await validations.validateLockStatus();
 
       // Process resource mappings if provided
       if (this.resourceMappings) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

This PR adds `validateLockStatus()` check to both `amplify gen2-migration generate` and `amplify gen2-migration refactor` commands to ensure the Gen1 stack is locked before executing these operations.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Manual verification following the `amplify gen2-migration lock` command.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
