### PR TITLE
fix(gen2-migration): graphql additional auth providers escape hatch compilation error

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/backend/synthesizer.ts
@@ -1089,7 +1089,7 @@ export class BackendSynthesizer {
     // Additional auth providers for GraphQL API
     if (renderArgs.data?.additionalAuthProviders && renderArgs.auth) {
       const cfnGraphQLApiVariableStatement = this.createVariableStatement(
-        this.createVariableDeclaration('cfnGraphQLApi', 'data.resources.cfnResources.cfnGraphQLApi'),
+        this.createVariableDeclaration('cfnGraphQLApi', 'data.resources.cfnResources.cfnGraphqlApi'),
       );
       nodes.push(cfnGraphQLApiVariableStatement);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The escape that is currently being generated has a compilation error:

```ts
backend.data.resources.cfnResources.cfnGraphQLApi
```

```console
Expected an assignment or function call and instead saw an expression.eslint[@typescript-eslint/no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions)
Property 'cfnGraphQLApi' does not exist on type 'AmplifyGraphqlApiCfnResources'. Did you mean 'cfnGraphqlApi'?ts(2551)
types.d.ts(667, 14): 'cfnGraphqlApi' is declared here.
```

It should be:

```ts
backend.data.resources.cfnResources.cfnGraphqlApi
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
