### PR TITLE
feat(gen2-migration): media vault test script

### DIFF
--- a/amplify-migration-apps/media-vault/gen1-test-script.ts
+++ b/amplify-migration-apps/media-vault/gen1-test-script.ts
@@ -1,0 +1,346 @@
+/***
+ * Consolidated Test Script for MediaVault App
+ *
+ * This script tests all functionality:
+ * 1. Authenticated GraphQL Queries (requires auth)
+ * 2. Authenticated GraphQL Mutations (requires auth)
+ * 3. Lambda Function Queries (thumbnail generation, user group management)
+ *
+ * IMPORTANT: Update TEST_USER credentials before running tests.
+ */
+
+// Polyfill crypto for Node.js environment (required for Amplify Auth)
+import { webcrypto } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = webcrypto;
+}
+
+import { generateClient } from 'aws-amplify/api';
+import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser, fetchAuthSession } from 'aws-amplify/auth';
+import { uploadData } from 'aws-amplify/storage';
+import { readFileSync } from 'fs';
+import amplifyconfig from './src/amplifyconfiguration.json';
+import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
+import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
+import { createTestRunner } from './test-utils';
+
+// Configure Amplify
+Amplify.configure(amplifyconfig);
+
+// Initialize test runner
+const { runTest, printSummary } = createTestRunner();
+
+// ============================================================
+// CONFIGURATION - Update with your test user credentials
+// ============================================================
+const TEST_USER = {
+  username: 'YOUR_USERNAME_HERE',
+  password: 'YOUR_PASSWORD_HERE',
+};
+
+// Test data for Lambda functions
+const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
+const TEST_GROUP = 'Admin'; // Group name for user management tests
+
+// ============================================================
+// Authentication Helper Functions
+// ============================================================
+async function authenticateUser(): Promise<boolean> {
+  console.log('\n🔐 Authenticating user...');
+  try {
+    await signIn({
+      username: TEST_USER.username,
+      password: TEST_USER.password,
+    });
+    const user = await getCurrentUser();
+    console.log(`✅ Signed in as: ${user.username}`);
+    return true;
+  } catch (error: any) {
+    if (error.name === 'UserAlreadyAuthenticatedException') {
+      const user = await getCurrentUser();
+      console.log(`✅ Already signed in as: ${user.username}`);
+      return true;
+    }
+    console.log('❌ Authentication failed:', error.message || error);
+    return false;
+  }
+}
+
+async function signOutUser(): Promise<void> {
+  console.log('\n🚪 Signing out...');
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error) {
+    console.log('❌ Sign out error:', error);
+  }
+}
+
+async function getUserSub(): Promise<string | null> {
+  try {
+    const session = await fetchAuthSession();
+    return (session.tokens?.idToken?.payload.sub as string) || null;
+  } catch (error) {
+    console.log('❌ Error getting user sub:', error);
+    return null;
+  }
+}
+
+// ============================================================
+// Query Test Functions - Notes
+// ============================================================
+async function testListNotes(): Promise<string | null> {
+  console.log('\n📋 Testing listNotes...');
+  const authClient = generateClient({ authMode: 'userPool' });
+  const result = await authClient.graphql({ query: listNotes });
+  const notes = (result as any).data.listNotes.items;
+  console.log(`✅ Found ${notes.length} notes:`);
+  notes.forEach((n: any) => console.log(`   - [${n.id}] ${n.title}${n.content ? ` - ${n.content.substring(0, 50)}...` : ''}`));
+  return notes.length > 0 ? notes[0].id : null;
+}
+
+async function testGetNote(id: string) {
+  console.log(`\n🔍 Testing getNote (id: ${id})...`);
+  const authClient = generateClient({ authMode: 'userPool' });
+  const result = await authClient.graphql({
+    query: getNote,
+    variables: { id },
+  });
+  const note = (result as any).data.getNote;
+  console.log('✅ Note:', {
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    owner: note.owner,
+    createdAt: note.createdAt,
+  });
+}
+
+// ============================================================
+// Mutation Test Functions - Notes
+// ============================================================
+async function testCreateNote(): Promise<string | null> {
+  console.log('\n🆕 Testing createNote...');
+  const authClient = generateClient({ authMode: 'userPool' });
+  const result = await authClient.graphql({
+    query: createNote,
+    variables: {
+      input: {
+        title: `Test Note ${Date.now()}`,
+        content: 'This is a test note created by the test script. It contains sample content for testing purposes.',
+      },
+    },
+  });
+  const note = (result as any).data.createNote;
+  console.log('✅ Created note:', {
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    owner: note.owner,
+  });
+  return note.id;
+}
+
+async function testUpdateNote(noteId: string): Promise<void> {
+  console.log(`\n✏️ Testing updateNote (id: ${noteId})...`);
+  const authClient = generateClient({ authMode: 'userPool' });
+  const result = await authClient.graphql({
+    query: updateNote,
+    variables: {
+      input: {
+        id: noteId,
+        title: 'Updated Test Note',
+        content: 'This note was updated by the test script with new content.',
+      },
+    },
+  });
+  const note = (result as any).data.updateNote;
+  console.log('✅ Updated note:', {
+    id: note.id,
+    title: note.title,
+    content: note.content,
+  });
+}
+
+async function testDeleteNote(noteId: string): Promise<void> {
+  console.log(`\n🗑️ Testing deleteNote (id: ${noteId})...`);
+  const authClient = generateClient({ authMode: 'userPool' });
+  const result = await authClient.graphql({
+    query: deleteNote,
+    variables: { input: { id: noteId } },
+  });
+  const deleted = (result as any).data.deleteNote;
+  console.log('✅ Deleted note:', deleted.title);
+}
+
+// ============================================================
+// Lambda Function Test Functions
+// ============================================================
+async function testGenerateThumbnail(): Promise<void> {
+  console.log('\n🖼️  Testing generateThumbnail Lambda function...');
+
+  try {
+    // Step 1: Upload a test image to S3
+    console.log('   📤 Uploading test image to S3...');
+    const imageBuffer = readFileSync(TEST_IMAGE_PATH);
+    const key = `media/test-${Date.now()}.jpg`;
+
+    const uploadResult = await uploadData({
+      path: ({ identityId }) => `private/${identityId}/${key}`,
+      data: imageBuffer,
+    }).result;
+
+    console.log(`   ✅ Image uploaded: ${key}`);
+
+    // Step 2: Get the full S3 path from upload result
+    const fullKey = uploadResult.path;
+    console.log(`   🔑 Full S3 key: ${fullKey}`);
+
+    // Step 3: Call the thumbnail generation Lambda
+    console.log('   🎨 Generating thumbnail...');
+    const publicClient = generateClient({ authMode: 'apiKey' });
+    const result = await publicClient.graphql({
+      query: generateThumbnail,
+      variables: { mediaFileKey: fullKey },
+    });
+    const response = (result as any).data.generateThumbnail;
+    console.log('✅ Thumbnail generation response:', {
+      statusCode: response.statusCode,
+      message: response.message,
+    });
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      console.log('⏭️  Skipping thumbnail test - test image file not found');
+      console.log(`   Please add an image file at: ${TEST_IMAGE_PATH}`);
+      console.log('   Or update TEST_IMAGE_PATH to point to an existing image');
+      return;
+    }
+    throw error;
+  }
+}
+
+async function testAddUserToGroup(): Promise<void> {
+  console.log(`\n👥 Testing addUserToGroup Lambda function...`);
+  const userSub = await getUserSub();
+  if (!userSub) {
+    throw new Error('Could not retrieve user sub');
+  }
+
+  // Use API Key auth mode (same as frontend publicClient)
+  const publicClient = generateClient({ authMode: 'apiKey' });
+  const result = await publicClient.graphql({
+    query: addUserToGroup,
+    variables: {
+      userSub: userSub,
+      group: TEST_GROUP,
+    },
+  });
+  const response = (result as any).data.addUserToGroup;
+  console.log('✅ Add user to group response:', {
+    statusCode: response.statusCode,
+    message: response.message,
+  });
+}
+
+async function testRemoveUserFromGroup(): Promise<void> {
+  console.log(`\n👥 Testing removeUserFromGroup Lambda function...`);
+  const userSub = await getUserSub();
+  if (!userSub) {
+    throw new Error('Could not retrieve user sub');
+  }
+
+  // Use API Key auth mode (same as frontend publicClient)
+  const publicClient = generateClient({ authMode: 'apiKey' });
+  const result = await publicClient.graphql({
+    query: removeUserFromGroup,
+    variables: {
+      userSub: userSub,
+      group: TEST_GROUP,
+    },
+  });
+  const response = (result as any).data.removeUserFromGroup;
+  console.log('✅ Remove user from group response:', {
+    statusCode: response.statusCode,
+    message: response.message,
+  });
+}
+
+// ============================================================
+// Main Test Runners
+// ============================================================
+async function runQueryTests() {
+  console.log('\n' + '='.repeat(50));
+  console.log('📖 PART 1: Authenticated GraphQL Queries');
+  console.log('='.repeat(50));
+
+  const noteId = await runTest('listNotes', testListNotes);
+  if (noteId) await runTest('getNote', () => testGetNote(noteId));
+}
+
+async function runMutationTests() {
+  console.log('\n' + '='.repeat(50));
+  console.log('✏️ PART 2: Authenticated GraphQL Mutations');
+  console.log('='.repeat(50));
+
+  // Create, update, and delete note
+  const noteId = await runTest('createNote', testCreateNote);
+  if (noteId) {
+    await runTest('updateNote', () => testUpdateNote(noteId));
+    await runTest('deleteNote', () => testDeleteNote(noteId));
+  }
+}
+
+async function runLambdaFunctionTests() {
+  console.log('\n' + '='.repeat(50));
+  console.log('⚡ PART 3: Lambda Function Operations');
+  console.log('='.repeat(50));
+
+  console.log('\n💡 Note: These tests require proper setup:');
+  console.log('   - Thumbnail generation requires a valid S3 media file key');
+  console.log('   - User group management requires Admin permissions\n');
+
+  await runTest('generateThumbnail', testGenerateThumbnail);
+  await runTest('addUserToGroup', testAddUserToGroup);
+  await runTest('removeUserFromGroup', testRemoveUserFromGroup);
+}
+
+async function runAllTests() {
+  console.log('🚀 Starting Consolidated Test Script for MediaVault\n');
+  console.log('This script tests:');
+  console.log('  1. Authenticated GraphQL Queries (Notes)');
+  console.log('  2. Authenticated GraphQL Mutations (Notes)');
+  console.log('  3. Lambda Function Operations (Thumbnails, User Groups)');
+
+  // Check credentials
+  if (TEST_USER.username === 'YOUR_USERNAME_HERE') {
+    console.log('\n⚠️  Please update TEST_USER credentials before running!');
+    console.log('   Edit the TEST_USER object at the top of this file.');
+    return;
+  }
+
+  // Authenticate
+  const isAuthenticated = await authenticateUser();
+  if (!isAuthenticated) {
+    console.log('\n❌ Cannot run tests without authentication');
+    return;
+  }
+
+  // Part 1: Queries
+  await runQueryTests();
+
+  // Part 2: Mutations
+  await runMutationTests();
+
+  // Part 3: Lambda Functions
+  await runLambdaFunctionTests();
+
+  // Sign out
+  await signOutUser();
+
+  // Print summary and exit with appropriate code
+  printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/media-vault/gen1-test-script.ts
+++ b/amplify-migration-apps/media-vault/gen1-test-script.ts
@@ -1,12 +1,12 @@
-/***
- * Consolidated Test Script for MediaVault App
+/**
+ * Gen1 Test Script for MediaVault App
  *
  * This script tests all functionality:
- * 1. Authenticated GraphQL Queries (requires auth)
- * 2. Authenticated GraphQL Mutations (requires auth)
- * 3. Lambda Function Queries (thumbnail generation, user group management)
+ * 1. Authenticated GraphQL Queries (Notes)
+ * 2. Authenticated GraphQL Mutations (Notes)
+ * 3. Lambda Function Operations (Thumbnails, User Groups)
  *
- * IMPORTANT: Update TEST_USER credentials before running tests.
+ * Credentials are provisioned automatically via Cognito SignUp + AdminConfirmSignUp.
  */
 
 // Polyfill crypto for Node.js environment (required for Amplify Auth)
@@ -15,316 +15,43 @@ if (typeof globalThis.crypto === 'undefined') {
   (globalThis as any).crypto = webcrypto;
 }
 
-import { generateClient } from 'aws-amplify/api';
 import { Amplify } from 'aws-amplify';
-import { signIn, signOut, getCurrentUser, fetchAuthSession } from 'aws-amplify/auth';
-import { uploadData } from 'aws-amplify/storage';
-import { readFileSync } from 'fs';
+import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
 import amplifyconfig from './src/amplifyconfiguration.json';
-import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
-import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
-import { createTestRunner } from './test-utils';
+import { TestRunner, provisionTestUser } from '../shared-test-utils/test-apps-test-utils';
+import testCredentials from '../shared-test-utils/test-credentials.json';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
 
 // Configure Amplify
 Amplify.configure(amplifyconfig);
 
-// Initialize test runner
-const { runTest, printSummary } = createTestRunner();
-
 // ============================================================
-// CONFIGURATION - Update with your test user credentials
+// Main Test Execution
 // ============================================================
-const TEST_USER = {
-  username: 'YOUR_USERNAME_HERE',
-  password: 'YOUR_PASSWORD_HERE',
-};
 
-// Test data for Lambda functions
-const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
-const TEST_GROUP = 'Admin'; // Group name for user management tests
-
-// ============================================================
-// Authentication Helper Functions
-// ============================================================
-async function authenticateUser(): Promise<boolean> {
-  console.log('\n🔐 Authenticating user...');
-  try {
-    await signIn({
-      username: TEST_USER.username,
-      password: TEST_USER.password,
-    });
-    const user = await getCurrentUser();
-    console.log(`✅ Signed in as: ${user.username}`);
-    return true;
-  } catch (error: any) {
-    if (error.name === 'UserAlreadyAuthenticatedException') {
-      const user = await getCurrentUser();
-      console.log(`✅ Already signed in as: ${user.username}`);
-      return true;
-    }
-    console.log('❌ Authentication failed:', error.message || error);
-    return false;
-  }
-}
-
-async function signOutUser(): Promise<void> {
-  console.log('\n🚪 Signing out...');
-  try {
-    await signOut();
-    console.log('✅ Signed out successfully');
-  } catch (error) {
-    console.log('❌ Sign out error:', error);
-  }
-}
-
-async function getUserSub(): Promise<string | null> {
-  try {
-    const session = await fetchAuthSession();
-    return (session.tokens?.idToken?.payload.sub as string) || null;
-  } catch (error) {
-    console.log('❌ Error getting user sub:', error);
-    return null;
-  }
-}
-
-// ============================================================
-// Query Test Functions - Notes
-// ============================================================
-async function testListNotes(): Promise<string | null> {
-  console.log('\n📋 Testing listNotes...');
-  const authClient = generateClient({ authMode: 'userPool' });
-  const result = await authClient.graphql({ query: listNotes });
-  const notes = (result as any).data.listNotes.items;
-  console.log(`✅ Found ${notes.length} notes:`);
-  notes.forEach((n: any) => console.log(`   - [${n.id}] ${n.title}${n.content ? ` - ${n.content.substring(0, 50)}...` : ''}`));
-  return notes.length > 0 ? notes[0].id : null;
-}
-
-async function testGetNote(id: string) {
-  console.log(`\n🔍 Testing getNote (id: ${id})...`);
-  const authClient = generateClient({ authMode: 'userPool' });
-  const result = await authClient.graphql({
-    query: getNote,
-    variables: { id },
-  });
-  const note = (result as any).data.getNote;
-  console.log('✅ Note:', {
-    id: note.id,
-    title: note.title,
-    content: note.content,
-    owner: note.owner,
-    createdAt: note.createdAt,
-  });
-}
-
-// ============================================================
-// Mutation Test Functions - Notes
-// ============================================================
-async function testCreateNote(): Promise<string | null> {
-  console.log('\n🆕 Testing createNote...');
-  const authClient = generateClient({ authMode: 'userPool' });
-  const result = await authClient.graphql({
-    query: createNote,
-    variables: {
-      input: {
-        title: `Test Note ${Date.now()}`,
-        content: 'This is a test note created by the test script. It contains sample content for testing purposes.',
-      },
-    },
-  });
-  const note = (result as any).data.createNote;
-  console.log('✅ Created note:', {
-    id: note.id,
-    title: note.title,
-    content: note.content,
-    owner: note.owner,
-  });
-  return note.id;
-}
-
-async function testUpdateNote(noteId: string): Promise<void> {
-  console.log(`\n✏️ Testing updateNote (id: ${noteId})...`);
-  const authClient = generateClient({ authMode: 'userPool' });
-  const result = await authClient.graphql({
-    query: updateNote,
-    variables: {
-      input: {
-        id: noteId,
-        title: 'Updated Test Note',
-        content: 'This note was updated by the test script with new content.',
-      },
-    },
-  });
-  const note = (result as any).data.updateNote;
-  console.log('✅ Updated note:', {
-    id: note.id,
-    title: note.title,
-    content: note.content,
-  });
-}
-
-async function testDeleteNote(noteId: string): Promise<void> {
-  console.log(`\n🗑️ Testing deleteNote (id: ${noteId})...`);
-  const authClient = generateClient({ authMode: 'userPool' });
-  const result = await authClient.graphql({
-    query: deleteNote,
-    variables: { input: { id: noteId } },
-  });
-  const deleted = (result as any).data.deleteNote;
-  console.log('✅ Deleted note:', deleted.title);
-}
-
-// ============================================================
-// Lambda Function Test Functions
-// ============================================================
-async function testGenerateThumbnail(): Promise<void> {
-  console.log('\n🖼️  Testing generateThumbnail Lambda function...');
-
-  try {
-    // Step 1: Upload a test image to S3
-    console.log('   📤 Uploading test image to S3...');
-    const imageBuffer = readFileSync(TEST_IMAGE_PATH);
-    const key = `media/test-${Date.now()}.jpg`;
-
-    const uploadResult = await uploadData({
-      path: ({ identityId }) => `private/${identityId}/${key}`,
-      data: imageBuffer,
-    }).result;
-
-    console.log(`   ✅ Image uploaded: ${key}`);
-
-    // Step 2: Get the full S3 path from upload result
-    const fullKey = uploadResult.path;
-    console.log(`   🔑 Full S3 key: ${fullKey}`);
-
-    // Step 3: Call the thumbnail generation Lambda
-    console.log('   🎨 Generating thumbnail...');
-    const publicClient = generateClient({ authMode: 'apiKey' });
-    const result = await publicClient.graphql({
-      query: generateThumbnail,
-      variables: { mediaFileKey: fullKey },
-    });
-    const response = (result as any).data.generateThumbnail;
-    console.log('✅ Thumbnail generation response:', {
-      statusCode: response.statusCode,
-      message: response.message,
-    });
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
-      console.log('⏭️  Skipping thumbnail test - test image file not found');
-      console.log(`   Please add an image file at: ${TEST_IMAGE_PATH}`);
-      console.log('   Or update TEST_IMAGE_PATH to point to an existing image');
-      return;
-    }
-    throw error;
-  }
-}
-
-async function testAddUserToGroup(): Promise<void> {
-  console.log(`\n👥 Testing addUserToGroup Lambda function...`);
-  const userSub = await getUserSub();
-  if (!userSub) {
-    throw new Error('Could not retrieve user sub');
-  }
-
-  // Use API Key auth mode (same as frontend publicClient)
-  const publicClient = generateClient({ authMode: 'apiKey' });
-  const result = await publicClient.graphql({
-    query: addUserToGroup,
-    variables: {
-      userSub: userSub,
-      group: TEST_GROUP,
-    },
-  });
-  const response = (result as any).data.addUserToGroup;
-  console.log('✅ Add user to group response:', {
-    statusCode: response.statusCode,
-    message: response.message,
-  });
-}
-
-async function testRemoveUserFromGroup(): Promise<void> {
-  console.log(`\n👥 Testing removeUserFromGroup Lambda function...`);
-  const userSub = await getUserSub();
-  if (!userSub) {
-    throw new Error('Could not retrieve user sub');
-  }
-
-  // Use API Key auth mode (same as frontend publicClient)
-  const publicClient = generateClient({ authMode: 'apiKey' });
-  const result = await publicClient.graphql({
-    query: removeUserFromGroup,
-    variables: {
-      userSub: userSub,
-      group: TEST_GROUP,
-    },
-  });
-  const response = (result as any).data.removeUserFromGroup;
-  console.log('✅ Remove user from group response:', {
-    statusCode: response.statusCode,
-    message: response.message,
-  });
-}
-
-// ============================================================
-// Main Test Runners
-// ============================================================
-async function runQueryTests() {
-  console.log('\n' + '='.repeat(50));
-  console.log('📖 PART 1: Authenticated GraphQL Queries');
-  console.log('='.repeat(50));
-
-  const noteId = await runTest('listNotes', testListNotes);
-  if (noteId) await runTest('getNote', () => testGetNote(noteId));
-}
-
-async function runMutationTests() {
-  console.log('\n' + '='.repeat(50));
-  console.log('✏️ PART 2: Authenticated GraphQL Mutations');
-  console.log('='.repeat(50));
-
-  // Create, update, and delete note
-  const noteId = await runTest('createNote', testCreateNote);
-  if (noteId) {
-    await runTest('updateNote', () => testUpdateNote(noteId));
-    await runTest('deleteNote', () => testDeleteNote(noteId));
-  }
-}
-
-async function runLambdaFunctionTests() {
-  console.log('\n' + '='.repeat(50));
-  console.log('⚡ PART 3: Lambda Function Operations');
-  console.log('='.repeat(50));
-
-  console.log('\n💡 Note: These tests require proper setup:');
-  console.log('   - Thumbnail generation requires a valid S3 media file key');
-  console.log('   - User group management requires Admin permissions\n');
-
-  await runTest('generateThumbnail', testGenerateThumbnail);
-  await runTest('addUserToGroup', testAddUserToGroup);
-  await runTest('removeUserFromGroup', testRemoveUserFromGroup);
-}
-
-async function runAllTests() {
-  console.log('🚀 Starting Consolidated Test Script for MediaVault\n');
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting Gen1 Test Script for MediaVault\n');
   console.log('This script tests:');
   console.log('  1. Authenticated GraphQL Queries (Notes)');
   console.log('  2. Authenticated GraphQL Mutations (Notes)');
   console.log('  3. Lambda Function Operations (Thumbnails, User Groups)');
 
-  // Check credentials
-  if (TEST_USER.username === 'YOUR_USERNAME_HERE') {
-    console.log('\n⚠️  Please update TEST_USER credentials before running!');
-    console.log('   Edit the TEST_USER object at the top of this file.');
-    return;
+  // Provision user via SDK, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig, testCredentials);
+
+  // Sign in from this module so the auth tokens are available to api/storage
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn has failed:', error.message || error);
+    process.exit(1);
   }
 
-  // Authenticate
-  const isAuthenticated = await authenticateUser();
-  if (!isAuthenticated) {
-    console.log('\n❌ Cannot run tests without authentication');
-    return;
-  }
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions();
+  const { runQueryTests, runMutationTests, runLambdaFunctionTests } = createTestOrchestrator(testFunctions, runner);
 
   // Part 1: Queries
   await runQueryTests();
@@ -336,10 +63,15 @@ async function runAllTests() {
   await runLambdaFunctionTests();
 
   // Sign out
-  await signOutUser();
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
 
   // Print summary and exit with appropriate code
-  printSummary();
+  runner.printSummary();
 }
 
 // Run all tests

--- a/amplify-migration-apps/media-vault/gen1-test-script.ts
+++ b/amplify-migration-apps/media-vault/gen1-test-script.ts
@@ -2,11 +2,11 @@
  * Gen1 Test Script for MediaVault App
  *
  * This script tests all functionality:
- * 1. Authenticated GraphQL Queries (Notes)
- * 2. Authenticated GraphQL Mutations (Notes)
+ * 1. Authenticated GraphQL Queries (requires auth)
+ * 2. Authenticated GraphQL Mutations (requires auth)
  * 3. Lambda Function Operations (Thumbnails, User Groups)
  *
- * Credentials are provisioned automatically via Cognito SignUp + AdminConfirmSignUp.
+ * Credentials are provisioned automatically via Cognito AdminCreateUser + AdminSetUserPassword.
  */
 
 // Polyfill crypto for Node.js environment (required for Amplify Auth)
@@ -18,8 +18,8 @@ if (typeof globalThis.crypto === 'undefined') {
 import { Amplify } from 'aws-amplify';
 import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
 import amplifyconfig from './src/amplifyconfiguration.json';
-import { TestRunner, provisionTestUser } from '../shared-test-utils/test-apps-test-utils';
-import testCredentials from '../shared-test-utils/test-credentials.json';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
 import { createTestFunctions, createTestOrchestrator } from './test-utils';
 
 // Configure Amplify
@@ -30,14 +30,14 @@ Amplify.configure(amplifyconfig);
 // ============================================================
 
 async function runAllTests(): Promise<void> {
-  console.log('🚀 Starting Gen1 Test Script for MediaVault\n');
+  console.log('🚀 Starting MediaVault Gen1 Test Script\n');
   console.log('This script tests:');
   console.log('  1. Authenticated GraphQL Queries (Notes)');
   console.log('  2. Authenticated GraphQL Mutations (Notes)');
   console.log('  3. Lambda Function Operations (Thumbnails, User Groups)');
 
-  // Provision user via SDK, then sign in here so tokens stay in this module's Amplify scope
-  const { signinValue, testUser } = await provisionTestUser(amplifyconfig, testCredentials);
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
 
   // Sign in from this module so the auth tokens are available to api/storage
   try {
@@ -45,7 +45,7 @@ async function runAllTests(): Promise<void> {
     const currentUser = await getCurrentUser();
     console.log(`✅ Signed in as: ${currentUser.username}`);
   } catch (error: any) {
-    console.error('❌ SignIn has failed:', error.message || error);
+    console.error('❌ SignIn failed:', error.message || error);
     process.exit(1);
   }
 

--- a/amplify-migration-apps/media-vault/test-utils.ts
+++ b/amplify-migration-apps/media-vault/test-utils.ts
@@ -1,0 +1,53 @@
+// test-utils.ts
+export interface TestFailure {
+  name: string;
+  error: string;
+}
+
+export function createTestRunner() {
+  const failures: TestFailure[] = [];
+
+  async function runTest<T>(name: string, testFn: () => Promise<T>): Promise<T | null> {
+    try {
+      const result = await testFn();
+      return result;
+    } catch (error: any) {
+      // Handle different error formats (GraphQL errors, standard errors, objects)
+      let errorMessage: string;
+      if (error.errors?.[0]?.message) {
+        // GraphQL error format
+        errorMessage = error.errors[0].message;
+      } else if (error.message) {
+        // Standard Error
+        errorMessage = error.message;
+      } else if (typeof error === 'object') {
+        // Generic object - stringify it
+        errorMessage = JSON.stringify(error, null, 2);
+      } else {
+        errorMessage = String(error);
+      }
+
+      failures.push({ name, error: errorMessage });
+      return null;
+    }
+  }
+
+  function printSummary(): void {
+    console.log('\n' + '='.repeat(50));
+    console.log('📊 TEST SUMMARY');
+    console.log('='.repeat(50));
+
+    if (failures.length === 0) {
+      console.log('\n✅ All tests passed!');
+    } else {
+      console.log(`\n❌ ${failures.length} test(s) failed:\n`);
+      failures.forEach((f) => {
+        console.log(`  • ${f.name}`);
+        console.log(`    Error: ${f.error}\n`);
+      });
+      process.exit(1);
+    }
+  }
+
+  return { failures, runTest, printSummary };
+}

--- a/amplify-migration-apps/media-vault/test-utils.ts
+++ b/amplify-migration-apps/media-vault/test-utils.ts
@@ -10,14 +10,14 @@ import { uploadData } from 'aws-amplify/storage';
 import { readFileSync } from 'fs';
 import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
 import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
-import { TestRunner } from './_test-common/test-apps-test-utils';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
 import amplifyconfig from './src/amplifyconfiguration.json';
 
 // Configure Amplify in this module to ensure api/storage singletons see the config
 Amplify.configure(amplifyconfig);
 
 // Test data for Lambda functions
-const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
+const TEST_IMAGE_PATH = './images/app.png'; // Uses existing app screenshot as test image
 const TEST_GROUP = 'Admin'; // Group name for user management tests
 
 // ============================================================

--- a/amplify-migration-apps/media-vault/test-utils.ts
+++ b/amplify-migration-apps/media-vault/test-utils.ts
@@ -1,53 +1,283 @@
 // test-utils.ts
-export interface TestFailure {
-  name: string;
-  error: string;
-}
+/**
+ * Shared test utilities for Media Vault Gen1 and Gen2 test scripts
+ */
 
-export function createTestRunner() {
-  const failures: TestFailure[] = [];
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/api';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { uploadData } from 'aws-amplify/storage';
+import { readFileSync } from 'fs';
+import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
+import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
+import { TestRunner } from '../shared-test-utils/test-apps-test-utils';
+import amplifyconfig from './src/amplifyconfiguration.json';
 
-  async function runTest<T>(name: string, testFn: () => Promise<T>): Promise<T | null> {
+// Configure Amplify in this module to ensure api/storage singletons see the config
+Amplify.configure(amplifyconfig);
+
+// ============================================================
+// Shared Test Functions Factory
+// ============================================================
+
+export function createTestFunctions() {
+  // Test data for Lambda functions
+  const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
+  const TEST_GROUP = 'Admin'; // Group name for user management tests
+
+  function getAuthClient() {
+    return generateClient({ authMode: 'userPool' });
+  }
+
+  function getPublicClient() {
+    return generateClient({ authMode: 'apiKey' });
+  }
+
+  async function getUserSub(): Promise<string | null> {
     try {
-      const result = await testFn();
-      return result;
-    } catch (error: any) {
-      // Handle different error formats (GraphQL errors, standard errors, objects)
-      let errorMessage: string;
-      if (error.errors?.[0]?.message) {
-        // GraphQL error format
-        errorMessage = error.errors[0].message;
-      } else if (error.message) {
-        // Standard Error
-        errorMessage = error.message;
-      } else if (typeof error === 'object') {
-        // Generic object - stringify it
-        errorMessage = JSON.stringify(error, null, 2);
-      } else {
-        errorMessage = String(error);
-      }
-
-      failures.push({ name, error: errorMessage });
+      const session = await fetchAuthSession();
+      return (session.tokens?.idToken?.payload.sub as string) || null;
+    } catch (error) {
+      console.log('❌ Error getting user sub:', error);
       return null;
     }
   }
 
-  function printSummary(): void {
-    console.log('\n' + '='.repeat(50));
-    console.log('📊 TEST SUMMARY');
-    console.log('='.repeat(50));
+  // ============================================================
+  // Query Test Functions - Notes
+  // ============================================================
 
-    if (failures.length === 0) {
-      console.log('\n✅ All tests passed!');
-    } else {
-      console.log(`\n❌ ${failures.length} test(s) failed:\n`);
-      failures.forEach((f) => {
-        console.log(`  • ${f.name}`);
-        console.log(`    Error: ${f.error}\n`);
+  async function testListNotes(): Promise<string | null> {
+    console.log('\n📋 Testing listNotes...');
+    const authClient = getAuthClient();
+    const result = await authClient.graphql({ query: listNotes });
+    const notes = (result as any).data.listNotes.items;
+    console.log(`✅ Found ${notes.length} notes:`);
+    notes.forEach((n: any) => console.log(`   - [${n.id}] ${n.title}${n.content ? ` - ${n.content.substring(0, 50)}...` : ''}`));
+    return notes.length > 0 ? notes[0].id : null;
+  }
+
+  async function testGetNote(id: string): Promise<void> {
+    console.log(`\n🔍 Testing getNote (id: ${id})...`);
+    const authClient = getAuthClient();
+    const result = await authClient.graphql({
+      query: getNote,
+      variables: { id },
+    });
+    const note = (result as any).data.getNote;
+    console.log('✅ Note:', {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      owner: note.owner,
+      createdAt: note.createdAt,
+    });
+  }
+
+  // ============================================================
+  // Mutation Test Functions - Notes
+  // ============================================================
+
+  async function testCreateNote(): Promise<string | null> {
+    console.log('\n🆕 Testing createNote...');
+    const authClient = getAuthClient();
+    const result = await authClient.graphql({
+      query: createNote,
+      variables: {
+        input: {
+          title: `Test Note ${Date.now()}`,
+          content: 'This is a test note created by the test script. It contains sample content for testing purposes.',
+        },
+      },
+    });
+    const note = (result as any).data.createNote;
+    console.log('✅ Created note:', {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+      owner: note.owner,
+    });
+    return note.id;
+  }
+
+  async function testUpdateNote(noteId: string): Promise<void> {
+    console.log(`\n✏️ Testing updateNote (id: ${noteId})...`);
+    const authClient = getAuthClient();
+    const result = await authClient.graphql({
+      query: updateNote,
+      variables: {
+        input: {
+          id: noteId,
+          title: 'Updated Test Note',
+          content: 'This note was updated by the test script with new content.',
+        },
+      },
+    });
+    const note = (result as any).data.updateNote;
+    console.log('✅ Updated note:', {
+      id: note.id,
+      title: note.title,
+      content: note.content,
+    });
+  }
+
+  async function testDeleteNote(noteId: string): Promise<void> {
+    console.log(`\n🗑️ Testing deleteNote (id: ${noteId})...`);
+    const authClient = getAuthClient();
+    const result = await authClient.graphql({
+      query: deleteNote,
+      variables: { input: { id: noteId } },
+    });
+    const deleted = (result as any).data.deleteNote;
+    console.log('✅ Deleted note:', deleted.title);
+  }
+
+  // ============================================================
+  // Lambda Function Test Functions
+  // ============================================================
+
+  async function testGenerateThumbnail(): Promise<void> {
+    console.log('\n🖼️  Testing generateThumbnail Lambda function...');
+
+    try {
+      // Step 1: Upload a test image to S3
+      console.log('   📤 Uploading test image to S3...');
+      const imageBuffer = readFileSync(TEST_IMAGE_PATH);
+      const key = `media/test-${Date.now()}.jpg`;
+
+      const uploadResult = await uploadData({
+        path: ({ identityId }) => `private/${identityId}/${key}`,
+        data: imageBuffer,
+      }).result;
+
+      console.log(`   ✅ Image uploaded: ${key}`);
+
+      // Step 2: Get the full S3 path from upload result
+      const fullKey = uploadResult.path;
+      console.log(`   🔑 Full S3 key: ${fullKey}`);
+
+      // Step 3: Call the thumbnail generation Lambda
+      console.log('   🎨 Generating thumbnail...');
+      const publicClient = getPublicClient();
+      const result = await publicClient.graphql({
+        query: generateThumbnail,
+        variables: { mediaFileKey: fullKey },
       });
-      process.exit(1);
+      const response = (result as any).data.generateThumbnail;
+      console.log('✅ Thumbnail generation response:', {
+        statusCode: response.statusCode,
+        message: response.message,
+      });
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        console.log('⏭️  Skipping thumbnail test - test image file not found');
+        console.log(`   Please add an image file at: ${TEST_IMAGE_PATH}`);
+        console.log('   Or update TEST_IMAGE_PATH to point to an existing image');
+        return;
+      }
+      throw error;
     }
   }
 
-  return { failures, runTest, printSummary };
+  async function testAddUserToGroup(): Promise<void> {
+    console.log(`\n👥 Testing addUserToGroup Lambda function...`);
+    const userSub = await getUserSub();
+    if (!userSub) {
+      throw new Error('Could not retrieve user sub');
+    }
+
+    const publicClient = getPublicClient();
+    const result = await publicClient.graphql({
+      query: addUserToGroup,
+      variables: {
+        userSub: userSub,
+        group: TEST_GROUP,
+      },
+    });
+    const response = (result as any).data.addUserToGroup;
+    console.log('✅ Add user to group response:', {
+      statusCode: response.statusCode,
+      message: response.message,
+    });
+  }
+
+  async function testRemoveUserFromGroup(): Promise<void> {
+    console.log(`\n👥 Testing removeUserFromGroup Lambda function...`);
+    const userSub = await getUserSub();
+    if (!userSub) {
+      throw new Error('Could not retrieve user sub');
+    }
+
+    const publicClient = getPublicClient();
+    const result = await publicClient.graphql({
+      query: removeUserFromGroup,
+      variables: {
+        userSub: userSub,
+        group: TEST_GROUP,
+      },
+    });
+    const response = (result as any).data.removeUserFromGroup;
+    console.log('✅ Remove user from group response:', {
+      statusCode: response.statusCode,
+      message: response.message,
+    });
+  }
+
+  return {
+    testListNotes,
+    testGetNote,
+    testCreateNote,
+    testUpdateNote,
+    testDeleteNote,
+    testGenerateThumbnail,
+    testAddUserToGroup,
+    testRemoveUserFromGroup,
+  };
+}
+
+// ============================================================
+// Shared Test Orchestration Functions
+// ============================================================
+
+export function createTestOrchestrator(testFunctions: ReturnType<typeof createTestFunctions>, runner: TestRunner) {
+  async function runQueryTests(): Promise<void> {
+    console.log('\n' + '='.repeat(50));
+    console.log('📖 PART 1: Authenticated GraphQL Queries');
+    console.log('='.repeat(50));
+
+    const noteId = await runner.runTest('listNotes', testFunctions.testListNotes);
+    if (noteId) await runner.runTest('getNote', () => testFunctions.testGetNote(noteId));
+  }
+
+  async function runMutationTests(): Promise<void> {
+    console.log('\n' + '='.repeat(50));
+    console.log('✏️ PART 2: Authenticated GraphQL Mutations');
+    console.log('='.repeat(50));
+
+    const noteId = await runner.runTest('createNote', testFunctions.testCreateNote);
+    if (noteId) {
+      await runner.runTest('updateNote', () => testFunctions.testUpdateNote(noteId));
+      await runner.runTest('deleteNote', () => testFunctions.testDeleteNote(noteId));
+    }
+  }
+
+  async function runLambdaFunctionTests(): Promise<void> {
+    console.log('\n' + '='.repeat(50));
+    console.log('⚡ PART 3: Lambda Function Operations');
+    console.log('='.repeat(50));
+
+    console.log('\n💡 Note: These tests require proper setup:');
+    console.log('   - Thumbnail generation requires a valid S3 media file key');
+    console.log('   - User group management requires Admin permissions\n');
+
+    await runner.runTest('generateThumbnail', testFunctions.testGenerateThumbnail);
+    await runner.runTest('addUserToGroup', testFunctions.testAddUserToGroup);
+    await runner.runTest('removeUserFromGroup', testFunctions.testRemoveUserFromGroup);
+  }
+
+  return {
+    runQueryTests,
+    runMutationTests,
+    runLambdaFunctionTests,
+  };
 }

--- a/amplify-migration-apps/media-vault/test-utils.ts
+++ b/amplify-migration-apps/media-vault/test-utils.ts
@@ -1,38 +1,30 @@
 // test-utils.ts
 /**
- * Shared test utilities for Media Vault Gen1 and Gen2 test scripts
+ * Shared test utilities for MediaVault Gen1 and Gen2 test scripts
  */
 
 import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/api';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { uploadData } from 'aws-amplify/storage';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
 import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
-import { TestRunner } from '../shared-test-utils/test-apps-test-utils';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
 import amplifyconfig from './src/amplifyconfiguration.json';
 
 // Configure Amplify in this module to ensure api/storage singletons see the config
 Amplify.configure(amplifyconfig);
+
+// Test data for Lambda functions
+const TEST_IMAGE_PATH = './test-image.jpg';
+const TEST_GROUP = 'Admin';
 
 // ============================================================
 // Shared Test Functions Factory
 // ============================================================
 
 export function createTestFunctions() {
-  // Test data for Lambda functions
-  const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
-  const TEST_GROUP = 'Admin'; // Group name for user management tests
-
-  function getAuthClient() {
-    return generateClient({ authMode: 'userPool' });
-  }
-
-  function getPublicClient() {
-    return generateClient({ authMode: 'apiKey' });
-  }
-
   async function getUserSub(): Promise<string | null> {
     try {
       const session = await fetchAuthSession();
@@ -49,7 +41,7 @@ export function createTestFunctions() {
 
   async function testListNotes(): Promise<string | null> {
     console.log('\n📋 Testing listNotes...');
-    const authClient = getAuthClient();
+    const authClient = generateClient({ authMode: 'userPool' });
     const result = await authClient.graphql({ query: listNotes });
     const notes = (result as any).data.listNotes.items;
     console.log(`✅ Found ${notes.length} notes:`);
@@ -59,11 +51,8 @@ export function createTestFunctions() {
 
   async function testGetNote(id: string): Promise<void> {
     console.log(`\n🔍 Testing getNote (id: ${id})...`);
-    const authClient = getAuthClient();
-    const result = await authClient.graphql({
-      query: getNote,
-      variables: { id },
-    });
+    const authClient = generateClient({ authMode: 'userPool' });
+    const result = await authClient.graphql({ query: getNote, variables: { id } });
     const note = (result as any).data.getNote;
     console.log('✅ Note:', {
       id: note.id,
@@ -80,7 +69,7 @@ export function createTestFunctions() {
 
   async function testCreateNote(): Promise<string | null> {
     console.log('\n🆕 Testing createNote...');
-    const authClient = getAuthClient();
+    const authClient = generateClient({ authMode: 'userPool' });
     const result = await authClient.graphql({
       query: createNote,
       variables: {
@@ -102,7 +91,7 @@ export function createTestFunctions() {
 
   async function testUpdateNote(noteId: string): Promise<void> {
     console.log(`\n✏️ Testing updateNote (id: ${noteId})...`);
-    const authClient = getAuthClient();
+    const authClient = generateClient({ authMode: 'userPool' });
     const result = await authClient.graphql({
       query: updateNote,
       variables: {
@@ -123,7 +112,7 @@ export function createTestFunctions() {
 
   async function testDeleteNote(noteId: string): Promise<void> {
     console.log(`\n🗑️ Testing deleteNote (id: ${noteId})...`);
-    const authClient = getAuthClient();
+    const authClient = generateClient({ authMode: 'userPool' });
     const result = await authClient.graphql({
       query: deleteNote,
       variables: { input: { id: noteId } },
@@ -139,60 +128,51 @@ export function createTestFunctions() {
   async function testGenerateThumbnail(): Promise<void> {
     console.log('\n🖼️  Testing generateThumbnail Lambda function...');
 
-    try {
-      // Step 1: Upload a test image to S3
-      console.log('   📤 Uploading test image to S3...');
-      const imageBuffer = readFileSync(TEST_IMAGE_PATH);
-      const key = `media/test-${Date.now()}.jpg`;
+    console.log('   📤 Uploading test image to S3...');
+    let imageBuffer: Buffer;
 
-      const uploadResult = await uploadData({
-        path: ({ identityId }) => `private/${identityId}/${key}`,
-        data: imageBuffer,
-      }).result;
-
-      console.log(`   ✅ Image uploaded: ${key}`);
-
-      // Step 2: Get the full S3 path from upload result
-      const fullKey = uploadResult.path;
-      console.log(`   🔑 Full S3 key: ${fullKey}`);
-
-      // Step 3: Call the thumbnail generation Lambda
-      console.log('   🎨 Generating thumbnail...');
-      const publicClient = getPublicClient();
-      const result = await publicClient.graphql({
-        query: generateThumbnail,
-        variables: { mediaFileKey: fullKey },
-      });
-      const response = (result as any).data.generateThumbnail;
-      console.log('✅ Thumbnail generation response:', {
-        statusCode: response.statusCode,
-        message: response.message,
-      });
-    } catch (error: any) {
-      if (error.code === 'ENOENT') {
-        console.log('⏭️  Skipping thumbnail test - test image file not found');
-        console.log(`   Please add an image file at: ${TEST_IMAGE_PATH}`);
-        console.log('   Or update TEST_IMAGE_PATH to point to an existing image');
-        return;
-      }
-      throw error;
+    if (existsSync(TEST_IMAGE_PATH)) {
+      imageBuffer = readFileSync(TEST_IMAGE_PATH);
+      console.log('   Using local image file');
+    } else {
+      const testImageBase64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAA3klEQVR42u3QMQEAAAgDILV/51nBzwci0JlYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqz8WgGPGAGBPQqrHAAAAABJRU5ErkJggg==';
+      imageBuffer = Buffer.from(testImageBase64, 'base64');
+      console.log('   Using generated test image (no local file found)');
     }
+
+    const key = `media/test-${Date.now()}.jpg`;
+    const uploadResult = await uploadData({
+      path: ({ identityId }: { identityId: string }) => `private/${identityId}/${key}`,
+      data: imageBuffer,
+    }).result;
+
+    console.log(`   ✅ Image uploaded: ${key}`);
+    const fullKey = uploadResult.path;
+    console.log(`   🔑 Full S3 key: ${fullKey}`);
+
+    console.log('   🎨 Generating thumbnail...');
+    const publicClient = generateClient({ authMode: 'apiKey' });
+    const result = await publicClient.graphql({
+      query: generateThumbnail,
+      variables: { mediaFileKey: fullKey },
+    });
+    const response = (result as any).data.generateThumbnail;
+    console.log('✅ Thumbnail generation response:', {
+      statusCode: response.statusCode,
+      message: response.message,
+    });
   }
 
   async function testAddUserToGroup(): Promise<void> {
     console.log(`\n👥 Testing addUserToGroup Lambda function...`);
     const userSub = await getUserSub();
-    if (!userSub) {
-      throw new Error('Could not retrieve user sub');
-    }
+    if (!userSub) throw new Error('Could not retrieve user sub');
 
-    const publicClient = getPublicClient();
+    const publicClient = generateClient({ authMode: 'apiKey' });
     const result = await publicClient.graphql({
       query: addUserToGroup,
-      variables: {
-        userSub: userSub,
-        group: TEST_GROUP,
-      },
+      variables: { userSub, group: TEST_GROUP },
     });
     const response = (result as any).data.addUserToGroup;
     console.log('✅ Add user to group response:', {
@@ -204,17 +184,12 @@ export function createTestFunctions() {
   async function testRemoveUserFromGroup(): Promise<void> {
     console.log(`\n👥 Testing removeUserFromGroup Lambda function...`);
     const userSub = await getUserSub();
-    if (!userSub) {
-      throw new Error('Could not retrieve user sub');
-    }
+    if (!userSub) throw new Error('Could not retrieve user sub');
 
-    const publicClient = getPublicClient();
+    const publicClient = generateClient({ authMode: 'apiKey' });
     const result = await publicClient.graphql({
       query: removeUserFromGroup,
-      variables: {
-        userSub: userSub,
-        group: TEST_GROUP,
-      },
+      variables: { userSub, group: TEST_GROUP },
     });
     const response = (result as any).data.removeUserFromGroup;
     console.log('✅ Remove user from group response:', {
@@ -275,9 +250,5 @@ export function createTestOrchestrator(testFunctions: ReturnType<typeof createTe
     await runner.runTest('removeUserFromGroup', testFunctions.testRemoveUserFromGroup);
   }
 
-  return {
-    runQueryTests,
-    runMutationTests,
-    runLambdaFunctionTests,
-  };
+  return { runQueryTests, runMutationTests, runLambdaFunctionTests };
 }

--- a/amplify-migration-apps/media-vault/test-utils.ts
+++ b/amplify-migration-apps/media-vault/test-utils.ts
@@ -7,24 +7,28 @@ import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/api';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { uploadData } from 'aws-amplify/storage';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync } from 'fs';
 import { getNote, listNotes, generateThumbnail, addUserToGroup, removeUserFromGroup } from './src/graphql/queries';
 import { createNote, updateNote, deleteNote } from './src/graphql/mutations';
-import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { TestRunner } from './_test-common/test-apps-test-utils';
 import amplifyconfig from './src/amplifyconfiguration.json';
 
 // Configure Amplify in this module to ensure api/storage singletons see the config
 Amplify.configure(amplifyconfig);
 
 // Test data for Lambda functions
-const TEST_IMAGE_PATH = './test-image.jpg';
-const TEST_GROUP = 'Admin';
+const TEST_IMAGE_PATH = 'YOUR_TEST_IMAGE_PATH'; // Path to a test image file
+const TEST_GROUP = 'Admin'; // Group name for user management tests
 
 // ============================================================
 // Shared Test Functions Factory
 // ============================================================
 
 export function createTestFunctions() {
+  // ============================================================
+  // Helper Functions
+  // ============================================================
+
   async function getUserSub(): Promise<string | null> {
     try {
       const session = await fetchAuthSession();
@@ -52,7 +56,10 @@ export function createTestFunctions() {
   async function testGetNote(id: string): Promise<void> {
     console.log(`\n🔍 Testing getNote (id: ${id})...`);
     const authClient = generateClient({ authMode: 'userPool' });
-    const result = await authClient.graphql({ query: getNote, variables: { id } });
+    const result = await authClient.graphql({
+      query: getNote,
+      variables: { id },
+    });
     const note = (result as any).data.getNote;
     console.log('✅ Note:', {
       id: note.id,
@@ -128,51 +135,61 @@ export function createTestFunctions() {
   async function testGenerateThumbnail(): Promise<void> {
     console.log('\n🖼️  Testing generateThumbnail Lambda function...');
 
-    console.log('   📤 Uploading test image to S3...');
-    let imageBuffer: Buffer;
+    try {
+      // Step 1: Upload a test image to S3
+      console.log('   📤 Uploading test image to S3...');
+      const imageBuffer = readFileSync(TEST_IMAGE_PATH);
+      const key = `media/test-${Date.now()}.jpg`;
 
-    if (existsSync(TEST_IMAGE_PATH)) {
-      imageBuffer = readFileSync(TEST_IMAGE_PATH);
-      console.log('   Using local image file');
-    } else {
-      const testImageBase64 =
-        'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAA3klEQVR42u3QMQEAAAgDILV/51nBzwci0JlYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqxYsWLFihUrVqz8WgGPGAGBPQqrHAAAAABJRU5ErkJggg==';
-      imageBuffer = Buffer.from(testImageBase64, 'base64');
-      console.log('   Using generated test image (no local file found)');
+      const uploadResult = await uploadData({
+        path: ({ identityId }: { identityId: string }) => `private/${identityId}/${key}`,
+        data: imageBuffer,
+      }).result;
+
+      console.log(`   ✅ Image uploaded: ${key}`);
+
+      // Step 2: Get the full S3 path from upload result
+      const fullKey = uploadResult.path;
+      console.log(`   🔑 Full S3 key: ${fullKey}`);
+
+      // Step 3: Call the thumbnail generation Lambda
+      console.log('   🎨 Generating thumbnail...');
+      const publicClient = generateClient({ authMode: 'apiKey' });
+      const result = await publicClient.graphql({
+        query: generateThumbnail,
+        variables: { mediaFileKey: fullKey },
+      });
+      const response = (result as any).data.generateThumbnail;
+      console.log('✅ Thumbnail generation response:', {
+        statusCode: response.statusCode,
+        message: response.message,
+      });
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        console.log('⏭️  Skipping thumbnail test - test image file not found');
+        console.log(`   Please add an image file at: ${TEST_IMAGE_PATH}`);
+        console.log('   Or update TEST_IMAGE_PATH to point to an existing image');
+        return;
+      }
+      throw error;
     }
-
-    const key = `media/test-${Date.now()}.jpg`;
-    const uploadResult = await uploadData({
-      path: ({ identityId }: { identityId: string }) => `private/${identityId}/${key}`,
-      data: imageBuffer,
-    }).result;
-
-    console.log(`   ✅ Image uploaded: ${key}`);
-    const fullKey = uploadResult.path;
-    console.log(`   🔑 Full S3 key: ${fullKey}`);
-
-    console.log('   🎨 Generating thumbnail...');
-    const publicClient = generateClient({ authMode: 'apiKey' });
-    const result = await publicClient.graphql({
-      query: generateThumbnail,
-      variables: { mediaFileKey: fullKey },
-    });
-    const response = (result as any).data.generateThumbnail;
-    console.log('✅ Thumbnail generation response:', {
-      statusCode: response.statusCode,
-      message: response.message,
-    });
   }
 
   async function testAddUserToGroup(): Promise<void> {
     console.log(`\n👥 Testing addUserToGroup Lambda function...`);
     const userSub = await getUserSub();
-    if (!userSub) throw new Error('Could not retrieve user sub');
+    if (!userSub) {
+      throw new Error('Could not retrieve user sub');
+    }
 
+    // Use API Key auth mode (same as frontend publicClient)
     const publicClient = generateClient({ authMode: 'apiKey' });
     const result = await publicClient.graphql({
       query: addUserToGroup,
-      variables: { userSub, group: TEST_GROUP },
+      variables: {
+        userSub: userSub,
+        group: TEST_GROUP,
+      },
     });
     const response = (result as any).data.addUserToGroup;
     console.log('✅ Add user to group response:', {
@@ -184,12 +201,18 @@ export function createTestFunctions() {
   async function testRemoveUserFromGroup(): Promise<void> {
     console.log(`\n👥 Testing removeUserFromGroup Lambda function...`);
     const userSub = await getUserSub();
-    if (!userSub) throw new Error('Could not retrieve user sub');
+    if (!userSub) {
+      throw new Error('Could not retrieve user sub');
+    }
 
+    // Use API Key auth mode (same as frontend publicClient)
     const publicClient = generateClient({ authMode: 'apiKey' });
     const result = await publicClient.graphql({
       query: removeUserFromGroup,
-      variables: { userSub, group: TEST_GROUP },
+      variables: {
+        userSub: userSub,
+        group: TEST_GROUP,
+      },
     });
     const response = (result as any).data.removeUserFromGroup;
     console.log('✅ Remove user from group response:', {
@@ -229,6 +252,7 @@ export function createTestOrchestrator(testFunctions: ReturnType<typeof createTe
     console.log('✏️ PART 2: Authenticated GraphQL Mutations');
     console.log('='.repeat(50));
 
+    // Create, update, and delete note
     const noteId = await runner.runTest('createNote', testFunctions.testCreateNote);
     if (noteId) {
       await runner.runTest('updateNote', () => testFunctions.testUpdateNote(noteId));
@@ -250,5 +274,9 @@ export function createTestOrchestrator(testFunctions: ReturnType<typeof createTe
     await runner.runTest('removeUserFromGroup', testFunctions.testRemoveUserFromGroup);
   }
 
-  return { runQueryTests, runMutationTests, runLambdaFunctionTests };
+  return {
+    runQueryTests,
+    runMutationTests,
+    runLambdaFunctionTests,
+  };
 }


### PR DESCRIPTION
This script provides comprehensive frontend-backend testing for the Media Vault app's Amplify Gen1 backend.

What it tests:

- GraphQL queries (listNotes, getNote)
- GraphQL mutations (CRUD operations for Notes)
- Lambda function operations (generateThumbnail, addUserToGroup, removeUserFromGroup)
- S3 Storage operations (file upload with Amplify v6 API)

How it works:

- Authenticates via Cognito user pool
- Runs authenticated queries to verify data retrieval (Notes with owner-based access)
- Performs full CRUD cycle on Notes (create → update → delete)
- Uploads test image to S3 using new Amplify v6 path API
- Tests thumbnail generation Lambda function with uploaded image
- Tests user group management Lambda functions (add/remove user from Admin group)
- Cleans up test data (deletes created notes) and signs out


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
