### PR TITLE
fix(gen2-migration): malformed comment escape hatching the `bucketName`

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/backend/synthesizer.ts
@@ -988,7 +988,6 @@ export class BackendSynthesizer {
         ` s3Bucket.bucketName = '${renderArgs.storage.bucketName}';`,
         true,
       );
-
       nodes.push(bucketNameComment1, bucketNameComment2);
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently, the following code is generated for s3 storage:

```ts
const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
// Use this bucket name post refactor
;
// s3Bucket.bucketName = 'projectboardsdb8c572205ef4c1b9d43a5d7dcdcae004620f-main';
;
```

For some reason there is a new line after every comment. We don't want that. This PR changes the comment structure to generate:

```ts
const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
// Use this bucket name post refactor
// s3Bucket.bucketName = 'projectboardsdb8c572205ef4c1b9d43a5d7dcdcae004620f-main';
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
