### PR TITLE
chore: fix gen2-migration release workflow

### DIFF
--- a/.github/workflows/release-gen2-migration.yml
+++ b/.github/workflows/release-gen2-migration.yml
@@ -10,9 +10,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: gen2-migration
-      - run: |
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+      - name: Install
+        run: |
+          node --version
+          npm --version
           yarn install
+      - name: Build
+        run: |
           yarn build
+      - name: Pack
+        run: |
           cd packages/amplify-cli
           package_name="@aws-amplify/cli-internal-gen2-migration-experimental-alpha"
           latest_version=$(npm view ${package_name} version 2>/dev/null || echo "0.0.0")
@@ -20,4 +31,14 @@ jobs:
           npm version ${new_version} --no-workspace-update --no-commit-hooks --no-git-tag-version --no-workspaces
           npm pkg set name=${package_name}
           npm pack
-          NPM_TRUSTED_PUBLISHER=true npm publish
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+      - name: Publish
+        run: |
+          cd packages/amplify-cli
+          npm --version
+          npm publish
+        env:
+          NPM_TRUSTED_PUBLISHER: 'true'


### PR DESCRIPTION
The workflow is currently [failing](https://github.com/aws-amplify/amplify-cli/actions/runs/20771604139/job/59648790561) with:

```console
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
npm error need auth You need to authorize this machine using `npm adduser`
```

Which means that the trusted publishing auth is not working. I've gone through all the settings and it all seems correct. (I am invoking this [workflow](https://github.com/aws-amplify/amplify-cli/blob/gen2-migration/.github/workflows/release-gen2-migration.yml) manually via the `gen2-migration` branch)

The only thing I can think of is that maybe its failing because i'm running the workflow from the `gen2-migration` branch and not from the default branch of the repo. The workflow file in the branch is also different then the one in dev.

So this PR 

- fixes the workflow itself by using the correct version of NPM (via node) that is required for trusted publishing
- aligns the workflow file to be the same in the `gen2-migration` and the `dev` branch. 

My hope is that if I trigger this workflow from the `dev` branch - trusted publishing will work.

Also changed the workflow to have distinct steps.