### PR TITLE
fix(gen2-migration): remove deletion protection step for user pools

### DIFF
--- a/packages/amplify-cli/src/commands/gen2-migration/lock.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/lock.ts
@@ -67,26 +67,6 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
       });
     }
 
-    for (const userPoolId of await this.userPoolIds()) {
-      operations.push({
-        validate: async () => {
-          return;
-        },
-        describe: async () => {
-          return [`Enable deletion protection for user pool '${userPoolId}'`];
-        },
-        execute: async () => {
-          await this.cognitoClient().send(
-            new UpdateUserPoolCommand({
-              UserPoolId: userPoolId,
-              DeletionProtection: 'ACTIVE',
-            }),
-          );
-          this.logger.info(`Enabled deletion protection for user pool '${userPoolId}'`);
-        },
-      });
-    }
-
     operations.push({
       validate: async () => {
         return;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This change removes deletion protection from the Cognito user pool during the `lock` step of Gen2 Migration. The logic that added deletion protection used the `UpdateUserPool` command from the Cognito API, which has limitations we cannot accept.

The Cognito API's `UpdateUserPool` command will revert keys that are not explicitly specified in the request to their default value. To prevent this, the caller needs to specify all keys in the request. We do not want to take the risk of getting the existing API state just to pass it back to Cognito again—it's not worth it for this protection.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Removal of a buggy step, no validations.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
