### PR TITLE
feat(gen2-migration): remove wrong handler entry name instruction

### DIFF
--- a/amplify-migration-apps/app-3/README.md
+++ b/amplify-migration-apps/app-3/README.md
@@ -454,12 +454,7 @@ after: (delete this line)
 before: `import amplifyconfig from './amplifyconfiguration.json';`    
 after: `import amplifyconfig from '../amplify_outputs.json';`   
 
-4. In `amplify/function/thumbnailgen/resource.ts`:
-   
-before: `entry: "index.handler",`     
-after: `entry: "index.js",`   
-
-5. In `amplify/data/resource.ts`:
+4. In `amplify/data/resource.ts`:
 
 after: Add `apiKeyAuthorizationMode: { expiresInDays: 100 }` to authorizationModes. 
  


### PR DESCRIPTION
This functionality was fixed in one of the previous prs. Don't need this instruction any more