### PR TITLE
fix(gen2-migration): TypeError in custom resource error handling

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/codegen-head/command-handlers.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/codegen-head/command-handlers.ts
@@ -465,7 +465,7 @@ export async function updateCdkStackFile(customResources: string[], destinationC
 
       await fs.writeFile(cdkStackFilePath, cdkStackContent, { encoding: 'utf-8' });
     } catch (error) {
-      throw error(`Error updating the custom resource ${resource}`);
+      throw new Error(`Error updating the custom resource ${resource}`, { cause: error });
     }
   }
 }


### PR DESCRIPTION
Fixed a bug in updateCdkStackFile where the caught error
object was being invoked as a function (throw error(...)) instead of
being properly thrown as an Error object. This would cause a
TypeError at runtime whenever an error occurred in the try block,
masking the original error and making debugging extremely difficult.

Changed from:
throw error(\`Error updating the custom resource \${resource}\`)

To:
throw new Error(\`Error updating the custom resource \${resource}\`,
{ cause: error })

The new implementation properly creates an Error object with a
descriptive message and preserves the original error as the cause,
following modern JavaScript error handling best practices.

Testing: Verified the fix compiles without TypeScript errors and the
build completes successfully.

---
Prompt: Fix this: Runtime TypeError: error Called as Function Instead of
Thrown as Object in command-handlers.ts. The caught error object is being invoked as a
function with error(...) which will throw a TypeError at runtime
whenever an error occurs in the try block, masking the original error
and causing confusing failures.