### PR TITLE
feat: add lambda layers to the project boards app

### DIFF
--- a/amplify-migration-apps/project-boards/README.md
+++ b/amplify-migration-apps/project-boards/README.md
@@ -146,6 +146,59 @@ amplify add function
 ? Do you want to edit the local lambda function now? No
 ```
 
+```console
+amplify add function
+```
+
+```console
+? Select which capability you want to add: Lambda layer (shared code & resource used across functions)
+? Provide a name for your Lambda layer: projectboardslambdalayer
+? Choose the runtime that you want to use: (Use arrow keys)
+❯ NodeJS
+? The current AWS account will always have access to this layer.
+  Optionally, configure who else can access this layer. (Hit <Enter> to skip)
+> Specific AWS accounts
+> Specific AWS organization
+```
+
+Node.js lambda function that generates tips.
+
+```console
+amplify add function
+```
+
+```console
+? Select which capability you want to add: Lambda function (serverless function)
+? Provide an AWS Lambda function name: quotegenerator
+? Choose the runtime that you want to use: NodeJS
+? Choose the function template that you want to use: Hello World
+
+✅ Available advanced settings:
+- Resource access permissions
+- Scheduled recurring invocation
+- Lambda layers configuration
+- Environment variables configuration
+- Secret values configuration
+
+? Do you want to configure advanced settings? No
+? Do you want to edit the local lambda function now? No
+```
+
+Link both functions to the lambda layer. Repeat for the other function
+
+```console
+amplify update function
+```
+
+```
+? Select the Lambda function you want to update: quotegenerator
+? Which setting do you want to update? Lambda layers configuration
+? Do you want to enable Lambda layers for this function? Yes
+? Provide existing Lambda layer ARNs or select layers in this project:
+  ❯◉ projectboardslambdalayer
+? Select a version for projectboardslambdalayer: Always choose latest version
+```
+
 ## Configure
 
 ```console

--- a/amplify-migration-apps/project-boards/configure.sh
+++ b/amplify-migration-apps/project-boards/configure.sh
@@ -2,3 +2,5 @@
 
 cp -f schema.graphql ./amplify/backend/api/projectboards/schema.graphql
 cp -f quotegenerator.js ./amplify/backend/function/quotegenerator/src/index.js
+cp -f tipsgenerator.js ./amplify/backend/function/tipsgenerator/src/index.js
+cp -f utils.js ./amplify/backend/function/projectboardslambdalayer/lib/nodejs/utils.js

--- a/amplify-migration-apps/project-boards/quotegenerator.js
+++ b/amplify-migration-apps/project-boards/quotegenerator.js
@@ -1,3 +1,5 @@
+const { getRandomItem, formatResponse } = require('/opt/nodejs/utils');
+
 /**
  * AppSync Lambda function handler
  * When using @function directive, return data directly (not API Gateway proxy format)
@@ -5,7 +7,6 @@
 exports.handler = async (event) => {
   console.log(`EVENT: ${JSON.stringify(event)}`);
 
-  // Array of motivational quotes
   const quotes = [
     { text: 'The only way to do great work is to love what you do.', author: 'Steve Jobs' },
     { text: 'Innovation distinguishes between a leader and a follower.', author: 'Steve Jobs' },
@@ -29,18 +30,11 @@ exports.handler = async (event) => {
     { text: 'Simplicity is the soul of efficiency.', author: 'Austin Freeman' },
   ];
 
-  // Get a random quote
-  const randomQuote = quotes[Math.floor(Math.random() * quotes.length)];
+  const randomQuote = getRandomItem(quotes);
 
-  // Add timestamp for uniqueness
-  const timestamp = new Date().toISOString();
-
-  // For AppSync @function directive, return the data object directly
-  return {
-    message: 'Quote generated successfully! 🎯',
+  return formatResponse('Quote generated successfully! 🎯', {
     quote: randomQuote.text,
     author: randomQuote.author,
-    timestamp: timestamp,
     totalQuotes: quotes.length,
-  };
+  });
 };

--- a/amplify-migration-apps/project-boards/schema.graphql
+++ b/amplify-migration-apps/project-boards/schema.graphql
@@ -6,8 +6,17 @@ type QuoteResponse {
   totalQuotes: Int! @auth(rules: [{ allow: public }])
 }
 
+type TipResponse {
+  message: String! @auth(rules: [{ allow: public }])
+  tip: String! @auth(rules: [{ allow: public }])
+  category: String! @auth(rules: [{ allow: public }])
+  timestamp: String! @auth(rules: [{ allow: public }])
+  totalTips: Int! @auth(rules: [{ allow: public }])
+}
+
 type Query {
   getRandomQuote: QuoteResponse @function(name: "quotegenerator-${env}") @auth(rules: [{ allow: public }])
+  getRandomTip: TipResponse @function(name: "projectboardslambda2-${env}") @auth(rules: [{ allow: public }])
 }
 
 enum ProjectStatus {
@@ -17,10 +26,7 @@ enum ProjectStatus {
   ARCHIVED
 }
 
-type Project @model @auth(rules: [
-  { allow: public, operations: [read] },
-  { allow: owner, operations: [create, read, update, delete] }
-]) {
+type Project @model @auth(rules: [{ allow: public, operations: [read] }, { allow: owner, operations: [create, read, update, delete] }]) {
   id: ID!
   title: String!
   description: String
@@ -30,10 +36,7 @@ type Project @model @auth(rules: [
   todos: [Todo] @hasMany
 }
 
-type Todo @model @auth(rules: [
-  { allow: public, operations: [read] },
-  { allow: owner, operations: [create, read, update, delete] }
-]) {
+type Todo @model @auth(rules: [{ allow: public, operations: [read] }, { allow: owner, operations: [create, read, update, delete] }]) {
   id: ID!
   name: String!
   description: String

--- a/amplify-migration-apps/project-boards/src/App.tsx
+++ b/amplify-migration-apps/project-boards/src/App.tsx
@@ -30,12 +30,32 @@ const getRandomQuote = /* GraphQL */ `
   }
 `;
 
+const getRandomTip = /* GraphQL */ `
+  query GetRandomTip {
+    getRandomTip {
+      message
+      tip
+      category
+      timestamp
+      totalTips
+    }
+  }
+`;
+
 type QuoteData = {
   message: string;
   quote: string;
   author: string;
   timestamp: string;
   totalQuotes: number;
+};
+
+type TipData = {
+  message: string;
+  tip: string;
+  category: string;
+  timestamp: string;
+  totalTips: number;
 };
 
 // Client for authenticated users (owner-based operations)
@@ -1109,6 +1129,10 @@ const AuthenticatedApp: React.FC<AppProps> = ({ signOut, user }) => {
   const [quote, setQuote] = useState<QuoteData | null>(null);
   const [loadingQuote, setLoadingQuote] = useState(false);
 
+  // Tip state
+  const [tip, setTip] = useState<TipData | null>(null);
+  const [loadingTip, setLoadingTip] = useState(false);
+
   const { theme, toggleTheme } = useTheme();
   const themedStyles = getThemedStyles(theme);
 
@@ -1295,6 +1319,22 @@ const AuthenticatedApp: React.FC<AppProps> = ({ signOut, user }) => {
     }
   }
 
+  async function fetchRandomTip() {
+    try {
+      setLoadingTip(true);
+      const result = await publicClient.graphql({
+        query: getRandomTip,
+      });
+      if ((result as any).data?.getRandomTip) {
+        setTip((result as any).data.getRandomTip as TipData);
+      }
+    } catch (err) {
+      console.log('Error fetching tip:', err);
+    } finally {
+      setLoadingTip(false);
+    }
+  }
+
   return (
     <div style={themedStyles.container}>
       <div style={themedStyles.header}>
@@ -1467,6 +1507,53 @@ const AuthenticatedApp: React.FC<AppProps> = ({ signOut, user }) => {
                       }}
                     >
                       {quote.totalQuotes} quotes available
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              <div style={{ marginTop: 24, padding: 16, backgroundColor: theme === 'dark' ? '#374151' : '#f8f9fa', borderRadius: 8 }}>
+                <h3 style={{ ...themedStyles.formTitle, fontSize: 18, marginBottom: 12 }}>🧠 Productivity Tips</h3>
+                <button style={{ ...themedStyles.button, marginBottom: tip ? 16 : 0 }} onClick={fetchRandomTip} disabled={loadingTip}>
+                  {loadingTip ? '⏳ Loading...' : '💡 Get Random Tip'}
+                </button>
+                {tip && (
+                  <div
+                    style={{
+                      padding: 16,
+                      backgroundColor: theme === 'dark' ? '#2d3748' : 'white',
+                      borderRadius: 8,
+                      borderLeft: '4px solid #28a745',
+                    }}
+                  >
+                    <p
+                      style={{
+                        margin: '0 0 8px 0',
+                        fontSize: 15,
+                        color: theme === 'dark' ? '#e1e8ed' : '#2c3e50',
+                        lineHeight: 1.6,
+                      }}
+                    >
+                      {tip.tip}
+                    </p>
+                    <p
+                      style={{
+                        margin: 0,
+                        fontSize: 13,
+                        fontWeight: '600',
+                        color: theme === 'dark' ? '#a0aec0' : '#5a6c7d',
+                      }}
+                    >
+                      📂 {tip.category}
+                    </p>
+                    <p
+                      style={{
+                        margin: '8px 0 0 0',
+                        fontSize: 11,
+                        color: theme === 'dark' ? '#718096' : '#6c757d',
+                      }}
+                    >
+                      {tip.totalTips} tips available
                     </p>
                   </div>
                 )}

--- a/amplify-migration-apps/project-boards/tipsgenerator.js
+++ b/amplify-migration-apps/project-boards/tipsgenerator.js
@@ -1,0 +1,28 @@
+const { getRandomItem, formatResponse } = require('/opt/nodejs/utils');
+
+const tips = [
+  { text: 'Break large tasks into smaller, manageable pieces.', category: 'Productivity' },
+  { text: 'Use version control for everything, even personal projects.', category: 'Best Practices' },
+  { text: 'Write tests before fixing bugs to prevent regressions.', category: 'Testing' },
+  { text: 'Document your decisions, not just your code.', category: 'Documentation' },
+  { text: 'Take regular breaks — your brain solves problems in the background.', category: 'Wellness' },
+  { text: 'Review your own PR before asking others to.', category: 'Code Review' },
+  { text: 'Automate anything you do more than twice.', category: 'Automation' },
+  { text: 'Keep your dependencies up to date.', category: 'Maintenance' },
+];
+
+/**
+ * AppSync Lambda function handler
+ * When using @function directive, return data directly (not API Gateway proxy format)
+ */
+exports.handler = async (event) => {
+  console.log(`EVENT: ${JSON.stringify(event)}`);
+
+  const tip = getRandomItem(tips);
+
+  return formatResponse('Tip generated successfully! 💡', {
+    tip: tip.text,
+    category: tip.category,
+    totalTips: tips.length,
+  });
+};

--- a/amplify-migration-apps/project-boards/utils.js
+++ b/amplify-migration-apps/project-boards/utils.js
@@ -1,0 +1,17 @@
+function getRandomItem(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function formatTimestamp() {
+  return new Date().toISOString();
+}
+
+function formatResponse(message, data) {
+  return {
+    message,
+    ...data,
+    timestamp: formatTimestamp(),
+  };
+}
+
+module.exports = { getRandomItem, formatTimestamp, formatResponse };


### PR DESCRIPTION
Linked to https://github.com/aws-amplify/amplify-cli/issues/14527

This pr 
1. adds functionality to add a lambda layer to the project boards app. 
2. adds a second lambda function that generates random tips from a hardcoded list. 
3. adds a shared utils file between `quotegenerator` and `tipsgenerator` which both functions import from