### PR TITLE
feat: adding kiro mcp config

### DIFF
--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -24,8 +24,7 @@
             "args": [
                 "mcp-proxy-for-aws@latest",
                 "https://aws-mcp.us-east-1.api.aws/mcp",
-                "--metadata",
-                "AWS_REGION=us-east-1"
+                "--metadata"
             ],
             "disabled": false,
             "autoApprove": [


### PR DESCRIPTION
MCP config for Kiro. Current enabled MCPs are AWS MCP and AWS IAC MCP.
These are the docs used for reference:
AWS MCP User guide - https://docs.aws.amazon.com/aws-mcp/latest/userguide/getting-started-aws-mcp-server.html
AWS MCP Servers github - https://github.com/awslabs/mcp?tab=readme-ov-file
AWS IAC MCP Documentation - https://awslabs.github.io/mcp/servers/aws-iac-mcp-server
AWS IAC MCP github - https://github.com/awslabs/mcp/tree/main/src/aws-iac-mcp-server

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
