### PR TITLE
feat(gen2-migration): auto replace `${env}` with `${branchName}` in schemas

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/generators/data/index.ts
@@ -164,27 +164,27 @@ export const generateDataSource = async (dataDefinition?: DataDefinition): Promi
   // Additional statements to include before the data export
   const schemaStatements: ts.Node[] = [];
 
-  if (dataDefinition.schema.includes('${env}')) {
-    const branchNameStatement = factory.createVariableStatement(
-      [],
-      factory.createVariableDeclarationList(
-        [
-          factory.createVariableDeclaration(
-            'branchName',
-            undefined,
-            undefined,
-            factory.createIdentifier('process.env.AWS_BRANCH ?? "sandbox"'),
-          ),
-        ],
-        ts.NodeFlags.Const,
-      ),
-    );
-    schemaStatements.push(branchNameStatement);
-    dataDefinition.schema = dataDefinition.schema.replaceAll('${env}', '${branchName}');
-  }
-
   // Generate schema variable declaration if schema is provided
   if (dataDefinition && dataDefinition.schema) {
+    if (dataDefinition.schema.includes('${env}')) {
+      const branchNameStatement = factory.createVariableStatement(
+        [],
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              'branchName',
+              undefined,
+              undefined,
+              factory.createIdentifier('process.env.AWS_BRANCH ?? "sandbox"'),
+            ),
+          ],
+          ts.NodeFlags.Const,
+        ),
+      );
+      schemaStatements.push(branchNameStatement);
+      dataDefinition.schema = dataDefinition.schema.replaceAll('${env}', '${branchName}');
+    }
+
     const schemaVariableDeclaration = factory.createVariableDeclaration(
       'schema',
       undefined,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Customers can declare the `@function` directive inside GraphQL schema to let a custom lambda function respond to queries:

```graphql
type Query {
  getRandomQuote: QuoteResponse @function(name: "quotegenerator-${env}") @auth(rules: [{ allow: public }])
}
```

In Gen1, the `${env}` place holder is used to facilitate multiple environments.

Currently, our codegen retains this `${env}` statement even though it doesn't work in Gen2. We instruct customers to manually change this to their gen2 branch after code-generation. 

This PR adds a very basic detect-and-replace mechanism to do this automatically and generate:

```ts
const branchName = process.env.AWS_BRANCH ?? "sandbox";
const schema = `type Query {
  getRandomQuote: QuoteResponse @function(name: "quotegenerator-${branchName}") @auth(rules: [{ allow: public }])
}
`
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
