### PR TITLE
feat(gen2-migration): gen2 test script integration

### DIFF
--- a/amplify-migration-apps/_test-common/signup.ts
+++ b/amplify-migration-apps/_test-common/signup.ts
@@ -32,8 +32,9 @@ function getErrorMessage(error: unknown): string {
 }
 
 function resolveSigninIdentifier(usernameAttributes: string[]): SigninIdentifier {
-  if (usernameAttributes.includes('PHONE_NUMBER')) return 'phone';
-  if (usernameAttributes.includes('EMAIL')) return 'email';
+  const normalized = usernameAttributes.map((a) => a.toUpperCase());
+  if (normalized.includes('PHONE_NUMBER') || normalized.includes('PHONE')) return 'phone';
+  if (normalized.includes('EMAIL')) return 'email';
   return 'username';
 }
 
@@ -41,9 +42,10 @@ function resolveSignupAttributes(signupAttributes: string[]): SignupAttribute[] 
   const mapping: Record<string, SignupAttribute> = {
     EMAIL: 'email',
     PHONE_NUMBER: 'phone',
+    PHONE: 'phone',
     USERNAME: 'username',
   };
-  const mapped = signupAttributes.map((attr) => mapping[attr]).filter((a): a is SignupAttribute => a !== undefined);
+  const mapped = signupAttributes.map((attr) => mapping[attr.toUpperCase()]).filter((a): a is SignupAttribute => a !== undefined);
   return mapped.length > 0 ? mapped : ['email'];
 }
 
@@ -154,11 +156,14 @@ function generateTestPassword(): string {
  * Returns the username to use for signIn.
  */
 export async function provisionTestUser(config: AmplifyConfig): Promise<{ signinValue: string; testUser: TestUser }> {
-  const { aws_user_pools_id: userPoolId, aws_cognito_region: region } = config;
+  // Support both Gen1 (aws_user_pools_id) and Gen2 (auth.user_pool_id) config formats
+  const gen2Auth = (config as any)?.auth;
+  const userPoolId = config.aws_user_pools_id ?? gen2Auth?.user_pool_id;
+  const region = config.aws_cognito_region ?? gen2Auth?.aws_region;
 
   const resolved: ResolvedAuthConfig = {
-    signinIdentifier: resolveSigninIdentifier(config.aws_cognito_username_attributes ?? []),
-    signupAttributes: resolveSignupAttributes(config.aws_cognito_signup_attributes ?? []),
+    signinIdentifier: resolveSigninIdentifier(config.aws_cognito_username_attributes ?? gen2Auth?.username_attributes ?? []),
+    signupAttributes: resolveSignupAttributes(config.aws_cognito_signup_attributes ?? gen2Auth?.standard_required_attributes ?? []),
   };
 
   const credentials = generateCredentials(resolved);

--- a/amplify-migration-apps/discussions/gen2-test-script.ts
+++ b/amplify-migration-apps/discussions/gen2-test-script.ts
@@ -1,8 +1,17 @@
 /**
  * Gen2 Test Script for Discussions App
  *
- * This script tests all functionality for Gen2 Amplify configuration.
- * IMPORTANT: Update TEST_USER credentials before running authenticated tests.
+ * This script tests all functionality for Amplify Gen2:
+ * 1. GraphQL Queries (Topics, Posts, Comments)
+ * 2. Topic CRUD Operations
+ * 3. Post CRUD Operations
+ * 4. Comment CRUD Operations
+ * 5. User Activity Tracking
+ * 6. S3 Storage (Avatars)
+ * 7. Bookmarks DDB
+ * 8. Cleanup (Delete Test Data)
+ *
+ * Credentials are provisioned automatically via Cognito AdminCreateUser.
  */
 
 // Polyfill crypto for Node.js environment (required for Amplify Auth)
@@ -12,59 +21,102 @@ if (typeof globalThis.crypto === 'undefined') {
 }
 
 import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
 import amplifyconfig from './src/amplify_outputs.json';
-import { createTestRunner, runAllTests } from './test-utils';
-import { getTopic, listTopics, getPost, listPosts, getComment, listComments, fetchUserActivity } from './src/graphql/queries';
-import {
-  createTopic,
-  updateTopic,
-  deleteTopic,
-  createPost,
-  updatePost,
-  deletePost,
-  createComment,
-  updateComment,
-  deleteComment,
-} from './src/graphql/mutations';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
 
-// Configure Amplify with Gen2 configuration
+// Configure Amplify with Gen2 outputs
 Amplify.configure(amplifyconfig);
 
 // ============================================================
-// CONFIGURATION - Update with your test user credentials
+// Main Test Execution
 // ============================================================
-const TEST_USER = {
-  username: 'YOUR_USERNAME_HERE', // Phone number format
-  password: 'YOUR_PASSWORD_HERE',
-};
 
-// ============================================================
-// Main Entry Point
-// ============================================================
-const { runTest, printSummary } = createTestRunner();
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting Discussions App Gen2 Test Script\n');
+  console.log('This script tests:');
+  console.log('  1. GraphQL Queries (Topics, Posts, Comments)');
+  console.log('  2. Topic CRUD Operations');
+  console.log('  3. Post CRUD Operations');
+  console.log('  4. Comment CRUD Operations');
+  console.log('  5. User Activity Tracking');
+  console.log('  6. S3 Storage (Avatars)');
+  console.log('  7. Bookmarks DDB');
+  console.log('  8. Cleanup (Delete Test Data)');
 
-void runAllTests({
-  queries: {
-    getTopic,
-    listTopics,
-    getPost,
-    listPosts,
-    getComment,
-    listComments,
-    fetchUserActivity,
-  },
-  mutations: {
-    createTopic,
-    updateTopic,
-    deleteTopic,
-    createPost,
-    updatePost,
-    deletePost,
-    createComment,
-    updateComment,
-    deleteComment,
-  },
-  testUser: TEST_USER,
-  runTest,
-  printSummary,
-});
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
+
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn failed:', error.message || error);
+    process.exit(1);
+  }
+
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions(amplifyconfig);
+  const {
+    runQueryTests,
+    runTopicMutationTests,
+    runPostMutationTests,
+    runCommentMutationTests,
+    runActivityTests,
+    runStorageTests,
+    runBookmarksTests,
+    runCleanupTests,
+  } = createTestOrchestrator(testFunctions, runner, amplifyconfig);
+
+  // Get current user ID for activity tests
+  const currentUser = await getCurrentUser();
+
+  // Part 1: Query tests
+  await runQueryTests();
+
+  // Part 2: Topic mutations
+  const topicId = await runTopicMutationTests();
+
+  // Part 3: Post mutations (requires topic)
+  let postId: string | null = null;
+  if (topicId) {
+    postId = await runPostMutationTests(topicId);
+  }
+
+  // Part 4: Comment mutations (requires post)
+  let commentId: string | null = null;
+  if (postId) {
+    commentId = await runCommentMutationTests(postId);
+  }
+
+  // Part 5: Activity tests
+  await runActivityTests(currentUser.userId);
+
+  // Part 6: S3 Storage (Avatars)
+  await runStorageTests();
+
+  // Part 7: Bookmarks DDB (requires a post to bookmark)
+  if (postId) {
+    await runBookmarksTests(currentUser.userId, postId);
+  }
+
+  // Part 8: Cleanup
+  await runCleanupTests(topicId, postId, commentId);
+
+  // Sign out
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
+
+  // Print summary and exit with appropriate code
+  runner.printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/discussions/gen2-test-script.ts
+++ b/amplify-migration-apps/discussions/gen2-test-script.ts
@@ -69,7 +69,7 @@ async function runAllTests(): Promise<void> {
     runStorageTests,
     runBookmarksTests,
     runCleanupTests,
-  } = createTestOrchestrator(testFunctions, runner, amplifyconfig);
+  } = createTestOrchestrator(testFunctions, runner);
 
   // Get current user ID for activity tests
   const currentUser = await getCurrentUser();

--- a/amplify-migration-apps/discussions/gen2-test-script.ts
+++ b/amplify-migration-apps/discussions/gen2-test-script.ts
@@ -59,7 +59,7 @@ async function runAllTests(): Promise<void> {
   }
 
   const runner = new TestRunner();
-  const testFunctions = createTestFunctions(amplifyconfig);
+  const testFunctions = createTestFunctions();
   const {
     runQueryTests,
     runTopicMutationTests,

--- a/amplify-migration-apps/fitness-tracker/gen2-test-script.ts
+++ b/amplify-migration-apps/fitness-tracker/gen2-test-script.ts
@@ -1,0 +1,184 @@
+/**
+ * Gen2 Test Script for Fitness Tracker App
+ *
+ * This script tests all functionality for Amplify Gen2:
+ * 1. Authenticated GraphQL Queries (requires auth)
+ * 2. Authenticated GraphQL Mutations (requires auth)
+ * 3. REST API Operations (nutrition logging)
+ *
+ * Credentials are provisioned automatically via Cognito AdminCreateUser.
+ */
+
+// Polyfill crypto for Node.js environment (required for Amplify Auth)
+import { webcrypto } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = webcrypto;
+}
+
+import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser, fetchAuthSession } from 'aws-amplify/auth';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
+import amplifyconfig from './src/amplify_outputs.json';
+import { SignatureV4 } from '@aws-sdk/signature-v4';
+import { HttpRequest } from '@aws-sdk/protocol-http';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
+
+// Configure Amplify with Gen2 outputs, merging REST API config
+const parsedConfig = parseAmplifyConfig(amplifyconfig);
+Amplify.configure({
+  ...parsedConfig,
+  API: {
+    ...parsedConfig.API,
+    REST: {
+      ...(amplifyconfig as any).custom?.API,
+    },
+  },
+});
+
+// ============================================================
+// REST API Test Functions (Gen2-specific, uses SigV4 signing)
+// ============================================================
+
+/**
+ * Make a signed REST API request using AWS SigV4.
+ * Gen2 REST APIs require manual signing since Amplify's post() helper
+ * has signing issues in Node.js environments.
+ */
+async function makeSignedRequest(
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: any,
+): Promise<any> {
+  const session = await fetchAuthSession();
+  const credentials = session.credentials;
+
+  if (!credentials) {
+    throw new Error('No credentials available');
+  }
+
+  const apiConfigs = (amplifyconfig as any).custom.API;
+  const apiName = Object.keys(apiConfigs)[0];
+  const apiConfig = apiConfigs[apiName];
+  let endpoint = apiConfig.endpoint;
+  const region = apiConfig.region;
+
+  if (endpoint.endsWith('/')) {
+    endpoint = endpoint.slice(0, -1);
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : '/' + path;
+  const url = new URL(endpoint + normalizedPath);
+
+  console.log('   🔗 Request URL:', url.toString());
+
+  const request = new HttpRequest({
+    method,
+    protocol: url.protocol,
+    hostname: url.hostname,
+    path: url.pathname + url.search,
+    headers: {
+      'Content-Type': 'application/json',
+      host: url.hostname,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const signer = new SignatureV4({
+    credentials,
+    region,
+    service: 'execute-api',
+    sha256: Sha256,
+  });
+
+  const signedRequest = await signer.sign(request);
+
+  const response = await fetch(url.toString(), {
+    method: signedRequest.method,
+    headers: signedRequest.headers,
+    body: signedRequest.body,
+  });
+
+  const responseText = await response.text();
+  console.log('   📥 Response status:', response.status);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${responseText}`);
+  }
+
+  return JSON.parse(responseText);
+}
+
+async function testNutritionLogAPI(): Promise<void> {
+  console.log('\n🍔 Testing Gen2 REST API - POST /nutrition/log...');
+  const user = await getCurrentUser();
+
+  const requestBody = {
+    userName: user.username,
+    content: `Test nutrition log via Gen2 REST API - Pizza and salad - ${Date.now()}`,
+  };
+
+  const response = await makeSignedRequest('POST', 'nutrition/log', requestBody);
+  console.log('✅ Gen2 REST API Response:', response);
+  console.log('   Message:', response.message);
+}
+
+// ============================================================
+// Main Test Execution
+// ============================================================
+
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting Gen2 Test Script for Fitness Tracker\n');
+  console.log('This script tests:');
+  console.log('  1. Authenticated GraphQL Queries');
+  console.log('  2. Authenticated GraphQL Mutations');
+  console.log('  3. REST API Operations (Nutrition Logging)');
+
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
+
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn failed:', error.message || error);
+    process.exit(1);
+  }
+
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions();
+  const { runQueryTests, runMutationTests } = createTestOrchestrator(testFunctions, runner);
+
+  // Part 1: Queries
+  await runQueryTests();
+
+  // Part 2: Mutations
+  await runMutationTests();
+
+  // Part 3: REST API (gen2-specific, uses SigV4 signing)
+  console.log('\n' + '='.repeat(50));
+  console.log('🌐 PART 3: REST API Operations');
+  console.log('='.repeat(50));
+
+  await runner.runTest('nutritionLogAPI', testNutritionLogAPI);
+
+  console.log('\n💡 Note: The REST API creates meals directly in DynamoDB.');
+  console.log('   Check your app to see the logged nutrition data!');
+
+  // Sign out
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
+
+  // Print summary and exit with appropriate code
+  runner.printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/media-vault/gen2-test-script.ts
+++ b/amplify-migration-apps/media-vault/gen2-test-script.ts
@@ -1,0 +1,77 @@
+/**
+ * Gen2 Test Script for MediaVault App
+ *
+ * This script tests all functionality for Amplify Gen2:
+ * 1. Authenticated GraphQL Queries (Notes)
+ * 2. Authenticated GraphQL Mutations (Notes)
+ * 3. Lambda Function Operations (Thumbnails, User Groups)
+ *
+ * Credentials are provisioned automatically via Cognito AdminCreateUser.
+ */
+
+// Polyfill crypto for Node.js environment (required for Amplify Auth)
+import { webcrypto } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = webcrypto;
+}
+
+import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
+import amplifyconfig from './amplify_outputs.json';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
+
+// Configure Amplify with Gen2 outputs
+Amplify.configure(amplifyconfig);
+
+// ============================================================
+// Main Test Execution
+// ============================================================
+
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting MediaVault Gen2 Test Script\n');
+  console.log('This script tests:');
+  console.log('  1. Authenticated GraphQL Queries (Notes)');
+  console.log('  2. Authenticated GraphQL Mutations (Notes)');
+  console.log('  3. Lambda Function Operations (Thumbnails, User Groups)');
+
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
+
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn failed:', error.message || error);
+    process.exit(1);
+  }
+
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions();
+  const { runQueryTests, runMutationTests, runLambdaFunctionTests } = createTestOrchestrator(testFunctions, runner);
+
+  // Part 1: Queries
+  await runQueryTests();
+
+  // Part 2: Mutations
+  await runMutationTests();
+
+  // Part 3: Lambda Functions
+  await runLambdaFunctionTests();
+
+  // Sign out
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
+
+  // Print summary and exit with appropriate code
+  runner.printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/product-catalog/gen2-test-script.ts
+++ b/amplify-migration-apps/product-catalog/gen2-test-script.ts
@@ -1,0 +1,116 @@
+/**
+ * Gen2 Test Script for Product Catalog App
+ *
+ * This script tests all functionality for Amplify Gen2:
+ * 1. GraphQL Queries (Products, Users, Comments, Low Stock Lambda)
+ * 2. Product Mutations (Create, Update, Delete)
+ * 3. User Mutations (Create, Update Role, Delete)
+ * 4. Comment Mutations (Create, Update, Delete)
+ * 5. S3 Storage Operations (Upload, Get URL, Product with Image)
+ * 6. Role-Based Access Control
+ * 7. Business Logic (Filtering, Sorting, Reports)
+ *
+ * Credentials are provisioned automatically via Cognito AdminCreateUser.
+ */
+
+// Polyfill crypto for Node.js environment (required for Amplify Auth)
+import { webcrypto } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = webcrypto;
+}
+
+import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
+import amplifyconfig from './amplify_outputs.json';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
+
+// Configure Amplify with Gen2 outputs
+Amplify.configure(amplifyconfig);
+
+// ============================================================
+// Main Test Execution
+// ============================================================
+
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting Product Catalog Gen2 Test Script\n');
+  console.log('This script tests:');
+  console.log('  1. GraphQL Queries (Products, Users, Comments, Low Stock)');
+  console.log('  2. Product Mutations (Create, Update, Delete)');
+  console.log('  3. User Mutations (Create, Update Role, Delete)');
+  console.log('  4. Comment Mutations (Create, Update, Delete)');
+  console.log('  5. S3 Storage Operations (Upload, Get URL)');
+  console.log('  6. Role-Based Access Control');
+  console.log('  7. Business Logic (Filtering, Sorting, Reports)');
+
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
+
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn failed:', error.message || error);
+    process.exit(1);
+  }
+
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions();
+  const {
+    runQueryTests,
+    runProductMutationTests,
+    runUserMutationTests,
+    runCommentMutationTests,
+    runStorageTests,
+    runRBACTests,
+    runBusinessLogicTests,
+  } = createTestOrchestrator(testFunctions, runner);
+
+  // Part 1: Query tests
+  const { productId: existingProductId } = await runQueryTests();
+
+  // Part 2: Product mutations
+  const testProductId = await runProductMutationTests();
+
+  // Part 3: User mutations
+  await runUserMutationTests();
+
+  // Part 4: Comment mutations (use test product or existing product)
+  const productForComments = testProductId || existingProductId;
+  if (productForComments) {
+    await runCommentMutationTests(productForComments);
+  } else {
+    console.log('\n⚠️ Skipping comment tests - no product available');
+  }
+
+  // Part 5: Storage tests
+  await runStorageTests();
+
+  // Part 6: RBAC tests
+  await runRBACTests();
+
+  // Part 7: Business logic tests
+  await runBusinessLogicTests();
+
+  // Cleanup: delete test product if created
+  if (testProductId) {
+    console.log('\n🧹 Cleanup: Deleting test product...');
+    await runner.runTest('deleteProduct_final', () => testFunctions.testDeleteProduct(testProductId));
+  }
+
+  // Sign out
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
+
+  // Print summary and exit with appropriate code
+  runner.printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/project-boards/gen2-test-script.ts
+++ b/amplify-migration-apps/project-boards/gen2-test-script.ts
@@ -1,0 +1,77 @@
+/**
+ * Gen2 Test Script for Project Boards App
+ *
+ * This script tests all functionality for Amplify Gen2:
+ * 1. Public GraphQL Queries (no auth required)
+ * 2. Authenticated GraphQL Mutations (requires auth)
+ * 3. S3 Storage Operations (requires auth)
+ *
+ * Credentials are provisioned automatically via Cognito AdminCreateUser.
+ */
+
+// Polyfill crypto for Node.js environment (required for Amplify Auth)
+import { webcrypto } from 'crypto';
+if (typeof globalThis.crypto === 'undefined') {
+  (globalThis as any).crypto = webcrypto;
+}
+
+import { Amplify } from 'aws-amplify';
+import { signIn, signOut, getCurrentUser } from 'aws-amplify/auth';
+import amplifyconfig from './amplify_outputs.json';
+import { TestRunner } from '../_test-common/test-apps-test-utils';
+import { provisionTestUser } from '../_test-common/signup';
+import { createTestFunctions, createTestOrchestrator } from './test-utils';
+
+// Configure Amplify with Gen2 outputs
+Amplify.configure(amplifyconfig);
+
+// ============================================================
+// Main Test Execution
+// ============================================================
+
+async function runAllTests(): Promise<void> {
+  console.log('🚀 Starting Gen2 Test Script\n');
+  console.log('This script tests:');
+  console.log('  1. Public GraphQL Queries');
+  console.log('  2. Authenticated GraphQL Mutations');
+  console.log('  3. S3 Storage Operations');
+
+  // Provision user via admin APIs, then sign in here so tokens stay in this module's Amplify scope
+  const { signinValue, testUser } = await provisionTestUser(amplifyconfig);
+
+  try {
+    await signIn({ username: signinValue, password: testUser.password });
+    const currentUser = await getCurrentUser();
+    console.log(`✅ Signed in as: ${currentUser.username}`);
+  } catch (error: any) {
+    console.error('❌ SignIn failed:', error.message || error);
+    process.exit(1);
+  }
+
+  const runner = new TestRunner();
+  const testFunctions = createTestFunctions();
+  const { runPublicQueryTests, runMutationTests, runStorageTests } = createTestOrchestrator(testFunctions, runner);
+
+  // Part 1: Public queries (no auth needed)
+  await runPublicQueryTests();
+
+  // Part 2: Mutations (already authenticated)
+  await runMutationTests();
+
+  // Part 3: Storage
+  await runStorageTests();
+
+  // Sign out
+  try {
+    await signOut();
+    console.log('✅ Signed out successfully');
+  } catch (error: any) {
+    console.error('❌ Sign out error:', error.message || error);
+  }
+
+  // Print summary and exit with appropriate code
+  runner.printSummary();
+}
+
+// Run all tests
+void runAllTests();

--- a/amplify-migration-apps/project-boards/test-utils.ts
+++ b/amplify-migration-apps/project-boards/test-utils.ts
@@ -1,6 +1,5 @@
 // test-utils.ts
 
-import { Amplify } from 'aws-amplify';
 import { generateClient } from 'aws-amplify/api';
 import { uploadData, getUrl, downloadData, getProperties } from 'aws-amplify/storage';
 import * as fs from 'fs';
@@ -8,10 +7,10 @@ import { getProject, getTodo, listProjects, listTodos } from './src/graphql/quer
 import { createProject, updateProject, deleteProject, createTodo, updateTodo, deleteTodo } from './src/graphql/mutations';
 import { ProjectStatus } from './src/API';
 import { TestRunner } from '../_test-common/test-apps-test-utils';
-import amplifyconfig from './src/amplifyconfiguration.json';
 
-// Configure Amplify in this module to ensure api/storage singletons see the config
-Amplify.configure(amplifyconfig);
+// NOTE: Amplify.configure() must be called by the importing script (gen1 or gen2)
+// before any test functions are invoked. The gen1 script configures with
+// amplifyconfiguration.json, the gen2 script with amplify_outputs.json.
 
 // Custom query for getRandomQuote (not in generated files)
 const getRandomQuote = /* GraphQL */ `

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -24,6 +24,7 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import { getCLIPath } from '@aws-amplify/amplify-e2e-core';
+import * as fsExtra from 'fs-extra';
 
 /** Options passed to app-specific post-generate scripts */
 interface PostGenerateOptions {
@@ -364,6 +365,140 @@ async function runPostRefactorScript(appName: string, targetAppPath: string, env
 }
 
 /**
+ * Run the app's gen1-test-script.ts to validate the Gen1 deployment.
+ *
+ * Copies _test-common to the migration target directory so relative
+ * imports like ../_test-common resolve, then executes the test script
+ * via npx tsx from the target app directory.
+ */
+async function runGen1TestScript(targetAppPath: string, migrationTargetPath: string, sourceAppsBasePath: string): Promise<void> {
+  const testScriptName = 'gen1-test-script.ts';
+
+  // Copy _test-common so ../_test-common imports resolve from the target app dir
+  const testCommonSource = path.join(sourceAppsBasePath, '_test-common');
+  const testCommonDest = path.join(migrationTargetPath, '_test-common');
+  logger.info(`Copying _test-common to ${testCommonDest}`);
+  await fsExtra.copy(testCommonSource, testCommonDest, { overwrite: true });
+
+  // Install dependencies for the test script (aws-amplify, etc.)
+  logger.info(`Installing dependencies in ${targetAppPath}`);
+  await execa('npm', ['install'], { cwd: targetAppPath });
+
+  // Install dependencies for _test-common
+  logger.info(`Installing _test-common dependencies in ${testCommonDest}`);
+  await execa('npm', ['install'], { cwd: testCommonDest });
+
+  logger.info(`Running ${testScriptName} in ${targetAppPath}`);
+  const result = await execa('npx', ['tsx', testScriptName], {
+    cwd: targetAppPath,
+    reject: false,
+  });
+
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+
+  // Always log full output at DEBUG level (visible with --verbose)
+  if (stdout) {
+    logger.debug(`[test-script] stdout:\n${stdout}`);
+  }
+  if (stderr) {
+    logger.debug(`[test-script] stderr:\n${stderr}`);
+  }
+
+  // At INFO level, surface the meaningful test result lines
+  const testResultLines = stdout.split('\n').filter((line) => {
+    const trimmed = line.trim();
+    return (
+      trimmed.startsWith('✅') ||
+      trimmed.startsWith('❌') ||
+      trimmed.includes('TEST SUMMARY') ||
+      trimmed.includes('All tests passed') ||
+      trimmed.includes('test(s) failed')
+    );
+  });
+
+  for (const line of testResultLines) {
+    logger.info(`[test-script] ${line.trim()}`);
+  }
+
+  if (result.exitCode !== 0) {
+    // Include output in the error so it's visible even without --verbose
+    const combinedOutput = [stdout, stderr].filter(Boolean).join('\n');
+    throw new Error(`${testScriptName} failed with exit code ${result.exitCode}\n${combinedOutput}`);
+  }
+
+  logger.info(`${testScriptName} completed successfully`);
+}
+
+/**
+ * Run the app's gen2-test-script.ts to validate the Gen2 deployment.
+ *
+ * Same pattern as runGen1TestScript but runs gen2-test-script.ts instead.
+ * Copies _test-common and installs deps before executing.
+ */
+async function runGen2TestScript(targetAppPath: string, migrationTargetPath: string, sourceAppsBasePath: string): Promise<void> {
+  const testScriptName = 'gen2-test-script.ts';
+
+  // Check if the gen2 test script exists
+  if (!fs.existsSync(path.join(targetAppPath, testScriptName))) {
+    logger.debug(`No ${testScriptName} found in ${targetAppPath}, skipping`);
+    return;
+  }
+
+  // Copy _test-common so ../_test-common imports resolve from the target app dir
+  const testCommonSource = path.join(sourceAppsBasePath, '_test-common');
+  const testCommonDest = path.join(migrationTargetPath, '_test-common');
+  logger.info(`Copying _test-common to ${testCommonDest}`);
+  await fsExtra.copy(testCommonSource, testCommonDest, { overwrite: true });
+
+  // Install dependencies for the test script
+  logger.info(`Installing dependencies in ${targetAppPath}`);
+  await execa('npm', ['install'], { cwd: targetAppPath });
+
+  // Install dependencies for _test-common
+  logger.info(`Installing _test-common dependencies in ${testCommonDest}`);
+  await execa('npm', ['install'], { cwd: testCommonDest });
+
+  logger.info(`Running ${testScriptName} in ${targetAppPath}`);
+  const result = await execa('npx', ['tsx', testScriptName], {
+    cwd: targetAppPath,
+    reject: false,
+  });
+
+  const stdout = result.stdout || '';
+  const stderr = result.stderr || '';
+
+  if (stdout) {
+    logger.debug(`[gen2-test-script] stdout:\n${stdout}`);
+  }
+  if (stderr) {
+    logger.debug(`[gen2-test-script] stderr:\n${stderr}`);
+  }
+
+  const testResultLines = stdout.split('\n').filter((line) => {
+    const trimmed = line.trim();
+    return (
+      trimmed.startsWith('✅') ||
+      trimmed.startsWith('❌') ||
+      trimmed.includes('TEST SUMMARY') ||
+      trimmed.includes('All tests passed') ||
+      trimmed.includes('test(s) failed')
+    );
+  });
+
+  for (const line of testResultLines) {
+    logger.info(`[gen2-test-script] ${line.trim()}`);
+  }
+
+  if (result.exitCode !== 0) {
+    const combinedOutput = [stdout, stderr].filter(Boolean).join('\n');
+    throw new Error(`${testScriptName} failed with exit code ${result.exitCode}\n${combinedOutput}`);
+  }
+
+  logger.info(`${testScriptName} completed successfully`);
+}
+
+/**
  * Spawn the amplify CLI directly to run amplify push --yes.
  *
  * Uses AMPLIFY_PATH env var if set, otherwise
@@ -390,9 +525,10 @@ async function amplifyPush(targetAppPath: string): Promise<void> {
 }
 
 /**
- * Initialize a single app
+ * Initialize a single app.
  * Copies the source directory to the migration target, runs amplify init,
- * and initializes all configured categories
+ * initializes categories, pushes, runs test scripts, and executes the
+ * full gen2-migration workflow.
  */
 async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise<void> {
   const { appName, deploymentName, config, migrationTargetPath, envName, profile } = params;
@@ -402,11 +538,13 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
 
   const sourceAppPath = appSelector.getAppPath(appName);
   logger.debug(`Source app path: ${sourceAppPath}`, context);
-
   logger.debug(`Config app name: ${config.app.name}`, context);
 
+  // Derive sourceAppsBasePath once for all test script calls
+  const sourceAppsBasePath = path.dirname(sourceAppPath);
+
   try {
-    // Create the target directory, where we will store our Amplify app
+    // Step 1: Create target directory and copy source
     const targetAppPath = await directoryManager.createAppDirectory({
       basePath: migrationTargetPath,
       appName: deploymentName,
@@ -422,9 +560,7 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
     await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
     logger.debug(`Updated package.json name to ${deploymentName}`, context);
 
-    logger.debug(`Running amplify init in ${targetAppPath}`, context);
-
-    // Use profile-based initialization (works for both atmosphere and local environments)
+    // Step 2: Amplify init
     logger.debug(`Using AWS profile '${profile}' for Amplify initialization`, context);
     await amplifyInitializer.initializeApp({
       appPath: targetAppPath,
@@ -434,7 +570,7 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
       profile,
     });
 
-    // Initialize categories (auth, api, storage, function, etc.)
+    // Step 3: Initialize categories (auth, api, storage, function, etc.)
     logger.info(`Initializing categories for ${deploymentName}...`, context);
     const categoryResult = await categoryInitializer.initializeCategories({
       appPath: targetAppPath,
@@ -442,7 +578,6 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
       deploymentName,
     });
 
-    // Log category initialization results
     if (categoryResult.initializedCategories.length > 0) {
       logger.info(`Successfully initialized categories: ${categoryResult.initializedCategories.join(', ')}`, context);
     }
@@ -456,62 +591,102 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
       throw new Error(`Failed to initialize ${categoryResult.errors.length} category(ies)`);
     }
 
-    // Push the initialized app to AWS
+    // Step 4: Run configure.sh if present (copies custom source files into amplify/backend/)
+    const configureScriptPath = path.join(targetAppPath, 'configure.sh');
+    if (fs.existsSync(configureScriptPath)) {
+      logger.info(`Running configure.sh for ${deploymentName}...`, context);
+      await execa('bash', ['configure.sh'], { cwd: targetAppPath });
+      logger.info(`Successfully ran configure.sh for ${deploymentName}`, context);
+    } else {
+      logger.debug(`No configure.sh found for ${deploymentName}, skipping`, context);
+    }
+
+    // Step 5: Push the initialized app to AWS
     logger.info(`Pushing ${deploymentName} to AWS...`, context);
     await amplifyPush(targetAppPath);
     logger.info(`Successfully pushed ${deploymentName} to AWS`, context);
 
-    // Initialize git repo and commit the Gen1 state
+    // Step 6: Run gen1 test script to validate the Gen1 deployment
+    logger.info(`Running gen1 test script (post-push) for ${deploymentName}...`, context);
+    await runGen1TestScript(targetAppPath, migrationTargetPath, sourceAppsBasePath);
+    logger.info(`Gen1 test script passed (post-push) for ${deploymentName}`, context);
+
+    // Step 7: Initialize git repo and commit the Gen1 state
     logger.info(`Initializing git repository for ${deploymentName}...`, context);
     await execa('git', ['init'], { cwd: targetAppPath });
     await execa('git', ['add', '.'], { cwd: targetAppPath });
     await execa('git', ['commit', '-m', 'feat: gen1 initial commit'], { cwd: targetAppPath });
     logger.info(`Git repository initialized and Gen1 state committed`, context);
 
-    // Run gen2-migration pre-deployment workflow (lock -> checkout -> generate)
+    // Step 8: Run gen2-migration pre-deployment workflow (lock -> checkout -> generate)
     logger.info(`Running gen2-migration pre-deployment workflow for ${deploymentName}...`, context);
     await gen2MigrationExecutor.runPreDeploymentWorkflow(targetAppPath, envName);
     logger.info(`Successfully completed gen2-migration pre-deployment workflow for ${deploymentName}`, context);
 
-    // Run app-specific post-generate script
+    // Step 9: Run app-specific post-generate script
     await runPostGenerateScript(appName, targetAppPath, envName);
 
-    // Commit Gen2 generated code
+    // Step 10: Commit Gen2 generated code
     logger.info(`Committing Gen2 generated code for ${deploymentName}...`, context);
     await execa('git', ['add', '.'], { cwd: targetAppPath });
     await execa('git', ['commit', '-m', 'feat: gen2 migration generate'], { cwd: targetAppPath });
     logger.info(`Gen2 generated code committed`, context);
 
-    // Deploy Gen2 using ampx sandbox
+    // Step 11: Deploy Gen2 using ampx sandbox
     logger.info(`Deploying Gen2 app using ampx sandbox for ${deploymentName}...`, context);
     const gen2BranchName = `gen2-${envName}`;
     const gen2StackName = await gen2MigrationExecutor.deployGen2Sandbox(targetAppPath, deploymentName, gen2BranchName);
     logger.info(`Gen2 app deployed with stack name: ${gen2StackName}`, context);
 
-    // Checkout back to main branch for refactor (refactor must run from Gen1 branch)
+    // Run gen2 test script to validate the Gen2 code before deploying
+    logger.info(`Running gen2 test script (post-generate) for ${deploymentName}...`, context);
+    await runGen2TestScript(targetAppPath, migrationTargetPath, sourceAppsBasePath);
+    logger.info(`Gen2 test script passed (post-generate) for ${deploymentName}`, context);
+
+    // Step 12: Checkout back to main branch for refactor (refactor must run from Gen1 branch)
     logger.info(`Checking out main branch for refactor (refactor requires Gen1 files)...`, context);
     await execa('git', ['checkout', 'main'], { cwd: targetAppPath });
 
-    // Run refactor to move stateful resources from Gen1 to Gen2
+    // Step 13: Run refactor to move stateful resources from Gen1 to Gen2
     logger.info(`Running gen2-migration refactor for ${deploymentName}...`, context);
     await gen2MigrationExecutor.refactor(targetAppPath, gen2StackName);
     logger.info(`Successfully completed gen2-migration refactor for ${deploymentName}`, context);
 
-    // Checkout back to Gen2 branch for post-refactor edits
+    // Step 14: Run gen1 test script to validate post-refactor state
+    logger.info(`Running gen1 test script (post-refactor) for ${deploymentName}...`, context);
+    await runGen1TestScript(targetAppPath, migrationTargetPath, sourceAppsBasePath);
+    logger.info(`Gen1 test script passed (post-refactor) for ${deploymentName}`, context);
+
+    // Step 15: Checkout back to Gen2 branch for post-refactor edits
     logger.info(`Checking out ${gen2BranchName} branch for post-refactor edits...`, context);
     await execa('git', ['checkout', gen2BranchName], { cwd: targetAppPath });
 
-    // Run app-specific post-refactor script
+    // Step 16: Run app-specific post-refactor script
     await runPostRefactorScript(appName, targetAppPath, envName);
 
-    // Redeploy Gen2 to pick up post-refactor changes
+    // Step 17: Commit post-refactor changes
+    logger.info(`Committing post-refactor changes for ${deploymentName}...`, context);
+    await execa('git', ['add', '.'], { cwd: targetAppPath });
+    await execa('git', ['commit', '-m', 'fix: post-refactor edits'], { cwd: targetAppPath });
+    logger.info(`Post-refactor changes committed`, context);
+
+    // Step 18: Redeploy Gen2 to pick up post-refactor changes
+    // Re-install Gen2 deps — npm install during the post-refactor test script
+    // (step 14) runs on the main branch and may wipe Gen2 node_modules.
+    logger.info(`Re-installing Gen2 dependencies before redeploy...`, context);
+    await execa('npm', ['install'], { cwd: targetAppPath });
     logger.info(`Redeploying Gen2 app after refactor for ${deploymentName}...`, context);
     await gen2MigrationExecutor.deployGen2Sandbox(targetAppPath, deploymentName, gen2BranchName);
     logger.info(`Gen2 app redeployed successfully`, context);
 
+    // Step 19: Run gen1 test script to validate final deployment
+    logger.info(`Running gen1 test script (post-redeployment) for ${deploymentName}...`, context);
+    await runGen1TestScript(targetAppPath, migrationTargetPath, sourceAppsBasePath);
+    logger.info(`Gen1 test script passed (post-redeployment) for ${deploymentName}`, context);
+
     logger.info(`App ${deploymentName} fully initialized and migrated at ${targetAppPath}`, context);
   } catch (error) {
-    logger.error(`Failed to initialize/migrate ${appName}`, error as Error, context);
+    logger.error(`Failed to initialize ${appName}`, error as Error, context);
     throw error;
   }
 }

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -566,7 +566,7 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
       profile,
     });
 
-    // Step 3: Initialize categories (auth, api, storage, function, etc.)
+    // Initialize categories (auth, api, storage, function, etc.)
     logger.info(`Initializing categories for ${deploymentName}...`, context);
     const categoryResult = await categoryInitializer.initializeCategories({
       appPath: targetAppPath,
@@ -614,21 +614,21 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
     await execa('git', ['commit', '-m', 'feat: gen1 initial commit'], { cwd: targetAppPath });
     logger.info(`Git repository initialized and Gen1 state committed`, context);
 
-    // Step 8: Run gen2-migration pre-deployment workflow (lock -> checkout -> generate)
+    // Run gen2-migration pre-deployment workflow (lock -> checkout -> generate)
     logger.info(`Running gen2-migration pre-deployment workflow for ${deploymentName}...`, context);
     await gen2MigrationExecutor.runPreDeploymentWorkflow(targetAppPath, envName);
     logger.info(`Successfully completed gen2-migration pre-deployment workflow for ${deploymentName}`, context);
 
-    // Step 9: Run app-specific post-generate script
+    // Run app-specific post-generate script
     await runPostGenerateScript(appName, targetAppPath, envName);
 
-    // Step 10: Commit Gen2 generated code
+    // Commit Gen2 generated code
     logger.info(`Committing Gen2 generated code for ${deploymentName}...`, context);
     await execa('git', ['add', '.'], { cwd: targetAppPath });
     await execa('git', ['commit', '-m', 'feat: gen2 migration generate'], { cwd: targetAppPath });
     logger.info(`Gen2 generated code committed`, context);
 
-    // Step 11: Deploy Gen2 using ampx sandbox
+    // Deploy Gen2 using ampx sandbox
     logger.info(`Deploying Gen2 app using ampx sandbox for ${deploymentName}...`, context);
     const gen2BranchName = `gen2-${envName}`;
     const gen2StackName = await gen2MigrationExecutor.deployGen2Sandbox(targetAppPath, deploymentName, gen2BranchName);
@@ -639,11 +639,11 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
     await runGen2TestScript(targetAppPath, migrationTargetPath, sourceAppsBasePath);
     logger.info(`Gen2 test script passed (post-generate) for ${deploymentName}`, context);
 
-    // Step 12: Checkout back to main branch for refactor (refactor must run from Gen1 branch)
+    // Checkout back to main branch for refactor (refactor must run from Gen1 branch)
     logger.info(`Checking out main branch for refactor (refactor requires Gen1 files)...`, context);
     await execa('git', ['checkout', 'main'], { cwd: targetAppPath });
 
-    // Step 13: Run refactor to move stateful resources from Gen1 to Gen2
+    // Run refactor to move stateful resources from Gen1 to Gen2
     logger.info(`Running gen2-migration refactor for ${deploymentName}...`, context);
     await gen2MigrationExecutor.refactor(targetAppPath, gen2StackName);
     logger.info(`Successfully completed gen2-migration refactor for ${deploymentName}`, context);
@@ -657,7 +657,7 @@ async function initializeAppFromCLI(params: InitializeAppFromCLIParams): Promise
     logger.info(`Checking out ${gen2BranchName} branch for post-refactor edits...`, context);
     await execa('git', ['checkout', gen2BranchName], { cwd: targetAppPath });
 
-    // Step 16: Run app-specific post-refactor script
+    // Run app-specific post-refactor script
     await runPostRefactorScript(appName, targetAppPath, envName);
 
     // Commit post-refactor changes

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -25,7 +25,6 @@ import os from 'os';
 import fs from 'fs';
 import * as fsExtra from 'fs-extra';
 import { getCLIPath } from '@aws-amplify/amplify-e2e-core';
-import * as fsExtra from 'fs-extra';
 
 /** Options passed to app-specific post-generate scripts */
 interface PostGenerateOptions {
@@ -400,7 +399,7 @@ async function runGen1TestScript(targetAppPath: string, migrationTargetPath: str
   const stderr = result.stderr || '';
 
   // Partition stdout into test-result summary lines (INFO) and everything else (DEBUG)
-  const isTestResultLine = (line: string): boolean => {
+  const testResultLines = stdout.split('\n').filter((line) => {
     const trimmed = line.trim();
     return (
       trimmed.startsWith('✅') ||

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -409,7 +409,7 @@ async function runGen1TestScript(targetAppPath: string, migrationTargetPath: str
       trimmed.includes('All tests passed') ||
       trimmed.includes('test(s) failed')
     );
-  });
+  };
 
   for (const line of testResultLines) {
     logger.info(`[test-script] ${line.trim()}`);

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -408,7 +408,7 @@ async function runGen1TestScript(targetAppPath: string, migrationTargetPath: str
       trimmed.includes('All tests passed') ||
       trimmed.includes('test(s) failed')
     );
-  };
+  });
 
   for (const line of testResultLines) {
     logger.info(`[test-script] ${line.trim()}`);


### PR DESCRIPTION
Related to https://github.com/aws-amplify/amplify-cli/issues/14536

#### Description of changes

Adds Gen2 test script execution to the e2e migration flow. After the Gen2 sandbox deploys (step 11), the system now runs `gen2-test-script.ts` if present in the app directory. This validates that the Gen2 deployment works before proceeding to refactor.

The gen2 test script for project-boards follows the same pattern as the gen1 script: uses `TestRunner` from `_test-common`, provisions users via `provisionTestUser`, and reuses `createTestFunctions`/`createTestOrchestrator` from `test-utils.ts`. The only difference is it reads `amplify_outputs.json` instead of `amplifyconfiguration.json`.

Changes:

- `gen2-test-script.ts` (new): Gen2 test entry point for project-boards, mirrors gen1-test-script structure
- `test-utils.ts`: Removed hardcoded Amplify config import — the calling script (gen1 or gen2) now handles `Amplify.configure()` before test functions are invoked
- `_test-common/signup.ts`: `provisionTestUser` now supports both Gen1 (`aws_user_pools_id`) and Gen2 (`auth.user_pool_id`) config formats, with case-insensitive attribute mapping for `username_attributes`
- `cli.ts`: Added `runGen2TestScript` function (same pattern as `runGen1TestScript`), call after step 11, and `npm install` before step 18 redeploy to restore Gen2 deps wiped by the post-refactor test script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
