### PR TITLE
fix: change MaxResults from 50 to 10

### DIFF
--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/secrets/ssmClientWrapper.ts
@@ -79,7 +79,7 @@ export class SSMClientWrapper {
         this.ssmClient.send(
           new GetParametersByPathCommand({
             Path: secretPath,
-            MaxResults: 50,
+            MaxResults: 10,
             ParameterFilters: [
               {
                 Key: 'Type',


### PR DESCRIPTION
changes ```MaxResults``` from 50 to 10, the max allowed value in aws-sdk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
