### PR TITLE
feat(gen2-migration): fitness tracker test scripts

### DIFF
--- a/amplify-migration-apps/fitness-tracker/gen1-test-script.ts
+++ b/amplify-migration-apps/fitness-tracker/gen1-test-script.ts
@@ -19,8 +19,8 @@ import { Amplify } from 'aws-amplify';
 import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
 import { post } from 'aws-amplify/api';
 import amplifyconfig from './src/amplifyconfiguration.json';
-import { TestRunner, provisionTestUser } from '../shared-test-utils/test-apps-test-utils';
-import testCredentials from '../shared-test-utils/test-credentials.json';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
 import { createTestFunctions, createTestOrchestrator } from './test-utils';
 
 // Configure Amplify
@@ -51,7 +51,6 @@ async function testNutritionLogAPI(): Promise<void> {
   console.log('   Message:', (response as any).message);
 }
 
-
 // ============================================================
 // Main Test Execution
 // ============================================================
@@ -64,7 +63,7 @@ async function runAllTests(): Promise<void> {
   console.log('  3. REST API Operations (Nutrition Logging)');
 
   // Provision user via SDK, then sign in here so tokens stay in this module's Amplify scope
-  const { signinValue, testUser } = await provisionTestUser(amplifyconfig, testCredentials);
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
 
   // Sign in from this module so the auth tokens are available to api/storage
   try {

--- a/amplify-migration-apps/fitness-tracker/test-utils.ts
+++ b/amplify-migration-apps/fitness-tracker/test-utils.ts
@@ -19,7 +19,7 @@ import {
   deleteMeal,
 } from './src/graphql/mutations';
 import { WorkoutProgramStatus } from './src/API';
-import { TestRunner } from '../shared-test-utils/test-apps-test-utils';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
 import amplifyconfig from './src/amplifyconfiguration.json';
 
 // Configure Amplify in this module to ensure api singletons see the config
@@ -47,7 +47,6 @@ export function createTestFunctions() {
     programs.forEach((p: any) => console.log(`   - [${p.id}] ${p.title} (${p.status})${p.deadline ? ` - Due: ${p.deadline}` : ''}`));
     return programs.length > 0 ? programs[0].id : null;
   }
-
 
   async function testListExercises(): Promise<string | null> {
     console.log('\n💪 Testing listExercises...');
@@ -172,7 +171,6 @@ export function createTestFunctions() {
     const deleted = (result as any).data.deleteWorkoutProgram;
     console.log('✅ Deleted workout program:', deleted.title);
   }
-
 
   // ============================================================
   // Mutation Test Functions - Exercises
@@ -310,8 +308,6 @@ export function createTestFunctions() {
     testDeleteMeal,
   };
 }
-
-
 
 // ============================================================
 // Shared Test Orchestration Functions


### PR DESCRIPTION
This script provides comprehensive frontend-backend testing for the Fitness Tracker app's Amplify Gen1 and Gen2 backend.

What it tests:

- GraphQL queries (listWorkoutPrograms, getWorkoutProgram, listExercises, getExercise, listMeals, getMeal)
- GraphQL mutations (CRUD operations for WorkoutPrograms, Exercises, and Meals)
- REST API nutrition logging via Lambda function

How it works:

- Authenticates via Cognito user pool
- Runs authenticated queries to verify data retrieval (WorkoutPrograms, Exercises)
- Runs public queries for Meals (using API key auth mode)
- Performs full CRUD cycle on WorkoutPrograms (create → update → delete)
- Performs full CRUD cycle on Exercises linked to WorkoutPrograms (create → update → delete)
- Performs full CRUD cycle on Meals (create → update → delete)
- Tests REST API nutrition logging endpoint
- Cleans up test data in reverse order (exercises → workout programs) and signs out

Users need to update TEST_USER credentials before running tests.

Note: Lambda DomainAllow is amazon.com, so either test creds need to be changed for this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
