### PR TITLE
fix(gen2-migration): skip imported auth resources in refactor step

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/refactor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/refactor.test.ts
@@ -128,10 +128,10 @@ function findGen2RootStackName(app: MigrationApp) {
   throw new Error(`Unable to find Gen2 root stack name for app: ${app.name}`);
 }
 
-function mockDiscover(resources: DiscoveredResource[]): jest.SpyInstance {
+function mockDiscover(resources: DiscoveredResource[], metaOverrides?: Record<string, unknown>): jest.SpyInstance {
   return jest.spyOn(Gen1App, 'create').mockResolvedValue({
     discover: () => resources,
-    meta: () => undefined,
+    meta: (category: string) => metaOverrides?.[category] as Record<string, unknown> | undefined,
   } as unknown as Gen1App);
 }
 
@@ -232,6 +232,17 @@ describe('AmplifyMigrationRefactorStep', () => {
       const plan = await step.forward();
       await plan.describe();
     });
+
+    it('skips imported auth resources', async () => {
+      infraSpy = mockCreateInfrastructure();
+      createSpy = mockDiscover([{ category: 'auth', resourceName: 'myImportedPool', service: 'Cognito', key: 'auth:Cognito' }], {
+        auth: { myImportedPool: { service: 'Cognito', serviceType: 'imported' } },
+      });
+
+      const step = createStep();
+      const plan = await step.forward();
+      await plan.describe();
+    });
   });
 
   describe('rollback()', () => {
@@ -249,6 +260,17 @@ describe('AmplifyMigrationRefactorStep', () => {
         { category: 'function', resourceName: 'myFunc', service: 'Lambda', key: 'function:Lambda' },
         { category: 'api', resourceName: 'myGateway', service: 'API Gateway', key: 'api:API Gateway' },
       ]);
+
+      const step = createStep();
+      const plan = await step.rollback();
+      await plan.describe();
+    });
+
+    it('skips imported auth resources', async () => {
+      infraSpy = mockCreateInfrastructure();
+      createSpy = mockDiscover([{ category: 'auth', resourceName: 'myImportedPool', service: 'Cognito', key: 'auth:Cognito' }], {
+        auth: { myImportedPool: { service: 'Cognito', serviceType: 'imported' } },
+      });
 
       const step = createStep();
       const plan = await step.rollback();

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor/refactor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor/refactor.ts
@@ -67,22 +67,32 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
 
     for (const resource of discovered) {
       switch (resource.key) {
-        case 'auth:Cognito':
-          refactorers.push(
-            new AuthCognitoForwardRefactorer(
-              gen1Env,
-              gen2Branch,
-              clients,
-              this.region,
-              accountId,
-              this.logger,
-              this.appId,
-              this.currentEnvName,
-              resource,
-              cfn,
-            ),
-          );
+        case 'auth:Cognito': {
+          // Imported auth resources have no CloudFormation stack to move — skip.
+          const isReferenceAuth = discovered
+            .filter((r) => r.category === 'auth')
+            .some((r) => {
+              const meta = (gen1App.meta('auth') ?? {})[r.resourceName] as Record<string, unknown> | undefined;
+              return meta?.serviceType === 'imported';
+            });
+          if (!isReferenceAuth) {
+            refactorers.push(
+              new AuthCognitoForwardRefactorer(
+                gen1Env,
+                gen2Branch,
+                clients,
+                this.region,
+                accountId,
+                this.logger,
+                this.appId,
+                this.currentEnvName,
+                resource,
+                cfn,
+              ),
+            );
+          }
           break;
+        }
         case 'auth:Cognito-UserPool-Groups':
           refactorers.push(
             new AuthUserPoolGroupsForwardRefactorer(gen1Env, gen2Branch, clients, this.region, accountId, this.logger, resource, cfn),
@@ -143,11 +153,21 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
 
     for (const resource of discovered) {
       switch (resource.key) {
-        case 'auth:Cognito':
-          refactorers.push(
-            new AuthCognitoRollbackRefactorer(gen1Env, gen2Branch, clients, this.region, accountId, this.logger, resource, cfn),
-          );
+        case 'auth:Cognito': {
+          // Imported auth resources have no CloudFormation stack to move — skip.
+          const isReferenceAuth = discovered
+            .filter((r) => r.category === 'auth')
+            .some((r) => {
+              const meta = (gen1App.meta('auth') ?? {})[r.resourceName] as Record<string, unknown> | undefined;
+              return meta?.serviceType === 'imported';
+            });
+          if (!isReferenceAuth) {
+            refactorers.push(
+              new AuthCognitoRollbackRefactorer(gen1Env, gen2Branch, clients, this.region, accountId, this.logger, resource, cfn),
+            );
+          }
           break;
+        }
         case 'auth:Cognito-UserPool-Groups':
           refactorers.push(
             new AuthUserPoolGroupsRollbackRefactorer(gen1Env, gen2Branch, clients, this.region, accountId, this.logger, resource, cfn),


### PR DESCRIPTION
When you run `amplify gen2-migration refactor` on an app with an imported auth resource, the refactor step was crashing with "unable to find source stack." That's because imported auth resources are just references to externally-managed Cognito resources — they don't have a nested CloudFormation stack in the Gen1 root stack. The `refactor` was trying to find one and failing.

The generate step already handled this correctly — it checks serviceType === 'imported' in amplify-meta.json and uses a ReferenceAuthGenerator instead of the normal AuthGenerator. The refactor step had no such check.

The fix adds the same check to refactor.ts in both forward() and rollback(). When the auth resource is imported, we skip creating the AuthCognitoForwardRefactorer / AuthCognitoRollbackRefactorer entirely — there's nothing to move. 

Source of truth - https://github.com/aws-amplify/amplify-cli/blob/4f88963cdebfaf6127182991080c07574e9d1e6a/packages/amplify-cli/src/commands/gen2-migration/generate.ts#L81