### PR TITLE
fix: non-existent function in app4 referenced in function directive

### DIFF
--- a/amplify-migration-apps/app-4/README.md
+++ b/amplify-migration-apps/app-4/README.md
@@ -132,10 +132,6 @@ type QuoteResponse {
   totalQuotes: Int!
 }
 
-type Query {
-  getRandomQuote: QuoteResponse @function(name: "quotegenerator") 
-}
-
 enum ProjectStatus {
   ACTIVE
   COMPLETED


### PR DESCRIPTION
This pr removes an incorrect function directive in the graphql schema README. It references a function that is not part of the instructions
