### PR TITLE
fix(gen2-migration): add rollback validation to lock step (holding stack approach)

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/lock.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/lock.test.ts
@@ -1,0 +1,161 @@
+import { AmplifyMigrationLockStep } from '../../../commands/gen2-migration/lock';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { Logger } from '../../../commands/gen2-migration';
+
+const mockValidateDeploymentStatus = jest.fn();
+const mockValidateLockStatus = jest.fn();
+
+jest.mock('../../../commands/gen2-migration/_validations', () => ({
+  AmplifyGen2MigrationValidations: jest.fn().mockImplementation(() => ({
+    validateDeploymentStatus: mockValidateDeploymentStatus,
+    validateLockStatus: mockValidateLockStatus,
+  })),
+}));
+
+const mockPaginateListStacks = jest.fn();
+jest.mock('@aws-sdk/client-cloudformation', () => ({
+  ...jest.requireActual('@aws-sdk/client-cloudformation'),
+  CloudFormationClient: jest.fn().mockImplementation(() => ({})),
+  paginateListStacks: (...args: unknown[]) => mockPaginateListStacks(...args),
+}));
+
+jest.mock('@aws-sdk/client-amplify');
+jest.mock('@aws-sdk/client-dynamodb');
+jest.mock('@aws-sdk/client-appsync');
+jest.mock('@aws-sdk/client-cognito-identity-provider');
+
+describe('AmplifyMigrationLockStep', () => {
+  let lockStep: AmplifyMigrationLockStep;
+  const mockContext = {} as $TSContext;
+  const testAppId = 'test-app-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lockStep = new AmplifyMigrationLockStep(
+      new Logger('lock', 'test-app', 'dev'),
+      'dev',
+      'test-app',
+      testAppId,
+      'amplify-test-app-dev-123456',
+      'us-east-1',
+      mockContext,
+    );
+  });
+
+  describe('rollbackValidate', () => {
+    it('should pass when no holding stacks exist', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield { StackSummaries: [] };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).resolves.not.toThrow();
+      expect(mockValidateDeploymentStatus).toHaveBeenCalled();
+      expect(mockValidateLockStatus).toHaveBeenCalled();
+    });
+
+    it('should throw MigrationError when holding stacks exist', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield {
+            StackSummaries: [{ StackName: `amplify-test-app-dev-auth-${testAppId}-abc123-holding` }],
+          };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).rejects.toMatchObject({
+        name: 'MigrationError',
+        message: expect.stringContaining('Cannot roll back lock'),
+        resolution: expect.stringContaining('refactor --rollback'),
+      });
+    });
+
+    it('should propagate validateDeploymentStatus errors', async () => {
+      const deploymentError = new Error('Stack not stable');
+      deploymentError.name = 'StackStateError';
+      mockValidateDeploymentStatus.mockRejectedValue(deploymentError);
+
+      await expect(lockStep.rollbackValidate()).rejects.toThrow('Stack not stable');
+      expect(mockValidateLockStatus).not.toHaveBeenCalled();
+    });
+
+    it('should propagate validateLockStatus errors', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      const lockError = new Error('Stack is not locked');
+      lockError.name = 'MigrationError';
+      mockValidateLockStatus.mockRejectedValue(lockError);
+
+      await expect(lockStep.rollbackValidate()).rejects.toThrow('Stack is not locked');
+    });
+
+    it('should throw when multiple holding stacks exist', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield {
+            StackSummaries: [
+              { StackName: `amplify-test-app-dev-auth-${testAppId}-abc123-holding` },
+              { StackName: `amplify-test-app-dev-storage-${testAppId}-def456-holding` },
+            ],
+          };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).rejects.toMatchObject({
+        name: 'MigrationError',
+        message: expect.stringContaining('Cannot roll back lock'),
+      });
+    });
+
+    it('should ignore holding stacks with a different appId', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield {
+            StackSummaries: [{ StackName: 'amplify-other-app-dev-auth-other-app-id-abc123-holding' }],
+          };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).resolves.not.toThrow();
+    });
+
+    it('should ignore stacks that do not end with holding suffix', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield {
+            StackSummaries: [{ StackName: `amplify-test-app-dev-auth-${testAppId}-abc123` }],
+          };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).resolves.not.toThrow();
+    });
+
+    it('should handle paginated results across multiple pages', async () => {
+      mockValidateDeploymentStatus.mockResolvedValue(undefined);
+      mockValidateLockStatus.mockResolvedValue(undefined);
+      mockPaginateListStacks.mockReturnValue(
+        (async function* () {
+          yield { StackSummaries: [{ StackName: 'unrelated-stack' }] };
+          yield {
+            StackSummaries: [{ StackName: `amplify-test-app-dev-auth-${testAppId}-abc123-holding` }],
+          };
+        })(),
+      );
+
+      await expect(lockStep.rollbackValidate()).rejects.toMatchObject({
+        name: 'MigrationError',
+      });
+    });
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/lock.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/lock.ts
@@ -1,12 +1,13 @@
 import { AmplifyMigrationStep } from './_step';
 import { AmplifyMigrationOperation } from './_operation';
 import { AmplifyError, stateManager } from '@aws-amplify/amplify-cli-core';
-import { CloudFormationClient, SetStackPolicyCommand } from '@aws-sdk/client-cloudformation';
+import { CloudFormationClient, SetStackPolicyCommand, paginateListStacks, StackStatus } from '@aws-sdk/client-cloudformation';
 import { AmplifyClient, UpdateAppCommand, GetAppCommand } from '@aws-sdk/client-amplify';
 import { DynamoDBClient, UpdateTableCommand, paginateListTables } from '@aws-sdk/client-dynamodb';
 import { AppSyncClient, paginateListGraphqlApis } from '@aws-sdk/client-appsync';
 import { CognitoIdentityProviderClient, UpdateUserPoolCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { AmplifyGen2MigrationValidations } from './_validations';
+import { HOLDING_STACK_SUFFIX } from './refactor/holding-stack';
 
 const GEN2_MIGRATION_ENVIRONMENT_NAME = 'GEN2_MIGRATION_ENVIRONMENT_NAME';
 
@@ -40,8 +41,41 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
   }
 
   public async rollbackValidate(): Promise<void> {
-    // https://github.com/aws-amplify/amplify-cli/issues/14570
-    return;
+    const validations = new AmplifyGen2MigrationValidations(this.logger, this.rootStackName, this.currentEnvName, this.context);
+    await validations.validateDeploymentStatus();
+    await validations.validateLockStatus();
+
+    const holdingStacks = await this.findHoldingStacks();
+    if (holdingStacks.length > 0) {
+      throw new AmplifyError('MigrationError', {
+        message: `Cannot roll back lock: refactor has already moved resources into holding stacks (${holdingStacks.join(', ')})`,
+        resolution: "Run 'amplify gen2-migration refactor --rollback' to restore resources before rolling back the lock.",
+      });
+    }
+  }
+
+  private async findHoldingStacks(): Promise<string[]> {
+    const cfnClient = new CloudFormationClient({ region: this.region });
+    const holdingStacks: string[] = [];
+    const paginator = paginateListStacks(
+      { client: cfnClient },
+      {
+        StackStatusFilter: [
+          StackStatus.CREATE_COMPLETE,
+          StackStatus.UPDATE_COMPLETE,
+          StackStatus.ROLLBACK_COMPLETE,
+          StackStatus.REVIEW_IN_PROGRESS,
+        ],
+      },
+    );
+    for await (const page of paginator) {
+      for (const stack of page.StackSummaries ?? []) {
+        if (stack.StackName?.endsWith(HOLDING_STACK_SUFFIX) && stack.StackName.includes(this.appId)) {
+          holdingStacks.push(stack.StackName);
+        }
+      }
+    }
+    return holdingStacks;
   }
 
   public async execute(): Promise<AmplifyMigrationOperation[]> {


### PR DESCRIPTION
## Summary
- Implements `rollbackValidate()` in the lock step to prevent `lock --rollback` when refactor has already moved resources into holding stacks
- Checks for holding stacks (CloudFormation stacks with `-holding` suffix containing the app ID) via `paginateListStacks`
- Throws `MigrationError` with resolution pointing to `refactor --rollback` if holding stacks are found
- Adds comprehensive unit tests covering happy path, error propagation, pagination, and appId filtering

Closes #14570

## Test plan
- [x] Unit tests pass: 8/8 scenarios covering:
  - No holding stacks → validation passes
  - Holding stacks exist → throws MigrationError
  - validateDeploymentStatus error propagation
  - validateLockStatus error propagation
  - Multiple holding stacks → still throws
  - Wrong appId → correctly ignored
  - Non-holding stacks → correctly ignored
  - Paginated results across multiple pages

