### PR TITLE
fix: improve error message for InvalidSignatureException

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/amplify-service-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/amplify-service-manager.test.ts
@@ -64,4 +64,23 @@ describe('init', () => {
     };
     await expect(init(amplifyServiceParamsStub)).rejects.toMatchInlineSnapshot(`[ConfigurationError: Missing Region in Config]`);
   });
+
+  it('throws ProjectInitError with helpful message on InvalidSignatureException', async () => {
+    mockAmplifyClient.on(CreateAppCommand).rejectsOnce({
+      name: 'InvalidSignatureException',
+      message: 'Forbidden',
+    });
+    getConfiguredAmplifyClientMock.mockResolvedValue(mockAmplifyClient as unknown as AmplifyClient);
+
+    const amplifyServiceParamsStub = {
+      context: {},
+      awsConfigInfo: {},
+      projectName: 'test-project',
+      envName: 'test',
+      stackName: 'test-stack-name',
+    };
+    await expect(init(amplifyServiceParamsStub)).rejects.toMatchInlineSnapshot(
+      `[ProjectInitError: The request to create the Amplify app failed with: Forbidden]`,
+    );
+  });
 });

--- a/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/amplify-service-manager.ts
@@ -146,6 +146,22 @@ export async function init(amplifyServiceParams) {
           e,
         );
       }
+      if (e.name === 'InvalidSignatureException') {
+        throw new AmplifyError(
+          'ProjectInitError',
+          {
+            message: 'The request to create the Amplify app failed with: Forbidden',
+            resolution:
+              'This usually means your AWS credentials are invalid or malformed. ' +
+              'Verify that your Access Key ID and Secret Access Key are correct ' +
+              'in your AWS profile or environment variables. ' +
+              'If you pasted credentials from a console, check for extra characters ' +
+              '(such as leading/trailing tildes). ' +
+              'For more information: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html',
+          },
+          e,
+        );
+      }
       if (context?.exeInfo?.awsConfigInfo?.configLevel === 'general' && e.name === 'ConfigError') {
         throw new AmplifyError('ConfigurationError', {
           code: e.name,


### PR DESCRIPTION

#### Issue #13342 

#### Description of changes
When `amplify init` encounters an `InvalidSignatureException` (e.g. due to malformed AWS credentials with extra characters like leading/trailing tildes), the CLI displays only `🛑 Forbidden` with no actionable guidance.

This PR adds a specific error handler for `InvalidSignatureException` in the `createApp()` call within `amplify-service-manager.ts`, replacing the generic `ProjectInitFault` with a `ProjectInitError` that includes a clear resolution message suggesting the user verify their AWS credentials.

**Before:**
```
🛑 Forbidden
```

**After:**
```
🛑 The request to create the Amplify app failed with: Forbidden
Resolution: This usually means your AWS credentials are invalid or malformed.
Verify that your Access Key ID and Secret Access Key are correct in your AWS
profile or environment variables. If you pasted credentials from a console,
check for extra characters (such as leading/trailing tildes).
For more information: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
```

#### Description of how you validated changes

- Added a unit test in `amplify-service-manager.test.ts` that mocks `CreateAppCommand` rejecting with `InvalidSignatureException` and asserts the new `ProjectInitError` with the improved message is thrown.
- All existing tests continue to pass (`yarn test`).

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.