### PR TITLE
fix(gen2-migration): phase 3 output fix for no drift case 

### DIFF
--- a/packages/amplify-cli/src/commands/drift-detection/services/drift-formatter.ts
+++ b/packages/amplify-cli/src/commands/drift-detection/services/drift-formatter.ts
@@ -944,6 +944,12 @@ export class DriftFormatter {
       return output;
     }
 
+    // Check if there are any local changes
+    if (this.phase3Results.totalDrifted === 0) {
+      output += `└── Status: ${chalk.green('NO DRIFT DETECTED')}\n`;
+      return output;
+    }
+
     // Group resources by category for structured display (including no-drift categories)
     const categoryGroups = this.groupPhase3ResourcesByCategory();
     const allCategories = this.getAllCategoriesForPhase3(categoryGroups);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Display NO DRIFT DETECTED when driftcount is 0 for phase 3 by adding this case to drift-formatter.ts

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

