### PR TITLE
fix(gen2-migration): functions are generated with incorrect access env variables

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/adapters/functions/index.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/adapters/functions/index.test.ts
@@ -1,7 +1,7 @@
 import { getFunctionDefinition } from '../../../../../../commands/gen2-migration/generate/adapters/functions/index';
 
 describe('getFunctionDefinition', () => {
-  test('storage env variables are removed', () => {
+  test('auth env variables are removed', () => {
     const definition = getFunctionDefinition(
       [
         {
@@ -10,9 +10,75 @@ describe('getFunctionDefinition', () => {
           Environment: {
             Variables: {
               SOME_ENV: 'some-value',
-              STORAGE_ACTIVITY_ARN: 'apiKey',
-              STORAGE_ACTIVITY_NAME: 'apidEndpoint',
-              STORAGE_ACTIVITY_STREAMARN: 'apiId',
+              AUTH_MEDIAVAULT_USERPOOLID: 'authUserPoolId',
+            },
+          },
+        },
+      ],
+      [],
+      new Map(),
+      {
+        function: {
+          MyFunc: {
+            service: 'Lambda',
+            providerPlugin: 'awscloudformation',
+            output: {
+              Name: 'MyFunc',
+            },
+          },
+        },
+      },
+    );
+
+    expect(definition.length).toEqual(1);
+    expect(definition[0].environment?.Variables).toEqual({ SOME_ENV: 'some-value' });
+  });
+
+  test('storage dynamo env variables are removed', () => {
+    const definition = getFunctionDefinition(
+      [
+        {
+          Handler: undefined,
+          FunctionName: 'MyFunc',
+          Environment: {
+            Variables: {
+              SOME_ENV: 'some-value',
+              STORAGE_ACTIVITY_ARN: 'storageArn',
+              STORAGE_ACTIVITY_NAME: 'storageName',
+              STORAGE_ACTIVITY_STREAMARN: 'storageStreamName',
+            },
+          },
+        },
+      ],
+      [],
+      new Map(),
+      {
+        function: {
+          MyFunc: {
+            service: 'Lambda',
+            providerPlugin: 'awscloudformation',
+            output: {
+              Name: 'MyFunc',
+            },
+          },
+        },
+      },
+    );
+
+    expect(definition.length).toEqual(1);
+    expect(definition[0].environment?.Variables).toEqual({ SOME_ENV: 'some-value' });
+  });
+
+  test('storage s3 env variables are removed', () => {
+    const definition = getFunctionDefinition(
+      [
+        {
+          Handler: undefined,
+          FunctionName: 'MyFunc',
+          Environment: {
+            Variables: {
+              SOME_ENV: 'some-value',
+              STORAGE_MEDIAVAULT_BUCKETNAME: 'storageBucketName',
             },
           },
         },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/adapters/functions/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/adapters/functions/index.ts
@@ -67,10 +67,28 @@ export const getFunctionDefinition = (
       }
     }
 
-    // storage access env variables
+    // storage dynamo access env variables
     for (const envSuffix of ['ARN', 'NAME', 'STREAMARN']) {
       for (const variable of Object.keys(configuration.Environment?.Variables ?? {})) {
         if (variable.startsWith('STORAGE_') && variable.endsWith(envSuffix)) {
+          delete configuration.Environment?.Variables[variable];
+        }
+      }
+    }
+
+    // storage s3 access env variables
+    for (const envSuffix of ['BUCKETNAME']) {
+      for (const variable of Object.keys(configuration.Environment?.Variables ?? {})) {
+        if (variable.startsWith('STORAGE_') && variable.endsWith(envSuffix)) {
+          delete configuration.Environment?.Variables[variable];
+        }
+      }
+    }
+
+    // auth access env variables
+    for (const envSuffix of ['USERPOOLID']) {
+      for (const variable of Object.keys(configuration.Environment?.Variables ?? {})) {
+        if (variable.startsWith('AUTH_') && variable.endsWith(envSuffix)) {
           delete configuration.Environment?.Variables[variable];
         }
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Same as https://github.com/aws-amplify/amplify-cli/pull/14435 but for storage (dynamo and s3) and auth.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Description of how you validated changes

- Unit test.
- Manual integ test.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
