### PR TITLE
fix(gen2-migration): update `decommission` step logging

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration.ts
@@ -114,6 +114,12 @@ export const run = async (context: $TSContext) => {
     });
   }
 
+  if (rollingBack && stepName === 'decommission') {
+    throw new AmplifyError('InputValidationError', {
+      message: 'Decommission is a one-way operation and does not support rollback.',
+    });
+  }
+
   // assuming all environment are deployed within the same app - can it be different?
   const appId = (Object.values(stateManager.getTeamProviderInfo())[0] as any).awscloudformation.AmplifyAppId;
 
@@ -179,8 +185,13 @@ export const run = async (context: $TSContext) => {
 
   printer.blankLine();
 
-  if (!rollingBack) {
+  if (!rollingBack && stepName !== 'decommission') {
     printer.info(chalk.grey(`(You can rollback this command by running: 'amplify gen2-migration ${stepName} --rollback')`));
+    printer.blankLine();
+  }
+
+  if (stepName === 'decommission') {
+    printer.info(chalk.grey('(Decommission is a one-way operation and cannot be rolled back.)'));
     printer.blankLine();
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Decommission is a one-way operation that should only be run after migration is complete. Previously, the CLI displayed a rollback hint when running `amplify gen2-migration decommission`, and accepted the `--rollback` flag without a clear rejection.

This change:
- Rejects `--rollback` early for decommission with a clear error message.
- Replaces the rollback hint with a message stating decommission cannot be rolled back.

**Pre fix:**

command: `amplify gen2-migration decommission`

```cli
You are about to execute 'decommission' on environment 'd136pyk8fntvyw/dev'.

Operations Summary

• Delete the Gen1 environment

Implications

• Delete the Gen1 environment

(You can rollback this command by running: 'amplify gen2-migration decommission --rollback')
```

command: `amplify gen2-migration decommission --rollback`

```cli
You are about to rollback 'decommission' on environment 'XXXXXXXX/main'.

Operations Summary
🛑  Not Implemented

```

**Post fix:**

command: `amplify gen2-migration decommission`

```cli
You are about to execute 'decommission' on environment 'XXXXXXXXX/dev'.

Operations Summary

• Delete the Gen1 environment

Implications

• Delete the Gen1 environment

(Decommission is a one-way operation and cannot be rolled back.)

? Do you want to continue? (y/N) ›
```

command: `amplify gen2-migration decommission --rollback`

```cli
🛑 Decommission is a one-way operation and does not support rollback.
```


#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Tested on a local Gen1 app.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
