### PR TITLE
fix: unsanitized input in pem file content handler

### DIFF
--- a/packages/amplify-category-notifications/src/__tests__/apns-cert-p12decoder.test.ts
+++ b/packages/amplify-category-notifications/src/__tests__/apns-cert-p12decoder.test.ts
@@ -1,0 +1,236 @@
+import fs from 'fs-extra';
+import { spawnSync, SpawnSyncReturns } from 'child_process';
+import { AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { run } from '../apns-cert-p12decoder';
+
+jest.mock('fs-extra');
+jest.mock('child_process');
+
+const fsMock = fs as jest.Mocked<typeof fs>;
+const spawnSyncMock = spawnSync as jest.MockedFunction<typeof spawnSync>;
+
+describe('apns-cert-p12decoder', () => {
+  const mockFilePath = '/path/to/cert.p12';
+  const mockPassword = 'test-password';
+  const mockInfo = {
+    P12FilePath: mockFilePath,
+    P12FilePassword: mockPassword,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fsMock.existsSync.mockReturnValue(true);
+  });
+
+  describe('run', () => {
+    const mockCertificate = 'MIIC+zCCAeOgAwIBAgIJALZM';
+    const mockPrivateKey = 'MIIEvgIBADANBgkqhkiG9w0B';
+
+    const createPemContent = (certContent: string, keyContent: string, keyType = 'PRIVATE KEY'): string => {
+      return `-----BEGIN CERTIFICATE-----
+${certContent}
+-----END CERTIFICATE-----
+-----BEGIN ${keyType}-----
+${keyContent}
+-----END ${keyType}-----`;
+    };
+
+    it('should extract certificate and private key from PEM content', () => {
+      const pemContent = createPemContent(mockCertificate, mockPrivateKey);
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContent);
+
+      const result = run(mockInfo);
+
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        'openssl',
+        ['pkcs12', '-in', mockFilePath, '-out', expect.any(String), '-nodes', '-passin', 'stdin'],
+        { input: mockPassword, encoding: 'utf8' },
+      );
+      expect(result.Certificate).toContain('-----BEGIN CERTIFICATE-----');
+      expect(result.Certificate).toContain('-----END CERTIFICATE-----');
+      expect(result.PrivateKey).toContain('-----BEGIN PRIVATE KEY-----');
+      expect(result.PrivateKey).toContain('-----END PRIVATE KEY-----');
+      expect(fsMock.removeSync).toHaveBeenCalled();
+    });
+
+    it('should extract RSA private key when standard private key is not found', () => {
+      const pemContent = createPemContent(mockCertificate, mockPrivateKey, 'RSA PRIVATE KEY');
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContent);
+
+      const result = run(mockInfo);
+
+      expect(result.PrivateKey).toContain('-----BEGIN RSA PRIVATE KEY-----');
+      expect(result.PrivateKey).toContain('-----END RSA PRIVATE KEY-----');
+    });
+
+    it('should extract encrypted private key as fallback', () => {
+      const pemContent = createPemContent(mockCertificate, mockPrivateKey, 'ENCRYPTED PRIVATE KEY');
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContent);
+
+      const result = run(mockInfo);
+
+      expect(result.PrivateKey).toContain('-----BEGIN ENCRYPTED PRIVATE KEY-----');
+      expect(result.PrivateKey).toContain('-----END ENCRYPTED PRIVATE KEY-----');
+    });
+
+    it('should throw AmplifyError when openssl command fails to spawn', () => {
+      spawnSyncMock.mockReturnValue({
+        status: null,
+        error: new Error('spawn openssl ENOENT'),
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+
+      const amplifyError = new AmplifyError('OpenSslCertificateError', {
+        message: 'OpenSSL command failed: spawn openssl ENOENT',
+        resolution: 'Ensure OpenSSL is installed and accessible in your PATH',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+    });
+
+    it('should throw AmplifyError when openssl returns non-zero exit code', () => {
+      spawnSyncMock.mockReturnValue({
+        status: 1,
+        error: undefined,
+        stderr: 'Mac verify error: invalid password?',
+      } as SpawnSyncReturns<string>);
+
+      const amplifyError = new AmplifyError('OpenSslCertificateError', {
+        message: 'OpenSSL failed to process the p12 file: Mac verify error: invalid password?',
+        resolution: 'Check the p12 file and password and try again',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+    });
+
+    it('should throw AmplifyError when certificate cannot be extracted', () => {
+      const pemContentNoCert = `-----BEGIN PRIVATE KEY-----
+${mockPrivateKey}
+-----END PRIVATE KEY-----`;
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContentNoCert);
+
+      const amplifyError = new AmplifyError('OpenSslCertificateError', {
+        message: 'OpenSSL can not extract the Certificate from the p12 file',
+        resolution: 'Check the p12 file and password and try again',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+    });
+
+    it('should throw AmplifyError when private key cannot be extracted', () => {
+      const pemContentNoKey = `-----BEGIN CERTIFICATE-----
+${mockCertificate}
+-----END CERTIFICATE-----`;
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContentNoKey);
+
+      const amplifyError = new AmplifyError('OpenSslCertificateError', {
+        message: 'OpenSSL can not extract the Private Key from the p12 file',
+        resolution: 'Check the p12 file and password and try again',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+    });
+
+    it('should pass password via stdin to prevent exposure in process listing', () => {
+      const maliciousPassword = '; rm -rf / ; echo "pwned"';
+      const maliciousInfo = {
+        P12FilePath: mockFilePath,
+        P12FilePassword: maliciousPassword,
+      };
+      const pemContent = createPemContent(mockCertificate, mockPrivateKey);
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContent);
+
+      run(maliciousInfo);
+
+      // Verify the password is passed via stdin, not as a command line argument
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        'openssl',
+        ['pkcs12', '-in', mockFilePath, '-out', expect.any(String), '-nodes', '-passin', 'stdin'],
+        { input: maliciousPassword, encoding: 'utf8' },
+      );
+    });
+
+    it('should cleanup temp file even when an error is thrown', () => {
+      spawnSyncMock.mockReturnValue({
+        status: 1,
+        error: undefined,
+        stderr: 'error',
+      } as SpawnSyncReturns<string>);
+
+      const amplifyError = new AmplifyError('OpenSslCertificateError', {
+        message: 'OpenSSL failed to process the p12 file: error',
+        resolution: 'Check the p12 file and password and try again',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+      expect(fsMock.existsSync).toHaveBeenCalled();
+      expect(fsMock.removeSync).toHaveBeenCalled();
+    });
+
+    it('should not attempt to remove temp file if it does not exist', () => {
+      const pemContent = createPemContent(mockCertificate, mockPrivateKey);
+
+      spawnSyncMock.mockReturnValue({
+        status: 0,
+        error: undefined,
+        stderr: '',
+      } as SpawnSyncReturns<string>);
+      fsMock.readFileSync.mockReturnValue(pemContent);
+      // First call checks if p12 file exists (return true), second call checks temp file (return false)
+      fsMock.existsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+      run(mockInfo);
+
+      expect(fsMock.existsSync).toHaveBeenCalledTimes(2);
+      expect(fsMock.removeSync).not.toHaveBeenCalled();
+    });
+
+    it('should throw AmplifyError when p12 file does not exist', () => {
+      fsMock.existsSync.mockReturnValue(false);
+
+      const amplifyError = new AmplifyError('InputValidationError', {
+        message: 'The p12 file does not exist: /path/to/cert.p12',
+        resolution: 'Verify the file path is correct and the file exists',
+      });
+
+      expect(() => run(mockInfo)).toThrow(amplifyError);
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/amplify-category-notifications/src/apns-cert-p12decoder.ts
+++ b/packages/amplify-category-notifications/src/apns-cert-p12decoder.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
-import { $TSAny, AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { spawnSync } from 'child_process';
+import { AmplifyError } from '@aws-amplify/amplify-cli-core';
 
 /**
  * Certificate Info
@@ -13,12 +13,28 @@ export interface ICertificateInfo {
 }
 
 /**
+ * P12 Decoder Input
+ */
+export interface IP12DecoderInput {
+  P12FilePath: string;
+  P12FilePassword: string;
+}
+
+/**
  * Run function of p12Decoder module
  * @param info filePath and Password for the decoder
  * @returns Certificate info
  */
-export const run = (info: $TSAny): ICertificateInfo => {
+export const run = (info: IP12DecoderInput): ICertificateInfo => {
   const { P12FilePath, P12FilePassword } = info;
+
+  if (!fs.existsSync(P12FilePath)) {
+    throw new AmplifyError('InputValidationError', {
+      message: `The p12 file does not exist: ${P12FilePath}`,
+      resolution: 'Verify the file path is correct and the file exists',
+    });
+  }
+
   const pemFileContent = getPemFileContent(P12FilePath, P12FilePassword);
   const Certificate = getCertificate(pemFileContent);
   let PrivateKey = getPrivateKey(pemFileContent);
@@ -50,16 +66,35 @@ export const run = (info: $TSAny): ICertificateInfo => {
 
 const getPemFileContent = (filePath: string, filePassword: string): string => {
   // eslint-disable-next-line spellcheck/spell-checker
-  const outputFilePath = path.join(os.tmpdir(), 'temp.pem');
-  // eslint-disable-next-line spellcheck/spell-checker
-  const cmd = `openssl pkcs12 -in ${filePath} -out ${outputFilePath} -nodes -passin pass:${filePassword}`;
-  execSync(cmd);
-  const content = fs.readFileSync(outputFilePath, 'utf8');
-  fs.removeSync(outputFilePath);
-  return content;
+  const outputFilePath = path.join(os.tmpdir(), `amplify-${Date.now()}.pem`);
+  try {
+    // Use spawnSync with stdin to prevent password from being visible in process listing
+    // eslint-disable-next-line spellcheck/spell-checker
+    const result = spawnSync('openssl', ['pkcs12', '-in', filePath, '-out', outputFilePath, '-nodes', '-passin', 'stdin'], {
+      input: filePassword,
+      encoding: 'utf8',
+    });
+    if (result.error) {
+      throw new AmplifyError('OpenSslCertificateError', {
+        message: `OpenSSL command failed: ${result.error.message}`,
+        resolution: 'Ensure OpenSSL is installed and accessible in your PATH',
+      });
+    }
+    if (result.status !== 0) {
+      throw new AmplifyError('OpenSslCertificateError', {
+        message: `OpenSSL failed to process the p12 file: ${result.stderr || 'Unknown error'}`,
+        resolution: 'Check the p12 file and password and try again',
+      });
+    }
+    return fs.readFileSync(outputFilePath, 'utf8');
+  } finally {
+    if (fs.existsSync(outputFilePath)) {
+      fs.removeSync(outputFilePath);
+    }
+  }
 };
 
-const getCertificate = (pemFileContent: $TSAny): string | undefined => {
+const getCertificate = (pemFileContent: string): string | undefined => {
   let certificate;
   const beginMark = '-----BEGIN CERTIFICATE-----';
   const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
@@ -74,7 +109,7 @@ const getCertificate = (pemFileContent: $TSAny): string | undefined => {
   return certificate;
 };
 
-const getPrivateKey = (pemFileContent: $TSAny): string | undefined => {
+const getPrivateKey = (pemFileContent: string): string | undefined => {
   let privateKey;
   const beginMark = '-----BEGIN PRIVATE KEY-----';
   const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
@@ -89,7 +124,7 @@ const getPrivateKey = (pemFileContent: $TSAny): string | undefined => {
   return privateKey;
 };
 
-const getRSAPrivateKey = (pemFileContent: $TSAny): string | undefined => {
+const getRSAPrivateKey = (pemFileContent: string): string | undefined => {
   let privateKey;
   const beginMark = '-----BEGIN RSA PRIVATE KEY-----';
   const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
@@ -104,7 +139,7 @@ const getRSAPrivateKey = (pemFileContent: $TSAny): string | undefined => {
   return privateKey;
 };
 
-const getEncryptedPrivateKey = (pemFileContent: $TSAny): string | undefined => {
+const getEncryptedPrivateKey = (pemFileContent: string): string | undefined => {
   let privateKey;
   const beginMark = '-----BEGIN ENCRYPTED PRIVATE KEY-----';
   const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixed an input vulnerability in the APNS certificate P12 decoder, which previously allowed arbitrary code execution within a shell. Added a validation to ensure PEM file exists, before attempting to access it.

By replacing `execSync` with `spawnSync` and passing in user-provided strings as parameters to `spawnSync`, we now always treat them as strings. This removes the possibility of executing the user-provided strings as code.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #: Internal Issue

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran a test script to manually verify the decoder works as expected:
[test-decoder.ts](https://github.com/user-attachments/files/24809163/test-decoder.ts)

Steps to use the test script:
1. Place the file under `packages/amplify-category-notifications`.
2. In that same directory, run the following commands:
3. `openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1 -nodes -subj "/CN=test" # Generate a self-signed cert and key`
4. `openssl pkcs12 -export -out test.p12 -inkey key.pem -in cert.pem -password pass:test123 # Bundle into p12 with password "test123"`
5. `npx ts-node test-decoder.ts ./test.p12 test123 # Then run the decoder`



Added unit tests to test existing code and this change.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [X] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
