### PR TITLE
fix(cli): add rollback validation to lock step (template drift approach)

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_validations-template-drift.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_validations-template-drift.test.ts
@@ -1,0 +1,125 @@
+import { AmplifyGen2MigrationValidations } from '../../../commands/gen2-migration/_validations';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { Logger } from '../../../commands/gen2-migration';
+
+jest.mock('@aws-sdk/client-cloudformation');
+jest.mock('bottleneck', () => {
+  return jest.fn().mockImplementation(() => ({
+    schedule: jest.fn((fn) => fn()),
+  }));
+});
+
+const mockSyncCloudBackendFromS3 = jest.fn();
+const mockGetClient = jest.fn();
+jest.mock('../../../commands/drift-detection/services', () => ({
+  CloudFormationService: jest.fn().mockImplementation(() => ({
+    syncCloudBackendFromS3: mockSyncCloudBackendFromS3,
+    getClient: mockGetClient,
+  })),
+}));
+
+const mockDetectTemplateDrift = jest.fn();
+jest.mock('../../../commands/drift-detection/detect-template-drift', () => ({
+  detectTemplateDrift: (...args: any[]) => mockDetectTemplateDrift(...args),
+}));
+
+describe('AmplifyGen2MigrationValidations - validateTemplateDrift', () => {
+  let mockContext: $TSContext;
+  let validations: AmplifyGen2MigrationValidations;
+  const mockCfnClient = {};
+
+  beforeEach(() => {
+    mockContext = {} as $TSContext;
+    validations = new AmplifyGen2MigrationValidations(new Logger('mock', 'mock', 'mock'), 'amplify-test-stack', 'dev', mockContext);
+    mockGetClient.mockResolvedValue(mockCfnClient);
+    jest.clearAllMocks();
+  });
+
+  it('should pass when no template drift is detected', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(true);
+    mockDetectTemplateDrift.mockResolvedValue({
+      changes: [],
+      skipped: false,
+    });
+
+    await expect(validations.validateTemplateDrift()).resolves.not.toThrow();
+    expect(mockSyncCloudBackendFromS3).toHaveBeenCalledWith(mockContext);
+    expect(mockDetectTemplateDrift).toHaveBeenCalledWith('amplify-test-stack', expect.any(Object), mockCfnClient);
+  });
+
+  it('should throw MigrationError when template drift is detected', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(true);
+    mockDetectTemplateDrift.mockResolvedValue({
+      changes: [{ LogicalResourceId: 'SomeResource', Action: 'Modify' }],
+      skipped: false,
+    });
+
+    await expect(validations.validateTemplateDrift()).rejects.toMatchObject({
+      name: 'MigrationError',
+      message: 'Template drift detected',
+    });
+  });
+
+  it('should throw MigrationError when S3 sync fails', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(false);
+
+    await expect(validations.validateTemplateDrift()).rejects.toMatchObject({
+      name: 'MigrationError',
+      message: 'Failed to sync cloud backend from S3',
+      resolution: 'Ensure the project is deployed and S3 bucket is accessible.',
+    });
+    expect(mockDetectTemplateDrift).not.toHaveBeenCalled();
+  });
+
+  it('should throw MigrationError when template drift detection is skipped', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(true);
+    mockDetectTemplateDrift.mockResolvedValue({
+      changes: [],
+      skipped: true,
+      skipReason: 'No cached CloudFormation template found',
+    });
+
+    await expect(validations.validateTemplateDrift()).rejects.toMatchObject({
+      name: 'MigrationError',
+      message: 'Template drift detection was skipped: No cached CloudFormation template found',
+    });
+  });
+
+  it('should throw MigrationError when detection is skipped due to nested stack errors', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(true);
+    mockDetectTemplateDrift.mockResolvedValue({
+      changes: [],
+      skipped: true,
+      skipReason: 'One or more nested stacks could not be analyzed',
+    });
+
+    await expect(validations.validateTemplateDrift()).rejects.toMatchObject({
+      name: 'MigrationError',
+      message: 'Template drift detection was skipped: One or more nested stacks could not be analyzed',
+    });
+  });
+
+  it('should pass the correct stack name and CFN client to detectTemplateDrift', async () => {
+    mockSyncCloudBackendFromS3.mockResolvedValue(true);
+    mockDetectTemplateDrift.mockResolvedValue({
+      changes: [],
+      skipped: false,
+    });
+
+    await validations.validateTemplateDrift();
+
+    expect(mockGetClient).toHaveBeenCalledWith(mockContext);
+    expect(mockDetectTemplateDrift).toHaveBeenCalledWith(
+      'amplify-test-stack',
+      expect.objectContaining({
+        info: expect.any(Function),
+        debug: expect.any(Function),
+        warn: expect.any(Function),
+        blankLine: expect.any(Function),
+        success: expect.any(Function),
+        error: expect.any(Function),
+      }),
+      mockCfnClient,
+    );
+  });
+});

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/lock.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/lock.test.ts
@@ -1,0 +1,100 @@
+import { AmplifyMigrationLockStep } from '../../../commands/gen2-migration/lock';
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { Logger } from '../../../commands/gen2-migration';
+
+const mockValidateDeploymentStatus = jest.fn();
+const mockValidateLockStatus = jest.fn();
+const mockValidateTemplateDrift = jest.fn();
+
+jest.mock('../../../commands/gen2-migration/_validations', () => ({
+  AmplifyGen2MigrationValidations: jest.fn().mockImplementation(() => ({
+    validateDeploymentStatus: mockValidateDeploymentStatus,
+    validateLockStatus: mockValidateLockStatus,
+    validateTemplateDrift: mockValidateTemplateDrift,
+    validateDrift: jest.fn(),
+  })),
+}));
+
+jest.mock('@aws-sdk/client-cloudformation');
+jest.mock('@aws-sdk/client-amplify');
+jest.mock('@aws-sdk/client-dynamodb');
+jest.mock('@aws-sdk/client-appsync');
+jest.mock('@aws-sdk/client-cognito-identity-provider');
+jest.mock('@aws-amplify/amplify-cli-core', () => ({
+  ...jest.requireActual('@aws-amplify/amplify-cli-core'),
+  stateManager: {
+    getMeta: jest.fn().mockReturnValue({}),
+  },
+}));
+
+describe('AmplifyMigrationLockStep - rollbackValidate', () => {
+  let step: AmplifyMigrationLockStep;
+  let mockContext: $TSContext;
+
+  beforeEach(() => {
+    mockContext = {} as $TSContext;
+    step = new AmplifyMigrationLockStep(
+      new Logger('lock', 'test-app', 'dev'),
+      'dev',
+      'test-app',
+      'test-app-id',
+      'amplify-test-stack',
+      'us-east-1',
+      mockContext,
+    );
+    jest.clearAllMocks();
+  });
+
+  it('should call all three validations in order', async () => {
+    mockValidateDeploymentStatus.mockResolvedValue(undefined);
+    mockValidateLockStatus.mockResolvedValue(undefined);
+    mockValidateTemplateDrift.mockResolvedValue(undefined);
+
+    await step.rollbackValidate();
+
+    expect(mockValidateDeploymentStatus).toHaveBeenCalledTimes(1);
+    expect(mockValidateLockStatus).toHaveBeenCalledTimes(1);
+    expect(mockValidateTemplateDrift).toHaveBeenCalledTimes(1);
+  });
+
+  it('should propagate error when validateDeploymentStatus fails', async () => {
+    const error = new Error('Stack not found');
+    error.name = 'StackNotFoundError';
+    mockValidateDeploymentStatus.mockRejectedValue(error);
+
+    await expect(step.rollbackValidate()).rejects.toThrow('Stack not found');
+    expect(mockValidateLockStatus).not.toHaveBeenCalled();
+    expect(mockValidateTemplateDrift).not.toHaveBeenCalled();
+  });
+
+  it('should propagate error when validateLockStatus fails', async () => {
+    mockValidateDeploymentStatus.mockResolvedValue(undefined);
+    const error = new Error('Stack is not locked');
+    error.name = 'MigrationError';
+    mockValidateLockStatus.mockRejectedValue(error);
+
+    await expect(step.rollbackValidate()).rejects.toThrow('Stack is not locked');
+    expect(mockValidateDeploymentStatus).toHaveBeenCalledTimes(1);
+    expect(mockValidateTemplateDrift).not.toHaveBeenCalled();
+  });
+
+  it('should propagate error when validateTemplateDrift fails', async () => {
+    mockValidateDeploymentStatus.mockResolvedValue(undefined);
+    mockValidateLockStatus.mockResolvedValue(undefined);
+    const error = new Error('Template drift detected');
+    error.name = 'MigrationError';
+    mockValidateTemplateDrift.mockRejectedValue(error);
+
+    await expect(step.rollbackValidate()).rejects.toThrow('Template drift detected');
+    expect(mockValidateDeploymentStatus).toHaveBeenCalledTimes(1);
+    expect(mockValidateLockStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass when all validations succeed with no drift', async () => {
+    mockValidateDeploymentStatus.mockResolvedValue(undefined);
+    mockValidateLockStatus.mockResolvedValue(undefined);
+    mockValidateTemplateDrift.mockResolvedValue(undefined);
+
+    await expect(step.rollbackValidate()).resolves.not.toThrow();
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
@@ -14,7 +14,6 @@ import execa from 'execa';
 import { Logger } from '../gen2-migration';
 import chalk from 'chalk';
 import { printer } from '@aws-amplify/amplify-prompts';
-import type { Printer } from '@aws-amplify/amplify-prompts';
 import { extractCategory } from './categories';
 import { detectTemplateDrift } from '../drift-detection/detect-template-drift';
 import { CloudFormationService } from '../drift-detection/services';
@@ -198,18 +197,7 @@ export class AmplifyGen2MigrationValidations {
   public async validateTemplateDrift(): Promise<void> {
     this.logger.info('Checking for template drift...');
 
-    const print: Printer = {
-      info: (msg: string) => this.logger.info(msg),
-      debug: (msg: string) => this.logger.debug(msg),
-      warn: (msg: string) => this.logger.warn(msg),
-      blankLine: () => {
-        return;
-      },
-      success: (msg: string) => this.logger.info(msg),
-      error: (msg: string) => this.logger.warn(msg),
-    };
-
-    const cfnService = new CloudFormationService(print);
+    const cfnService = new CloudFormationService(printer);
     const syncSuccess = await cfnService.syncCloudBackendFromS3(this.context);
     if (!syncSuccess) {
       throw new AmplifyError('MigrationError', {
@@ -219,7 +207,7 @@ export class AmplifyGen2MigrationValidations {
     }
 
     const cfn = await cfnService.getClient(this.context);
-    const results = await detectTemplateDrift(this.rootStackName, print, cfn);
+    const results = await detectTemplateDrift(this.rootStackName, printer, cfn);
 
     if (results.skipped) {
       throw new AmplifyError('MigrationError', {

--- a/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_validations.ts
@@ -14,7 +14,10 @@ import execa from 'execa';
 import { Logger } from '../gen2-migration';
 import chalk from 'chalk';
 import { printer } from '@aws-amplify/amplify-prompts';
+import type { Printer } from '@aws-amplify/amplify-prompts';
 import { extractCategory } from './categories';
+import { detectTemplateDrift } from '../drift-detection/detect-template-drift';
+import { CloudFormationService } from '../drift-detection/services';
 
 export class AmplifyGen2MigrationValidations {
   private limiter = new Bottleneck({
@@ -190,6 +193,50 @@ export class AmplifyGen2MigrationValidations {
     }
 
     this.logger.info(chalk.green(`Stack ${this.rootStackName} is locked ✔`));
+  }
+
+  public async validateTemplateDrift(): Promise<void> {
+    this.logger.info('Checking for template drift...');
+
+    const print: Printer = {
+      info: (msg: string) => this.logger.info(msg),
+      debug: (msg: string) => this.logger.debug(msg),
+      warn: (msg: string) => this.logger.warn(msg),
+      blankLine: () => {
+        return;
+      },
+      success: (msg: string) => this.logger.info(msg),
+      error: (msg: string) => this.logger.warn(msg),
+    };
+
+    const cfnService = new CloudFormationService(print);
+    const syncSuccess = await cfnService.syncCloudBackendFromS3(this.context);
+    if (!syncSuccess) {
+      throw new AmplifyError('MigrationError', {
+        message: 'Failed to sync cloud backend from S3',
+        resolution: 'Ensure the project is deployed and S3 bucket is accessible.',
+      });
+    }
+
+    const cfn = await cfnService.getClient(this.context);
+    const results = await detectTemplateDrift(this.rootStackName, print, cfn);
+
+    if (results.skipped) {
+      throw new AmplifyError('MigrationError', {
+        message: `Template drift detection was skipped: ${results.skipReason}`,
+        resolution: 'Ensure the project is deployed and templates are available.',
+      });
+    }
+
+    if (results.changes.length > 0) {
+      throw new AmplifyError('MigrationError', {
+        message: 'Template drift detected',
+        resolution:
+          'The CloudFormation templates have changed since the lock was applied. This may indicate that a refactor has already been performed. Resolve the drift before rolling back.',
+      });
+    }
+
+    this.logger.info(chalk.green('No template drift detected ✔'));
   }
 
   private async getStatefulResources(

--- a/packages/amplify-cli/src/commands/gen2-migration/lock.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/lock.ts
@@ -40,8 +40,10 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
   }
 
   public async rollbackValidate(): Promise<void> {
-    // https://github.com/aws-amplify/amplify-cli/issues/14570
-    return;
+    const validations = new AmplifyGen2MigrationValidations(this.logger, this.rootStackName, this.currentEnvName, this.context);
+    await validations.validateDeploymentStatus();
+    await validations.validateLockStatus();
+    await validations.validateTemplateDrift();
   }
 
   public async execute(): Promise<AmplifyMigrationOperation[]> {


### PR DESCRIPTION
## Summary
- Implements `rollbackValidate()` in the lock migration step to detect post-refactor state before allowing rollback
- Adds `validateTemplateDrift()` to `AmplifyGen2MigrationValidations` — runs Phase 2 (template drift) only, using CloudFormation change sets to compare deployed templates against the S3-cached baseline
- Rollback validation now checks: deployment status, lock status, and template drift (in that order)

Closes #14570

## Changes
- `_validations.ts`: Added `validateTemplateDrift()` method that syncs cloud backend from S3, then runs `detectTemplateDrift()` to compare templates via change sets
- `lock.ts`: Implemented `rollbackValidate()` calling `validateDeploymentStatus()`, `validateLockStatus()`, and `validateTemplateDrift()`
- `lock.test.ts`: 5 unit tests for rollbackValidate() — happy path, error propagation for each validation
- `_validations-template-drift.test.ts`: 6 unit tests for validateTemplateDrift() — no drift, drift detected, S3 sync failure, skipped detection scenarios

## Test plan
- [x] `lock.test.ts` — 5 tests pass (rollbackValidate calls all validations, error propagation)
- [x] `_validations-template-drift.test.ts` — 6 tests pass (template drift detection scenarios)
- [x] All 11 tests pass locally with `npx jest --no-coverage`
