### PR TITLE
fix(gen2-migration): function dependencies are copied to the wrong `package.json` file

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/codegen-generate/src/core/migration-pipeline.ts
@@ -228,7 +228,14 @@ export const createGen2Renderer = ({
   const ensureAmplifyDirectory = new EnsureDirectory(path.join(outputDir, 'amplify'));
   // Generate amplify/package.json with ES module configuration
   const amplifyPackageJson = new JsonRenderer(
-    async () => ({ type: 'module' }),
+    async () => {
+      // Merge dependencies from all Gen 1 functions
+      const { dependencies: functionDeps, devDependencies: functionDevDeps } = functions?.length
+        ? await mergeAllFunctionDependencies(functions)
+        : { dependencies: {}, devDependencies: {} };
+
+      return { type: 'module', dependencies: functionDeps, devDependencies: functionDevDeps };
+    },
     (content) => fileWriter(content, path.join(outputDir, 'amplify', 'package.json')),
   );
   // Generate root package.json with Gen 2 dependencies
@@ -243,27 +250,10 @@ export const createGen2Renderer = ({
       } catch (e) {
         // File doesn't exist or is inaccessible. Ignore.
       }
-      // Merge dependencies from all Gen 1 functions
-      const { dependencies: functionDeps, devDependencies: functionDevDeps } = functions?.length
-        ? await mergeAllFunctionDependencies(functions)
-        : { dependencies: {}, devDependencies: {} };
-
-      // Merge function dependencies into the package.json
-      const updatedPackageJson = {
-        ...packageJson,
-        dependencies: {
-          ...(packageJson.dependencies || {}),
-          ...functionDeps,
-        },
-        devDependencies: {
-          ...(packageJson.devDependencies || {}),
-          ...functionDevDeps,
-        },
-      };
 
       // Restrict dev dependencies to specific versions based on create-amplify gen2 flow:
       // https://github.com/aws-amplify/amplify-backend/blob/2dab201cb9a222c3b8c396a46c17d661411839ab/packages/create-amplify/src/amplify_project_creator.ts#L15-L24
-      return patchNpmPackageJson(updatedPackageJson, {
+      return patchNpmPackageJson(packageJson, {
         'aws-cdk': '^2',
         'aws-cdk-lib': '^2',
         'ci-info': '^4.3.1',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

In https://github.com/aws-amplify/amplify-cli/pull/14399, we added support for copying over function dependencies to the Gen2 app. However, we copied them to the root `package.json` of the app, instead of the backend specific `amplify/package.json` file.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

Manual test

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
