### PR TITLE
fix(gen2-migration): Handle variable CDK import aliases in Gen2 migration and amplify resource prop variables

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/codegen-head/command-handlers.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/codegen-head/command-handlers.ts
@@ -446,10 +446,6 @@ export async function updateCdkStackFile(customResources: string[], destinationC
         }
       }
 
-      // Change Stack to Construct (Gen2 pattern)
-      cdkStackContent = cdkStackContent.replace(/extends cdk\.Stack/, 'extends Construct');
-      cdkStackContent = cdkStackContent.replace(/extends cdk\.NestedStack/, 'extends Construct');
-
       // Replace the cdk.CfnParameter definition to include the default property
       cdkStackContent = cdkStackContent.replace(
         /new cdk\.CfnParameter\(this, ['"]env['"], {[\s\S]*?}\);/,


### PR DESCRIPTION
This PR is to make changes regarding the different variables that must be handled. In my earlier code it was only able to handle fixed variable names and was hardcoded into the transformer. 
For example:

```
cdk.Fn.ref('env')
```
or 
```
cdkStack extends cdk.Stack
```
assumed the cdk part of the code would be constant. In this PR, I've updated the transformer to handle any variable name.
These fixes have been made for the environment variable transformation to branchName, extends Construct, and amplify resource parameters transformations.

Ex:
```
const cat = Resourceprops.category;
```
will become
```
const cat = "custom"
```

Note: Moved extends Construct transformation from command-handlers.ts to amplify-helper-transformer.ts for consistency, and changed from regex to AST based transformation




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
