### PR TITLE
fix(gen2-migration): sanitize generated variable names in rest api

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.test.ts
@@ -574,6 +574,27 @@ describe('RestApiRenderer', () => {
     `);
   });
 
+  it('sanitizes hyphenated path names into valid variable names', () => {
+    const renderer = new RestApiRenderer(false, new Set(['myFunc']));
+    const restApi = createBasicRestApi({
+      paths: [{ path: '/auth-test', methods: ['GET'], lambdaFunction: 'myFunc' }],
+    });
+    const output = printStatements(renderer.renderApi(restApi));
+
+    expect(output).toContain('const authtest = ');
+    expect(output).not.toContain('const auth-test');
+  });
+
+  it('sanitizes hyphenated api names into valid variable names', () => {
+    const renderer = new RestApiRenderer(false, new Set(['myFunc']));
+    const restApi = createBasicRestApi({ apiName: 'my-api' });
+    const output = printStatements(renderer.renderApi(restApi));
+
+    expect(output).toContain('const myapiStack = ');
+    expect(output).toContain('const myapiApi = ');
+    expect(output).not.toContain('const my-api');
+  });
+
   it('handles no uniqueFunctions gracefully', () => {
     const renderer = new RestApiRenderer(false, new Set());
     const restApi = createBasicRestApi({ uniqueFunctions: undefined });

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.ts
@@ -67,10 +67,11 @@ export class RestApiRenderer {
    */
   public renderApi(restApi: RestApiDefinition): ts.Statement[] {
     const statements: ts.Statement[] = [];
-    const stackVarName = `${restApi.apiName}Stack`;
-    const apiVarName = `${restApi.apiName}Api`;
-    const gen1ApiVarName = `gen1${restApi.apiName}Api`;
-    const gen1PolicyVarName = `gen1${restApi.apiName}Policy`;
+    const sanitizedName = restApi.apiName.replace(/[^a-zA-Z0-9]/g, '');
+    const stackVarName = `${sanitizedName}Stack`;
+    const apiVarName = `${sanitizedName}Api`;
+    const gen1ApiVarName = `gen1${sanitizedName}Api`;
+    const gen1PolicyVarName = `gen1${sanitizedName}Policy`;
 
     statements.push(this.renderStack(restApi, stackVarName));
     statements.push(this.renderRestApiConstruct(restApi, stackVarName, apiVarName));
@@ -365,7 +366,7 @@ export class RestApiRenderer {
     for (const apiPath of restApi.paths) {
       const pathSegments = apiPath.path.split('/').filter((segment) => segment && segment !== '{proxy+}');
 
-      let resourceName = pathSegments.join('') || 'root';
+      let resourceName = pathSegments.join('').replace(/[^a-zA-Z0-9]/g, '') || 'root';
       if (this.functionNames.has(resourceName)) {
         resourceName = `${resourceName}Resource`;
       }


### PR DESCRIPTION
Solves https://github.com/aws-amplify/amplify-cli/issues/14739

#### Description of changes

The REST API renderer in the gen2 migration tool uses path names and API names directly as JavaScript variable names in the generated `backend.ts`. When these names contain non-alphanumeric characters (e.g. `auth-test`), the generated code produces invalid identifiers like `const auth-test = ...`, which fails to compile.

This strips non-alphanumeric characters from path segments and API names before using them as variable names, matching the sanitization pattern already used by the policy renderers in the same file.
