### PR TITLE
fix(gen2-migration): bugs in template generator tests

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/generators/setup-jest.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/generators/setup-jest.ts
@@ -1,6 +1,14 @@
-import { expect } from '@jest/globals';
 import { toBeACloudFormationCommand } from './custom-test-matchers';
 import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
+
+// Mock AWS SDK config loading
+jest.mock('@smithy/shared-ini-file-loader', () => ({
+  loadSharedConfigFiles: jest.fn().mockResolvedValue({
+    configFile: { default: {} },
+    credentialsFile: { default: {} },
+  }),
+  getProfileName: jest.fn().mockReturnValue('default'),
+}));
 
 expect.extend({
   toBeACloudFormationCommand,


### PR DESCRIPTION

## Issue 
This PR solves bugs in the `template-generator.test.ts` file by fixing Jest custom matcher type compatibility and adding proper AWS SDK configuration mocking.

The `template-generator.test.ts` file was failing with two errorss:

1. **TypeScript Error**: Custom Jest matcher `toBeACloudFormationCommand` was not recognized
2. **Runtime Error**: AWS SDK configuration loading failures in test environment



The root causes were:
- Type mismatch between `@jest/globals` imports and legacy Jest matcher declarations
- Missing AWS SDK configuration mocks causing the SDK to attempt reading actual config files during tests


### Changes Made
- Modified `setup-jest.ts` to remove `@jest/globals` import
- Added AWS SDK config mocking
- Ensured test isolation from host system AWS configuration
