### PR TITLE
feat(gen2-migration): add decommission step to e2e test flow

### DIFF
--- a/packages/amplify-gen2-migration-e2e-system/src/core/app.ts
+++ b/packages/amplify-gen2-migration-e2e-system/src/core/app.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { getCLIPath, initJSProjectWithProfile } from '@aws-amplify/amplify-e2e-core';
+import { getCLIPath, initJSProjectWithProfile, amplifyPullNonInteractive } from '@aws-amplify/amplify-e2e-core';
 import { Logger, LogLevel } from './logger';
 import { Git } from './git';
 import * as snapshot from './snapshot';
@@ -276,6 +276,11 @@ export class App {
     await this.testGen2();
 
     await this.testSharedData();
+
+    await this.git.checkout(this.gen1BranchName, false);
+    await amplifyPullNonInteractive(this.targetAppPath, { appId: this.getAmplifyAppId(), envName: this.envName });
+    await this.decommission();
+    await this.testGen2();
   }
 
   /**
@@ -299,6 +304,13 @@ export class App {
   public async generate(): Promise<void> {
     await this.runMigrationStep('generate');
     this.removeGitignoreLine('amplify_outputs*');
+  }
+
+  /**
+   * Run `amplify gen2-migration decommission` to tear down the Gen1 environment.
+   */
+  public async decommission(): Promise<void> {
+    await this.runMigrationStep('decommission');
   }
 
   /**
@@ -458,6 +470,16 @@ export class App {
     const configPath = path.join(this.targetAppPath, 'migration', 'config.json');
     if (!fs.existsSync(configPath)) return {};
     return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as MigrationConfig;
+  }
+
+  private getAmplifyAppId(): string {
+    const tpiPath = path.join(this.targetAppPath, 'amplify', 'team-provider-info.json');
+    const tpi = JSON.parse(fs.readFileSync(tpiPath, 'utf-8')) as Record<string, Record<string, Record<string, string>>>;
+    const appId = tpi[this.envName]?.awscloudformation?.AmplifyAppId;
+    if (!appId) {
+      throw new Error(`AmplifyAppId not found in team-provider-info.json for env ${this.envName}`);
+    }
+    return appId;
   }
 
   private async runAmplify(args: string[], options?: { stdio?: 'inherit' }): Promise<void> {


### PR DESCRIPTION
### Description of changes

Wire `gen2-migration decommission` into the E2E migration flow so every run exercises the full lifecycle including Gen1 teardown.

### Issue #, if available

#14790 

### Description of how you validated changes
### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Pull request labels are added

---

By submitting this pull request, I confirm that my contribution is
made under the terms of the Apache 2.0 license.
