### PR TITLE
feat(api): optimize AppSync resolver deployment by skipping unchanged…

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
+++ b/packages/amplify-provider-awscloudformation/src/upload-appsync-files.js
@@ -7,7 +7,7 @@ const TransformPackage = require('graphql-transformer-core');
 const { S3 } = require('./aws-utils/aws-s3');
 const { fileLogger } = require('./utils/aws-logger');
 const { minifyAllJSONInFolderRecursively } = require('./utils/minify-json');
-
+const { optimizeAppSyncResolverDeployment } = require('./utils/appsync-resolver-optimizer');
 const logger = fileLogger('upload-appsync-files');
 
 const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files';
@@ -187,6 +187,17 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
     const deploymentRootKey = await getDeploymentRootKey(resourceDir);
     writeUpdatedParametersJson(resource, deploymentRootKey);
 
+    if (context.input.options?.['skip-unchanged-resolvers'] && category === 'api') {
+      await optimizeAppSyncResolverDeployment(
+        context,
+        category,
+        resourceName,
+        resourceBuildDir,
+        deploymentRootKey,
+        useDeprecatedParameters,
+      );
+    }
+
     // Upload build/* to S3.
     const s3Client = await S3.getInstance(context);
     if (!fs.existsSync(resourceBuildDir)) {
@@ -195,6 +206,7 @@ async function uploadAppSyncFiles(context, resourcesToUpdate, allResources, opti
     if (context.input.options?.minify) {
       minifyAllJSONInFolderRecursively(resourceBuildDir);
     }
+
     const spinner = new ora('Uploading files.');
     spinner.start();
     await TransformPackage.uploadAPIProject({

--- a/packages/amplify-provider-awscloudformation/src/utils/appsync-resolver-optimizer.d.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/appsync-resolver-optimizer.d.ts
@@ -1,0 +1,261 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+
+/**
+ * Result of VTL file comparison
+ */
+export interface VtlComparisonResult {
+  /** Whether the files have changes */
+  hasChanges: boolean;
+  /** Details of the changes detected */
+  changes?: {
+    /** Lines added */
+    additions?: number;
+    /** Lines removed */
+    deletions?: number;
+    /** Specific change details */
+    details?: string[];
+  };
+}
+
+/**
+ * Validation result for deployment prerequisites
+ */
+export interface ValidationResult {
+  /** Whether validation passed */
+  isValid: boolean;
+  /** Previous deployment root key if exists */
+  oldDeploymentRootKey?: string | null;
+  /** Path to current CloudFormation template */
+  cfFilePath?: string;
+  /** Validation error message if failed */
+  errorMessage?: string;
+}
+
+/**
+ * CloudFormation template structure
+ */
+export interface CloudFormationTemplate {
+  AWSTemplateFormatVersion?: string;
+  Description?: string;
+  Resources?: {
+    [key: string]: CloudFormationResource;
+  };
+  Parameters?: Record<string, any>;
+  Outputs?: Record<string, any>;
+  Conditions?: Record<string, any>;
+  Mappings?: Record<string, any>;
+}
+
+/**
+ * CloudFormation resource definition
+ */
+export interface CloudFormationResource {
+  Type: string;
+  Properties?: Record<string, any>;
+  DependsOn?: string | string[];
+  Condition?: string;
+  Metadata?: Record<string, any>;
+}
+
+/**
+ * S3 location reference using CloudFormation intrinsic functions
+ */
+export interface S3Location {
+  'Fn::Join': [string, Array<string | { Ref: string } | { 'Fn::GetAtt': string[] }>];
+}
+
+/**
+ * AppSync function configuration resource
+ */
+export interface AppSyncFunctionResource extends CloudFormationResource {
+  Type: 'AWS::AppSync::FunctionConfiguration';
+  Properties: {
+    ApiId: string | { Ref: string };
+    Name: string;
+    Description?: string;
+    DataSourceName: string | { Ref: string };
+    FunctionVersion: string;
+    RequestMappingTemplateS3Location?: S3Location;
+    ResponseMappingTemplateS3Location?: S3Location;
+    RequestMappingTemplate?: string;
+    ResponseMappingTemplate?: string;
+  };
+}
+
+/**
+ * Nested stack resource
+ */
+export interface NestedStackResource extends CloudFormationResource {
+  Type: 'AWS::CloudFormation::Stack';
+  Properties: {
+    TemplateURL: string | S3Location;
+    Parameters?: Record<string, any>;
+    Tags?: Array<{
+      Key: string;
+      Value: string;
+    }>;
+  };
+}
+
+/**
+ * Optimizes AppSync resolver deployment by reusing unchanged VTL templates
+ *
+ * This function analyzes CloudFormation templates and VTL files to determine which
+ * resolver templates have changed. Unchanged templates reuse their existing S3 locations,
+ * avoiding unnecessary uploads and improving deployment performance.
+ *
+ * @param context - Amplify CLI context object with print methods
+ * @param category - Resource category (typically 'api')
+ * @param resourceName - Name of the AppSync API resource
+ * @param resourceBuildDir - Path to the build directory containing CloudFormation templates
+ * @param deploymentRootKey - S3 deployment root key for the current deployment (e.g., 'amplify-appsync-files/abc123')
+ * @param useDeprecatedParameters - Use timestamp-based deployment keys instead of hash-based (default: false)
+ * @returns Promise that resolves when optimization is complete
+ * @throws Error if CloudFormation template processing fails
+ *
+ * @example
+ * ```typescript
+ * await optimizeAppSyncResolverDeployment(
+ *   context,
+ *   'api',
+ *   'myGraphQLApi',
+ *   '/path/to/build',
+ *   'amplify-appsync-files/hash123',
+ *   false
+ * );
+ * ```
+ */
+export declare function optimizeAppSyncResolverDeployment(
+  context: $TSContext,
+  category: string,
+  resourceName: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  useDeprecatedParameters?: boolean,
+): Promise<void>;
+
+/**
+ * Validates deployment prerequisites before optimization
+ * @internal
+ */
+declare function validateDeploymentPrerequisites(
+  context: $TSContext,
+  resourceName: string,
+  resourceBuildDir: string,
+  currentResourceDirectoryPath: string,
+  useDeprecatedParameters: boolean,
+): Promise<ValidationResult>;
+
+/**
+ * Checks if a deployment already exists in the specified directory
+ * @internal
+ */
+declare function isExistingDeployment(directoryPath: string): boolean;
+
+/**
+ * Gets the deployment root key for a resource directory
+ * @internal
+ */
+declare function getDeploymentRootKey(resourceDirectoryPath: string, useDeprecatedParameters: boolean): Promise<string>;
+
+/**
+ * Processes CloudFormation templates to optimize resolver uploads
+ * @internal
+ */
+declare function processCloudFormationTemplates(
+  cfFilePath: string,
+  currentResourceDirectoryPath: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  context: $TSContext,
+): Promise<void>;
+
+/**
+ * Processes a nested stack for resolver optimization
+ * @internal
+ */
+declare function processNestedStack(
+  stackName: string,
+  currentResourceDirectoryPath: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  context: $TSContext,
+): Promise<void>;
+
+/**
+ * Optimizes AppSync resolvers within a nested stack
+ * @internal
+ */
+declare function optimizeNestedStackResolvers(
+  newNestedStack: CloudFormationTemplate,
+  oldNestedStack: CloudFormationTemplate,
+  stackName: string,
+  currentResourceDirectoryPath: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  context: $TSContext,
+): Promise<CloudFormationTemplate>;
+
+/**
+ * Optimizes request and response mapping templates for a resolver
+ * @internal
+ */
+declare function optimizeResolverTemplates(
+  newFunction: AppSyncFunctionResource,
+  oldFunction: AppSyncFunctionResource,
+  functionName: string,
+  stackName: string,
+  currentResourceDirectoryPath: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  context: $TSContext,
+): Promise<void>;
+
+/**
+ * Optimizes a single mapping template (request or response)
+ * @internal
+ */
+declare function optimizeMappingTemplate(
+  newFunction: AppSyncFunctionResource,
+  oldFunction: AppSyncFunctionResource,
+  templateType: 'RequestMappingTemplateS3Location' | 'ResponseMappingTemplateS3Location',
+  functionName: string,
+  stackName: string,
+  currentResourceDirectoryPath: string,
+  resourceBuildDir: string,
+  deploymentRootKey: string,
+  context: $TSContext,
+): void;
+
+/**
+ * Extracts filename from CloudFormation S3 location object
+ * @internal
+ */
+declare function extractFileNameFromS3Location(s3Location: S3Location): string;
+
+/**
+ * Reuses existing S3 location for unchanged templates
+ * @internal
+ */
+declare function reuseExistingS3Location(newLocation: S3Location, oldLocation: S3Location, deploymentRootKey: string): void;
+
+/**
+ * Reads and parses a JSON file
+ * @internal
+ */
+declare function readJsonFile(filePath: string): any;
+
+/**
+ * Writes a JSON file with proper formatting (2-space indent)
+ * @internal
+ */
+declare function writeJsonFile(filePath: string, data: any): void;
+
+/**
+ * Hashes a directory to generate a consistent deployment key
+ * Excludes the 'build' folder from hashing
+ *
+ * @param directory - Path to the directory to hash
+ * @returns Promise resolving to the hex-encoded hash string
+ */
+export declare function hashDirectory(directory: string): Promise<string>;

--- a/packages/amplify-provider-awscloudformation/src/utils/appsync-resolver-optimizer.js
+++ b/packages/amplify-provider-awscloudformation/src/utils/appsync-resolver-optimizer.js
@@ -1,0 +1,388 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { pathManager } = require('@aws-amplify/amplify-cli-core');
+const { compareVtlFilesDetailed } = require('./compare-vtl');
+const { hashElement } = require('folder-hash');
+
+/**
+ * Constants for AppSync deployment optimization
+ */
+const CLOUDFORMATION_TEMPLATE_FILENAME = 'cloudformation-template.json';
+const BUILD_DIRECTORY = 'build';
+const STACKS_DIRECTORY = 'stacks';
+const NESTED_STACK_TYPE = 'AWS::CloudFormation::Stack';
+const APPSYNC_FUNCTION_TYPE = 'AWS::AppSync::FunctionConfiguration';
+const S3_LOCATION_JOIN_INDEX = 3;
+const ROOT_APPSYNC_S3_KEY = 'amplify-appsync-files';
+
+/**
+ * Optimizes AppSync resolver deployment by reusing unchanged VTL templates
+ * @param {Object} context - Amplify context object
+ * @param {string} category - Resource category
+ * @param {string} resourceName - Resource name
+ * @param {string} resourceBuildDir - Build directory path
+ * @param {string} deploymentRootKey - Deployment root key for S3
+ * @param {boolean} [useDeprecatedParameters=false] - Flag to use deprecated parameters for deployment key
+ * @returns {Promise<void>}
+ */
+async function optimizeAppSyncResolverDeployment(
+  context,
+  category,
+  resourceName,
+  resourceBuildDir,
+  deploymentRootKey,
+  useDeprecatedParameters = false,
+) {
+  try {
+    const currentBackEndDir = pathManager.getCurrentCloudBackendDirPath();
+    const currentResourceDirectoryPath = path.join(currentBackEndDir, category, resourceName);
+
+    // Validate prerequisites
+    const validationResult = await validateDeploymentPrerequisites(
+      context,
+      resourceName,
+      resourceBuildDir,
+      currentResourceDirectoryPath,
+      useDeprecatedParameters,
+    );
+
+    if (!validationResult.isValid) {
+      return;
+    }
+
+    const { oldDeploymentRootKey, cfFilePath } = validationResult;
+
+    context.print.info(`Optimizing AppSync resolver deployment for ${resourceName}...`);
+    context.print.debug(`Previous deployment key: ${oldDeploymentRootKey || 'none'}`);
+    context.print.debug(`Current deployment key: ${deploymentRootKey}`);
+
+    // Process CloudFormation templates
+    await processCloudFormationTemplates(
+      cfFilePath,
+      currentResourceDirectoryPath,
+      resourceBuildDir,
+      oldDeploymentRootKey || deploymentRootKey,
+      context,
+    );
+
+    context.print.success(`Successfully optimized resolver deployment for ${resourceName}`);
+  } catch (error) {
+    context.print.error(`Failed to optimize AppSync deployment: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
+ * Validates deployment prerequisites
+ * @private
+ */
+async function validateDeploymentPrerequisites(
+  context,
+  resourceName,
+  resourceBuildDir,
+  currentResourceDirectoryPath,
+  useDeprecatedParameters,
+) {
+  const cfFilePath = resourceBuildDir ? path.join(resourceBuildDir, CLOUDFORMATION_TEMPLATE_FILENAME) : undefined;
+
+  if (!cfFilePath || !fs.existsSync(cfFilePath)) {
+    context.print.error(`CloudFormation template not found in build directory for resource: ${resourceName}`);
+    return { isValid: false };
+  }
+
+  let oldDeploymentRootKey = null;
+
+  if (isExistingDeployment(currentResourceDirectoryPath)) {
+    oldDeploymentRootKey = await getDeploymentRootKey(currentResourceDirectoryPath, useDeprecatedParameters);
+  }
+
+  return {
+    isValid: true,
+    oldDeploymentRootKey,
+    cfFilePath,
+  };
+}
+
+/**
+ * Checks if a deployment already exists
+ * @private
+ */
+function isExistingDeployment(directoryPath) {
+  return fs.existsSync(directoryPath) && fs.readdirSync(directoryPath).length !== 0;
+}
+
+/**
+ * Processes CloudFormation templates to optimize resolver uploads
+ * @private
+ */
+async function processCloudFormationTemplates(cfFilePath, currentResourceDirectoryPath, resourceBuildDir, deploymentRootKey, context) {
+  const cfTemplate = readJsonFile(cfFilePath);
+
+  if (!cfTemplate.Resources) {
+    context.print.debug('No resources found in CloudFormation template');
+    return;
+  }
+
+  for (const [stackName, stackResource] of Object.entries(cfTemplate.Resources)) {
+    if (stackResource.Type === NESTED_STACK_TYPE) {
+      await processNestedStack(stackName, currentResourceDirectoryPath, resourceBuildDir, deploymentRootKey, context);
+    }
+  }
+}
+
+/**
+ * Processes a nested stack for resolver optimization
+ * @private
+ */
+async function processNestedStack(stackName, currentResourceDirectoryPath, resourceBuildDir, deploymentRootKey, context) {
+  const oldStackPath = path.join(currentResourceDirectoryPath, BUILD_DIRECTORY, STACKS_DIRECTORY, `${stackName}.json`);
+
+  const newStackPath = path.join(resourceBuildDir, STACKS_DIRECTORY, `${stackName}.json`);
+
+  if (!fs.existsSync(oldStackPath)) {
+    context.print.info(`New nested stack detected: ${stackName} - will upload to ${deploymentRootKey}/stacks/${stackName}.json`);
+    return;
+  }
+
+  const newNestedStack = readJsonFile(newStackPath);
+  const oldNestedStack = readJsonFile(oldStackPath);
+
+  const updatedStack = await optimizeNestedStackResolvers(
+    newNestedStack,
+    oldNestedStack,
+    stackName,
+    currentResourceDirectoryPath,
+    resourceBuildDir,
+    deploymentRootKey,
+    context,
+  );
+
+  writeJsonFile(newStackPath, updatedStack);
+}
+
+/**
+ * Optimizes AppSync resolvers within a nested stack
+ * @private
+ */
+async function optimizeNestedStackResolvers(
+  newNestedStack,
+  oldNestedStack,
+  stackName,
+  currentResourceDirectoryPath,
+  resourceBuildDir,
+  deploymentRootKey,
+  context,
+) {
+  if (!newNestedStack.Resources) {
+    return newNestedStack;
+  }
+
+  for (const [functionName, functionResource] of Object.entries(newNestedStack.Resources)) {
+    if (functionResource.Type !== APPSYNC_FUNCTION_TYPE) {
+      continue;
+    }
+
+    const oldFunction = oldNestedStack.Resources?.[functionName];
+
+    if (!oldFunction) {
+      context.print.info(`New AppSync function detected: ${functionName} in stack ${stackName}`);
+      continue;
+    }
+
+    await optimizeResolverTemplates(
+      functionResource,
+      oldFunction,
+      functionName,
+      stackName,
+      currentResourceDirectoryPath,
+      resourceBuildDir,
+      deploymentRootKey,
+      context,
+    );
+  }
+
+  return newNestedStack;
+}
+
+/**
+ * Optimizes request and response mapping templates for a resolver
+ * @private
+ */
+async function optimizeResolverTemplates(
+  newFunction,
+  oldFunction,
+  functionName,
+  stackName,
+  currentResourceDirectoryPath,
+  resourceBuildDir,
+  deploymentRootKey,
+  context,
+) {
+  // Optimize request mapping template
+  optimizeMappingTemplate(
+    newFunction,
+    oldFunction,
+    'RequestMappingTemplateS3Location',
+    functionName,
+    stackName,
+    currentResourceDirectoryPath,
+    resourceBuildDir,
+    deploymentRootKey,
+    context,
+  );
+
+  // Optimize response mapping template if exists
+  if (newFunction.Properties.ResponseMappingTemplateS3Location) {
+    optimizeMappingTemplate(
+      newFunction,
+      oldFunction,
+      'ResponseMappingTemplateS3Location',
+      functionName,
+      stackName,
+      currentResourceDirectoryPath,
+      resourceBuildDir,
+      deploymentRootKey,
+      context,
+    );
+  }
+}
+
+/**
+ * Optimizes a single mapping template (request or response)
+ * @private
+ */
+function optimizeMappingTemplate(
+  newFunction,
+  oldFunction,
+  templateType,
+  functionName,
+  stackName,
+  currentResourceDirectoryPath,
+  resourceBuildDir,
+  deploymentRootKey,
+  context,
+) {
+  const oldLocation = oldFunction.Properties[templateType];
+  const newLocation = newFunction.Properties[templateType];
+
+  if (!oldLocation || !newLocation) {
+    return;
+  }
+
+  const oldFileName = extractFileNameFromS3Location(oldLocation);
+  const newFileName = extractFileNameFromS3Location(newLocation);
+
+  const oldFilePath = path.join(currentResourceDirectoryPath, BUILD_DIRECTORY, oldFileName);
+  const newFilePath = path.join(resourceBuildDir, newFileName);
+
+  if (!fs.existsSync(oldFilePath)) {
+    context.print.info(`New ${templateType} template for function ${functionName} in stack ${stackName}`);
+    return;
+  }
+
+  const changes = compareVtlFilesDetailed(oldFilePath, newFilePath);
+
+  if (changes.hasChanges) {
+    context.print.info(
+      `Changed ${templateType} for function ${functionName} in stack ${stackName}: ` + `${JSON.stringify(changes.changes, null, 2)}`,
+    );
+  } else {
+    // Reuse existing S3 location to avoid re-upload
+    reuseExistingS3Location(newFunction.Properties[templateType], oldLocation, deploymentRootKey);
+
+    context.print.debug(`Reusing unchanged ${templateType} for function ${functionName}`);
+  }
+}
+
+/**
+ * Extracts filename from S3 location object
+ * @private
+ */
+function extractFileNameFromS3Location(s3Location) {
+  const joinArray = s3Location['Fn::Join']?.[1];
+  if (!joinArray || !Array.isArray(joinArray)) {
+    throw new Error('Invalid S3 location format');
+  }
+  return joinArray[joinArray.length - 1];
+}
+
+/**
+ * Reuses existing S3 location for unchanged templates
+ * @private
+ */
+function reuseExistingS3Location(newLocation, oldLocation, deploymentRootKey) {
+  const oldJoinArray = oldLocation['Fn::Join']?.[1];
+  const newJoinArray = newLocation['Fn::Join']?.[1];
+
+  if (!oldJoinArray || !newJoinArray) {
+    return;
+  }
+
+  // Preserve existing S3 key or use deployment root key
+  if (typeof oldJoinArray[S3_LOCATION_JOIN_INDEX] === 'string') {
+    newJoinArray[S3_LOCATION_JOIN_INDEX] = oldJoinArray[S3_LOCATION_JOIN_INDEX];
+  } else {
+    newJoinArray[S3_LOCATION_JOIN_INDEX] = deploymentRootKey;
+  }
+}
+
+/**
+ * Reads and parses a JSON file
+ * @private
+ */
+function readJsonFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to read JSON file ${filePath}: ${error.message}`);
+  }
+}
+
+/**
+ * Writes a JSON file with proper formatting
+ * @private
+ */
+function writeJsonFile(filePath, data) {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to write JSON file ${filePath}: ${error.message}`);
+  }
+}
+
+/**
+ * Hashes the project directory into a single value. The same project configuration
+ * should return the same hash.
+ */
+async function hashDirectory(directory) {
+  const options = {
+    encoding: 'hex',
+    folders: {
+      exclude: ['build'],
+    },
+  };
+
+  const hashResult = await hashElement(directory, options);
+
+  return hashResult.hash;
+}
+
+/**
+ * Generates deployment root key based on directory hash
+ * @private
+ */
+async function getDeploymentRootKey(resourceDir, useDeprecatedParameters) {
+  let deploymentSubKey;
+  if (useDeprecatedParameters) {
+    deploymentSubKey = new Date().getTime();
+  } else {
+    deploymentSubKey = await hashDirectory(resourceDir);
+  }
+  const deploymentRootKey = `${ROOT_APPSYNC_S3_KEY}/${deploymentSubKey}`;
+  return deploymentRootKey;
+}
+
+module.exports = {
+  optimizeAppSyncResolverDeployment,
+};

--- a/packages/amplify-provider-awscloudformation/src/utils/compare-json.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/compare-json.ts
@@ -1,0 +1,352 @@
+import * as fs from 'fs-extra';
+
+/**
+ * Interface for detailed change information
+ */
+interface StackChange {
+  path: string;
+  type: 'added' | 'removed' | 'value_change' | 'type_change' | 'null_change' | 'array_length_change';
+  oldValue?: any;
+  newValue?: any;
+  oldType?: string;
+  newType?: string;
+  oldLength?: number;
+  newLength?: number;
+}
+
+/**
+ * Interface for detailed comparison result
+ */
+interface DetailedComparisonResult {
+  hasChanges: boolean;
+  changes: StackChange[];
+}
+
+/**
+ * Check if a value is an object (but not null or array)
+ * @param obj the value to check
+ * @returns true if the value is an object
+ */
+const isObject = (obj: any): obj is Record<string, any> => {
+  return obj !== null && typeof obj === 'object' && !Array.isArray(obj);
+};
+
+/**
+ * Get all unique keys from two objects in sorted order
+ * @param obj1 first object
+ * @param obj2 second object
+ * @returns array of all unique keys sorted alphabetically
+ */
+const getAllKeys = (obj1: Record<string, any> | undefined, obj2: Record<string, any> | undefined): string[] => {
+  const keys1 = Object.keys(obj1 || {});
+  const keys2 = Object.keys(obj2 || {});
+  return [...new Set([...keys1, ...keys2])].sort();
+};
+
+/**
+ * Normalize a value for comparison (handles object key ordering)
+ * @param value the value to normalize
+ * @returns normalized value
+ */
+const normalizeValue = (value: any): any => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item));
+  }
+
+  if (isObject(value)) {
+    const normalized: Record<string, any> = {};
+    const sortedKeys = Object.keys(value).sort();
+    for (const key of sortedKeys) {
+      normalized[key] = normalizeValue(value[key]);
+    }
+    return normalized;
+  }
+
+  return value;
+};
+
+/**
+ * Create a deterministic string representation of a value for comparison
+ * @param value the value to stringify
+ * @returns deterministic string representation
+ */
+const deterministicStringify = (value: any): string => {
+  return JSON.stringify(normalizeValue(value));
+};
+
+/**
+ * Deep comparison helper function
+ * @param val1 first value to compare
+ * @param val2 second value to compare
+ * @param path current path in the object hierarchy
+ * @returns true if changes are detected, false otherwise
+ */
+const deepCompare = (val1: any, val2: any, path = ''): boolean => {
+  // Normalize values for comparison
+  const norm1 = normalizeValue(val1);
+  const norm2 = normalizeValue(val2);
+
+  // If both values are identical after normalization
+  if (deterministicStringify(norm1) === deterministicStringify(norm2)) {
+    return false; // No changes
+  }
+
+  // If types are different
+  if (typeof val1 !== typeof val2) {
+    console.log(`Change detected at ${path}: type mismatch (${typeof val1} vs ${typeof val2})`);
+    return true; // Changes detected
+  }
+
+  // If one is null/undefined and the other isn't
+  if ((val1 == null) !== (val2 == null)) {
+    console.log(`Change detected at ${path}: null/undefined mismatch`);
+    return true; // Changes detected
+  }
+
+  // If both are arrays
+  if (Array.isArray(val1) && Array.isArray(val2)) {
+    if (val1.length !== val2.length) {
+      console.log(`Change detected at ${path}: array length mismatch (${val1.length} vs ${val2.length})`);
+      return true; // Changes detected
+    }
+
+    // Compare each element
+    for (let i = 0; i < val1.length; i++) {
+      if (deepCompare(val1[i], val2[i], `${path}[${i}]`)) {
+        return true; // Changes detected
+      }
+    }
+    return false; // No changes
+  }
+
+  // If both are objects (but not arrays)
+  if (isObject(val1) && isObject(val2)) {
+    const allKeys = getAllKeys(val1, val2);
+
+    // Check each key
+    for (const key of allKeys) {
+      const newPath = path ? `${path}.${key}` : key;
+
+      // If key exists in one but not the other
+      if (!(key in val1) || !(key in val2)) {
+        console.log(`Change detected at ${newPath}: key exists in one stack but not the other`);
+        return true; // Changes detected
+      }
+
+      // Recursively compare the values
+      if (deepCompare(val1[key], val2[key], newPath)) {
+        return true; // Changes detected
+      }
+    }
+    return false; // No changes
+  }
+
+  // For primitive values that aren't equal
+  console.log(`Change detected at ${path}: value mismatch (${val1} vs ${val2})`);
+  return true; // Changes detected
+};
+
+/**
+ * Compare two CloudFormation stack objects and return true if there are changes
+ * @param stack1 first CloudFormation stack object
+ * @param stack2 second CloudFormation stack object
+ * @returns true if there are changes, false if identical
+ */
+export const compareCloudFormationStacks = (stack1: any, stack2: any): boolean => {
+  // Quick check using normalized comparison
+  if (deterministicStringify(stack1) === deterministicStringify(stack2)) {
+    return false; // No changes
+  }
+
+  // If quick check shows differences, do detailed comparison for logging
+  return deepCompare(stack1, stack2);
+};
+
+/**
+ * Deep comparison helper function for detailed comparison
+ * @param val1 first value to compare
+ * @param val2 second value to compare
+ * @param path current path in the object hierarchy
+ * @param changes array to collect changes
+ */
+const deepCompareDetailed = (val1: any, val2: any, path = '', changes: StackChange[]): void => {
+  // Use normalized values for comparison
+  const norm1 = normalizeValue(val1);
+  const norm2 = normalizeValue(val2);
+
+  if (deterministicStringify(norm1) === deterministicStringify(norm2)) {
+    return;
+  }
+
+  if (typeof val1 !== typeof val2) {
+    changes.push({
+      path,
+      type: 'type_change',
+      oldType: typeof val1,
+      newType: typeof val2,
+      oldValue: val1,
+      newValue: val2,
+    });
+    return;
+  }
+
+  if ((val1 == null) !== (val2 == null)) {
+    changes.push({
+      path,
+      type: 'null_change',
+      oldValue: val1,
+      newValue: val2,
+    });
+    return;
+  }
+
+  if (Array.isArray(val1) && Array.isArray(val2)) {
+    if (val1.length !== val2.length) {
+      changes.push({
+        path,
+        type: 'array_length_change',
+        oldLength: val1.length,
+        newLength: val2.length,
+      });
+    }
+
+    const maxLength = Math.max(val1.length, val2.length);
+    for (let i = 0; i < maxLength; i++) {
+      if (i >= val1.length) {
+        changes.push({
+          path: `${path}[${i}]`,
+          type: 'added',
+          newValue: val2[i],
+        });
+      } else if (i >= val2.length) {
+        changes.push({
+          path: `${path}[${i}]`,
+          type: 'removed',
+          oldValue: val1[i],
+        });
+      } else {
+        deepCompareDetailed(val1[i], val2[i], `${path}[${i}]`, changes);
+      }
+    }
+    return;
+  }
+
+  if (isObject(val1) && isObject(val2)) {
+    const allKeys = getAllKeys(val1, val2);
+
+    for (const key of allKeys) {
+      const newPath = path ? `${path}.${key}` : key;
+
+      if (!(key in val1)) {
+        changes.push({
+          path: newPath,
+          type: 'added',
+          newValue: val2[key],
+        });
+      } else if (!(key in val2)) {
+        changes.push({
+          path: newPath,
+          type: 'removed',
+          oldValue: val1[key],
+        });
+      } else {
+        deepCompareDetailed(val1[key], val2[key], newPath, changes);
+      }
+    }
+    return;
+  }
+
+  changes.push({
+    path,
+    type: 'value_change',
+    oldValue: val1,
+    newValue: val2,
+  });
+};
+
+/**
+ * Compare two CloudFormation stack objects and return detailed changes
+ * @param stack1 first CloudFormation stack object
+ * @param stack2 second CloudFormation stack object
+ * @returns object with hasChanges boolean and changes array
+ */
+export const compareCloudFormationStacksDetailed = (stack1: any, stack2: any): DetailedComparisonResult => {
+  const changes: StackChange[] = [];
+  deepCompareDetailed(stack1, stack2, '', changes);
+
+  return {
+    hasChanges: changes.length > 0,
+    changes: changes,
+  };
+};
+
+/**
+ * Parse JSON content safely, handling both minified and formatted JSON
+ * @param content JSON string content
+ * @param filePath file path for error messages
+ * @returns parsed JSON object
+ */
+const parseJSONContent = (content: string, filePath: string): any => {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON from ${filePath}: ${error}`);
+  }
+};
+
+/**
+ * Compare two CloudFormation stack files
+ * @param stackFile1Path path to the first stack file
+ * @param stackFile2Path path to the second stack file
+ * @returns true if there are changes, false if identical
+ */
+export const compareCloudFormationStackFiles = (stackFile1Path: string, stackFile2Path: string): boolean => {
+  if (!stackFile1Path.includes('.json') || !stackFile2Path.includes('.json')) {
+    throw new Error('Both files must be JSON files');
+  }
+
+  const content1 = fs.readFileSync(stackFile1Path, 'utf-8');
+  const content2 = fs.readFileSync(stackFile2Path, 'utf-8');
+
+  const stack1 = parseJSONContent(content1, stackFile1Path);
+  const stack2 = parseJSONContent(content2, stackFile2Path);
+
+  return compareCloudFormationStacks(stack1, stack2);
+};
+
+/**
+ * Compare two CloudFormation stack files and return detailed changes
+ * @param stackFile1Path path to the first stack file
+ * @param stackFile2Path path to the second stack file
+ * @returns object with hasChanges boolean and changes array
+ */
+export const compareCloudFormationStackFilesDetailed = (stackFile1Path: string, stackFile2Path: string): DetailedComparisonResult => {
+  if (!stackFile1Path.includes('.json') || !stackFile2Path.includes('.json')) {
+    throw new Error('Both files must be JSON files');
+  }
+
+  const content1 = fs.readFileSync(stackFile1Path, 'utf-8');
+  const content2 = fs.readFileSync(stackFile2Path, 'utf-8');
+
+  const stack1 = parseJSONContent(content1, stackFile1Path);
+  const stack2 = parseJSONContent(content2, stackFile2Path);
+
+  return compareCloudFormationStacksDetailed(stack1, stack2);
+};
+
+/**
+ * Compare two CloudFormation stacks from JSON strings
+ * @param jsonString1 first JSON string
+ * @param jsonString2 second JSON string
+ * @returns true if there are changes, false if identical
+ */
+export const compareCloudFormationStackStrings = (jsonString1: string, jsonString2: string): boolean => {
+  const stack1 = parseJSONContent(jsonString1, 'string1');
+  const stack2 = parseJSONContent(jsonString2, 'string2');
+
+  return compareCloudFormationStacks(stack1, stack2);
+};

--- a/packages/amplify-provider-awscloudformation/src/utils/compare-vtl.ts
+++ b/packages/amplify-provider-awscloudformation/src/utils/compare-vtl.ts
@@ -1,0 +1,107 @@
+import * as fs from 'fs-extra';
+
+/**
+ * Interface for detailed change information for VTL files
+ */
+interface VtlChange {
+  line: number;
+  type: 'added' | 'removed' | 'changed';
+  oldValue?: string;
+  newValue?: string;
+}
+
+/**
+ * Interface for detailed comparison result for VTL files
+ */
+interface VtlDetailedComparisonResult {
+  hasChanges: boolean;
+  changes: VtlChange[];
+}
+
+/**
+ * Compare two arrays of lines and return detailed changes
+ * @param lines1 lines from the first file
+ * @param lines2 lines from the second file
+ * @returns array of changes
+ */
+const compareLinesDetailed = (lines1: string[], lines2: string[]): VtlChange[] => {
+  const changes: VtlChange[] = [];
+  const maxLength = Math.max(lines1.length, lines2.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const line1 = lines1[i];
+    const line2 = lines2[i];
+
+    if (line1 === undefined && line2 !== undefined) {
+      changes.push({
+        line: i + 1,
+        type: 'added',
+        newValue: line2,
+      });
+    } else if (line1 !== undefined && line2 === undefined) {
+      changes.push({
+        line: i + 1,
+        type: 'removed',
+        oldValue: line1,
+      });
+    } else if (line1 !== line2) {
+      changes.push({
+        line: i + 1,
+        type: 'changed',
+        oldValue: line1,
+        newValue: line2,
+      });
+    }
+  }
+
+  return changes;
+};
+
+/**
+ * Compare two VTL files (AppSync resolver templates) and return true if there are changes
+ * @param vtlFile1Path path to the first VTL file
+ * @param vtlFile2Path path to the second VTL file
+ * @returns true if there are changes, false if identical
+ */
+export const compareVtlFiles = (vtlFile1Path: string, vtlFile2Path: string): boolean => {
+  if (!vtlFile1Path.endsWith('.vtl') || !vtlFile2Path.endsWith('.vtl')) {
+    throw new Error('Both files must be VTL files');
+  }
+
+  const vtl1 = fs.readFileSync(vtlFile1Path, 'utf-8').split(/\r?\n/);
+  const vtl2 = fs.readFileSync(vtlFile2Path, 'utf-8').split(/\r?\n/);
+
+  if (vtl1.length !== vtl2.length) {
+    return true;
+  }
+
+  for (let i = 0; i < vtl1.length; i++) {
+    if (vtl1[i] !== vtl2[i]) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Compare two VTL files (AppSync resolver templates) and return detailed changes
+ * @param vtlFile1Path path to the first VTL file
+ * @param vtlFile2Path path to the second VTL file
+ * @returns object with hasChanges boolean and changes array
+ */
+export const compareVtlFilesDetailed = (vtlFile1Path: string, vtlFile2Path: string): VtlDetailedComparisonResult => {
+  if (!vtlFile1Path.endsWith('.vtl') || !vtlFile2Path.endsWith('.vtl')) {
+    throw new Error('Both files must be VTL files');
+  }
+
+  const vtl1 = fs.readFileSync(vtlFile1Path, 'utf-8').split(/\r?\n/);
+  const vtl2 = fs.readFileSync(vtlFile2Path, 'utf-8').split(/\r?\n/);
+
+  const changes = compareLinesDetailed(vtl1, vtl2);
+
+  return {
+    hasChanges: changes.length > 0,
+    changes,
+  };
+};


### PR DESCRIPTION
… VTL templates

- Add resolver optimization to reduce unnecessary S3 uploads during push
- Compare VTL templates between current and new builds to detect changes
- Reuse existing S3 deployment paths for unchanged resolver templates
- Add --skip-unchanged-resolvers flag to amplify push command
- Preserve deployment root keys for unchanged nested stack resources

Performance improvement for AppSync APIs with many resolvers where only a subset have changed. This optimization can significantly reduce deployment time by avoiding re-uploading identical VTL mapping templates to S3.

The optimization process:
1. Compares request/response mapping templates between builds
2. Identifies unchanged AppSync function configurations
3. Preserves existing S3 locations for unchanged templates
4. Only uploads modified resolver templates

This change is backward compatible and opt-in via the --skip-unchanged-resolvers flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
