### PR TITLE
fix: graphql function directive references no environment in app5

### DIFF
--- a/amplify-migration-apps/app-5/README.md
+++ b/amplify-migration-apps/app-5/README.md
@@ -142,7 +142,7 @@ type QuoteResponse {
 }
 
 type Query {
-  getRandomQuote: QuoteResponse @function(name: "quotegenerator")  @auth(rules: [{ allow: public }])
+  getRandomQuote: QuoteResponse @function(name: "quotegenerator-${env}")  @auth(rules: [{ allow: public }])
 }
 
 enum ProjectStatus {


### PR DESCRIPTION
This pr adds -{env} suffix inside the function directive in the README to correctly reference it to the dev environment and maintain migration correctness

