### PR TITLE
fix(gen2-migration): `cfnIdentityPool` constant is created for no reason

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -1182,14 +1182,12 @@ export class BackendSynthesizer {
     }
 
     // Identity pool overrides
-    if (renderArgs.auth?.guestLogin === false || (renderArgs.auth?.identityPoolName && !renderArgs?.auth?.referenceAuth)) {
+    if (renderArgs.auth?.guestLogin === false && !renderArgs?.auth?.referenceAuth) {
       const cfnIdentityPoolVariableStatement = this.createVariableStatement(
         this.createVariableDeclaration('cfnIdentityPool', 'auth.resources.cfnResources.cfnIdentityPool'),
       );
       nodes.push(cfnIdentityPoolVariableStatement);
-      if (renderArgs.auth?.guestLogin === false) {
-        nodes.push(this.setPropertyValue(factory.createIdentifier('cfnIdentityPool'), 'allowUnauthenticatedIdentities', false));
-      }
+      nodes.push(this.setPropertyValue(factory.createIdentifier('cfnIdentityPool'), 'allowUnauthenticatedIdentities', false));
     }
 
     // User pool client overrides


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently we generate the following statement:

```ts
const cfnIdentityPool = backend.auth.resources.cfnResources.cfnIdentityPool;
```

But the constant itself is not being used. This PR removes the constant if its not needed.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
