### PR TITLE
fix(gen2-migration): drift detection summary table is malformed

### DIFF
--- a/packages/amplify-cli/src/commands/drift.ts
+++ b/packages/amplify-cli/src/commands/drift.ts
@@ -242,71 +242,71 @@ export class AmplifyDriftDetector {
 
     if (options.format === 'json') {
       const simplifiedJson = this.formatter.createSimplifiedJsonOutput();
-      this.printer.info(JSON.stringify(simplifiedJson, null, 2));
+      printer.info(JSON.stringify(simplifiedJson, null, 2));
     } else if (options.format === 'summary') {
       const output = this.formatter.formatDrift('summary');
-      this.printer.info(output.summaryDashboard);
+      printer.info(output.summaryDashboard);
       if (output.categoryBreakdown) {
-        this.printer.info(output.categoryBreakdown);
+        printer.info(output.categoryBreakdown);
       }
 
       // Display Phase 2 results (between AMPLIFY CATEGORIES and LOCAL CHANGES)
       const phase2Output = this.formatter.formatPhase2Results();
       if (phase2Output) {
-        this.printer.info(phase2Output);
+        printer.info(phase2Output);
       }
 
       // Display Phase 3 results
       const phase3Output = this.formatter.formatPhase3Results();
       if (phase3Output) {
-        this.printer.info(phase3Output);
+        printer.info(phase3Output);
       }
     } else if (options.format === 'tree') {
       const output = this.formatter.formatDrift('tree');
-      this.printer.info(output.summaryDashboard);
+      printer.info(output.summaryDashboard);
       if (output.treeView) {
-        this.printer.info(output.treeView);
+        printer.info(output.treeView);
       }
 
       // Display detailed changes for drifted resources
       if (output.detailedChanges) {
-        this.printer.info(output.detailedChanges);
+        printer.info(output.detailedChanges);
       }
 
       if (options.debug && output.categoryBreakdown) {
-        this.printer.info(output.categoryBreakdown);
+        printer.info(output.categoryBreakdown);
       }
 
       // Display Phase 2 results (between AMPLIFY CATEGORIES and LOCAL CHANGES)
       const phase2Output = this.formatter.formatPhase2Results();
       if (phase2Output) {
-        this.printer.info(phase2Output);
+        printer.info(phase2Output);
       }
 
       // Display Phase 3 results
       const phase3Output = this.formatter.formatPhase3Results();
       if (phase3Output) {
-        this.printer.info(phase3Output);
+        printer.info(phase3Output);
       }
     } else {
       // This shouldn't happen with TypeScript, but handle gracefully
-      this.printer.warn(`Unknown format: ${options.format}. Using summary format.`);
+      printer.warn(`Unknown format: ${options.format}. Using summary format.`);
       const output = this.formatter.formatDrift('summary');
-      this.printer.info(output.summaryDashboard);
+      printer.info(output.summaryDashboard);
       if (output.categoryBreakdown) {
-        this.printer.info(output.categoryBreakdown);
+        printer.info(output.categoryBreakdown);
       }
 
       // Display Phase 2 results (between AMPLIFY CATEGORIES and LOCAL CHANGES)
       const phase2Output = this.formatter.formatPhase2Results();
       if (phase2Output) {
-        this.printer.info(phase2Output);
+        printer.info(phase2Output);
       }
 
       // Display Phase 3 results
       const phase3Output = this.formatter.formatPhase3Results();
       if (phase3Output) {
-        this.printer.info(phase3Output);
+        printer.info(phase3Output);
       }
     }
   }


### PR DESCRIPTION
#### Description of changes

The table showing drift detection result is somewhat malformed right now:

```console
[2025-12-29T23:18:54.577Z] [lock] [projectboards/main] • Drift detection completed

[2025-12-29T23:18:55.140Z] [lock] [projectboards/main] • ┌─────────────────────────────────────────────────────────────┐
│                   DRIFT DETECTION SUMMARY                   │
├─────────────────────────────────────────────────────────────┤
│ Project: projectboards                                      │
│ Total Stacks Checked: 10                                    │
│ Resources with Drift: 0                                     │
│ Resources in Sync: 74                                       │
│ Unchecked Resources: 26                                     │
└─────────────────────────────────────────────────────────────┘
[2025-12-29T23:18:55.141Z] [lock] [projectboards/main] • 
STACK HIERARCHY:
```

Notice how the table drawing starts with our common log prefix, which messes things up. There are also empty log lines caused because of it. 

This PR removes the usage of the common logger when printing the table in favor of the standard print function, which doesn't add the problematic prefix. Not the elegant of ways, but will do for now.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Manually ran drift detection on an app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
