### PR TITLE
feat(gen2-migration): update README for app2 to represent the latest functionality

### DIFF
--- a/amplify-migration-apps/app-2/README.md
+++ b/amplify-migration-apps/app-2/README.md
@@ -459,4 +459,10 @@ after: `import { DynamoDBClient } from '@aws-sdk/client-dynamodb';`
 before: `return (result.Items || []).map(item => ({`   
 after: `return (result.Items || []).map((item: any) => ({`  
 
+5. in `data/resource.ts`:   
+
+before: `@function(name: "activityLogger-\${env}")`   
+after: `@function(name: "amplify-<appId>-gen2<branchName>-handlerlambda<hash>-<suffix>")`   
+(Find actual Lambda name in CloudFormation → Stack Resources → search "handlerlambda") 
+
 The migration tool currently does not support lambda triggers on the dynamoDB resource. You will need to manually migrate this.


### PR DESCRIPTION
This pr removes outdated post-generate instructions for the migration tool. It also instructs users to manually handle lambda triggers