### PR TITLE
chore: fix custom resource e2es

### DIFF
--- a/packages/amplify-category-custom/resources/package.json
+++ b/packages/amplify-category-custom/resources/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@aws-amplify/cli-extensibility-helper": "^3.0.0",
-    "aws-cdk-lib": "~2.189.1",
+    "aws-cdk-lib": "~2.241.0",
     "constructs": "^10.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Custom resource `aws-cdk-lib` version was incompatible with the version used by the rest of the repo.

#### Description of how you validated changes
Custom resource e2es should now be passing - we will still have a failing e2e run overall because of the container-api tests. 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
