### PR TITLE
chore(gen2-migration): fix migration app README and formatting

### DIFF
--- a/amplify-migration-apps/discussions/README.md
+++ b/amplify-migration-apps/discussions/README.md
@@ -18,7 +18,7 @@ npm install
 
 ```console
 amplify init
-````
+```
 
 ```console
 ⚠️ For new projects, we recommend starting with AWS Amplify Gen 2, our new code-first developer experience. Get started at https://docs.amplify.aws/react/start/quickstart/
@@ -116,7 +116,7 @@ amplify add api
 
 ### Storage
 
-DynamoDB table for storing user activity logs with partition key, sort key, 
+DynamoDB table for storing user activity logs with partition key, sort key,
 and global secondary index for querying by activity type.
 
 ```console
@@ -309,23 +309,23 @@ Wait for the deployment to finish successfully.
 
 ### Create A User
 
-Since our AWS accounts are not configured to send SMS messages, we must confirm user creation 
+Since our AWS accounts are not configured to send SMS messages, we must confirm user creation
 directly via the cognito user pool.
 
-First, login to the app itself and click *Sign Up*, fill the form and click *Sign Up* again. Normally you 
+First, login to the app itself and click _Sign Up_, fill the form and click _Sign Up_ again. Normally you
 would get a SMS message with a confirmation code; to bypass that:
 
-1. Go to *AWS Console* → *Cognito* → *User Pools*
+1. Go to _AWS Console_ → _Cognito_ → _User Pools_
 2. Click on your user pool: `discussions<hash>_userpool_<hash>-main`
 3. Click on your user (shows up with the email)
-4. Click *Actions* → *Confirm account*
-5. Go to *User Attributes* → *Edit*.
-6. Check *Mark phone number as verified* and *Mark email address as verified*
-7. Click *Save changes*
+4. Click _Actions_ → _Confirm account_
+5. Go to _User Attributes_ → _Edit_.
+6. Check _Mark phone number as verified_ and _Mark email address as verified_
+7. Click _Save changes_
 
 ![](./images/confirm-user.png)
 
-Then, reload the app and sign in with the details you provided. You can repeat 
+Then, reload the app and sign in with the details you provided. You can repeat
 this process for any number of users.
 
 ## Migrating to Gen2
@@ -353,7 +353,7 @@ git checkout -b gen2-main
 npx amplify gen2-migration generate
 ```
 
-**Edit in `./amplify/backend/data/resource.ts`:**
+**Edit in `./amplify/data/resource.ts`:**
 
 ```diff
 - branchName: "main"
@@ -386,14 +386,14 @@ npx amplify gen2-migration generate
 + }
 ```
 
-**Edit in `./amplify/backend/storage/fetchuseractivity/index.js`:**
+**Edit in `./amplify/storage/fetchuseractivity/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
 + export async function handler(event) {
 ```
 
-**Edit in `./amplify/backend/storage/recorduseractivity/index.js`:**
+**Edit in `./amplify/storage/recorduseractivity/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
@@ -417,6 +417,5 @@ Now connect the `gen2-main` branch to the hosting service:
 
 ![](./images/add-gen2-main-branch.png)
 ![](./images/deploying-gen2-main-branch.png)
-
 
 Wait for the deployment to finish successfully.

--- a/amplify-migration-apps/media-vault/README.md
+++ b/amplify-migration-apps/media-vault/README.md
@@ -2,7 +2,7 @@
 
 ![](./images/app.png)
 
-A personal media management application featuring social authentication, GraphQL API, Lambda functions, S3 storage, and DynamoDB. 
+A personal media management application featuring social authentication, GraphQL API, Lambda functions, S3 storage, and DynamoDB.
 Users sign up with email/phone or social login (Facebook/Google)
 
 > [!NOTICE]
@@ -19,7 +19,7 @@ npm install
 
 ```console
 amplify init
-````
+```
 
 ```console
 ⚠️ For new projects, we recommend starting with AWS Amplify Gen 2, our new code-first developer experience. Get started at https://docs.amplify.aws/react/start/quickstart/
@@ -71,7 +71,7 @@ amplify add auth
 
 ```console
 Do you want to use the default authentication and security configuration? Default configuration with Social Provider (Federation)
-Warning: you will not be able to edit these selections. 
+Warning: you will not be able to edit these selections.
 How do you want users to be able to sign in? Email or Phone Number
 Do you want to configure advanced settings? No, I am done.
 What domain name prefix do you want to use? (accept default value)
@@ -80,21 +80,21 @@ Enter your redirect signin URI: https://main.<appId>.amplifyapp.com/ (replace <a
 Enter your redirect signout URI: https://main.<appId>.amplifyapp.com/ (replace <appId> with the actual value)
 ? Do you want to add another redirect signout URI No
 Select the social providers you want to configure for your user pool: Facebook, Google
-  
-You've opted to allow users to authenticate via Facebook.  If you haven't already, you'll need to go to https://developers.facebook.com and create an App ID. 
- 
+
+You've opted to allow users to authenticate via Facebook.  If you haven't already, you'll need to go to https://developers.facebook.com and create an App ID.
+
 Enter your Facebook App ID for your OAuth flow:  (secret)
 Enter your Facebook App Secret for your OAuth flow:  (secret)
-  
-You've opted to allow users to authenticate via Google.  If you haven't already, you'll need to go to https://developers.google.com/identity and create an App ID. 
- 
+
+You've opted to allow users to authenticate via Google.  If you haven't already, you'll need to go to https://developers.google.com/identity and create an App ID.
+
 Enter your Google Web Client ID for your OAuth flow:  (secret)
 Enter your Google Web Client Secret for your OAuth flow:  (secret)
 ```
 
 > [!NOTE]
-> Publishing SMS messages to US numbers requires AWS account configuration not covered by this guide. If you happen to 
-> own a foreign phone number you can configure it directly via the [SNS text messaging console](https://console.aws.amazon.com/sns/v3/home#/mobile/text-messaging). 
+> Publishing SMS messages to US numbers requires AWS account configuration not covered by this guide. If you happen to
+> own a foreign phone number you can configure it directly via the [SNS text messaging console](https://console.aws.amazon.com/sns/v3/home#/mobile/text-messaging).
 > Otherwise use email to sign up for the deployed app.
 
 ```console
@@ -323,37 +323,37 @@ Next, accept all default values and follow the getting started wizard to connect
 ![](./images/add-main-branch.png)
 ![](./images/deploying-main-branch.png)
 
-Wait for the deployment to finish successfully. Now you need to setup social provider identities for the Cognito user pool. 
+Wait for the deployment to finish successfully. Now you need to setup social provider identities for the Cognito user pool.
 Grab the App ID from the Amplify Console and the Cognito domain prefix from the Cognito Console.
 
 ![](./images/cognito-domain-prefix.png)
 
 **Facebook**
 
-1. Follow the [instructions](https://docs.amplify.aws/gen1/javascript/build-a-backend/auth/add-social-provider/#set-up-your-social-auth-provider) 
-in the Facebook Login_ tab. 
+1. Follow the [instructions](https://docs.amplify.aws/gen1/javascript/build-a-backend/auth/add-social-provider/#set-up-your-social-auth-provider)
+   in the Facebook Login\_ tab.
 
    - Set application name to `amplify-media-vault-gen1`.
    - Note the `App ID` and `App Secret` values, they will be needed later on.
 
-2. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _App Settings_ → _Basic_  → _App domains_.
+2. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _App Settings_ → _Basic_ → _App domains_.
 
-    - `https://main.<appId>.amplifyapp.com`
-    - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/`
+   - `https://main.<appId>.amplifyapp.com`
+   - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/`
 
-3. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _Use Cases_ → _Authenticate and request data from users with Facebook Login → Settings → _Valid OAuth Redirect URIs_.
+3. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _Use Cases_ → _Authenticate and request data from users with Facebook Login → Settings → \_Valid OAuth Redirect URIs_.
 
-    - `https://main.<appId>.amplifyapp.com/oauth2/idpresponse/`
-    - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/oauth2/idpresponse/`
+   - `https://main.<appId>.amplifyapp.com/oauth2/idpresponse/`
+   - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/oauth2/idpresponse/`
 
-4. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _Use Cases_ → _Authenticate and request data from users with Facebook Login → Permissions and features → _email_ → _Add_.
+4. In [facebook dev console](https://developers.facebook.com/apps/), locate your app and navigate to _Use Cases_ → _Authenticate and request data from users with Facebook Login → Permissions and features → \_email_ → _Add_.
 
-    ![](./images/facebook-email-scope.png)
+   ![](./images/facebook-email-scope.png)
 
 **Google**
 
-1. Follow the [instructions](https://docs.amplify.aws/gen1/javascript/build-a-backend/auth/add-social-provider/#set-up-your-social-auth-provider) 
-in the _Google Sign-In_ tab. 
+1. Follow the [instructions](https://docs.amplify.aws/gen1/javascript/build-a-backend/auth/add-social-provider/#set-up-your-social-auth-provider)
+   in the _Google Sign-In_ tab.
 
    - Set application name to `amplify-media-vault-gen1`.
    - Set client name to `GoogleWebClient1`.
@@ -361,13 +361,13 @@ in the _Google Sign-In_ tab.
 
 2. Navigate to _Clients_ → _GoogleWebClient1_ → _Authorized JavaScript origins_.
 
-    - `https://main.<appId>.amplifyapp.com`
-    - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/`
+   - `https://main.<appId>.amplifyapp.com`
+   - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/`
 
 3. Navigate to _Clients_ → _GoogleWebClient1_ → _Authorized redirect URIs_.
 
-    - `https://main.<appId>.amplifyapp.com/oauth2/idpresponse/`
-    - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/oauth2/idpresponse/`
+   - `https://main.<appId>.amplifyapp.com/oauth2/idpresponse/`
+   - `https://<cognito-prefix>.auth.us-east-1.amazoncognito.com/oauth2/idpresponse/`
 
 ## Migrating to Gen2
 
@@ -394,7 +394,7 @@ git checkout -b gen2-main
 npx amplify gen2-migration generate
 ```
 
-**Edit in `./amplify/backend/data/resource.ts`:**
+**Edit in `./amplify/data/resource.ts`:**
 
 ```diff
 - branchName: "main"
@@ -494,21 +494,21 @@ Add this to every configured prefix:
 + backend.removeuserfromgroup.addEnvironment('AUTH_MEDIAVAULT_USERPOOLID', backend.auth.resources.userPool.userPoolId);
 ```
 
-**Edit in `./amplify/backend/function/addusertogroup/index.js`:**
+**Edit in `./amplify/function/addusertogroup/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
 + export async function handler(event) {
 ```
 
-**Edit in `./amplify/backend/function/removeuserfromgroup/index.js`:**
+**Edit in `./amplify/function/removeuserfromgroup/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
 + export async function handler(event) {
 ```
 
-**Edit in `./amplify/backend/storage/thumbnailgen/index.js`:**
+**Edit in `./amplify/storage/thumbnailgen/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {

--- a/amplify-migration-apps/product-catalog/README.md
+++ b/amplify-migration-apps/product-catalog/README.md
@@ -2,7 +2,7 @@
 
 <img width="250" height="300" src="./images/app.png" />
 
-An inventory management application built with Amplify Gen1, featuring role-based authentication, 
+An inventory management application built with Amplify Gen1, featuring role-based authentication,
 GraphQL API, Lambda functions, S3 storage, and DynamoDB.
 
 > [!NOTICE]
@@ -19,7 +19,7 @@ npm install
 
 ```console
 amplify init
-````
+```
 
 ```console
 ⚠️ For new projects, we recommend starting with AWS Amplify Gen 2, our new code-first developer experience. Get started at https://docs.amplify.aws/react/start/quickstart/
@@ -63,7 +63,7 @@ https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 
 ### Api
 
-GraphQL API with schema containing 
+GraphQL API with schema containing
 
 - _Comment_ model.
 - _Product_ model with a `@hasMany` relationship to the _Comment_ model.
@@ -87,11 +87,11 @@ API key configuration
 ✔ After how many days from now the API key should expire (1-365): · 7
 Cognito UserPool configuration
 Using service: Cognito, provided by: awscloudformation
- 
- The current configured provider is Amazon Cognito. 
- 
+
+ The current configured provider is Amazon Cognito.
+
  Do you want to use the default authentication and security configuration? Default configuration
- Warning: you will not be able to edit these selections. 
+ Warning: you will not be able to edit these selections.
  How do you want users to be able to sign in? Email
  Do you want to configure advanced settings? No, I am done.
 ✅ Successfully added auth resource productcatalog3766b428 locally
@@ -208,7 +208,7 @@ On the AWS Amplify console, locate the application id.
 
 ![](./images/gen1-app-id.png)
 
-**Edit in `./amplify/backend/api/productcatalog/custom-roles.json`:**
+**Edit in `./amplify/api/productcatalog/custom-roles.json`:**
 
 ```diff
 - "amplify-${appId}"
@@ -279,7 +279,7 @@ git checkout -b gen2-main
 npx amplify gen2-migration generate
 ```
 
-**Edit in `./amplify/backend/data/resource.ts`:**
+**Edit in `./amplify/data/resource.ts`:**
 
 ```diff
 - branchName: "main"
@@ -319,7 +319,7 @@ npx amplify gen2-migration generate
 +     actions: ['appsync:GraphQL'],
 +     resources: [`arn:aws:appsync:${backend.data.stack.region}:${backend.data.stack.account}:apis/${backend.data.apiId}/types/Mutation/*`]
 + }))
-``` 
+```
 
 On the AppSync AWS Console, locate the ID of Gen1 API, it will be named `productcatalog-main`.
 
@@ -335,8 +335,7 @@ On the AppSync AWS Console, locate the ID of Gen1 API, it will be named `product
 + }))
 ```
 
-
-**Edit in `./amplify/backend/function/lowstockproducts/index.js`:**
+**Edit in `./amplify/function/lowstockproducts/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
@@ -348,7 +347,7 @@ On the AppSync AWS Console, locate the ID of Gen1 API, it will be named `product
 + const secretValue = process.env['PRODUCT_CATALOG_SECRET'];
 ```
 
-**Edit in `./amplify/backend/function/lowstockproducts/resource.ts`:**
+**Edit in `./amplify/function/lowstockproducts/resource.ts`:**
 
 ```diff
 - import { defineFunction } from "@aws-amplify/backend";
@@ -358,10 +357,10 @@ On the AppSync AWS Console, locate the ID of Gen1 API, it will be named `product
 + PRODUCT_CATALOG_SECRET: secret("PRODUCT_CATALOG_SECRET")
 ```
 
-**Edit in `./amplify/backend/storage/S3Trigger<suffix>/index.js`:**
+**Edit in `./amplify/storage/S3Trigger<suffix>/index.js`:**
 
 ```diff
-- exports.handler = async (event) => {
+- exports.handler = async function (event) {
 + export async function handler(event) {
 ```
 
@@ -386,7 +385,6 @@ Now connect the `gen2-main` branch to the hosting service:
 
 ![](./images/add-gen2-main-branch.png)
 ![](./images/deploying-gen2-main-branch.png)
-
 
 Wait for the deployment to finish successfully. Next, locate the root stack of the Gen2 branch:
 

--- a/amplify-migration-apps/project-boards/README.md
+++ b/amplify-migration-apps/project-boards/README.md
@@ -2,12 +2,12 @@
 
 <img width="625" height="300" src="./images/app.png" />
 
-This is a project board app that supports authentication. Each Project board can hold multiple Todo items, 
-each of which has a title, description, and optionally, images. Todos do not need to be in a Project 
-and can exist unassigned. 
+This is a project board app that supports authentication. Each Project board can hold multiple Todo items,
+each of which has a title, description, and optionally, images. Todos do not need to be in a Project
+and can exist unassigned.
 
 - Unauthenticated users can only view Projects and Todos, and cannot modify or delete them.
-- Authenticated users can create Projects and Todos, and modify/delete their own. They may add 
+- Authenticated users can create Projects and Todos, and modify/delete their own. They may add
 
 Todos to Projects that are not their own, but cannot change the Project settings.
 
@@ -25,7 +25,7 @@ npm install
 
 ```console
 amplify init
-````
+```
 
 ```console
 ⚠️ For new projects, we recommend starting with AWS Amplify Gen 2, our new code-first developer experience. Get started at https://docs.amplify.aws/react/start/quickstart/
@@ -67,7 +67,7 @@ https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 
 ## Add Categories
 
-### Auth 
+### Auth
 
 Cognito-based auth using email.
 
@@ -77,7 +77,7 @@ amplify add auth
 
 ```console
  Do you want to use the default authentication and security configuration? Default configuration
- Warning: you will not be able to edit these selections. 
+ Warning: you will not be able to edit these selections.
  How do you want users to be able to sign in? Email
  Do you want to configure advanced settings? No, I am done.
 ```
@@ -88,8 +88,8 @@ GraphQL API with schema containing:
 
 - _Todo_ model.
 - _Project_ model with a `@hasMany` relationship to the _Todo_ model.
-- _getRandomQuote_ query that returns inspirational quotes by invoking a 
-lambda function using the `@function` directive.
+- _getRandomQuote_ query that returns inspirational quotes by invoking a
+  lambda function using the `@function` directive.
 
 ```console
 amplify add api
@@ -104,7 +104,7 @@ amplify add api
 
 ### Storage
 
-S3-based storage for images of the _Todo_ model. Authenticated users can perform all operations, 
+S3-based storage for images of the _Todo_ model. Authenticated users can perform all operations,
 unauthenticated users can only read.
 
 ```console
@@ -191,7 +191,6 @@ Next, accept all the default values and follow the getting started wizard to con
 ![](./images/add-main-branch.png)
 ![](./images/deploying-main-branch.png)
 
-
 Wait for the deployment to finish successfully.
 
 ## Migrating to Gen2
@@ -215,14 +214,14 @@ git checkout -b gen2-main
 npx amplify gen2-migration generate
 ```
 
-**Edit in `./amplify/backend/data/resource.ts`:**
+**Edit in `./amplify/data/resource.ts`:**
 
 ```diff
 - branchName: "main"
 + branchName: "gen2-main"
 ```
 
-**Edit in `./amplify/backend/function/quotegenerator/index.js`:**
+**Edit in `./amplify/function/quotegenerator/index.js`:**
 
 ```diff
 - exports.handler = async (event) => {
@@ -246,7 +245,6 @@ Now connect the `gen2-main` branch to the hosting service:
 
 ![](./images/add-gen2-main-branch.png)
 ![](./images/deploying-gen2-main-branch.png)
-
 
 Wait for the deployment to finish successfully. Next, locate the root stack of the Gen2 branch:
 


### PR DESCRIPTION
fixes documentation issues in migration app readme:
- correct Gen2 file paths in migration instructions (`./amplify/backend/` → `./amplify/`)
- fix S3 trigger handler diff to show correct original code (`exports.handler = async function (event)` not `exports.handler = async (event)`)
- rest are just format markdown (sry...)
