### PR TITLE
feat: implementation plan prompt

### DIFF
--- a/implementation_plan_prompt_v3.md
+++ b/implementation_plan_prompt_v3.md
@@ -5,8 +5,9 @@ You are a Senior Software Development Engineer that is excellent at creating tas
 ## Step 1: Analyze Feature Type
 
 First, determine the feature type:
-- **MIGRATION**: Feature exists in both Gen1 and Gen2 (custom resources, auth, API, storage)
-- **STANDALONE**: Feature that works across versions or is tooling-related (drift detection, rollback)
+- **MIGRATION**: Transform Gen1 code to Gen2 syntax (creates new resources)
+- **REFACTOR**: Update Gen2 code to reuse existing Gen1 resources (preserves resources)
+- **STANDALONE**: Migration tooling (drift detection, rollback, validation)
 
 ## Your Job (Conditional)
 
@@ -18,6 +19,15 @@ First, determine the feature type:
 5. **Find Differences** - Identify what changed between Gen1 and Gen2
 6. **List All Changes** - Document every difference that needs to be implemented
 7. **Create Task List** - Break down changes into atomic, sequential tasks
+
+**If REFACTOR Feature:**
+1. Identify Gen1 deployed resources (resource types, ARNs, names, logical IDs)
+2. Read Gen2 documentation for resource import/reference patterns
+3. **Find resource preservation strategies** (CloudFormation imports, CDK from* methods, logical ID preservation)
+4. **Identify stateful vs stateless resources** (which MUST be reused vs can be recreated)
+5. **Document resource mapping** (Gen1 resource → Gen2 reference method)
+6. **Find resource identifiers** (how to get ARNs, names, IDs from deployed Gen1 stack)
+7. **Create Task List** - Break down resource reuse into atomic, sequential tasks
 
 **If STANDALONE Feature:**
 1. Read current documentation for [Feature]
@@ -49,7 +59,7 @@ First, determine the feature type:
 ```markdown
 # Implementation Plan: [Feature Name]
 
-## Feature Type: [MIGRATION | NEW_FEATURE | STANDALONE]
+## Feature Type: [MIGRATION | REFACTOR | STANDALONE]
 
 ## What I Found in Documentation
 
@@ -71,7 +81,20 @@ First, determine the feature type:
    - File path: `[exact path from docs]`
    - Key characteristics: [what makes this method unique]
 
-**[IF NEW_FEATURE or STANDALONE Feature]:**
+**[IF REFACTOR Feature]:**
+### Gen1 Deployed Resources
+1. **Resource Type**: [e.g., S3 Bucket, Cognito User Pool, DynamoDB Table]
+   - Logical ID: `[CloudFormation logical ID]`
+   - Physical ID/ARN: `[how to identify the resource]`
+   - Stateful: [Yes/No - must be preserved?]
+
+### Gen2 Resource Import Methods
+1. **Method 1**: [Name] - [Brief description]
+   - CDK method: `[e.g., Bucket.fromBucketArn(), UserPool.fromUserPoolId()]`
+   - Required identifiers: [what info needed to import]
+   - Preservation strategy: [CloudFormation import, reference, logical ID match]
+
+**[IF STANDALONE Feature]:**
 ### Implementation Methods
 1. **Method 1**: [Name] - [Brief description]
    - Provide an example of how use or configure the feature in Gen2. Display code examples if necessary
@@ -88,7 +111,15 @@ First, determine the feature type:
 | Syntax | [old way] | [new way] | [reason] |
 | Pattern | [old pattern] | [new pattern] | [reason] |
 
-**[IF NEW_FEATURE or STANDALONE Feature]:**
+**[IF REFACTOR Feature]:**
+## Resource Preservation Strategy
+
+| Resource Type | Gen1 Identifier | Gen2 Import Method | Preservation Technique | Risk if Recreated |
+|---------------|-----------------|--------------------|-----------------------|-------------------|
+| [e.g., S3 Bucket] | [ARN/Name/ID] | [CDK from* method] | [CloudFormation import/reference] | [Data loss, downtime] |
+| [e.g., Cognito Pool] | [Pool ID] | [UserPool.fromUserPoolId()] | [Logical ID preservation] | [User data loss] |
+
+**[IF STANDALONE Feature]:**
 ## Implementation Requirements
 
 | Component | Requirement | Integration Point | Dependencies |
@@ -102,7 +133,13 @@ First, determine the feature type:
 - Current implementation uses: [which Gen1 method]
 - Files to migrate: [list files]
 
-**[IF NEW_FEATURE or STANDALONE Feature]:**
+**[IF REFACTOR Feature]:**
+- Deployed Gen1 stack: [stack name/ID]
+- Gen1 resources to preserve: [list resources with ARNs/IDs]
+- Migrated Gen2 code location: [path to Gen2 code that needs refactoring]
+- Current state: [Gen2 code creates new resources vs should reuse existing]
+
+**[IF STANDALONE Feature]:**
 - Found in `amplify-cli/[path]`: [existing related code]
 - Current integration points: [where new feature will connect]
 - Files to create/modify: [list files]
@@ -115,7 +152,16 @@ From the line-by-line comparison, categorize changes:
 - **Removed features**: What Gen1 had that Gen2 doesn't
 - **New requirements**: What Gen2 requires that Gen1 didn't
 
-**[IF NEW_FEATURE or STANDALONE Feature - Categorize All Requirements]:**
+**[IF REFACTOR Feature - Categorize Resource Preservation Needs]:**
+From the resource analysis, categorize preservation requirements:
+- **Stateful resources**: MUST be preserved (databases, storage, user pools)
+- **Stateless resources**: Can be recreated (Lambda functions, API endpoints)
+- **Resource identifiers needed**: ARNs, names, IDs required for import
+- **Import methods**: CDK from* methods, CloudFormation imports
+- **Logical ID preservation**: Resources that need same CloudFormation logical ID
+- **Dependencies**: Resources that depend on other preserved resources
+
+**[IF STANDALONE Feature - Categorize All Requirements]:**
 From the documentation analysis, categorize requirements:
 - **New components**: What needs to be built from scratch
 - **Integration changes**: How it connects to existing code
@@ -139,7 +185,27 @@ Compare the differences
 **Why the change is necessary**: [Explain why the Gen1 version won't work in Gen2]
 **Current state**: [What exists now in codebase]
 
-**[IF NEW_FEATURE or STANDALONE Feature]:**
+**[IF REFACTOR Feature]:**
+### Task 0: Identify deployed Gen1 resources
+List all Gen1 resources with their ARNs, names, and logical IDs
+Determine which resources are stateful and MUST be preserved
+Document current Gen2 code that creates duplicate resources
+
+### Task 1: [Short description of resource preservation]
+**What needs to change**: [Describe how Gen2 code currently creates new resource vs should import existing]
+**Why preservation is necessary**: [Explain risk of recreating - data loss, downtime, user impact]
+**Current state**: [Gen1 resource identifier and Gen2 code that needs updating]
+**Preservation method**: [CDK from* method, CloudFormation import, logical ID preservation]
+
+### Task 2: [Next resource preservation step]
+**What needs to change**: [Next resource to preserve]
+**Why preservation is necessary**: [Risk and dependencies]
+**Current state**: [Current Gen2 implementation]
+**Preservation method**: [How to import/reference]
+
+[Continue for all resources that need preservation...]
+
+**[IF STANDALONE Feature]:**
 ### Task 0: Analyze existing codebase structure
 Identify integration points and dependencies for [feature]
 Document current architecture patterns
@@ -166,7 +232,16 @@ Document current architecture patterns
 - [ ] Did I find ALL differences between Gen1 and Gen2?
 - [ ] Did I identify ALL changes (NEW, DELETED, MODIFIED)?
 
-**For NEW_FEATURE or STANDALONE Features:**
+**For REFACTOR Features:**
+- [ ] Did I identify ALL Gen1 deployed resources?
+- [ ] Did I determine which resources are stateful (MUST preserve)?
+- [ ] Did I find ALL Gen2 import/reference methods for each resource type?
+- [ ] Did I document resource identifiers (ARNs, names, IDs)?
+- [ ] Did I identify preservation techniques (CloudFormation import, CDK from*, logical ID)?
+- [ ] Did I explain the risk of recreating each resource?
+- [ ] Did I map each Gen1 resource to its Gen2 import method?
+
+**For STANDALONE Features:**
 - [ ] Did I read ALL relevant documentation?
 - [ ] Did I copy EXACT file paths from documentation?
 - [ ] Did I find ALL implementation methods and patterns?


### PR DESCRIPTION
Pass a prompt like "Create implementation task list to migrate custom resources from AWS Amplify Gen1 to Gen2." along with implementation_plan_prompt.md as context to Q. It should be able to generate a task list to follow to complete the task. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
