### PR TITLE
fix(gen2-migration): relax lock status validation to check for `Deny` statement existence instead of exact policy match

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_infra/validations.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_infra/validations.test.ts
@@ -700,6 +700,39 @@ describe('AmplifyGen2MigrationValidations', () => {
       await expect(validations.validateLockStatus()).resolves.not.toThrow();
     });
 
+    it('should pass when lock statement exists alongside other statements', async () => {
+      jest.spyOn(stateManager, 'getTeamProviderInfo').mockReturnValue({
+        mock: {
+          awscloudformation: {
+            StackName: 'test-stack',
+          },
+        },
+      });
+
+      const policyWithBoth = {
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 'Update:*',
+            Principal: '*',
+            Resource: '*',
+          },
+          {
+            Effect: 'Deny',
+            Action: 'Update:*',
+            Principal: '*',
+            Resource: '*',
+          },
+        ],
+      };
+
+      mockCfnSend.mockResolvedValue({
+        StackPolicyBody: JSON.stringify(policyWithBoth),
+      });
+
+      await expect(validations.validateLockStatus()).resolves.not.toThrow();
+    });
+
     it('should throw MigrationError when stack policy has wrong effect', async () => {
       jest.spyOn(stateManager, 'getTeamProviderInfo').mockReturnValue({
         mock: {

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
@@ -160,18 +160,11 @@ export class AmplifyGen2MigrationValidations {
     }
 
     const currentPolicy = JSON.parse(StackPolicyBody);
-    const expectedPolicy = {
-      Statement: [
-        {
-          Effect: 'Deny',
-          Action: 'Update:*',
-          Principal: '*',
-          Resource: '*',
-        },
-      ],
-    };
+    const hasLockStatement = currentPolicy.Statement.some(
+      (s: Record<string, string>) => s.Effect === 'Deny' && s.Action === 'Update:*' && s.Principal === '*' && s.Resource === '*',
+    );
 
-    if (JSON.stringify(currentPolicy) !== JSON.stringify(expectedPolicy)) {
+    if (!hasLockStatement) {
       throw new AmplifyError('MigrationError', {
         message: 'Stack policy does not match expected lock policy',
         resolution: 'Run the lock command to set the correct stack policy.',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes #14752 


`validateLockStatus` used strict comparison against the entire stack policy. After a lock -> rollback -> lock cycle, the policy contains both an `Allow` and `Deny` statement, failing the comparison. Changed to check that the `Deny` lock statement exists in the policy rather than requiring an exact match.

Before:

```cli
amplify gen2-migration refactor --to xxx
```
```console
→ Planning complete
→ Validating complete

Failed Validations Report

✘ Lock status

Stack policy does not match expected lock policy

Validations Summary

┌─────────────┬──────────┐
│ Validation  │ Status   │
├─────────────┼──────────┤
│ Lock status │ ✘ Failed │
├─────────────┼──────────┤
│ Assessment  │ ✔ Passed │
└─────────────┴──────────┘

🛑 Validations failed

Resolution: Resolve the validation errors or skip them by running 'amplify gen2-migration refactor --to xxx --skip-validations'
Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/
```

After:

```cli
amplify gen2-migration refactor --to xxx
```

```console
→ Planning complete
→ Validating complete

Validations Summary

┌─────────────┬──────────┐
│ Validation  │ Status   │
├─────────────┼──────────┤
│ Lock status │ ✔ Passed │
├─────────────┼──────────┤
│ Assessment  │ ✔ Passed │
└─────────────┴──────────┘

You are about to execute 'refactor' on environment 'XXX/main'.

Implications

• Stateful resources (Cognito, S3, DynamoDB, etc...) will be moved from Gen1 to Gen2 CloudFormation stacks
• Your Gen1 app will no longer manage these resources

(You can rollback this command by running: 'amplify gen2-migration refactor --rollback')

? Do you want to continue? (y/N) › 

```
#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Manually tested on a gen1 app

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
