### PR TITLE
chore(gen2-migration): update README for fitnesstracker

### DIFF
--- a/amplify-migration-apps/fitness-tracker/README.md
+++ b/amplify-migration-apps/fitness-tracker/README.md
@@ -337,6 +337,24 @@ Navigate to the Amplify Console to find the `<gen1-rest-api-id>` and `<gen1-root
 + export async function handler(event, context) {
 ```
 
+**Edit in `./amplify/function/lognutrition/app.js`:**
+
+```diff
+- const express = require('express');
+- const bodyParser = require('body-parser');
+- const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware');
+- const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+- const { DynamoDBDocumentClient, PutCommand } = require('@aws-sdk/lib-dynamodb');
+- const express = require('express');
+
++ import express from 'express';
++ import bodyParser from 'body-parser';
++ import awsServerlessExpressMiddleware from 'aws-serverless-express/middleware';
++ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
++ import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
++ import crypto from 'crypto';
+```
+
 **Edit in `./amplify/function/fitnesstrackerd21d4fcdd21d4fcdPreSignup/src/index.js`:**
 
 > Note: The hash value after `fitnesstracker` changes for each app; you will have a different one.


### PR DESCRIPTION
Missing instructions to convert the imports in the lambda function to ESM format causes deployment failure. 