### PR TITLE
chore(gen2-migration): remove protective conditions that mask the dynamodb table mapping error

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -203,6 +203,8 @@ export const generateDataSource = async (gen1Env: string, dataDefinition?: DataD
     const apiId = await getApiId(gen1Env);
     if (apiId) {
       tableMappings = createDataSourceMapping(dataDefinition.schema, apiId, gen1Env);
+    } else {
+      throw new Error(`Unable to find AppSync API for environment '${gen1Env}'. Ensure the API exists and is properly tagged.`);
     }
   }
 


### PR DESCRIPTION
Currently, model name to dyanmoDB table name mappings are lost in certain situations. We are unaware of the real reason why.

This pr removes two protective `if` statements that could be potentially masking this error. This would allow the error to propagate and fail the migration, aiding detection. 
