### PR TITLE
feat(gen2-migration): throw error for non-Node.js functions during migration

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
@@ -204,7 +204,12 @@ export const createGen2Renderer = ({
   if (functions && functions.length) {
     const functionNamesAndCategory = new Map<string, string>();
     for (const func of functions) {
-      if (func.name && func.runtime?.startsWith('nodejs')) {
+      if (func.name) {
+        if (!func.runtime?.startsWith('nodejs')) {
+          throw new Error(
+            `Function '${func.name}' uses unsupported runtime '${func.runtime}'. Gen 2 migration only supports Node.js functions.`,
+          );
+        }
         const resourceName = func.resourceName;
         assert(resourceName);
         const funcCategory = func.category;


### PR DESCRIPTION
The `generate` command was attempting to process all Lambda functions regardless of runtime. This pr adds runtime filtering to the Gen 2 migration tool to only process Node.js Lambda functions and throw error on the others. This is because the Gen 2 `defineFunction()` amplify api currently only supports Node.js runtimes.
