### PR TITLE
feat(gen2-migration): add extended resolvers to product catalog app

### DIFF
--- a/amplify-migration-apps/product-catalog/Query.listProducts.postDataLoad.1.res.vtl
+++ b/amplify-migration-apps/product-catalog/Query.listProducts.postDataLoad.1.res.vtl
@@ -1,0 +1,14 @@
+#set($items = $ctx.prev.result.items)
+#foreach($item in $items)
+  #set($stock = 0)
+  #if($item.stock)
+    #set($stock = $item.stock)
+  #end
+  #set($price = 0)
+  #if($item.price)
+    #set($price = $item.price)
+  #end
+  #set($total = $price * $stock)
+  $util.qr($item.put("totalValue", $total))
+#end
+$util.toJson($ctx.prev.result)

--- a/amplify-migration-apps/product-catalog/Query.listProducts.res.vtl
+++ b/amplify-migration-apps/product-catalog/Query.listProducts.res.vtl
@@ -1,0 +1,11 @@
+## Add 10% discount to all products
+#foreach($item in $ctx.result.items)
+  #if($item.price)
+    #set($discount = $item.price * 0.10)
+    #set($discountedPrice = $item.price - $discount)
+    $util.qr($item.put("discountedPrice", $discountedPrice))
+    $util.qr($item.put("savings", $discount))
+  #end
+#end
+
+$util.toJson($ctx.result)

--- a/amplify-migration-apps/product-catalog/README.md
+++ b/amplify-migration-apps/product-catalog/README.md
@@ -344,6 +344,18 @@ On the AppSync AWS Console, locate the ID of Gen1 API, it will be named `product
 + export async function handler(event) {
 ```
 
+```diff
+- const crypto = require('@aws-crypto/sha256-js');
+- const { defaultProvider } = require('@aws-sdk/credential-provider-node');
+- const { SignatureV4 } = require('@aws-sdk/signature-v4');
+- const { HttpRequest } = require('@aws-sdk/protocol-http');
+- const Sha256 = crypto.Sha256;
++ import { Sha256 } from '@aws-crypto/sha256-js';
++ import { defaultProvider } from '@aws-sdk/credential-provider-node';
++ import { SignatureV4 } from '@aws-sdk/signature-v4';
++ import { HttpRequest } from '@aws-sdk/protocol-http';
+```
+
 **Edit in `./src/main.tsx`:**
 
 ```diff

--- a/amplify-migration-apps/product-catalog/configure.sh
+++ b/amplify-migration-apps/product-catalog/configure.sh
@@ -10,3 +10,4 @@ cp -f lowstockproducts.package.json ./amplify/backend/function/lowstockproducts/
 cp -f onimageuploaded.js ./amplify/backend/function/${s3_trigger_function_name}/src/index.js
 cp -f onimageuploaded.package.json ./amplify/backend/function/${s3_trigger_function_name}/src/package.json
 cp -f custom-roles.json ./amplify/backend/api/productcatalog/custom-roles.json
+cp -f Query.listProducts.res.vtl ./amplify/backend/api/productcatalog/resolvers/Query.listProducts.res.vtl

--- a/amplify-migration-apps/product-catalog/configure.sh
+++ b/amplify-migration-apps/product-catalog/configure.sh
@@ -11,3 +11,4 @@ cp -f onimageuploaded.js ./amplify/backend/function/${s3_trigger_function_name}/
 cp -f onimageuploaded.package.json ./amplify/backend/function/${s3_trigger_function_name}/src/package.json
 cp -f custom-roles.json ./amplify/backend/api/productcatalog/custom-roles.json
 cp -f Query.listProducts.res.vtl ./amplify/backend/api/productcatalog/resolvers/Query.listProducts.res.vtl
+cp -f Query.listProducts.postDataLoad.1.res.vtl ./amplify/backend/api/productcatalog/resolvers/Query.listProducts.postDataLoad.1.res.vtl

--- a/amplify-migration-apps/product-catalog/schema.graphql
+++ b/amplify-migration-apps/product-catalog/schema.graphql
@@ -27,11 +27,10 @@ type Product @model @auth(rules: [{ allow: private, provider: iam }]) {
   images: [String]
   createdBy: String
   updatedBy: String
-  discountedPrice: Float
-  savings: Float
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   comments: [Comment] @hasMany(indexName: "byProduct", fields: ["id"])
+  totalValue: Float
 }
 
 type Comment @model @auth(rules: [{ allow: private, provider: iam }, { allow: owner, ownerField: "authorId" }]) {

--- a/amplify-migration-apps/product-catalog/schema.graphql
+++ b/amplify-migration-apps/product-catalog/schema.graphql
@@ -4,10 +4,7 @@ enum UserRole {
   VIEWER
 }
 
-type User @model @auth(rules: [
-  { allow: private, provider: iam },
-  { allow: owner, ownerField: "id" }
-]) {
+type User @model @auth(rules: [{ allow: private, provider: iam }, { allow: owner, ownerField: "id" }]) {
   id: ID!
   email: String!
   name: String!
@@ -30,15 +27,14 @@ type Product @model @auth(rules: [{ allow: private, provider: iam }]) {
   images: [String]
   createdBy: String
   updatedBy: String
+  discountedPrice: Float
+  savings: Float
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   comments: [Comment] @hasMany(indexName: "byProduct", fields: ["id"])
 }
 
-type Comment @model @auth(rules: [
-  { allow: private, provider: iam },
-  { allow: owner, ownerField: "authorId" }
-]) {
+type Comment @model @auth(rules: [{ allow: private, provider: iam }, { allow: owner, ownerField: "authorId" }]) {
   id: ID!
   productId: ID! @index(name: "byProduct")
   authorId: String!
@@ -59,8 +55,7 @@ type LowStockResponse {
 }
 
 type Query {
-  checkLowStock: LowStockResponse @function(name: "lowstockproducts-${env}") @auth(rules: [
-    { allow: private, provider: iam },
-    { allow: public, provider: apiKey }
-  ])
+  checkLowStock: LowStockResponse
+    @function(name: "lowstockproducts-${env}")
+    @auth(rules: [{ allow: private, provider: iam }, { allow: public, provider: apiKey }])
 }

--- a/amplify-migration-apps/product-catalog/src/App.tsx
+++ b/amplify-migration-apps/product-catalog/src/App.tsx
@@ -1175,9 +1175,34 @@ function App({ signOut, user }: AppProps) {
                         </Text>
                       </View>
                       {product.price && (
-                        <Text fontSize="2xl" fontWeight="800" color="#10b981">
-                          ${product.price}
-                        </Text>
+                        <View textAlign="right">
+                          {(product as any).discountedPrice && (
+                            <>
+                              <Text fontSize="xs" color="#64748b" style={{ textDecoration: 'line-through' }}>
+                                ${product.price.toFixed(2)}
+                              </Text>
+                              <Text fontSize="2xl" fontWeight="800" color="#10b981">
+                                ${(product as any).discountedPrice.toFixed(2)}
+                              </Text>
+                              <Badge
+                                style={{
+                                  backgroundColor: '#fef3c7',
+                                  color: '#92400e',
+                                  fontWeight: '600',
+                                  fontSize: '10px',
+                                  padding: '0.15rem 0.5rem',
+                                }}
+                              >
+                                Save ${(product as any).savings.toFixed(2)}
+                              </Badge>
+                            </>
+                          )}
+                          {!(product as any).discountedPrice && (
+                            <Text fontSize="2xl" fontWeight="800" color="#10b981">
+                              ${product.price}
+                            </Text>
+                          )}
+                        </View>
                       )}
                     </Flex>
 

--- a/amplify-migration-apps/product-catalog/src/App.tsx
+++ b/amplify-migration-apps/product-catalog/src/App.tsx
@@ -1175,34 +1175,9 @@ function App({ signOut, user }: AppProps) {
                         </Text>
                       </View>
                       {product.price && (
-                        <View textAlign="right">
-                          {(product as any).discountedPrice && (
-                            <>
-                              <Text fontSize="xs" color="#64748b" style={{ textDecoration: 'line-through' }}>
-                                ${product.price.toFixed(2)}
-                              </Text>
-                              <Text fontSize="2xl" fontWeight="800" color="#10b981">
-                                ${(product as any).discountedPrice.toFixed(2)}
-                              </Text>
-                              <Badge
-                                style={{
-                                  backgroundColor: '#fef3c7',
-                                  color: '#92400e',
-                                  fontWeight: '600',
-                                  fontSize: '10px',
-                                  padding: '0.15rem 0.5rem',
-                                }}
-                              >
-                                Save ${(product as any).savings.toFixed(2)}
-                              </Badge>
-                            </>
-                          )}
-                          {!(product as any).discountedPrice && (
-                            <Text fontSize="2xl" fontWeight="800" color="#10b981">
-                              ${product.price}
-                            </Text>
-                          )}
-                        </View>
+                        <Text fontSize="2xl" fontWeight="800" color="#10b981">
+                          ${product.price}
+                        </Text>
                       )}
                     </Flex>
 
@@ -1233,17 +1208,40 @@ function App({ signOut, user }: AppProps) {
                           {product.brand}
                         </Badge>
                       )}
-                      {product.stock !== undefined && product.stock !== null && (
+                      {(product as any).stockStatus && (
                         <Badge
                           style={{
-                            backgroundColor: (product.stock || 0) > 0 ? '#dcfce7' : '#fef3c7',
-                            color: (product.stock || 0) > 0 ? '#166534' : '#92400e',
+                            backgroundColor:
+                              (product as any).stockStatus === 'OUT_OF_STOCK'
+                                ? '#fef2f2'
+                                : (product as any).stockStatus === 'LOW_STOCK'
+                                ? '#fef3c7'
+                                : '#dcfce7',
+                            color:
+                              (product as any).stockStatus === 'OUT_OF_STOCK'
+                                ? '#dc2626'
+                                : (product as any).stockStatus === 'LOW_STOCK'
+                                ? '#92400e'
+                                : '#166534',
                             fontWeight: '600',
                             borderRadius: '6px',
                             padding: '0.25rem 0.75rem',
                           }}
                         >
-                          {(product.stock || 0) > 0 ? `${product.stock} in stock` : 'Out of stock'}
+                          {(product as any).stockStatus.replace('_', ' ')}
+                        </Badge>
+                      )}
+                      {(product as any).totalValue && (
+                        <Badge
+                          style={{
+                            backgroundColor: '#f0f9ff',
+                            color: '#0369a1',
+                            fontWeight: '600',
+                            borderRadius: '6px',
+                            padding: '0.25rem 0.75rem',
+                          }}
+                        >
+                          Total: ${(product as any).totalValue}
                         </Badge>
                       )}
                     </Flex>

--- a/amplify-migration-apps/product-catalog/src/graphql/queries.ts
+++ b/amplify-migration-apps/product-catalog/src/graphql/queries.ts
@@ -57,6 +57,7 @@ export const listProducts = /* GraphQL */ `query ListProducts(
       savings
       createdAt
       updatedAt
+      totalValue
       __typename
     }
     nextToken

--- a/amplify-migration-apps/product-catalog/src/graphql/queries.ts
+++ b/amplify-migration-apps/product-catalog/src/graphql/queries.ts
@@ -53,6 +53,8 @@ export const listProducts = /* GraphQL */ `query ListProducts(
       images
       createdBy
       updatedBy
+      discountedPrice
+      savings
       createdAt
       updatedAt
       __typename

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -2423,6 +2423,9 @@ export class BackendSynthesizer {
       imports.push(this.createImportStatement([factory.createIdentifier('join'), factory.createIdentifier('dirname')], 'path'));
       imports.push(this.createImportStatement([factory.createIdentifier('fileURLToPath')], 'url'));
 
+      const blankLine = ts.factory.createExpressionStatement(ts.factory.createIdentifier(''));
+      nodes.push(blankLine);
+
       // Generate __dirname equivalent for ES modules
       const dirnameStatement = factory.createVariableStatement(
         [],

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -2416,6 +2416,257 @@ export class BackendSynthesizer {
       });
     }
 
+    // Generate resolver override escape hatches if resolvers exist
+    if (renderArgs.data?.hasResolvers) {
+      // Add required imports for resolver overrides
+      imports.push(this.createImportStatement([factory.createIdentifier('readdirSync'), factory.createIdentifier('readFileSync')], 'fs'));
+      imports.push(this.createImportStatement([factory.createIdentifier('join'), factory.createIdentifier('dirname')], 'path'));
+      imports.push(this.createImportStatement([factory.createIdentifier('fileURLToPath')], 'url'));
+
+      // Generate __dirname equivalent for ES modules
+      const dirnameStatement = factory.createVariableStatement(
+        [],
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              '__dirname',
+              undefined,
+              undefined,
+              factory.createCallExpression(factory.createIdentifier('dirname'), undefined, [
+                factory.createCallExpression(factory.createIdentifier('fileURLToPath'), undefined, [
+                  factory.createPropertyAccessExpression(factory.createIdentifier('import'), factory.createIdentifier('meta.url')),
+                ]),
+              ]),
+            ),
+          ],
+          ts.NodeFlags.Const,
+        ),
+      );
+      nodes.push(dirnameStatement);
+
+      // Generate resolver override logic
+      const resolversDirStatement = factory.createVariableStatement(
+        [],
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              'resolversDir',
+              undefined,
+              undefined,
+              factory.createCallExpression(factory.createIdentifier('join'), undefined, [
+                factory.createIdentifier('__dirname'),
+                factory.createStringLiteral('data/resolvers'),
+              ]),
+            ),
+          ],
+          ts.NodeFlags.Const,
+        ),
+      );
+      nodes.push(resolversDirStatement);
+
+      const resolverFilesStatement = factory.createVariableStatement(
+        [],
+        factory.createVariableDeclarationList(
+          [
+            factory.createVariableDeclaration(
+              'resolverFiles',
+              undefined,
+              undefined,
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createCallExpression(factory.createIdentifier('readdirSync'), undefined, [
+                    factory.createIdentifier('resolversDir'),
+                  ]),
+                  factory.createIdentifier('filter'),
+                ),
+                undefined,
+                [
+                  factory.createArrowFunction(
+                    undefined,
+                    undefined,
+                    [factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('f'))],
+                    undefined,
+                    factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(factory.createIdentifier('f'), factory.createIdentifier('endsWith')),
+                      undefined,
+                      [factory.createStringLiteral('.res.vtl')],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          ts.NodeFlags.Const,
+        ),
+      );
+      nodes.push(resolverFilesStatement);
+
+      // Generate for loop to process resolver files
+      const forOfStatement = factory.createForOfStatement(
+        undefined,
+        factory.createVariableDeclarationList(
+          [factory.createVariableDeclaration('file', undefined, undefined, undefined)],
+          ts.NodeFlags.Const,
+        ),
+        factory.createIdentifier('resolverFiles'),
+        factory.createBlock(
+          [
+            // Parse file name
+            factory.createVariableStatement(
+              [],
+              factory.createVariableDeclarationList(
+                [
+                  factory.createVariableDeclaration(
+                    factory.createArrayBindingPattern([
+                      factory.createBindingElement(undefined, undefined, 'typeName'),
+                      factory.createBindingElement(undefined, undefined, 'fieldName'),
+                    ]),
+                    undefined,
+                    undefined,
+                    factory.createCallExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createCallExpression(
+                          factory.createPropertyAccessExpression(factory.createIdentifier('file'), factory.createIdentifier('replace')),
+                          undefined,
+                          [factory.createStringLiteral('.res.vtl'), factory.createStringLiteral('')],
+                        ),
+                        factory.createIdentifier('split'),
+                      ),
+                      undefined,
+                      [factory.createStringLiteral('.')],
+                    ),
+                  ),
+                ],
+                ts.NodeFlags.Const,
+              ),
+            ),
+            // Generate function ID
+            factory.createVariableStatement(
+              [],
+              factory.createVariableDeclarationList(
+                [
+                  factory.createVariableDeclaration(
+                    'functionId',
+                    undefined,
+                    undefined,
+                    factory.createTemplateExpression(factory.createTemplateHead(''), [
+                      factory.createTemplateSpan(factory.createIdentifier('typeName'), factory.createTemplateMiddle('')),
+                      factory.createTemplateSpan(
+                        factory.createBinaryExpression(
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createCallExpression(
+                                factory.createPropertyAccessExpression(
+                                  factory.createIdentifier('fieldName'),
+                                  factory.createIdentifier('charAt'),
+                                ),
+                                undefined,
+                                [factory.createNumericLiteral('0')],
+                              ),
+                              factory.createIdentifier('toUpperCase'),
+                            ),
+                            undefined,
+                            [],
+                          ),
+                          factory.createToken(ts.SyntaxKind.PlusToken),
+                          factory.createCallExpression(
+                            factory.createPropertyAccessExpression(
+                              factory.createIdentifier('fieldName'),
+                              factory.createIdentifier('slice'),
+                            ),
+                            undefined,
+                            [factory.createNumericLiteral('1')],
+                          ),
+                        ),
+                        factory.createTemplateTail('DataResolverFn'),
+                      ),
+                    ]),
+                  ),
+                ],
+                ts.NodeFlags.Const,
+              ),
+            ),
+            // Get pipeline function
+            factory.createVariableStatement(
+              [],
+              factory.createVariableDeclarationList(
+                [
+                  factory.createVariableDeclaration(
+                    'pipelineFunction',
+                    undefined,
+                    undefined,
+                    factory.createElementAccessExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('backend.data.resources.cfnResources'),
+                        factory.createIdentifier('cfnFunctionConfigurations'),
+                      ),
+                      factory.createIdentifier('functionId'),
+                    ),
+                  ),
+                ],
+                ts.NodeFlags.Const,
+              ),
+            ),
+            // If statement to check if pipeline function exists
+            factory.createIfStatement(
+              factory.createIdentifier('pipelineFunction'),
+              factory.createBlock(
+                [
+                  // Read template file
+                  factory.createVariableStatement(
+                    [],
+                    factory.createVariableDeclarationList(
+                      [
+                        factory.createVariableDeclaration(
+                          'template',
+                          undefined,
+                          undefined,
+                          factory.createCallExpression(factory.createIdentifier('readFileSync'), undefined, [
+                            factory.createCallExpression(factory.createIdentifier('join'), undefined, [
+                              factory.createIdentifier('resolversDir'),
+                              factory.createIdentifier('file'),
+                            ]),
+                            factory.createStringLiteral('utf8'),
+                          ]),
+                        ),
+                      ],
+                      ts.NodeFlags.Const,
+                    ),
+                  ),
+                  // Clear S3 location
+                  factory.createExpressionStatement(
+                    factory.createBinaryExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('pipelineFunction'),
+                        factory.createIdentifier('responseMappingTemplateS3Location'),
+                      ),
+                      factory.createToken(ts.SyntaxKind.EqualsToken),
+                      factory.createIdentifier('undefined'),
+                    ),
+                  ),
+                  // Set inline template
+                  factory.createExpressionStatement(
+                    factory.createBinaryExpression(
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier('pipelineFunction'),
+                        factory.createIdentifier('responseMappingTemplate'),
+                      ),
+                      factory.createToken(ts.SyntaxKind.EqualsToken),
+                      factory.createIdentifier('template'),
+                    ),
+                  ),
+                ],
+                true,
+              ),
+            ),
+          ],
+          true,
+        ),
+      );
+      nodes.push(forOfStatement);
+    }
+
     // returns backend.ts file
     return factory.createNodeArray([...imports, newLineIdentifier, ...errors, newLineIdentifier, backendStatement, ...nodes], true);
   }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -2416,7 +2416,7 @@ export class BackendSynthesizer {
       });
     }
 
-    // Generate resolver override escape hatches if resolvers exist
+    // Override resolver templates from data/resolvers folder
     if (renderArgs.data?.hasResolvers) {
       // Add required imports for resolver overrides
       imports.push(this.createImportStatement([factory.createIdentifier('readdirSync'), factory.createIdentifier('readFileSync')], 'fs'));
@@ -2444,7 +2444,7 @@ export class BackendSynthesizer {
       );
       nodes.push(dirnameStatement);
 
-      // Generate resolver override logic
+      // Get resolvers directory path
       const resolversDirStatement = factory.createVariableStatement(
         [],
         factory.createVariableDeclarationList(
@@ -2464,6 +2464,7 @@ export class BackendSynthesizer {
       );
       nodes.push(resolversDirStatement);
 
+      // Filter for .res.vtl files
       const resolverFilesStatement = factory.createVariableStatement(
         [],
         factory.createVariableDeclarationList(
@@ -2502,7 +2503,7 @@ export class BackendSynthesizer {
       );
       nodes.push(resolverFilesStatement);
 
-      // Generate for loop to process resolver files
+      // Process each resolver file
       const forOfStatement = factory.createForOfStatement(
         undefined,
         factory.createVariableDeclarationList(
@@ -2512,7 +2513,7 @@ export class BackendSynthesizer {
         factory.createIdentifier('resolverFiles'),
         factory.createBlock(
           [
-            // Parse file name
+            // Extract type and field names from filename (e.g., Query.listProducts.res.vtl)
             factory.createVariableStatement(
               [],
               factory.createVariableDeclarationList(
@@ -2541,7 +2542,7 @@ export class BackendSynthesizer {
                 ts.NodeFlags.Const,
               ),
             ),
-            // Generate function ID
+            // Build pipeline function ID (e.g., QueryListProductsDataResolverFn)
             factory.createVariableStatement(
               [],
               factory.createVariableDeclarationList(
@@ -2587,7 +2588,7 @@ export class BackendSynthesizer {
                 ts.NodeFlags.Const,
               ),
             ),
-            // Get pipeline function
+            // Get the pipeline function configuration
             factory.createVariableStatement(
               [],
               factory.createVariableDeclarationList(
@@ -2608,12 +2609,12 @@ export class BackendSynthesizer {
                 ts.NodeFlags.Const,
               ),
             ),
-            // If statement to check if pipeline function exists
+            // Override the response mapping template if pipeline function exists
             factory.createIfStatement(
               factory.createIdentifier('pipelineFunction'),
               factory.createBlock(
                 [
-                  // Read template file
+                  // Read the VTL template content
                   factory.createVariableStatement(
                     [],
                     factory.createVariableDeclarationList(
@@ -2634,7 +2635,7 @@ export class BackendSynthesizer {
                       ts.NodeFlags.Const,
                     ),
                   ),
-                  // Clear S3 location
+                  // Clear the S3 template location to use inline template
                   factory.createExpressionStatement(
                     factory.createBinaryExpression(
                       factory.createPropertyAccessExpression(
@@ -2645,7 +2646,7 @@ export class BackendSynthesizer {
                       factory.createIdentifier('undefined'),
                     ),
                   ),
-                  // Set inline template
+                  // Set the inline response mapping template
                   factory.createExpressionStatement(
                     factory.createBinaryExpression(
                       factory.createPropertyAccessExpression(

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -28,6 +28,7 @@ export interface BackendRenderParameters {
     importFrom: string;
     additionalAuthProviders?: AdditionalAuthProvider[];
     restApis?: RestApiDefinition[];
+    hasResolvers?: boolean;
   };
   auth?: {
     importFrom: string;

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -2423,8 +2423,7 @@ export class BackendSynthesizer {
       imports.push(this.createImportStatement([factory.createIdentifier('join'), factory.createIdentifier('dirname')], 'path'));
       imports.push(this.createImportStatement([factory.createIdentifier('fileURLToPath')], 'url'));
 
-      const blankLine = ts.factory.createExpressionStatement(ts.factory.createIdentifier(''));
-      nodes.push(blankLine);
+      nodes.push(factory.createEmptyStatement());
 
       // Generate __dirname equivalent for ES modules
       const dirnameStatement = factory.createVariableStatement(

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/backend/synthesizer.ts
@@ -2423,8 +2423,6 @@ export class BackendSynthesizer {
       imports.push(this.createImportStatement([factory.createIdentifier('join'), factory.createIdentifier('dirname')], 'path'));
       imports.push(this.createImportStatement([factory.createIdentifier('fileURLToPath')], 'url'));
 
-      nodes.push(factory.createEmptyStatement());
-
       // Generate __dirname equivalent for ES modules
       const dirnameStatement = factory.createVariableStatement(
         [],

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
@@ -4,7 +4,7 @@ import glob from 'glob';
 import assert from 'node:assert';
 
 import { DataDefinition } from '../core/migration-pipeline';
-import { AdditionalAuthProvider } from '../generators/data';
+import { AdditionalAuthProvider, ResolverConfig, getProjectName } from '../generators/data';
 import { pathManager } from '@aws-amplify/amplify-cli-core';
 
 // Source - amplify-category-api/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -129,6 +129,29 @@ export class DataDefinitionFetcher {
    * @param ccbFetcher - Downloads current cloud backend artifacts
    */
   constructor(private backendEnvironmentResolver: BackendEnvironmentResolver, private ccbFetcher: BackendDownloader) {}
+
+  /**
+   * Checks if GraphQL API has resolvers directory with VTL files and copies them
+   */
+  private copyResolvers = (): boolean => {
+    const rootDir = pathManager.findProjectRoot();
+    const projectName = getProjectName();
+
+    const resolversPath = path.join(rootDir, 'amplify', 'backend', 'api', projectName, 'resolvers');
+
+    if (!require('fs').existsSync(resolversPath)) return false;
+
+    const files = require('fs').readdirSync(resolversPath);
+
+    if (!files.some((file: string) => file.endsWith('.vtl'))) return false;
+
+    const targetPath = path.join(rootDir, 'amplify', 'data', 'resolvers');
+
+    require('fs').mkdirSync(path.dirname(targetPath), { recursive: true });
+    require('fs').cpSync(resolversPath, targetPath, { recursive: true });
+
+    return true;
+  };
 
   /**
    * Reads and parses a JSON file.
@@ -462,6 +485,10 @@ export class DataDefinitionFetcher {
         const additionalAuthProviders = apiId ? await this.getAdditionalAuthProvidersFromConsole(apiId) : [];
         const logging = apiId ? await this.getLoggingConfigFromConsole(apiId) : undefined;
 
+        // Handle resolver copying
+        const resolversCopied = this.copyResolvers();
+        const resolvers: ResolverConfig | undefined = resolversCopied ? { hasResolvers: true } : undefined;
+
         return {
           tableMappings: undefined,
           schema,
@@ -469,6 +496,7 @@ export class DataDefinitionFetcher {
           additionalAuthProviders: additionalAuthProviders.length > 0 ? additionalAuthProviders : undefined,
           logging,
           restApis: restApis.length > 0 ? restApis : undefined,
+          resolvers,
         };
       }
 

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
@@ -4,7 +4,7 @@ import glob from 'glob';
 import assert from 'node:assert';
 
 import { DataDefinition } from '../core/migration-pipeline';
-import { AdditionalAuthProvider, ResolverConfig, getProjectName } from '../generators/data';
+import { AdditionalAuthProvider, getProjectName } from '../generators/data';
 import { pathManager } from '@aws-amplify/amplify-cli-core';
 
 // Source - amplify-category-api/packages/amplify-graphql-transformer-core/src/graphql-api.ts
@@ -101,6 +101,11 @@ export interface CorsConfiguration {
   allowOrigins?: string[];
   exposeHeaders?: string[];
   maxAge?: number;
+}
+
+// Add locally in the fetcher
+export interface ResolverConfig {
+  hasResolvers: boolean;
 }
 
 import { BackendEnvironmentResolver } from './backend_environment_selector';

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
@@ -112,6 +112,7 @@ import { BackendEnvironmentResolver } from './backend_environment_selector';
 import { BackendDownloader } from './backend_downloader';
 import { fileOrDirectoryExists } from './directory_exists';
 import { AppSyncClient, GetGraphqlApiCommand } from '@aws-sdk/client-appsync';
+import { hasRestParameter } from 'typescript';
 
 /**
  * Fetches and processes data definitions from Amplify Gen1 projects for migration to Gen2.
@@ -136,9 +137,9 @@ export class DataDefinitionFetcher {
   constructor(private backendEnvironmentResolver: BackendEnvironmentResolver, private ccbFetcher: BackendDownloader) {}
 
   /**
-   * Checks if GraphQL API has resolvers directory with VTL files and copies them
+   * Checks if GraphQL API has resolvers directory with VTL files
    */
-  private copyResolvers = (): boolean => {
+  private hasResolvers = (): boolean => {
     const rootDir = pathManager.findProjectRoot();
     const projectName = getProjectName();
 
@@ -148,14 +149,7 @@ export class DataDefinitionFetcher {
 
     const files = require('fs').readdirSync(resolversPath);
 
-    if (!files.some((file: string) => file.endsWith('.vtl'))) return false;
-
-    const targetPath = path.join(rootDir, 'amplify', 'data', 'resolvers');
-
-    require('fs').mkdirSync(path.dirname(targetPath), { recursive: true });
-    require('fs').cpSync(resolversPath, targetPath, { recursive: true });
-
-    return true;
+    return files.some((file: string) => file.endsWith('.vtl'));
   };
 
   /**
@@ -490,9 +484,9 @@ export class DataDefinitionFetcher {
         const additionalAuthProviders = apiId ? await this.getAdditionalAuthProvidersFromConsole(apiId) : [];
         const logging = apiId ? await this.getLoggingConfigFromConsole(apiId) : undefined;
 
-        // Handle resolver copying
-        const resolversCopied = this.copyResolvers();
-        const resolvers: ResolverConfig | undefined = resolversCopied ? { hasResolvers: true } : undefined;
+        // Handle resolver checking
+        const hasResolvers = this.hasResolvers();
+        const resolvers: ResolverConfig | undefined = hasResolvers ? { hasResolvers: true } : undefined;
 
         return {
           tableMappings: undefined,

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/codegen-head/data_definition_fetcher.ts
@@ -6,6 +6,10 @@ import assert from 'node:assert';
 import { DataDefinition } from '../core/migration-pipeline';
 import { AdditionalAuthProvider, getProjectName } from '../generators/data';
 import { pathManager } from '@aws-amplify/amplify-cli-core';
+import { BackendEnvironmentResolver } from './backend_environment_selector';
+import { BackendDownloader } from './backend_downloader';
+import { fileOrDirectoryExists } from './directory_exists';
+import { AppSyncClient, GetGraphqlApiCommand } from '@aws-sdk/client-appsync';
 
 // Source - amplify-category-api/packages/amplify-graphql-transformer-core/src/graphql-api.ts
 interface Gen1AuthConfig {
@@ -107,12 +111,6 @@ export interface CorsConfiguration {
 export interface ResolverConfig {
   hasResolvers: boolean;
 }
-
-import { BackendEnvironmentResolver } from './backend_environment_selector';
-import { BackendDownloader } from './backend_downloader';
-import { fileOrDirectoryExists } from './directory_exists';
-import { AppSyncClient, GetGraphqlApiCommand } from '@aws-sdk/client-appsync';
-import { hasRestParameter } from 'typescript';
 
 /**
  * Fetches and processes data definitions from Amplify Gen1 projects for migration to Gen2.

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
@@ -58,8 +58,10 @@ import {
 } from '../generators/storage';
 
 import { DataDefinition, DataTableMapping, generateDataSource } from '../generators/data/index';
+import { getProjectName } from '../generators/data';
 import { DataModelTableAccess } from '../codegen-head/data_model_access_parser';
 import { ApiTriggerDetector } from '../adapters/functions/api-trigger-detector';
+import { pathManager } from '@aws-amplify/amplify-cli-core';
 
 import { FunctionDefinition, renderFunctions } from '../generators/functions/index';
 import assert from 'assert';
@@ -116,6 +118,22 @@ export interface Gen2RenderingOptions {
   /** Custom file writer function for testing or alternative output methods */
   fileWriter?: (content: string, path: string) => Promise<void>;
 }
+/**
+ * Copies resolver files from Gen1 to Gen2 structure
+ */
+const copyResolverFiles = (outputDir: string): Renderer => ({
+  render: async () => {
+    const rootDir = pathManager.findProjectRoot();
+    const projectName = getProjectName();
+    const resolversPath = path.join(rootDir, 'amplify', 'backend', 'api', projectName, 'resolvers');
+    const targetPath = path.join(outputDir, 'amplify', 'data', 'resolvers');
+
+    if (require('fs').existsSync(resolversPath)) {
+      require('fs').cpSync(resolversPath, targetPath, { recursive: true });
+    }
+  },
+});
+
 /**
  * Creates a file writer function for the specified path
  * @param path - File path to write to
@@ -487,6 +505,10 @@ export const createGen2Renderer = ({
   // Process data (GraphQL/DynamoDB) configuration - only if table mappings exist for the environment
   if (data) {
     renderers.push(new EnsureDirectory(path.join(outputDir, 'amplify', 'data')));
+    if (data.resolvers?.hasResolvers) {
+      renderers.push(new EnsureDirectory(path.join(outputDir, 'amplify', 'data', 'resolvers')));
+      renderers.push(copyResolverFiles(outputDir));
+    }
     renderers.push(
       new TypescriptNodeArrayRenderer(
         async () => generateDataSource(backendEnvironmentName, data),

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
@@ -497,6 +497,7 @@ export const createGen2Renderer = ({
       importFrom: './data/resource',
       additionalAuthProviders: data.additionalAuthProviders,
       restApis: data.restApis,
+      hasResolvers: data.resolvers?.hasResolvers,
     };
   }
 

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/core/migration-pipeline.ts
@@ -129,7 +129,14 @@ const copyResolverFiles = (outputDir: string): Renderer => ({
     const targetPath = path.join(outputDir, 'amplify', 'data', 'resolvers');
 
     if (require('fs').existsSync(resolversPath)) {
-      require('fs').cpSync(resolversPath, targetPath, { recursive: true });
+      const files = require('fs').readdirSync(resolversPath);
+      const vtlFiles = files.filter((file: string) => file.endsWith('.vtl'));
+
+      for (const file of vtlFiles) {
+        const srcFile = path.join(resolversPath, file);
+        const destFile = path.join(targetPath, file);
+        require('fs').copyFileSync(srcFile, destFile);
+      }
     }
   },
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -24,25 +24,6 @@ export interface AdditionalAuthProvider {
   };
 }
 
-/**
- * Checks if GraphQL API has resolvers directory with VTL files and copies them
- */
-const copyResolvers = (): boolean => {
-  const rootDir = pathManager.findProjectRoot();
-  const projectName = getProjectName();
-
-  const resolversPath = path.join(rootDir, 'amplify', 'backend', 'api', projectName, 'resolvers');
-  if (!fs.existsSync(resolversPath)) return false;
-
-  const files = fs.readdirSync(resolversPath);
-  if (!files.some((file) => file.endsWith('.vtl'))) return false;
-
-  const targetPath = path.join(rootDir, 'amplify', 'data', 'resolvers');
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.cpSync(resolversPath, targetPath, { recursive: true });
-  return true;
-};
-
 const factory = ts.factory;
 
 /**
@@ -78,7 +59,7 @@ const extractModelsFromSchema = (schema: string): string[] => {
   return models;
 };
 
-const getProjectName = (): string | undefined => {
+export const getProjectName = (): string | undefined => {
   try {
     const fs = require('fs');
     const path = require('path');
@@ -171,14 +152,6 @@ export const generateDataSource = async (gen1Env: string, dataDefinition?: DataD
   // Return undefined if no schema and no REST APIs
   if (!dataDefinition.schema && (!dataDefinition.restApis || dataDefinition.restApis.length === 0)) {
     return undefined;
-  }
-
-  // Handle resolver copying if GraphQL API exists
-  if (dataDefinition.schema) {
-    const resolversCopied = copyResolvers();
-    if (resolversCopied) {
-      dataDefinition.resolvers = { hasResolvers: true };
-    }
   }
   // Properties for the defineData() function call
   const dataRenderProperties: ObjectLiteralElementLike[] = [];

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -4,6 +4,14 @@ import { AppSyncClient, paginateListGraphqlApis } from '@aws-sdk/client-appsync'
 import type { ConstructFactory, AmplifyFunction } from '@aws-amplify/plugin-types';
 import type { AuthorizationModes, DataLoggingOptions } from '@aws-amplify/backend-data';
 import { RestApiDefinition } from '../../codegen-head/data_definition_fetcher';
+/**
+ * Resolver configuration for GraphQL API
+ */
+export interface ResolverConfig {
+  /** Whether resolvers directory was found and copied */
+  hasResolvers: boolean;
+}
+
 export interface AdditionalAuthProvider {
   authenticationType: 'API_KEY' | 'AWS_IAM' | 'OPENID_CONNECT' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_LAMBDA';
   userPoolConfig?: {
@@ -102,6 +110,8 @@ export type DataDefinition = {
   logging?: DataLoggingOptions;
   /* REST API definitions */
   restApis?: RestApiDefinition[];
+  /* Resolver configuration */
+  resolvers?: ResolverConfig;
 };
 
 /** Key name for the migrated table mappings property in the generated data resource */
@@ -137,6 +147,14 @@ export const generateDataSource = async (gen1Env: string, dataDefinition?: DataD
   // Return undefined if no schema and no REST APIs
   if (!dataDefinition.schema && (!dataDefinition.restApis || dataDefinition.restApis.length === 0)) {
     return undefined;
+  }
+
+  // Handle resolver copying if GraphQL API exists
+  if (dataDefinition.schema) {
+    const resolversCopied = handleResolversCopy();
+    if (resolversCopied) {
+      dataDefinition.resolvers = { hasResolvers: true };
+    }
   }
   // Properties for the defineData() function call
   const dataRenderProperties: ObjectLiteralElementLike[] = [];

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -30,7 +30,6 @@ export interface AdditionalAuthProvider {
 const copyResolvers = (): boolean => {
   const rootDir = pathManager.findProjectRoot();
   const projectName = getProjectName();
-  if (!projectName) return false;
 
   const resolversPath = path.join(rootDir, 'amplify', 'backend', 'api', projectName, 'resolvers');
   if (!fs.existsSync(resolversPath)) return false;

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -3,19 +3,7 @@ import { renderResourceTsFile } from '../../resource/resource';
 import { AppSyncClient, paginateListGraphqlApis } from '@aws-sdk/client-appsync';
 import type { ConstructFactory, AmplifyFunction } from '@aws-amplify/plugin-types';
 import type { AuthorizationModes, DataLoggingOptions } from '@aws-amplify/backend-data';
-import { RestApiDefinition } from '../../codegen-head/data_definition_fetcher';
-
-import fs from 'fs';
-import path from 'path';
-import { pathManager } from '@aws-amplify/amplify-cli-core';
-
-/**
- * Resolver configuration for GraphQL API
- */
-export interface ResolverConfig {
-  /** Whether resolvers directory was found and copied */
-  hasResolvers: boolean;
-}
+import { RestApiDefinition, ResolverConfig } from '../../codegen-head/data_definition_fetcher';
 
 export interface AdditionalAuthProvider {
   authenticationType: 'API_KEY' | 'AWS_IAM' | 'OPENID_CONNECT' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_LAMBDA';

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/generators/data/index.ts
@@ -4,6 +4,11 @@ import { AppSyncClient, paginateListGraphqlApis } from '@aws-sdk/client-appsync'
 import type { ConstructFactory, AmplifyFunction } from '@aws-amplify/plugin-types';
 import type { AuthorizationModes, DataLoggingOptions } from '@aws-amplify/backend-data';
 import { RestApiDefinition } from '../../codegen-head/data_definition_fetcher';
+
+import fs from 'fs';
+import path from 'path';
+import { pathManager } from '@aws-amplify/amplify-cli-core';
+
 /**
  * Resolver configuration for GraphQL API
  */
@@ -18,6 +23,26 @@ export interface AdditionalAuthProvider {
     userPoolId?: string;
   };
 }
+
+/**
+ * Checks if GraphQL API has resolvers directory with VTL files and copies them
+ */
+const copyResolvers = (): boolean => {
+  const rootDir = pathManager.findProjectRoot();
+  const projectName = getProjectName();
+  if (!projectName) return false;
+
+  const resolversPath = path.join(rootDir, 'amplify', 'backend', 'api', projectName, 'resolvers');
+  if (!fs.existsSync(resolversPath)) return false;
+
+  const files = fs.readdirSync(resolversPath);
+  if (!files.some((file) => file.endsWith('.vtl'))) return false;
+
+  const targetPath = path.join(rootDir, 'amplify', 'data', 'resolvers');
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.cpSync(resolversPath, targetPath, { recursive: true });
+  return true;
+};
 
 const factory = ts.factory;
 
@@ -151,7 +176,7 @@ export const generateDataSource = async (gen1Env: string, dataDefinition?: DataD
 
   // Handle resolver copying if GraphQL API exists
   if (dataDefinition.schema) {
-    const resolversCopied = handleResolversCopy();
+    const resolversCopied = copyResolvers();
     if (resolversCopied) {
       dataDefinition.resolvers = { hasResolvers: true };
     }


### PR DESCRIPTION
## Context

Extended resolvers are functions which we can place at locations within a pipeline resolver. Documentation for the slots to place a function in Amplify gen1 can be found [here](https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/custom-business-logic/#supported-resolver-slots).

By default, Amplify generates these resolvers: 

**Example: getProducts**

1. QuerygetProductauth0Function
2. QuerygetUserpostAuth0Function
3. QueryGetProductDataResolverFn

Note: The above are the functions inside a default resolver. They also may differ from resolver to resolver. For example, 

**Example: listUsers**

1. QuerygetUserauth0Function
2. QuerygetUserpostAuth0Function
3. QueryListUsersDataResolverFn

As you can see, the default resolvers tend to follow a pattern of placing them within the slots auth0, postAuth0, DataResolver. Furthermore, the only default resolver with a data source is the DataResolverFn.

**Example: listUsers**
Function: QueryListUsersDataResolverFn
Data Source: UserTable

Function: QuerygetUserauth0Function
Data Source: NONE_DS

Furthermore, any new extended functions added in Amplify Gen1 also have a data source of NONE_DS.

## EXAMPLE MIGRATION

## Gen1 app product catalog
The following resolver functions are placed inside the resolvers/ directory. 
`Query.listProducts.postDataLoad.1.res.vtl`
```vtl
#set($items = $ctx.prev.result.items)
#foreach($item in $items)
  #set($stock = 0)
  #if($item.stock)
    #set($stock = $item.stock)
  #end
  #set($price = 0)
  #if($item.price)
    #set($price = $item.price)
  #end
  #set($total = $price * $stock)
  $util.qr($item.put("totalValue", $total))
#end
$util.toJson($ctx.prev.result)

```
`Query.listProducts.postAuth.2.req.vtl`
```vtl
{}
```
`Query.listProducts.postAuth.3.res.vtl`
```vtl
$util.toJson($ctx.prev.result)
```

Post `generate`, the resolvers/ directory is copy pasted under `amplify/data/` which has the same vtl files as gen1 (no change). In `backend.ts`, the following code needs to be generated
`amplify/backend.ts`
```typescript
// EXTENDING RESOLVERS
const __dirname = dirname(fileURLToPath(import.meta.url));
const resolversDir = join(__dirname, "data/resolvers");

const noneDataSource = backend.data.resources.graphqlApi.addNoneDataSource('none');

// postAuth.2.req.vtl
const postAuth2ReqFunction = new aws_appsync.AppsyncFunction(backend.data.stack, 'QuerylistProductspostAuth2reqvtl', {
  name: 'QuerylistProductspostAuth2reqvtl',
  api: backend.data.resources.graphqlApi,
  dataSource: noneDataSource,
  requestMappingTemplate: aws_appsync.MappingTemplate.fromFile(join(resolversDir, 'Query.listProducts.postAuth.2.req.vtl')),
  responseMappingTemplate: aws_appsync.MappingTemplate.fromString('$util.toJson($ctx.prev.result)'),
});

// postAuth.3.res.vtl
const postAuth3ResFunction = new aws_appsync.AppsyncFunction(backend.data.stack, 'QuerylistProductspostAuth3resvtl', {
  name: 'QuerylistProductspostAuth3resvtl',
  api: backend.data.resources.graphqlApi,
  dataSource: noneDataSource,
  requestMappingTemplate: aws_appsync.MappingTemplate.fromString('$util.toJson({})'),
  responseMappingTemplate: aws_appsync.MappingTemplate.fromFile(join(resolversDir, 'Query.listProducts.postAuth.3.res.vtl')),
});

// postDataLoad.1.res.vtl
const postDataLoad1ResFunction = new aws_appsync.AppsyncFunction(backend.data.stack, 'QuerylistProductspostDataLoad1resvtl', {
  name: 'QuerylistProductspostDataLoad1resvtl',
  api: backend.data.resources.graphqlApi,
  dataSource: noneDataSource,
  requestMappingTemplate: aws_appsync.MappingTemplate.fromString('$util.toJson({})'),
  responseMappingTemplate: aws_appsync.MappingTemplate.fromFile(join(resolversDir, 'Query.listProducts.postDataLoad.1.res.vtl')),
});

const resolver = backend.data.resources.cfnResources.cfnResolvers['Query.listProducts'] as CfnResolver;
const pipelineConfig = resolver.pipelineConfig as CfnResolver.PipelineConfigProperty;
const existingFunctions = pipelineConfig.functions || [];

existingFunctions.splice(2, 0, postAuth2ReqFunction.functionId);
existingFunctions.splice(3, 0, postAuth3ResFunction.functionId);
existingFunctions.splice(5, 0, postDataLoad1ResFunction.functionId);

resolver.pipelineConfig = {
  functions: existingFunctions,
};
```

**Note**
Identifying the correct slot order to place the new functions in is crucial. `existingFunctions` contains the default functions in that resolver and we need to generate indexing according to it. Importantly, refer to the table [here](https://docs.amplify.aws/gen1/react/build-a-backend/graphqlapi/custom-business-logic/#supported-resolver-slots) for determining the correct indexes. The indexes are also dynamic. By using `splice`, we are inserting it at the said index. That means that all the functions of it get shifted by +1. This needs to be taken into consideration. 

**Assumptions to take note of**

1. All existing pipeline resolvers have the same three default function slots
2. All existing pipeline resolvers have the same type of functions (Query, Mutation, Subscription)
3. Amplify Gen1 doesn't allow user to configure data sources for extended functions in resolvers and they default to NONE
4. We also have to ensure that overriden resolver functions are handled correctly since they are both vtl files.