### PR TITLE
fix(gen2-migration): function entry is not configured correctly

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/codegen-generate/src/adapters/functions/index.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/codegen-generate/src/adapters/functions/index.test.ts
@@ -1,0 +1,57 @@
+import { getFunctionDefinition } from '../../../../../../../../src/commands/gen2-migration/codegen-generate/src/adapters/functions/index';
+
+describe('getFunctionDefinition', () => {
+  test('entry defaults to ./index.js', () => {
+    const definition = getFunctionDefinition(
+      [
+        {
+          Handler: undefined,
+          FunctionName: 'MyFunc',
+        },
+      ],
+      [],
+      new Map(),
+      {
+        function: {
+          MyFunc: {
+            service: 'Lambda',
+            providerPlugin: 'awscloudformation',
+            output: {
+              Name: 'MyFunc',
+            },
+          },
+        },
+      },
+    );
+
+    expect(definition.length).toEqual(1);
+    expect(definition[0].entry).toEqual('./index.js');
+  });
+
+  test('entry is derived from Handler', () => {
+    const definition = getFunctionDefinition(
+      [
+        {
+          Handler: 'index.handler',
+          FunctionName: 'MyFunc',
+        },
+      ],
+      [],
+      new Map(),
+      {
+        function: {
+          MyFunc: {
+            service: 'Lambda',
+            providerPlugin: 'awscloudformation',
+            output: {
+              Name: 'MyFunc',
+            },
+          },
+        },
+      },
+    );
+
+    expect(definition.length).toEqual(1);
+    expect(definition[0].entry).toEqual('./index.js');
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/adapters/functions/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/adapters/functions/index.ts
@@ -17,6 +17,27 @@ export type AmplifyMetaWithFunction = {
   function: Record<string, AmplifyMetaFunction>;
 };
 
+/**
+ * Extracts the file path from an AWS Lambda handler string.
+ * Converts handler strings like "index.handler" or "src/handler.myFunction"
+ * to file paths like "./index.js" or "./src/handler.js".
+ *
+ * @param handler - The AWS Lambda handler string (e.g., "index.handler", "src/handler.myFunction")
+ * @returns The file path with .js extension (e.g., "./index.js", "./src/handler.js")
+ */
+const extractFilePathFromHandler = (handler: string): string => {
+  // Split on the last dot to separate file path from function name
+  const lastDotIndex = handler.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    // No dot found, treat the whole string as the file path
+    return `./${handler}.js`;
+  }
+
+  // Extract the file path part (everything before the last dot)
+  const filePath = handler.substring(0, lastDotIndex);
+  return `./${filePath}.js`;
+};
+
 export const getFunctionDefinition = (
   functionConfigurations: FunctionConfiguration[],
   functionSchedules: FunctionSchedule[],
@@ -27,7 +48,7 @@ export const getFunctionDefinition = (
 
   for (const configuration of functionConfigurations) {
     const funcDef: FunctionDefinition = {};
-    funcDef.entry = configuration?.Handler;
+    funcDef.entry = extractFilePathFromHandler(configuration?.Handler ?? 'index.js');
     funcDef.name = configuration?.FunctionName;
     funcDef.timeoutSeconds = configuration?.Timeout;
     funcDef.memoryMB = configuration?.MemorySize;


### PR DESCRIPTION
#### Description of changes

> _AI Assisted with Kiro_

Currently, functions are being generated like so:

```ts
export const quotegenerator = defineFunction({
    entry: "index.handler",
    ...
});
```

However, `index.handler` is not a valid value for the `entry` property. Deployment causes the following error:

```console
5:53:39 PM [ERROR] [BackendBuildError] Unable to deploy due to CDK Assembly Error
  ∟ Caused by: [AssemblyError] Assembly builder failed
    ∟ Caused by: [NodeJSFunctionConstructInitializationError] Failed to instantiate nodejs function construct
      ∟ Caused by: [ValidationError] Only JavaScript or TypeScript entry files are supported.
```

Instead, it should point to the handler file, i.e `./index.js`. 

```ts
export const quotegenerator = defineFunction({
    entry: "./index.js",
    ...
});
```

Where `index.js` is the file we copied over from Gen1. This PR adds a function that derives the correct value of `entry` property from the function's raw `Handler` property.

#### Description of how you validated changes

Added unit tess

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
