### PR TITLE
chore: dry run release workflow for the `gen2-migration` branch

### DIFF
--- a/.github/workflows/release-gen2-migration.yml
+++ b/.github/workflows/release-gen2-migration.yml
@@ -10,13 +10,13 @@ jobs:
         with:
           ref: gen2-migration
       - run: |
-           yarn install
-           yarn build
-           cd packages/amplify-cli
-           package_name="@aws-amplify/cli-internal-gen2-migration-alpha"
-           latest_version=$(npm view ${package_name} version 2>/dev/null || echo "0.0.0")
-           new_version=$(npx semver --increment minor ${latest_version})
-           npm version ${new_version} --no-workspace-update --no-commit-hooks --no-git-tag-version --no-workspaces
-           npm pkg set name=${package_name}
-           npm pack
-           NPM_TRUSTED_PUBLISHER=true npm publish --dry-run
+          yarn install
+          yarn build
+          cd packages/amplify-cli
+          package_name="@aws-amplify/cli-internal-gen2-migration-alpha"
+          latest_version=$(npm view ${package_name} version 2>/dev/null || echo "0.0.0")
+          new_version=$(npx semver --increment minor ${latest_version})
+          npm version ${new_version} --no-workspace-update --no-commit-hooks --no-git-tag-version --no-workspaces
+          npm pkg set name=${package_name}
+          npm pack
+          NPM_TRUSTED_PUBLISHER=true npm publish --dry-run


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Added a GitHub workflow that builds the `@aws-amplify/cli-internal` package in the `gen2-migration` branch and publishes it to NPM.

- Publish under a new package name so we don't collide with the regular package release: `@aws-amplify/cli-internal-gen2-migration-alpha`
- Give the package an `-alpha` suffix and a `0.x` version since it is experimental.

**Currently the workflow only performs a dry-run; once we see the expected result we will remove the `dry-run` option.**

The publishing itself will leverage NPM trusted publishing after an initial manual release with a token.

#### Why not release the `@aws-amplify/cli` package?

The [@aws-amplify/cli](https://github.com/aws-amplify/amplify-cli/tree/dev/packages/amplify-cli-npm) package is a wrapper on top of [@aws-amplify/cli-internal](https://github.com/aws-amplify/amplify-cli/tree/dev/packages/amplify-cli) that dynamically installs an amplify binary based on the operating system of the user.

Those binaries are built and published via the standard CLI release process, which we currently would like to avoid. The consequence of this is creating a standard NPM package with many dependencies - instead of a bundled executable binary. For the purposes of this experimental release - this is ok.

Note that contrary to what the name suggests, the `@aws-amplify/cli-internal` is actually public and [already published to NPM](https://www.npmjs.com/package/@aws-amplify/cli-internal), so we are not publishing anything we don't already publish.

#### Description of how you validated changes

Manually executed the steps locally on a clean clone of the repo.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
