### PR TITLE
test(gen2-migration): e2e codebuild for amplify-migration-apps

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -64,6 +64,18 @@ function generatePkgCli {
   cp ../yarn.lock ./
   yarn workspaces focus --production
 
+  # Workaround for yao-pkg/pkg#195: pkg's snapshot filesystem can't resolve
+  # ESM imports from .mjs files referenced by the "module-sync" export condition.
+  # We strip just the "module-sync" line from each affected package.json so pkg
+  # falls back to the "default" (CJS) condition instead.
+  for esm_pkg in async-function async-generator-function generator-function; do
+    pkg_dir="node_modules/$esm_pkg"
+    if [ -d "$pkg_dir" ]; then
+      sed -i.bak '/"module-sync"/d' "$pkg_dir/package.json" && rm -f "$pkg_dir/package.json.bak"
+      echo "Patched $esm_pkg: removed module-sync export (yao-pkg/pkg#195)"
+    fi
+  done
+
   # Optimize package size
   find . \
     -name "*.d.ts" -or -name "*.js.map" -or -name "*.d.ts.map" -or \

--- a/amplify-migration-apps/backend-only/package.json
+++ b/amplify-migration-apps/backend-only/package.json
@@ -14,7 +14,7 @@
     "test:gen1": "true",
     "test:gen2": "true",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app backend-only --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app backend-only --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app backend-only --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "true",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/discussions/package.json
+++ b/amplify-migration-apps/discussions/package.json
@@ -18,7 +18,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose --testPathIgnorePatterns='shared-data'",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose --testPathIgnorePatterns='shared-data'",
     "test:shared-data": "NODE_OPTIONS='--experimental-vm-modules' jest --verbose tests/shared-data.test.ts",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app discussions --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app discussions --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app discussions --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "true",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/fitness-tracker/package.json
+++ b/amplify-migration-apps/fitness-tracker/package.json
@@ -20,7 +20,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app fitness-tracker --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app fitness-tracker --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app fitness-tracker --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "npx tsx migration/pre-push.ts",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/imported-resources/package.json
+++ b/amplify-migration-apps/imported-resources/package.json
@@ -19,7 +19,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app imported-resources --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app imported-resources --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app imported-resources --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "true",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/media-vault/package.json
+++ b/amplify-migration-apps/media-vault/package.json
@@ -18,7 +18,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app media-vault --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app media-vault --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app media-vault --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "npx tsx migration/pre-push.ts",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/mood-board/package.json
+++ b/amplify-migration-apps/mood-board/package.json
@@ -17,7 +17,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app mood-board --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app mood-board --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app mood-board --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "true",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/product-catalog/package.json
+++ b/amplify-migration-apps/product-catalog/package.json
@@ -18,7 +18,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app product-catalog --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app product-catalog --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app product-catalog --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "npx tsx migration/pre-push.ts",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/project-boards/package.json
+++ b/amplify-migration-apps/project-boards/package.json
@@ -18,7 +18,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app project-boards --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app project-boards --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app project-boards --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "true",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/amplify-migration-apps/store-locator/package.json
+++ b/amplify-migration-apps/store-locator/package.json
@@ -17,7 +17,7 @@
     "test:gen1": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-src/amplifyconfiguration.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:gen2": "APP_CONFIG_PATH=${APP_CONFIG_PATH:-amplify_outputs.json} NODE_OPTIONS='--experimental-vm-modules' jest --verbose",
     "test:shared-data": "true",
-    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app store-locator --profile ${AWS_PROFILE:-default}",
+    "test:e2e": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app store-locator --profile ${AWS_PROFILE:-default} ${TEARDOWN:+--teardown}",
     "deploy": "cd ../../packages/amplify-gen2-migration-e2e-system && npx tsx src/cli.ts --app store-locator --step deploy --profile ${AWS_PROFILE:-default}",
     "pre-push": "npx tsx migration/pre-push.ts",
     "post-generate": "npx tsx migration/post-generate.ts",

--- a/codebuild_specs/gen2_migration_pr_workflow.yml
+++ b/codebuild_specs/gen2_migration_pr_workflow.yml
@@ -1,0 +1,130 @@
+# Gen2 Migration PR Workflow
+#
+# This workflow runs when there is a PR to the gen2-migration branch.
+# It executes the full migration E2E test for each app in amplify-migration-apps.
+#
+# Each migration test takes approximately 30 minutes and runs in parallel.
+# The workflow first builds the CLI binaries, then runs all 9 migration tests concurrently.
+#
+# To trigger this workflow, configure a CodeBuild project with:
+#   - Source: GitHub webhook on PR to gen2-migration branch
+#   - Buildspec: codebuild_specs/gen2_migration_pr_workflow.yml
+#   - Environment variables: TEST_ACCOUNT_ROLE (IAM role ARN for test account)
+#
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_MEDIUM
+  variables:
+    AWS_DEFAULT_REGION: us-east-1
+    AWS_REGION: us-east-1
+    CDK_DEFAULT_REGION: us-east-1
+    CLI_REGION: us-east-1
+    AMPLIFY_DIR: '$CODEBUILD_SRC_DIR/out'
+    AMPLIFY_PATH: '$CODEBUILD_SRC_DIR/out/amplify-pkg-linux-x64'
+
+batch:
+  fast-fail: false
+  build-graph:
+    # Build phase - required for all migration tests
+    - identifier: build_linux
+      buildspec: codebuild_specs/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+
+    - identifier: publish_to_local_registry
+      buildspec: codebuild_specs/publish_to_local_registry.yml
+      depend-on:
+        - build_linux
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+
+    - identifier: build_pkg_binaries_linux
+      buildspec: codebuild_specs/build_pkg_binaries_linux.yml
+      depend-on:
+        - publish_to_local_registry
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+
+    - identifier: upb
+      buildspec: codebuild_specs/upload_pkg_binaries_linux_only.yml
+      depend-on:
+        - build_pkg_binaries_linux
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+
+    # Migration E2E tests - run in parallel after binaries are ready
+    # Each test takes ~30 minutes and deploys real AWS resources
+    - identifier: migrate_backend_only
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: backend-only
+      depend-on:
+        - upb
+
+    - identifier: migrate_discussions
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: discussions
+      depend-on:
+        - upb
+
+    - identifier: migrate_fitness_tracker
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: fitness-tracker
+      depend-on:
+        - upb
+
+    # TODO: migrate_imported_resources is excluded - not ready for CI yet
+
+    - identifier: migrate_media_vault
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: media-vault
+      depend-on:
+        - upb
+
+    - identifier: migrate_mood_board
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: mood-board
+      depend-on:
+        - upb
+
+    - identifier: migrate_product_catalog
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: product-catalog
+      depend-on:
+        - upb
+
+    - identifier: migrate_project_boards
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: project-boards
+      depend-on:
+        - upb
+
+    - identifier: migrate_store_locator
+      buildspec: codebuild_specs/run_gen2_migration_e2e.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          MIGRATION_APP: store-locator
+      depend-on:
+        - upb

--- a/codebuild_specs/gen2_migration_pr_workflow.yml
+++ b/codebuild_specs/gen2_migration_pr_workflow.yml
@@ -1,13 +1,11 @@
 # Gen2 Migration PR Workflow
 #
-# This workflow runs when there is a PR to the gen2-migration branch.
-# It executes the full migration E2E test for each app in amplify-migration-apps.
+# This workflow executes the full migration E2E test for apps in amplify-migration-apps.
 #
 # Each migration test takes approximately 30 minutes and runs in parallel.
-# The workflow first builds the CLI binaries, then runs all 9 migration tests concurrently.
+# The workflow first builds the CLI binaries, then runs migration tests concurrently.
 #
 # To trigger this workflow, configure a CodeBuild project with:
-#   - Source: GitHub webhook on PR to gen2-migration branch
 #   - Buildspec: codebuild_specs/gen2_migration_pr_workflow.yml
 #   - Environment variables: TEST_ACCOUNT_ROLE (IAM role ARN for test account)
 #

--- a/codebuild_specs/run_gen2_migration_e2e.yml
+++ b/codebuild_specs/run_gen2_migration_e2e.yml
@@ -1,0 +1,25 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    CI: true
+    IS_AMPLIFY_CI: true
+    TEARDOWN: "1"
+
+phases:
+  build:
+    commands:
+      - export NODE_OPTIONS=--max-old-space-size=4096
+      - export AMPLIFY_DIR=$CODEBUILD_SRC_DIR/out
+      - export AMPLIFY_PATH=$CODEBUILD_SRC_DIR/out/amplify-pkg-linux-x64
+      - echo "AMPLIFY_DIR=$AMPLIFY_DIR"
+      - echo "AMPLIFY_PATH=$AMPLIFY_PATH"
+      - echo "MIGRATION_APP=$MIGRATION_APP"
+      - source ./shared-scripts.sh && _runGen2MigrationE2E
+
+  post_build:
+    commands:
+      - echo "Migration E2E test completed for $MIGRATION_APP"
+
+# 45 minute timeout to accommodate ~30 min migration + buffer
+# This is set at the CodeBuild project level, but documented here for reference

--- a/codebuild_specs/upload_pkg_binaries_linux_only.yml
+++ b/codebuild_specs/upload_pkg_binaries_linux_only.yml
@@ -1,0 +1,11 @@
+version: 0.2
+env:
+  shell: bash
+phases:
+  build:
+    commands:
+      - source ./shared-scripts.sh && _uploadPkgBinariesLinuxOnly
+
+artifacts:
+  files:
+    - 'shared-scripts.sh'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cloud-e2e-beta": "bash -c 'source ./scripts/cloud-e2e.sh && cloudE2EBeta'",
     "cloud-e2e-local": "bash -c 'source ./scripts/cloud-e2e.sh && cloudE2ELocal'",
     "cloud-e2e": "bash -c 'source ./scripts/cloud-e2e.sh && cloudE2E'",
+    "cloud-gen2-migration": "bash -c 'source ./scripts/cloud-gen2-migration.sh && cloudGen2Migration'",
     "cloud-pr": "./scripts/cloud-pr.sh",
     "commit": "git-cz",
     "coverage:collect": "ts-node ./scripts/collect-test-coverage.ts",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -65,7 +65,6 @@
     "@aws-amplify/amplify-util-import": "2.8.6",
     "@aws-amplify/amplify-util-mock": "5.10.26",
     "@aws-amplify/amplify-util-uibuilder": "1.14.25",
-    "@aws-amplify/backend-data": "^1.6.2",
     "@aws-amplify/plugin-types": "^1.11.1",
     "@aws-cdk/cloudformation-diff": "~2.68.0",
     "@aws-sdk/client-amplify": "^3.919.0",

--- a/packages/amplify-gen2-migration-e2e-system/src/cli.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/cli.ts
@@ -33,6 +33,11 @@ async function main(): Promise<void> {
       choices: ['deploy', 'migrate'],
       string: true,
     })
+    .option('teardown', {
+      type: 'boolean',
+      description: 'Delete all deployed resources after execution',
+      default: false,
+    })
     .help()
     .alias('help', 'h')
     .version()
@@ -70,6 +75,10 @@ async function main(): Promise<void> {
   } catch (error) {
     (error as Error).message = `Execution failed: ${chalk.red((error as Error).message)} (${app.targetAppPath})`;
     throw error;
+  } finally {
+    if (argv.teardown) {
+      await app.teardown();
+    }
   }
 }
 

--- a/packages/amplify-gen2-migration-e2e-system/src/core/app.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/core/app.ts
@@ -7,8 +7,15 @@ import { Logger, LogLevel } from './logger';
 import { Git } from './git';
 import * as snapshot from './snapshot';
 import { sanitize } from './sanitize';
-import { CloudFormationClient, paginateListStacks, StackStatus } from '@aws-sdk/client-cloudformation';
 import { normalize } from './normalize';
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  paginateListStacks,
+  StackStatus,
+  waitUntilStackDeleteComplete,
+} from '@aws-sdk/client-cloudformation';
+import { AmplifyClient, ListAppsCommand, DeleteAppCommand } from '@aws-sdk/client-amplify';
 
 const MIGRATION_TARGET_DIR = path.join(os.tmpdir(), 'amplify-gen2-migration-e2e-system', 'output-apps');
 const MIGRATION_SNAPSHOT_DIR = path.join(os.tmpdir(), 'amplify-gen2-migration-e2e-system', 'snapshots');
@@ -437,6 +444,107 @@ export class App {
         filter: (src: string, _dst: string) => !src.includes('node_modules'),
       });
     }
+  }
+
+  // ============================================================
+  // Teardown
+  // ============================================================
+
+  /**
+   * Delete all deployed resources (Gen1 backend + Gen2 sandbox + holding stacks).
+   * Runs in a best-effort manner — logs errors but does not throw.
+   */
+  public async teardown(): Promise<void> {
+    this.logger.info('Starting teardown...');
+
+    // Delete Gen2 sandbox stack
+    try {
+      this.logger.info('Deleting Gen2 sandbox...');
+      await this.git.checkout(this.gen2BranchName, false);
+      const sandboxResult = await execa('npx', ['ampx', 'sandbox', 'delete', '--yes'], {
+        cwd: this.targetAppPath,
+        reject: false,
+        stdio: 'inherit',
+        env: { ...process.env, AWS_BRANCH: this.gen2BranchName },
+      });
+      if (sandboxResult.exitCode !== 0) {
+        this.logger.info(`ampx sandbox delete exited with code ${sandboxResult.exitCode} (continuing teardown)`);
+      } else {
+        this.logger.info('Gen2 sandbox deleted');
+      }
+    } catch (e) {
+      this.logger.info(`Gen2 sandbox delete failed: ${(e as Error).message} (continuing teardown)`);
+    }
+
+    // Delete holding stacks created during refactor
+    try {
+      this.logger.info('Deleting holding stacks...');
+      const cfnClient = new CloudFormationClient({});
+      for await (const page of paginateListStacks(
+        { client: cfnClient },
+        { StackStatusFilter: [StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE, StackStatus.REVIEW_IN_PROGRESS] },
+      )) {
+        for (const stack of page.StackSummaries ?? []) {
+          if (stack.StackName?.includes(this.deploymentName) && stack.StackName.endsWith('-holding')) {
+            this.logger.info(`Deleting holding stack: ${stack.StackName}`);
+            await cfnClient.send(new DeleteStackCommand({ StackName: stack.StackName }));
+          }
+        }
+      }
+    } catch (e) {
+      this.logger.info(`Holding stack cleanup failed: ${(e as Error).message} (continuing teardown)`);
+    }
+
+    // Delete Gen1 CFN stacks directly (amplify delete doesn't work after migration mutates the workspace)
+    try {
+      this.logger.info('Deleting Gen1 CloudFormation stacks...');
+      const cfnClient = new CloudFormationClient({});
+      const stackPrefix = `amplify-${this.deploymentName}-`;
+      for await (const page of paginateListStacks(
+        { client: cfnClient },
+        {
+          StackStatusFilter: [
+            StackStatus.CREATE_COMPLETE,
+            StackStatus.UPDATE_COMPLETE,
+            StackStatus.UPDATE_ROLLBACK_COMPLETE,
+            StackStatus.ROLLBACK_COMPLETE,
+            StackStatus.DELETE_FAILED,
+          ],
+        },
+      )) {
+        for (const stack of page.StackSummaries ?? []) {
+          if (stack.StackName?.startsWith(stackPrefix) && !stack.RootId) {
+            this.logger.info(`Deleting stack: ${stack.StackName}`);
+            await cfnClient.send(new DeleteStackCommand({ StackName: stack.StackName }));
+            try {
+              await waitUntilStackDeleteComplete({ client: cfnClient, maxWaitTime: 300 }, { StackName: stack.StackName });
+            } catch {
+              this.logger.info(`Stack ${stack.StackName} delete did not complete within timeout (continuing teardown)`);
+            }
+          }
+        }
+      }
+    } catch (e) {
+      this.logger.info(`Gen1 stack cleanup failed: ${(e as Error).message} (continuing teardown)`);
+    }
+
+    // Delete the Amplify console app
+    try {
+      this.logger.info('Deleting Amplify console app...');
+      const amplifyClient = new AmplifyClient({});
+      const apps = await amplifyClient.send(new ListAppsCommand({ maxResults: 25 }));
+      const app = apps.apps?.find((a) => a.name === this.deploymentName);
+      if (app?.appId) {
+        await amplifyClient.send(new DeleteAppCommand({ appId: app.appId }));
+        this.logger.info(`Deleted Amplify app: ${this.deploymentName} (${app.appId})`);
+      } else {
+        this.logger.info(`Amplify app ${this.deploymentName} not found (may already be deleted)`);
+      }
+    } catch (e) {
+      this.logger.info(`Amplify app cleanup failed: ${(e as Error).message} (continuing teardown)`);
+    }
+
+    this.logger.info('Teardown complete');
   }
 
   // ============================================================

--- a/packages/amplify-gen2-migration-e2e-system/src/core/git.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/core/git.ts
@@ -16,7 +16,7 @@ export class Git {
   }
 
   public async init(): Promise<void> {
-    await this.run('init');
+    await this.run('init', '--initial-branch=main');
   }
 
   public async diff(): Promise<void> {

--- a/scripts/cloud-gen2-migration.sh
+++ b/scripts/cloud-gen2-migration.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+# Trigger Gen2 Migration E2E tests using the existing AmplifyCLI-E2E-Testing project
+# with a buildspec override to run only the migration tests.
+#
+# Usage:
+#   source ./scripts/cloud-gen2-migration.sh && cloudGen2Migration
+
+source ./scripts/cloud-cli-utils.sh
+export CURR_BRANCH=$(git branch --show-current)
+export E2E_ROLE_NAME=CodeBuildE2E
+export E2E_PROFILE_NAME=AmplifyCLIE2E
+export E2E_PROJECT_NAME=AmplifyCLI-E2E-Testing
+
+function cloudGen2Migration {
+    echo "Running Gen2 Migration E2E Tests on branch: $CURR_BRANCH"
+    
+    account_number=$E2E_ACCOUNT_PROD
+    role_name=$E2E_ROLE_NAME
+    profile_name="${E2E_PROFILE_NAME}Prod"
+    
+    authenticate $account_number $role_name $profile_name
+    
+    echo "AWS Account: $account_number"
+    echo "Project: $E2E_PROJECT_NAME"
+    echo "Buildspec: codebuild_specs/gen2_migration_pr_workflow.yml"
+    
+    RESULT=$(aws codebuild start-build-batch \
+      --profile="${profile_name}" \
+      --project-name $E2E_PROJECT_NAME \
+      --source-version=$CURR_BRANCH \
+      --buildspec-override "codebuild_specs/gen2_migration_pr_workflow.yml" \
+      --environment-variables-override name=BRANCH_NAME,value=$CURR_BRANCH,type=PLAINTEXT \
+      --query 'buildBatch.id' --output text)
+    
+    echo ""
+    echo "Build started! View at:"
+    echo "https://us-east-1.console.aws.amazon.com/codesuite/codebuild/$account_number/projects/$E2E_PROJECT_NAME/batch/$RESULT?region=us-east-1"
+}

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -263,6 +263,19 @@ function _uploadPkgBinaries {
 
     storeCache $CODEBUILD_SRC_DIR/out all-binaries
 }
+
+# Upload only linux binaries - used by gen2 migration workflow which only needs linux
+function _uploadPkgBinariesLinuxOnly {
+    echo Consolidate linux binaries cache and upload
+
+    loadCache repo $CODEBUILD_SRC_DIR
+    loadCache repo-out-linux $CODEBUILD_SRC_DIR/out
+
+    echo Done loading linux binaries
+    ls $CODEBUILD_SRC_DIR/out
+
+    storeCache $CODEBUILD_SRC_DIR/out all-binaries
+}
 function _buildBinaries {
     echo Start verdaccio and package CLI
     binaryType="$1"
@@ -791,4 +804,67 @@ function _deploymentVerificationRCOrTagged {
     echo Verify Tagged or RC Deployment
     version=$(cat .amplify-pkg-version)
     yarn ts-node scripts/verify-deployment.ts --version $version --exclude-github
+}
+
+function _runGen2MigrationE2E {
+    echo "Running Gen2 Migration E2E test for app: $MIGRATION_APP"
+
+    # Load cached artifacts
+    _loadE2ECache
+    _install_packaged_cli_linux
+
+    # Verify CLI installation
+    which amplify
+    amplify version
+
+    # Start local registry for npm packages
+    source .circleci/local_publish_helpers_codebuild.sh && startLocalRegistry "$CODEBUILD_SRC_DIR/.circleci/verdaccio.yaml"
+    setNpmRegistryUrlToLocal
+    changeNpmGlobalPath
+
+    # Load test account credentials
+    _loadTestAccountCredentials
+
+    # Configure AWS profile for the migration CLI
+    # The migration CLI requires a named profile, so we create one with the assumed role credentials
+    mkdir -p ~/.aws
+    cat > ~/.aws/credentials << EOF
+[amplify-migration-test]
+aws_access_key_id = $AWS_ACCESS_KEY_ID
+aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+aws_session_token = $AWS_SESSION_TOKEN
+EOF
+
+    cat > ~/.aws/config << EOF
+[profile amplify-migration-test]
+region = ${CLI_REGION:-us-east-1}
+output = json
+EOF
+
+    export AWS_PROFILE=amplify-migration-test
+
+    # Unset credential env vars to avoid conflicts with AWS_PROFILE
+    # The credentials are now stored in ~/.aws/credentials
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_SESSION_TOKEN
+
+    # Bootstrap CDK if not already done (required for ampx sandbox)
+    # This is idempotent - safe to run even if already bootstrapped
+    echo "Bootstrapping CDK for region ${CLI_REGION:-us-east-1}..."
+    npx cdk bootstrap aws://$(aws sts get-caller-identity --query Account --output text)/${CLI_REGION:-us-east-1} || echo "Bootstrap may already exist or failed, continuing..."
+
+    # Configure git identity for commits during migration
+    git config --global user.email "amplify-cli-e2e@test.com"
+    git config --global user.name "Amplify CLI E2E Test Name"
+
+    # Navigate to the migration app directory
+    cd $CODEBUILD_SRC_DIR/amplify-migration-apps/$MIGRATION_APP
+
+    # Run the e2e migration test
+    # The test:e2e script runs the migration CLI which handles the full workflow
+    echo "Starting migration E2E test for $MIGRATION_APP"
+    npm run test:e2e
+
+    echo "Migration E2E test completed for $MIGRATION_APP"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,7 +2073,6 @@ __metadata:
     "@aws-amplify/amplify-util-import": 2.8.6
     "@aws-amplify/amplify-util-mock": 5.10.26
     "@aws-amplify/amplify-util-uibuilder": 1.14.25
-    "@aws-amplify/backend-data": ^1.6.2
     "@aws-amplify/plugin-types": ^1.11.1
     "@aws-cdk/cloudformation-diff": ~2.68.0
     "@aws-sdk/client-amplify": ^3.919.0


### PR DESCRIPTION
## Description of changes

### CodeBuild Infrastructure

Added the complete CodeBuild pipeline for running Gen2 migration E2E tests:

- `gen2_migration_pr_workflow.yml` — batch workflow that builds the CLI, publishes to Verdaccio, builds the linux pkg binary, then runs all migration apps in parallel
- `run_gen2_migration_e2e.yml` — per-app buildspec that loads the cached binary and runs a single migration test
- `upload_pkg_binaries_linux_only.yml` — uploads only the linux binary (the migration workflow doesn't need macOS/Windows)
- `cloud-gen2-migration.sh` — CI entry points for triggering the workflow
- `_runGen2MigrationE2E` in `shared-scripts.sh` — configures AWS credentials via a named profile, unsets credential env vars to avoid SDK conflicts, bootstraps CDK, configures git identity, and runs the migration test
- `_uploadPkgBinariesLinuxOnly` in `shared-scripts.sh` — caches only the linux binary to S3

### Git Init Fix

Changed `git init` to `git init --initial-branch=main` in `git.ts` so the default branch is always `main`. This fixes checkout failures in CodeBuild where the default branch name is `master`.

### Resource Teardown

Added a `--teardown` CLI option that cleans up all deployed resources after test execution:

- Deletes the Gen2 sandbox via `ampx sandbox delete --yes`
- Finds and deletes holding stacks (CFN stacks with `-holding` suffix created during refactor)
- Deletes Gen1 root CFN stacks matching the deployment name prefix via the CloudFormation SDK
- Deletes the Amplify console app via the Amplify SDK

This uses direct SDK calls instead of `amplify delete` because the migration mutates the workspace and breaks `amplify delete`. The teardown runs in a `finally` block so it executes whether the test passes or fails. All migration app `package.json` files pass `${TEARDOWN:+--teardown}`, and the buildspec sets `TEARDOWN=1`.

### Binary Packaging Fix ([yao-pkg/pkg#195](https://github.com/yao-pkg/pkg/issues/195))

A `yarn.lock` drift bumped `get-intrinsic` from `1.3.0` to `1.3.1`, which added `async-function`, `async-generator-function`, and `generator-function` as new dependencies. These packages ship with a `"module-sync"` export condition that points to `.mjs` entry points. Inside `pkg`'s snapshot filesystem, the ESM module resolution triggered by `module-sync` fails with `ERR_MODULE_NOT_FOUND`.

The fix patches the affected packages during `generatePkgCli` by stripping the `"module-sync"` line from their `package.json` via `sed`. Node then falls through to the `"default"` condition which points to a CJS file that `pkg` handles correctly.

#### Description of how you validated changes

CodeBuild runs in an account dedicated to E2E workflow runs. Uses existing CodeBuild job AmplifyCLI-E2E-Testing.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
