### PR TITLE
chore: provide a link to the Gen2 migration tool in Gen2 banner 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,11 +23,9 @@
 >
 > If you are starting a new project, we recommend starting with [Amplify Gen 2](https://github.com/aws-amplify/amplify-backend).
 >
-> If you are an existing Gen 1 customer, we encourage you to start planning your move to Gen2 by
-> testing the [beta version of migration tool](https://github.com/aws-amplify/amplify-cli/discussions/14490)
-> on **non production** environments. We remain committed to supporting both Gen 1 and Gen 2 for the foreseeable future.
->
-> Customers on Gen 1 will continue to receive support for high-priority bugs and essential security updates.
+> If you are an existing Gen 1 customer, we encourage you to start planning your migration to Gen 2 by
+> testing the [beta version of our migration tool](https://github.com/aws-amplify/amplify-cli/discussions/14490)
+> on **non-production** environments. We remain committed to supporting both Gen 1 and Gen 2 for the foreseeable future.
 
 # AWS Amplify CLI (Gen 1)
 


### PR DESCRIPTION
In the banner that talks about Gen2, add a link to the migration tool and encourage customers to start planning their move.