### PR TITLE
fix(gen2-migration): main.tsx in app4 imports the wrong file

### DIFF
--- a/amplify-migration-apps/app-4/src/main.tsx
+++ b/amplify-migration-apps/app-4/src/main.tsx
@@ -4,8 +4,8 @@ import './index.css';
 import App from './App.tsx';
 
 import { Amplify } from 'aws-amplify';
-import amplifyconfig from '../amplify_outputs.json';
-Amplify.configure(amplifyconfig);
+import awsExports from './aws-exports.js';
+Amplify.configure(awsExports);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
Currently, app4 is importing a file that is only created in gen2. It needs to import a gen1 config file. 

Both aws_exports or amplifyconfiguration.json can be used. They contain the same information in different formats