### PR TITLE
fix(gen2-migration): wildcard auth permissions for read access ignored

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/auth_access_analyzer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/auth_access_analyzer.ts
@@ -63,6 +63,7 @@ const AUTH_ACTION_MAPPING: Record<string, keyof AuthAccess> = {
   'cognito-idp:AdminUpdateUserAttributes': 'updateUserAttributes',
   'cognito-idp:ListUsers': 'listUsers',
   'cognito-idp:ListUsersInGroup': 'listUsersInGroup',
+  'cognito-idp:ListGroups': 'listGroups',
 
   // Actions that don't have individual permissions - map to grouped
   'cognito-idp:AdminConfirmSignUp': 'manageUsers',
@@ -90,7 +91,16 @@ function extractCognitoActionsFromPolicy(amplifyResourcesPolicy: any): string[] 
 
     for (const action of statementActions) {
       if (typeof action === 'string' && action.startsWith('cognito-idp:')) {
-        if (!actions.includes(action)) {
+        // Expand Gen1 read access wildcards to specific actions
+        if (action === 'cognito-idp:AdminList*') {
+          ['cognito-idp:AdminListDevices', 'cognito-idp:AdminListGroupsForUser'].forEach((a) => {
+            if (!actions.includes(a)) actions.push(a);
+          });
+        } else if (action === 'cognito-idp:List*') {
+          ['cognito-idp:ListUsers', 'cognito-idp:ListUsersInGroup', 'cognito-idp:ListGroups'].forEach((a) => {
+            if (!actions.includes(a)) actions.push(a);
+          });
+        } else if (!actions.includes(action)) {
           actions.push(action);
         }
       }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/functions/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/functions/index.ts
@@ -33,6 +33,7 @@ export interface AuthAccess {
   listDevices?: boolean;
   listGroupsForUser?: boolean;
   listUsersInGroup?: boolean;
+  listGroups?: boolean;
   removeUserFromGroup?: boolean;
   resetUserPassword?: boolean;
   setUserMfaPreference?: boolean;


### PR DESCRIPTION
Solves https://github.com/aws-amplify/amplify-cli/issues/14598

When migrating Gen1 functions with "read" auth access to Gen2, the migration tool was missing permissions. This occurred because Gen1 uses wildcard IAM actions (`cognito-idp:List*`, `cognito-idp:AdminList*`) that weren't being properly expanded to their constituent actions by the auth "access" analyzer file. 

**Gen1 defines its permissions here in its source code:** https://github.com/aws-amplify/amplify-cli/blob/b94107238638880fbaad0a43b62b53e33bab0df6/packages/amplify-category-auth/src/provider-utils/awscloudformation/service-walkthroughs/auth-questions.ts#L690

**Gen 2 has a action- permission mapping here in its source code:** https://github.com/aws-amplify/amplify-backend/blob/11184215e2fe8db636dfb0cc55fefae5b43e3046/packages/backend-auth/src/userpool_access_policy_factory.ts#L115


**Note:** The Gen2 documentation has an incomplete mapping table. It does not include the `listGroups` action. This has been added as per the table in the Gen2 source code.


## Before
```typescript
access: (allow: any) => [
    allow.resource(admin).to(["getDevice"]),
    allow.resource(admin).to(["getUser"])
],
```

## After
```typescript
access: (allow: any) => [
    allow.resource(admin).to(["getDevice"]),
    allow.resource(admin).to(["getUser"]),
    allow.resource(admin).to(["listUsers"]),
    allow.resource(admin).to(["listUsersInGroup"]), 
    allow.resource(admin).to(["listGroups"]),
    allow.resource(admin).to(["listDevices"]),
    allow.resource(admin).to(["listGroupsForUser"])
],
```