### PR TITLE
fix: expired GPG key used to install yarn using apt-key add in linux docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,9 +206,8 @@ RUN set -ex \
 ENV NODE_VERSION="22.12.0"
 
 RUN  n $NODE_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
-     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-     && apt-get update && apt-get install -y -qq --no-install-recommends yarn \
+     && corepack enable \
+     && corepack prepare yarn@stable --activate \
      && yarn --version \
      && cd / && rm -rf $N_SRC_DIR && rm -rf /tmp/*
 

--- a/codebuild_specs/build_image.yml
+++ b/codebuild_specs/build_image.yml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
       # increment DEFAULT_TAG version to a unique consecutive version whenever you make changes to the dockerfile or image settings
-      - export DEFAULT_TAG=2.0.0
+      - export DEFAULT_TAG=2.0.1
       - export IMAGE_TAG=${CUSTOM_TAG:=$DEFAULT_TAG}
       - echo $IMAGE_TAG
       - echo $PKG_BINARY_CACHE_BUCKET_NAME


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- The 2.0.0 linux image uses an expired GPG key from https://dl.yarnpkg.com/debian/pubkey.gpg, when it was built
- Although https://dl.yarnpkg.com/debian/pubkey.gpg has valid GPG keys, it requires rebuilding the image
- `apt-key` stores keys in /etc/apt/trusted.gpg, which is now deprecated
- switched to yarn corepack, which avoids the use of GPG keys

#### Checklist

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
