### PR TITLE
fix(gen2-migration): add awsRegion to userPoolConfig in additional auth providers

### DIFF
--- a/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/backend.ts
@@ -38,6 +38,7 @@ cfnGraphqlApi.additionalAuthenticationProviders = [
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',
     userPoolConfig: {
       userPoolId: backend.auth.resources.userPool.userPoolId,
+      awsRegion: backend.auth.stack.region,
     },
   },
 ];

--- a/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/backend.ts
@@ -42,6 +42,7 @@ cfnGraphqlApi.additionalAuthenticationProviders = [
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',
     userPoolConfig: {
       userPoolId: backend.auth.resources.userPool.userPoolId,
+      awsRegion: backend.auth.stack.region,
     },
   },
 ];

--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/backend.ts
@@ -45,6 +45,7 @@ cfnGraphqlApi.additionalAuthenticationProviders = [
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',
     userPoolConfig: {
       userPoolId: backend.auth.resources.userPool.userPoolId,
+      awsRegion: backend.auth.stack.region,
     },
   },
 ];

--- a/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/backend.ts
@@ -38,6 +38,7 @@ cfnGraphqlApi.additionalAuthenticationProviders = [
     authenticationType: 'AMAZON_COGNITO_USER_POOLS',
     userPoolConfig: {
       userPoolId: backend.auth.resources.userPool.userPoolId,
+      awsRegion: backend.auth.stack.region,
     },
   },
 ];

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
@@ -149,6 +149,18 @@ export class DataGenerator implements Planner {
               ),
             ),
           );
+          userPoolConfigProps.push(
+            factory.createPropertyAssignment(
+              'awsRegion',
+              factory.createPropertyAccessExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createPropertyAccessExpression(factory.createIdentifier('backend'), factory.createIdentifier('auth')),
+                  factory.createIdentifier('stack'),
+                ),
+                factory.createIdentifier('region'),
+              ),
+            ),
+          );
         }
         props.push(factory.createPropertyAssignment('userPoolConfig', factory.createObjectLiteralExpression(userPoolConfigProps, true)));
       }


### PR DESCRIPTION
When `DataGenerator` emits `additionalAuthenticationProviders` with a `AMAZON_COGNITO_USER_POOLS` auth type, the generated `userPoolConfig` was missing the `awsRegion` property. Without it, AppSync can't resolve the user pool region and falls back to defaults, which breaks cross-region setups.

This adds `awsRegion: backend.auth.stack.region` alongside the existing `userPoolId` in the generated output, and updates all four migration app snapshots that include a user pool additional auth provider.
