### PR TITLE
fix(gen2-migration): sync `product-catalog` post-generate API ID with pre-generate snapshot

### DIFF
--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/backend.ts
@@ -54,7 +54,7 @@ backend.auth.resources.authenticatedUserIamRole.addToPrincipalPolicy(
     effect: aws_iam.Effect.ALLOW,
     actions: ['appsync:GraphQL'],
     resources: [
-      `arn:aws:appsync:${backend.data.stack.region}:${backend.data.stack.account}:apis/3oy6oxkj6ffojmc2upd52ftdsq/*`,
+      `arn:aws:appsync:${backend.data.stack.region}:${backend.data.stack.account}:apis/hscmwhprkbaljmcpavj3dcztrq/*`,
     ],
   })
 );


### PR DESCRIPTION
the product-catalog post-generate snapshot had a stale AppSync API ID (that diverged from the pre-generate snapshot after #14782 and #14778 merged in sequence.)

This PR updates the hardcoded API ID in `_snapshot.post.generate/amplify/backend.ts` to match the one in `_snapshot.pre.generate/amplify/backend/amplify-meta.json`, which the codegen reads at runtime to produce the IAM auth grant ARN fixing the product-catalog snapshot test failure in `generate.test.ts`.