### PR TITLE
chore(gen2-migration): some QoL improvements

### DIFF
--- a/amplify-migration-apps/README.md
+++ b/amplify-migration-apps/README.md
@@ -344,6 +344,7 @@ npx jest --no-coverage src/__tests__/commands/gen2-migration/generate.test.ts -t
 
 Always review the diff after updating to make sure the changes are intentional.
 
+
 > [!NOTE]
 > When updating snapshots, the first run with `--updateSnapshot` will still report a failure
 > because it detects the diff before writing the updated files. Run the tests a second time

--- a/amplify-migration-apps/README.md
+++ b/amplify-migration-apps/README.md
@@ -283,7 +283,7 @@ are needed, and adding a new app automatically gets correct mocks without extra 
 ### Adding a Snapshot Test | `generate`
 
 To add a snapshot test that validates the `gen2-migration generate` command for a new app,
-add a new test to [`command-handlers.test.ts`](../packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/codegen-head/command-handlers.test.ts):
+add a new test to [`generate.test.ts`](../packages/amplify-cli/src/__tests__/commands/gen2-migration/generate.test.ts):
 
 ```typescript
 // For apps WITH Amplify Hosting:
@@ -312,8 +312,8 @@ test('<app-name> snapshot', async () => {
 
 ```console
 cd packages/amplify-cli
-npx jest --no-coverage src/__tests__/commands/gen2-migration/generate/codegen-head/command-handlers.test.ts -t '<app-name> snapshot'
-npx jest --no-coverage src/__tests__/commands/gen2-migration/refactor/refactor.test.ts -t '<app-name> snapshot'
+npx jest --no-coverage src/__tests__/commands/gen2-migration/generate.test.ts -t '<app-name> snapshot'
+npx jest --no-coverage src/__tests__/commands/gen2-migration/refactor.test.ts -t '<app-name> snapshot'
 ```
 
 The tests should pass with no differences. They could fail for two reasons:
@@ -333,14 +333,19 @@ When the migration tool code changes and you need to update expected snapshots:
 
 ```console
 cd packages/amplify-cli
-npx jest --no-coverage src/__tests__/commands/gen2-migration/generate/codegen-head/command-handlers.test.ts --updateSnapshot
+npx jest --no-coverage src/__tests__/commands/gen2-migration/generate.test.ts --updateSnapshot
 ```
 
 This updates all snapshots. You can also target a specific app:
 
 ```console
-npx jest --no-coverage src/__tests__/commands/gen2-migration/generate/codegen-head/command-handlers.test.ts \
-  -t '<app-name> snapshot' --updateSnapshot
+npx jest --no-coverage src/__tests__/commands/gen2-migration/generate.test.ts -t '<app-name> snapshot' --updateSnapshot
 ```
 
 Always review the diff after updating to make sure the changes are intentional.
+
+> [!NOTE]
+> When updating snapshots, the first run with `--updateSnapshot` will still report a failure
+> because it detects the diff before writing the updated files. Run the tests a second time
+> (without `--updateSnapshot`) to verify the snapshots are now correct.
+

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/snapshot.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/snapshot.ts
@@ -81,14 +81,6 @@ export class Snapshot {
   public async compare(actualDir: string, ignorePatterns?: RegExp[]): Promise<Report> {
     const fullIgnorePatterns = [...(ignorePatterns ?? []), /node_modules/];
     const differences = await diff({ expectedDir: this.props.expectedPath, actualDir, ignorePatterns: fullIgnorePatterns });
-
-    // copy the temporary actual path to repo (ignored) for easy manual comparison
-    const ignoredActualPath = `${this.props.expectedPath}.actual.${Date.now()}`;
-    if (fs.existsSync(ignoredActualPath)) {
-      fs.rmSync(ignoredActualPath, { recursive: true, force: true });
-    }
-    copySync({ src: actualDir, dest: ignoredActualPath, ignorePatterns: fullIgnorePatterns });
-
     return new Report({
       app: this.props.app,
       expectedPath: this.props.expectedPath,
@@ -109,6 +101,7 @@ export class Snapshot {
   public update(actualDir: string) {
     console.log(`Updating snapshot: ${this.props.expectedPath}`);
     fs.rmSync(this.props.expectedPath, { recursive: true });
-    copySync({ src: actualDir, dest: this.props.expectedPath });
+    copySync({ src: actualDir, dest: this.props.expectedPath, ignorePatterns: [/node_modules/] });
+    console.log(`Finished updating snapshot: ${this.props.expectedPath}`);
   }
 }


### PR DESCRIPTION
#### Description of changes

Two small fixes to the snapshot test framework:

1. **README path corrections** — The migration-apps README referenced old test
   file paths (`command-handlers.test.ts`, `refactor.test.ts` under nested dirs)
   that were renamed in a previous PR. Updated all references to the current
   `generate.test.ts` and `refactor.test.ts` at the top-level test directory.
   Also added a note about the two-pass snapshot update behavior (first run
   writes updated files but still reports failure; second run confirms).

2. **Snapshot.compare cleanup** — Removed the `.actual.*` copy side effect from
   `compare()`. This was copying the actual output into the repo on every
   comparison, which cluttered the working tree. The diff report already
   contains everything needed for debugging.

3. **Snapshot.update fix** — Added `node_modules` to the ignore patterns when
   copying actual output into the expected snapshot directory. Without this,
   `node_modules` from the temp dir would get copied into the snapshot,
   bloating the repo. Added a completion log line for visibility.

#### Issue #, if available

N/A

#### Description of how you validated changes

Built the `amplify-cli` package successfully (`yarn build`).

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
