### PR TITLE
fix: resolve handlebars to 4.7.9 (CVE-2026-33937)

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "fast-xml-parser": "~4.5.4",
     "glob-parent": "^6.0.2",
     "got": "^11.8.5",
-    "handlebars": "4.7.9",
+    "handlebars": "^4.7.9",
     "istanbul/async": "^2.6.4",
     "jake/async": "^2.6.4",
     "json5": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "fast-xml-parser": "~4.5.4",
     "glob-parent": "^6.0.2",
     "got": "^11.8.5",
+    "handlebars": "4.7.9",
     "istanbul/async": "^2.6.4",
     "jake/async": "^2.6.4",
     "json5": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22671,12 +22671,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.7, handlebars@npm:^4.0.1, handlebars@npm:^4.7.7":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
+"handlebars@npm:4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: ^1.2.5
-    neo-async: ^2.6.0
+    neo-async: ^2.6.2
     source-map: ^0.6.1
     uglify-js: ^3.1.4
     wordwrap: ^1.0.0
@@ -22685,7 +22685,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 4c0913fc0018a2a2e358ee94e4fe83f071762b8bec51a473d187e6642e94e569843adcf550ffe329554c63ad450c062f3a05447bd2e3fff5ebfe698e214225c6
+  checksum: 22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -27123,7 +27123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
+"neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d

--- a/yarn.lock
+++ b/yarn.lock
@@ -22671,7 +22671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.9":
+"handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:


### PR DESCRIPTION
## Description

Resolves handlebars to 4.7.9 via yarn resolutions to address:
- **Dependabot alert #498** (Critical - CVE-2026-33937)
- **Dependabot alert #500** (High - DoS via Malformed Decorator Syntax)

## Why a resolution?

`@aws-amplify/graphql-docs-generator@4.2.1` pins `handlebars: 4.7.7` (exact version), preventing normal dependency updates. This repo already uses 22+ yarn resolutions for similar cases.

## Changes

- Added `"handlebars": "4.7.9"` to root `package.json` resolutions
- Updated `yarn.lock`

## Risk

LOW — patch-level bump (4.7.7 → 4.7.9), no API changes.

## Testing

- [x] `yarn why handlebars` confirms all instances resolve to 4.7.9
- [x] E2E tests pass