### PR TITLE
fix(gen2-migration): add missing npm run-scripts for configure commands in discussion

### DIFF
--- a/amplify-migration-apps/discussions/package.json
+++ b/amplify-migration-apps/discussions/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "configure": "sh configure.sh",
+    "configure-schema": "sh configure-schema.sh",
+    "configure-functions": "sh configure-functions.sh"
   },
   "devDependencies": {
     "vite": "^7.2.2"


### PR DESCRIPTION
Add missing npm run-scripts for configure commands in discussions app package.json to match the README instructions.

#### Description of how you validated changes
Ran the scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.