### PR TITLE
feat(gen2-migration): merge Gen 1 function dependencies into Gen 2 package.json during migration

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
@@ -129,7 +129,7 @@ const extractGen1FunctionDependencies = async (
 };
 
 /**
- * Merges dependencies from all Gen 1 functions
+ * Merges dependencies from all Gen 1 functions, selecting highest version for conflicts
  * @param functions - Array of function definitions
  * @returns Combined dependencies and devDependencies
  */
@@ -139,11 +139,19 @@ const mergeAllFunctionDependencies = async (
   const functionDeps: Record<string, string> = {};
   const functionDevDeps: Record<string, string> = {};
 
+  const mergeWithHighestVersion = (target: Record<string, string>, source: Record<string, string>) => {
+    for (const [pkg, version] of Object.entries(source)) {
+      if (!target[pkg] || version > target[pkg]) {
+        target[pkg] = version;
+      }
+    }
+  };
+
   for (const func of functions) {
     if (func.resourceName) {
       const deps = await extractGen1FunctionDependencies(func.resourceName);
-      Object.assign(functionDeps, deps.dependencies || {});
-      Object.assign(functionDevDeps, deps.devDependencies || {});
+      mergeWithHighestVersion(functionDeps, deps.dependencies || {});
+      mergeWithHighestVersion(functionDevDeps, deps.devDependencies || {});
     }
   }
 


### PR DESCRIPTION
This PR enables functionality to automatically extract and merge dependencies from all Gen 1 Lambda function `package.json` files into the generated Gen 2 project `package.json` 

**_NOTE:_** In the case where we have two lambda functions which rely on a conflicting and incompatible version dependencies, the lambda requiring the older dependency may break. This is due to the inherent limitations introduced in gen2 by unifying dependencies to one package.json.

### Example
**Before:** Gen 2 migration would lose function dependencies
```json
// Gen 1 function package.json
{
  "dependencies": {
    "lodash": "^4.17.0",
    "axios": "^1.0.0"
  }
}

// Generated Gen 2 package.json (missing function deps)
{
  "name": "my-gen2-app",
  "dependencies": {},
  "devDependencies": {
    "@aws-amplify/backend": "^1.18.0"
  }
}
```

**After:**
```json
// Generated Gen 2 package.json (includes function deps)
{
  "name": "my-gen2-app", 
  "dependencies": {
    "lodash": "^4.17.0",
    "axios": "^1.0.0"
  },
  "devDependencies": {
    "@aws-amplify/backend": "^1.18.0"
  }
}
```