### PR TITLE
fix(amplify-provider-awscloudformation): mfa role assumption fails with cached credentials

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/system-config-manager.test.ts
@@ -1,4 +1,4 @@
-import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { $TSContext, JSONUtilities, pathManager } from '@aws-amplify/amplify-cli-core';
 import fs from 'fs-extra';
 import { fromProcess } from '@aws-sdk/credential-providers';
 import { getProfileCredentials, getProfiledAwsConfig } from '../system-config-manager';
@@ -11,8 +11,36 @@ jest.mock('../utils/aws-logger', () => ({
 jest.mock('fs-extra');
 const fs_mock = fs as jest.Mocked<typeof fs>;
 
+jest.mock('@aws-amplify/amplify-cli-core', () => {
+  const actual = jest.requireActual('@aws-amplify/amplify-cli-core');
+  return {
+    ...actual,
+    pathManager: {
+      ...actual.pathManager,
+      getHomeDotAmplifyDirPath: jest.fn().mockReturnValue('/mock/home/.amplify'),
+      getAWSCredentialsFilePath: jest.fn().mockReturnValue('/mock/home/.aws/credentials'),
+      getAWSConfigFilePath: jest.fn().mockReturnValue('/mock/home/.aws/config'),
+    },
+    JSONUtilities: {
+      readJson: jest.fn(),
+      writeJson: jest.fn(),
+    },
+  };
+});
+
 jest.mock('@aws-sdk/credential-providers');
 const fromProcessMock = fromProcess as jest.MockedFunction<typeof fromProcess>;
+
+// Mock STS client
+const mockSTSSend = jest.fn();
+jest.mock('@aws-sdk/client-sts', () => ({
+  STSClient: jest.fn().mockImplementation(() => ({
+    send: mockSTSSend,
+  })),
+  AssumeRoleCommand: jest.fn().mockImplementation((input) => input),
+}));
+
+const JSONUtilitiesMock = JSONUtilities as jest.Mocked<typeof JSONUtilities>;
 
 const context_stub = {
   print: {
@@ -126,5 +154,208 @@ describe('profile tests', () => {
     expect(creds).toBeDefined();
     expect(fs_mock.existsSync).toHaveBeenCalledTimes(1);
     expect(fs_mock.readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  describe('credential caching for role assumption', () => {
+    const mockRoleArn = 'arn:aws:iam::123456789012:role/TestRole';
+    const mockSessionName = 'amplify';
+    const futureExpiration = new Date(Date.now() + 3600000); // 1 hour from now
+    const pastExpiration = new Date(Date.now() - 3600000); // 1 hour ago
+
+    const mockValidCredentials = {
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      sessionToken: 'FwoGZXIvYXdzEBYaDk...',
+      expiration: futureExpiration.toISOString(),
+    };
+
+    const roleProfileConfig = `[profile testrole]
+region = us-east-1
+role_arn = ${mockRoleArn}
+source_profile = testuser
+
+[profile testuser]
+region = us-east-1`;
+
+    const sourceProfileCredentials = `[testuser]
+aws_access_key_id = AKIAIOSFODNN7SOURCE
+aws_secret_access_key = sourceSecretKey`;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      fs_mock.existsSync.mockReturnValue(true);
+      fs_mock.ensureDirSync.mockReturnValue(undefined);
+      mockSTSSend.mockReset();
+    });
+
+    describe('getCachedRoleCredentials behavior', () => {
+      it('should return undefined when cache file does not exist', async () => {
+        // Setup: profile with role_arn, but no cache file
+        fs_mock.existsSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('.amplify')) return false; // cache doesn't exist
+            return true; // config/credentials exist
+          }
+          return false;
+        });
+        fs_mock.readFileSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('config')) return roleProfileConfig;
+            if (path.includes('credentials')) return sourceProfileCredentials;
+          }
+          return '';
+        });
+
+        // Mock STS to return credentials (since no cache)
+        mockSTSSend.mockResolvedValue({
+          Credentials: {
+            AccessKeyId: 'AKIAIOSFODNN7ASSUMED',
+            SecretAccessKey: 'assumedSecretKey',
+            SessionToken: 'assumedSessionToken',
+            Expiration: futureExpiration,
+          },
+        });
+
+        const result = await getProfiledAwsConfig(context_stub, 'testrole');
+
+        // Should have called STS to get new credentials (not from cache)
+        expect(mockSTSSend).toHaveBeenCalled();
+        expect(result.credentials.accessKeyId).toBe('AKIAIOSFODNN7ASSUMED');
+      });
+
+      it('should return undefined when roleArn not in cache', async () => {
+        fs_mock.existsSync.mockReturnValue(true);
+        fs_mock.readFileSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('config')) return roleProfileConfig;
+            if (path.includes('credentials')) return sourceProfileCredentials;
+          }
+          return '';
+        });
+
+        // Cache exists but doesn't have our role
+        JSONUtilitiesMock.readJson.mockReturnValue({
+          'arn:aws:iam::999999999999:role/OtherRole': {
+            amplify: mockValidCredentials,
+          },
+        });
+
+        mockSTSSend.mockResolvedValue({
+          Credentials: {
+            AccessKeyId: 'AKIAIOSFODNN7ASSUMED',
+            SecretAccessKey: 'assumedSecretKey',
+            SessionToken: 'assumedSessionToken',
+            Expiration: futureExpiration,
+          },
+        });
+
+        const result = await getProfiledAwsConfig(context_stub, 'testrole');
+
+        // Should have called STS since role not in cache
+        expect(mockSTSSend).toHaveBeenCalled();
+      });
+
+      it('should return undefined when cached credentials are expired', async () => {
+        fs_mock.existsSync.mockReturnValue(true);
+        fs_mock.readFileSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('config')) return roleProfileConfig;
+            if (path.includes('credentials')) return sourceProfileCredentials;
+          }
+          return '';
+        });
+
+        // Cache has expired credentials
+        JSONUtilitiesMock.readJson.mockReturnValue({
+          [mockRoleArn]: {
+            [mockSessionName]: {
+              ...mockValidCredentials,
+              expiration: pastExpiration.toISOString(),
+            },
+          },
+        });
+
+        mockSTSSend.mockResolvedValue({
+          Credentials: {
+            AccessKeyId: 'AKIAIOSFODNN7ASSUMED',
+            SecretAccessKey: 'assumedSecretKey',
+            SessionToken: 'assumedSessionToken',
+            Expiration: futureExpiration,
+          },
+        });
+
+        const result = await getProfiledAwsConfig(context_stub, 'testrole');
+
+        // Should have called STS since cached credentials are expired
+        expect(mockSTSSend).toHaveBeenCalled();
+      });
+
+      it('should return valid cached credentials with Date expiration', async () => {
+        fs_mock.existsSync.mockReturnValue(true);
+        fs_mock.readFileSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('config')) return roleProfileConfig;
+            if (path.includes('credentials')) return sourceProfileCredentials;
+          }
+          return '';
+        });
+
+        // Cache has valid credentials (stored as flat object with string expiration)
+        JSONUtilitiesMock.readJson.mockReturnValue({
+          [mockRoleArn]: {
+            [mockSessionName]: mockValidCredentials,
+          },
+        });
+
+        const result = await getProfiledAwsConfig(context_stub, 'testrole');
+
+        // Should NOT have called STS since valid credentials in cache
+        expect(mockSTSSend).not.toHaveBeenCalled();
+        expect(result.credentials.accessKeyId).toBe(mockValidCredentials.accessKeyId);
+        expect(result.credentials.secretAccessKey).toBe(mockValidCredentials.secretAccessKey);
+        // Verify expiration is a Date object, not a string
+        expect(result.credentials.expiration).toBeInstanceOf(Date);
+      });
+    });
+
+    describe('cacheRoleCredentials behavior', () => {
+      it('should cache credentials in flat format (not nested)', async () => {
+        fs_mock.existsSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('.amplify')) return false; // no existing cache
+            return true;
+          }
+          return false;
+        });
+        fs_mock.readFileSync.mockImplementation((path: unknown) => {
+          if (typeof path === 'string') {
+            if (path.includes('config')) return roleProfileConfig;
+            if (path.includes('credentials')) return sourceProfileCredentials;
+          }
+          return '';
+        });
+
+        mockSTSSend.mockResolvedValue({
+          Credentials: {
+            AccessKeyId: 'AKIAIOSFODNN7ASSUMED',
+            SecretAccessKey: 'assumedSecretKey',
+            SessionToken: 'assumedSessionToken',
+            Expiration: futureExpiration,
+          },
+        });
+
+        await getProfiledAwsConfig(context_stub, 'testrole');
+
+        // Verify credentials were cached in flat format
+        expect(JSONUtilitiesMock.writeJson).toHaveBeenCalled();
+        const writeCall = JSONUtilitiesMock.writeJson.mock.calls[0];
+        const cachedData = writeCall[1];
+
+        // The cached credentials should be flat (accessKeyId at top level)
+        // NOT nested ({ credentials: { accessKeyId: ... } })
+        expect(cachedData[mockRoleArn][mockSessionName].accessKeyId).toBe('AKIAIOSFODNN7ASSUMED');
+        expect(cachedData[mockRoleArn][mockSessionName].credentials).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
+++ b/packages/amplify-provider-awscloudformation/src/system-config-manager.ts
@@ -186,7 +186,7 @@ const getRoleCredentials = async (context: $TSContext, profileName: string, prof
       log(ex);
     }
     if (profileConfig.role_arn && roleSessionName && roleCredentials) {
-      cacheRoleCredentials(profileConfig.role_arn, roleSessionName, roleCredentials);
+      cacheRoleCredentials(profileConfig.role_arn, roleSessionName, roleCredentials.credentials);
     }
   }
 
@@ -245,9 +245,14 @@ const getCachedRoleCredentials = (roleArn: string, sessionName: string): $TSAny 
       return undefined;
     }
   }
+  if (!roleCredentials) {
+    return undefined;
+  }
   return {
     credentials: {
       ...roleCredentials,
+      // Ensure expiration is a Date object (JSON serialization converts it to string)
+      expiration: roleCredentials.expiration ? new Date(roleCredentials.expiration) : undefined,
     },
   };
 };


### PR DESCRIPTION
## Description

Fixes three cascading bugs in the MFA role assumption credential caching logic introduced by commit `04f7bcfc24` (PR #14315, fixing #14290). These bugs cause MFA-based role assumption to fail with `Resolved credential object is not valid`.

**Bug 1 — MFA prompt never appears:** `getCachedRoleCredentials()` always returned `{ credentials: {} }` even when no valid cached credentials existed, so the STS `AssumeRole` call was never executed.

**Bug 2 — Cache validation always fails:** Credentials were cached in nested format `{ credentials: { accessKeyId, ... } }` but `validateCachedCredentials()` expected flat format `{ accessKeyId, ... }`.

**Bug 3 — `expiration.getTime is not a function`:** Cached `Date` is deserialized as a string from JSON, but the AWS SDK calls `expiration.getTime()`. PR #14315 only fixed this in `getConfiguredAWSClientConfig()`, not in `getProfiledAwsConfig()`.

## Issue #

Closes #14626

## How did you test these changes?

- Added unit tests for `getCachedRoleCredentials` and `cacheRoleCredentials` covering:
  - Returns `undefined` when cache file does not exist
  - Returns `undefined` when `roleArn` not in cache
  - Returns `undefined` when cached credentials are expired
  - Returns valid cached credentials with `expiration` converted to `Date`
  - Caches credentials in flat format (not nested)
- Manual testing with an AWS profile configured with `role_arn` + `source_profile` + `mfa_serial`

## Checklist

- [x] If this is a change to a feature that has existing integration tests, I updated the existing integration tests
- [x] My change meets the acceptance criteria set in the issue
- [x] This change does not directly reference any internal resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.