### PR TITLE
fix: errant certificate mark handling

### DIFF
--- a/packages/amplify-category-notifications/src/apns-cert-p12decoder.ts
+++ b/packages/amplify-category-notifications/src/apns-cert-p12decoder.ts
@@ -94,62 +94,23 @@ const getPemFileContent = (filePath: string, filePassword: string): string => {
   }
 };
 
-const getCertificate = (pemFileContent: string): string | undefined => {
-  let certificate;
-  const beginMark = '-----BEGIN CERTIFICATE-----';
-  const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
-  if (beginIndex > -1) {
-    const endMark = '-----END CERTIFICATE-----';
-    const endIndex = pemFileContent.indexOf(endMark, beginIndex);
-    if (endIndex > -1) {
-      certificate = pemFileContent.slice(beginIndex, endIndex).replace(/\s/g, '');
-      return beginMark + os.EOL + certificate + os.EOL + endMark;
-    }
-  }
-  return certificate;
+const extractPemBlock = (pemFileContent: string, beginMark: string, endMark: string): string | undefined => {
+  const rawIndex = pemFileContent.indexOf(beginMark);
+  if (rawIndex === -1) return undefined;
+  const beginIndex = rawIndex + beginMark.length;
+  const endIndex = pemFileContent.indexOf(endMark, beginIndex);
+  if (endIndex === -1) return undefined;
+  const content = pemFileContent.slice(beginIndex, endIndex).replace(/\s/g, '');
+  return beginMark + os.EOL + content + os.EOL + endMark;
 };
 
-const getPrivateKey = (pemFileContent: string): string | undefined => {
-  let privateKey;
-  const beginMark = '-----BEGIN PRIVATE KEY-----';
-  const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
-  if (beginIndex > -1) {
-    const endMark = '-----END PRIVATE KEY-----';
-    const endIndex = pemFileContent.indexOf(endMark, beginIndex);
-    if (endIndex > -1) {
-      privateKey = pemFileContent.slice(beginIndex, endIndex).replace(/\s/g, '');
-      return beginMark + os.EOL + privateKey + os.EOL + endMark;
-    }
-  }
-  return privateKey;
-};
+const getCertificate = (pem: string): string | undefined =>
+  extractPemBlock(pem, '-----BEGIN CERTIFICATE-----', '-----END CERTIFICATE-----');
 
-const getRSAPrivateKey = (pemFileContent: string): string | undefined => {
-  let privateKey;
-  const beginMark = '-----BEGIN RSA PRIVATE KEY-----';
-  const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
-  if (beginIndex > -1) {
-    const endMark = '-----END RSA PRIVATE KEY-----';
-    const endIndex = pemFileContent.indexOf(endMark, beginIndex);
-    if (endIndex > -1) {
-      privateKey = pemFileContent.slice(beginIndex, endIndex).replace(/\s/g, '');
-      return beginMark + os.EOL + privateKey + os.EOL + endMark;
-    }
-  }
-  return privateKey;
-};
+const getPrivateKey = (pem: string): string | undefined => extractPemBlock(pem, '-----BEGIN PRIVATE KEY-----', '-----END PRIVATE KEY-----');
 
-const getEncryptedPrivateKey = (pemFileContent: string): string | undefined => {
-  let privateKey;
-  const beginMark = '-----BEGIN ENCRYPTED PRIVATE KEY-----';
-  const beginIndex = pemFileContent.indexOf(beginMark) + beginMark.length;
-  if (beginIndex > -1) {
-    const endMark = '-----END ENCRYPTED PRIVATE KEY-----';
-    const endIndex = pemFileContent.indexOf(endMark, beginIndex);
-    if (endIndex > -1) {
-      privateKey = pemFileContent.slice(beginIndex, endIndex).replace(/\s/g, '');
-      return beginMark + os.EOL + privateKey + os.EOL + endMark;
-    }
-  }
-  return privateKey;
-};
+const getRSAPrivateKey = (pem: string): string | undefined =>
+  extractPemBlock(pem, '-----BEGIN RSA PRIVATE KEY-----', '-----END RSA PRIVATE KEY-----');
+
+const getEncryptedPrivateKey = (pem: string): string | undefined =>
+  extractPemBlock(pem, '-----BEGIN ENCRYPTED PRIVATE KEY-----', '-----END ENCRYPTED PRIVATE KEY-----');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixed bug in PEM block extraction where `beginIndex > -1` was always true after adding `beginMark.length`, causing incorrect parsing when the marker wasn't found. Now correctly checks if the marker exists before calculating the index.


Refactored `getCertificate`, `getPrivateKey`, `getRSAPrivateKey`, and `getEncryptedPrivateKey` into a single `extractPemBlock` helper function to eliminate code duplication

#### Description of how you validated changes
Manual testing with a script: 
[test-decoder.ts](https://github.com/user-attachments/files/24812008/test-decoder.ts)

Steps to use the test script:

Place the file under packages/amplify-category-notifications.
In that same directory, run the following commands:
1. `openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1 -nodes -subj "/CN=test"` # Generate a self-signed cert and key
2. `openssl pkcs12 -export -out test.p12 -inkey key.pem -in cert.pem -password pass:test123` # Bundle into p12 with password "test123"
3. `npx ts-node test-decoder.ts ./test.p12 test123` # Then run the decoder

Output:
```shell
ianhou@c889f3e263eb amplify-category-notifications % npx ts-node test-decoder.ts ./test.p12 test123                    
Decoding: ./test.p12

✓ Successfully decoded p12 file

Certificate (first 100 chars):
-----BEGIN CERTIFICATE-----
MIIC/zCCAeegAwIBAgIUS4ua6oTTxbjbbH7bmn2aPRFGCz8wDQYJKoZIhvcNAQELBQAwDzEN...

Private Key (first 100 chars):
-----BEGIN PRIVATE KEY-----
MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDo7IoGsAX+uf7dnH2Vr++a...
```

Ran unit tests.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [X] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
