### PR TITLE
feat(gen2-migration): enable Cognito User Pool deletion protection 

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/lock.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/lock.ts
@@ -1,20 +1,23 @@
 import { AmplifyMigrationStep } from './_step';
 import { AmplifyMigrationOperation } from './_operation';
-import { AmplifyError } from '@aws-amplify/amplify-cli-core';
+import { AmplifyError, stateManager } from '@aws-amplify/amplify-cli-core';
 import { CloudFormationClient, SetStackPolicyCommand } from '@aws-sdk/client-cloudformation';
 import { AmplifyClient, UpdateAppCommand, GetAppCommand } from '@aws-sdk/client-amplify';
 import { DynamoDBClient, UpdateTableCommand, paginateListTables } from '@aws-sdk/client-dynamodb';
 import { AppSyncClient, paginateListGraphqlApis } from '@aws-sdk/client-appsync';
+import { CognitoIdentityProviderClient, UpdateUserPoolCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { AmplifyGen2MigrationValidations } from './_validations';
 
 const GEN2_MIGRATION_ENVIRONMENT_NAME = 'GEN2_MIGRATION_ENVIRONMENT_NAME';
 
 export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
   private _dynamoTableNames: string[];
+  private _userPoolIds: string[];
 
   private _ddbClient: DynamoDBClient;
   private _amplifyClient: AmplifyClient;
   private _cfnClient: CloudFormationClient;
+  private _cognitoClient: CognitoIdentityProviderClient;
 
   public async executeImplications(): Promise<string[]> {
     return [
@@ -57,6 +60,23 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
             }),
           );
           this.logger.info(`Enabled deletion protection for table '${tableName}'`);
+        },
+      });
+    }
+
+    for (const userPoolId of await this.userPoolIds()) {
+      operations.push({
+        describe: async () => {
+          return [`Enable deletion protection for user pool '${userPoolId}'`];
+        },
+        execute: async () => {
+          await this.cognitoClient().send(
+            new UpdateUserPoolCommand({
+              UserPoolId: userPoolId,
+              DeletionProtection: 'ACTIVE',
+            }),
+          );
+          this.logger.info(`Enabled deletion protection for user pool '${userPoolId}'`);
         },
       });
     }
@@ -112,6 +132,17 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
       operations.push({
         describe: async () => {
           return [`Preserve deletion protection for table '${tableName}'`];
+        },
+        execute: async () => {
+          return;
+        },
+      });
+    }
+
+    for (const userPoolId of await this.userPoolIds()) {
+      operations.push({
+        describe: async () => {
+          return [`Preserve deletion protection for user pool '${userPoolId}'`];
         },
         execute: async () => {
           return;
@@ -217,5 +248,29 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
       this._cfnClient = new CloudFormationClient({});
     }
     return this._cfnClient;
+  }
+
+  private cognitoClient() {
+    if (!this._cognitoClient) {
+      this._cognitoClient = new CognitoIdentityProviderClient({});
+    }
+    return this._cognitoClient;
+  }
+
+  private async userPoolIds(): Promise<string[]> {
+    if (!this._userPoolIds) {
+      this._userPoolIds = [];
+      const meta = stateManager.getMeta();
+      const authCategory = meta?.auth;
+      if (authCategory) {
+        for (const [, resource] of Object.entries(authCategory)) {
+          const typedResource = resource as { service?: string; output?: { UserPoolId?: string } };
+          if (typedResource.service === 'Cognito' && typedResource.output?.UserPoolId) {
+            this._userPoolIds.push(typedResource.output.UserPoolId);
+          }
+        }
+      }
+    }
+    return this._userPoolIds;
   }
 }


### PR DESCRIPTION
The amplify gen2-migration lock command already enables deletion protection on DynamoDB tables to safeguard stateful resources during migration. This PR extends that same protection to Cognito User Pools.

What changed:

- Added userPoolIds() method that reads User Pool IDs from amplify-meta.json via stateManager.getMeta(), filtering auth resources where service === 'Cognito'
- Added cognitoClient() lazy accessor for CognitoIdentityProviderClient
- In execute(): for each discovered User Pool, pushes an operation that calls UpdateUserPoolCommand with DeletionProtection: 'ACTIVE'
- In rollback(): follows the existing DynamoDB pattern — pushes a no-op "preserve" operation since the original protection state is unknown

Resolves https://github.com/aws-amplify/amplify-cli/issues/14522

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

