### PR TITLE
fix(gen2-migration): tarball installation cannot find `proxyAgent`

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -114,6 +114,7 @@
     "prettier": "^2.8.4",
     "progress": "^2.0.3",
     "promise-sequential": "^1.1.1",
+    "proxy-agent": "^6.3.0",
     "semver": "^7.5.4",
     "tar-fs": "^2.1.1",
     "treeify": "^1.1.0",

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/aws-clients.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/aws-clients.ts
@@ -13,6 +13,16 @@ import { STSClient } from '@aws-sdk/client-sts';
 import { $TSContext } from '@aws-amplify/amplify-cli-core';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import type { AmplifyClientConfig } from '@aws-sdk/client-amplify';
+import { ProxyAgent } from 'proxy-agent';
+
+export const proxyAgent = () => {
+  let httpAgent = undefined;
+  const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+  if (httpProxy) {
+    httpAgent = new ProxyAgent();
+  }
+  return httpAgent;
+};
 
 // all clients share the same config so we just use one of them
 // to encapsulate all properties we need.
@@ -68,8 +78,8 @@ export class AwsClients {
       ...cred,
       customUserAgent: provider.formUserAgentParam(context, 'gen2-migration'),
       requestHandler: new NodeHttpHandler({
-        httpAgent: provider.proxyAgent(),
-        httpsAgent: provider.proxyAgent(),
+        httpAgent: proxyAgent(),
+        httpsAgent: proxyAgent(),
       }),
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,6 +1886,7 @@ __metadata:
     prettier: ^2.8.4
     progress: ^2.0.3
     promise-sequential: ^1.1.1
+    proxy-agent: ^6.3.0
     semver: ^7.5.4
     tar-fs: ^2.1.1
     treeify: ^1.1.0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Re-implement `proxyAgent` instead of calling `provider.proxyAgent`. In the `dev` branch, `proxyAgent` is not exported from the cloudformation provider package:

https://github.com/aws-amplify/amplify-cli/blob/e366e6f68ca9be0a83f44236fc8e54bcc632805b/packages/amplify-provider-awscloudformation/src/index.ts#L216-L218

Since the `gen2-migration` tarball only packages the `amplify-cli` package, all other packages are consumed via normal dependencies that were published from the `dev` branch. 

Note that in the `gen2-migration` branch, `proxyAgent` is exported since we added it:

https://github.com/aws-amplify/amplify-cli/blob/64edeeb975da01359039b633bf8f3f6ce602baf6/packages/amplify-provider-awscloudformation/src/index.ts#L216-L219

Meaning that when we merge `gen2-migration` with `dev`, we can remove this. 

The implementation of `proxyAgent` came from here:

https://github.com/aws-amplify/amplify-cli/blob/e366e6f68ca9be0a83f44236fc8e54bcc632805b/packages/amplify-provider-awscloudformation/src/aws-utils/aws-globals.ts#L1-L10

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

https://github.com/aws-amplify/amplify-cli/issues/14754

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

1. Build and install the local tarball
2. Ran `npx amplify gen2-migration asses` 

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
