### PR TITLE
chore(gen2-migration): turn on strict mode, and associated fixes

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/auth/auth-user-pool-groups-forward.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/auth/auth-user-pool-groups-forward.test.ts
@@ -39,8 +39,8 @@ describe('AuthUserPoolGroupsForwardRefactorer.buildResourceMappings — GroupNam
       new Map([['amplifyAuthAdminGroup1234', r('AWS::Cognito::UserPoolGroup', { GroupName: 'Admin' })]]),
     );
     expect(mappings).toHaveLength(1);
-    expect(mappings[0].Source.LogicalResourceId).toBe('AdminGroup');
-    expect(mappings[0].Destination.LogicalResourceId).toBe('amplifyAuthAdminGroup1234');
+    expect(mappings[0].Source!.LogicalResourceId).toBe('AdminGroup');
+    expect(mappings[0].Destination!.LogicalResourceId).toBe('amplifyAuthAdminGroup1234');
   });
 
   it('does not match groups with different GroupName', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/resolvers/cfn-output-resolver.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor/resolvers/cfn-output-resolver.test.ts
@@ -90,8 +90,8 @@ describe('resolveOutputs', () => {
       region: 'us-east-1',
       accountId: '123456789',
     });
-    expect(result.Outputs.UserPoolIdOutput.Value).toBe('us-east-1_ABC');
-    expect(result.Outputs.UserPoolArnOutput.Value).toBe('arn:aws:cognito-idp:us-east-1:123:userpool/ABC');
+    expect(result.Outputs!.UserPoolIdOutput.Value).toBe('us-east-1_ABC');
+    expect(result.Outputs!.UserPoolArnOutput.Value).toBe('arn:aws:cognito-idp:us-east-1:123:userpool/ABC');
   });
 
   it('throws when Kinesis stream physical ID is not an ARN', () => {

--- a/packages/amplify-cli/src/commands/drift-detection/services/cloudformation-service.ts
+++ b/packages/amplify-cli/src/commands/drift-detection/services/cloudformation-service.ts
@@ -86,7 +86,7 @@ export class CloudFormationService {
 
       try {
         // Download the latest backend state from S3
-        currentCloudBackendZip = await downloadZip(s3, tempDir, S3BackendZipFileName, '');
+        currentCloudBackendZip = await downloadZip(s3, tempDir, S3BackendZipFileName, context.amplify.getEnvInfo().envName);
       } catch (err: any) {
         if (err?.name === 'NoSuchBucket') {
           // Environment not deployed yet, nothing to sync

--- a/packages/amplify-cli/src/commands/drift-detection/services/cloudformation-service.ts
+++ b/packages/amplify-cli/src/commands/drift-detection/services/cloudformation-service.ts
@@ -86,7 +86,7 @@ export class CloudFormationService {
 
       try {
         // Download the latest backend state from S3
-        currentCloudBackendZip = await downloadZip(s3, tempDir, S3BackendZipFileName, undefined);
+        currentCloudBackendZip = await downloadZip(s3, tempDir, S3BackendZipFileName, '');
       } catch (err: any) {
         if (err?.name === 'NoSuchBucket') {
           // Environment not deployed yet, nothing to sync

--- a/packages/amplify-cli/src/commands/drift-detection/services/drift-formatter.ts
+++ b/packages/amplify-cli/src/commands/drift-detection/services/drift-formatter.ts
@@ -125,12 +125,12 @@ function collectDriftBlocks(phase1: CloudFormationDriftResults, phase2: Template
         if (change.ResourceType === 'AWS::CloudFormation::Stack' && change.nestedChanges && change.nestedChanges.length > 0) {
           flattenChanges(
             change.nestedChanges,
-            extractCategory(change.LogicalResourceId),
+            extractCategory(change.LogicalResourceId!),
             change.ChangeSetId || fallbackChangeSetId,
             change.PhysicalResourceId || parentStackArn,
           );
         } else {
-          const resourceCategory = extractCategory(change.LogicalResourceId);
+          const resourceCategory = extractCategory(change.LogicalResourceId!);
           blocks.push({
             categoryName: resourceCategory !== 'Other' ? resourceCategory : fallbackCategory,
             logicalId: change.LogicalResourceId || 'Unknown',

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/aws-clients.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/aws-clients.ts
@@ -3,7 +3,7 @@ import { AppSyncClient } from '@aws-sdk/client-appsync';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
-import { S3Client } from '@aws-sdk/client-s3';
+import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { CloudWatchEventsClient } from '@aws-sdk/client-cloudwatch-events';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -16,7 +16,7 @@ import type { AmplifyClientConfig } from '@aws-sdk/client-amplify';
 import { ProxyAgent } from 'proxy-agent';
 
 export const proxyAgent = () => {
-  let httpAgent = undefined;
+  let httpAgent;
   const httpProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
   if (httpProxy) {
     httpAgent = new ProxyAgent();
@@ -52,7 +52,7 @@ export class AwsClients {
     this.cloudFormation = new CloudFormationClient(config);
     this.cognitoIdentityProvider = new CognitoIdentityProviderClient(config);
     this.cognitoIdentity = new CognitoIdentityClient(config);
-    this.s3 = new S3Client(config);
+    this.s3 = new S3Client(config as S3ClientConfig);
     this.lambda = new LambdaClient(config);
     this.cloudWatchEvents = new CloudWatchEventsClient(config);
     this.dynamoDB = new DynamoDBClient(config);

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
@@ -29,7 +29,7 @@ export class AmplifyGen2MigrationValidations {
     const result = await new AmplifyDriftDetector(this.context, this.logger).detect();
     if (result.code !== 0) {
       throw new AmplifyError('MigrationError', {
-        message: result.report!.trim() ?? 'Drift detected',
+        message: result.report?.trim() ?? 'Drift detected',
         resolution: 'Inspect the drift report above and resolve the drift',
       });
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
@@ -29,7 +29,7 @@ export class AmplifyGen2MigrationValidations {
     const result = await new AmplifyDriftDetector(this.context, this.logger).detect();
     if (result.code !== 0) {
       throw new AmplifyError('MigrationError', {
-        message: result.report.trim() ?? 'Drift detected',
+        message: result.report!.trim() ?? 'Drift detected',
         resolution: 'Inspect the drift report above and resolve the drift',
       });
     }
@@ -63,7 +63,7 @@ export class AmplifyGen2MigrationValidations {
     // added in the edge case of resuming migration from a failed state
     const validStatuses = ['UPDATE_COMPLETE', 'CREATE_COMPLETE', 'UPDATE_ROLLBACK_COMPLETE'];
 
-    if (!validStatuses.includes(stackStatus)) {
+    if (!validStatuses.includes(stackStatus!)) {
       throw new AmplifyError('StackStateError', {
         message: `Root stack status is ${stackStatus}, expected UPDATE_COMPLETE or CREATE_COMPLETE`,
         resolution: 'Complete the deployment before proceeding.',
@@ -200,8 +200,8 @@ export class AmplifyGen2MigrationValidations {
         } else if (resource.ResourceType && STATEFUL_RESOURCES.has(resource.ResourceType)) {
           if (resource.ResourceType === 'AWS::DynamoDB::Table') {
             const templateResponse = await this.gen1App.clients.cloudFormation.send(new GetTemplateCommand({ StackName: stackName }));
-            const template = JSON.parse(templateResponse.TemplateBody);
-            if (template.Resources[resource.LogicalResourceId].DeletionPolicy === 'Retain') {
+            const template = JSON.parse(templateResponse.TemplateBody!);
+            if (template.Resources[resource.LogicalResourceId!].DeletionPolicy === 'Retain') {
               continue;
             }
           }

--- a/packages/amplify-cli/src/commands/gen2-migration/decommission.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/decommission.ts
@@ -128,7 +128,7 @@ export class AmplifyMigrationDecommissionStep extends AmplifyMigrationStep {
       { StackName: this.gen1App.rootStackName, ChangeSetName: changeSetName },
     );
 
-    const allChanges = [];
+    const allChanges: NonNullable<DescribeChangeSetOutput['Changes']> = [];
     let nextToken: string | undefined;
     let changeSet!: DescribeChangeSetOutput;
     do {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/_infra/gen1-app.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/_infra/gen1-app.ts
@@ -84,8 +84,8 @@ export class Gen1App {
   private readonly _meta: $TSMeta;
 
   private constructor(props: Gen1AppProps) {
-    this.appId = props.app.appId;
-    this.appName = props.app.name;
+    this.appId = props.app.appId!;
+    this.appName = props.app.name!;
     this.envName = props.envName;
     this.clients = props.clients;
     this.ccbDir = props.ccbDir;
@@ -111,7 +111,7 @@ export class Gen1App {
     const appId = (Object.values(tpi)[0] as $TSAny).awscloudformation.AmplifyAppId;
     const app = await clients.amplify.send(new GetAppCommand({ appId }));
 
-    const envName = await Gen1App.currentEnvName(app.app);
+    const envName = await Gen1App.currentEnvName(app.app!);
     const envInfo = tpi[envName];
     if (!envInfo) {
       throw new AmplifyError('MigrationError', {
@@ -128,7 +128,7 @@ export class Gen1App {
     }
 
     const ccbDir = await Gen1App.downloadCloudBackend(clients.s3, cfnProvider.DeploymentBucketName);
-    return new Gen1App({ ccbDir, clients, envName, app: app.app });
+    return new Gen1App({ ccbDir, clients, envName, app: app.app! });
   }
 
   /**

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -798,7 +798,7 @@ export class AuthRenderer {
       | undefined,
   ): PropertyAssignment {
     const userAttributeIdentifier = factory.createIdentifier('userAttributes');
-    const userAttributeProperties = [];
+    const userAttributeProperties: PropertyAssignment[] = [];
 
     if (standardAttributes !== undefined) {
       const standardAttributeProperties = Object.entries(standardAttributes).map(([key, value]) => {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
@@ -51,7 +51,7 @@ export class AmplifyHelperTransformer {
 
     const transformer = <T extends ts.Node>(context: ts.TransformationContext) => {
       return (node: T) => {
-        function visit(node: ts.Node): ts.Node {
+        function visit(node: ts.Node): ts.Node | undefined {
           // Remove import statements for amplify-dependent-resources-ref and cli-extensibility-helper
           if (ts.isImportDeclaration(node)) {
             const moduleSpecifier = node.moduleSpecifier;
@@ -340,7 +340,7 @@ export class AmplifyHelperTransformer {
 
           return visitedNode;
         }
-        return ts.visitNode(node, visit);
+        return ts.visitNode(node, visit) as T;
       };
     };
 
@@ -396,11 +396,11 @@ export class AmplifyHelperTransformer {
         )
       : undefined;
 
-    const newStatements = [];
-    newStatements.push(...sourceFile.statements.filter((stmt) => ts.isImportDeclaration(stmt)));
+    const newStatements: ts.Statement[] = [];
+    newStatements.push(...sourceFile.statements.filter((statement) => ts.isImportDeclaration(statement)));
     if (!hasBranchName) newStatements.push(branchNameDeclaration);
     if (!hasProjectName && projectNameDeclaration) newStatements.push(projectNameDeclaration);
-    newStatements.push(...sourceFile.statements.filter((stmt) => !ts.isImportDeclaration(stmt)));
+    newStatements.push(...sourceFile.statements.filter((statement) => !ts.isImportDeclaration(statement)));
 
     return ts.factory.updateSourceFile(sourceFile, newStatements);
   }

--- a/packages/amplify-cli/src/commands/gen2-migration/lock.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/lock.ts
@@ -111,7 +111,7 @@ function hasRealDrift(changes: ResourceChangeWithNested[]): boolean {
 }
 
 export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
-  private _dynamoTableNames: string[];
+  private _dynamoTableNames: string[] | undefined;
 
   public async forward(): Promise<Plan> {
     const operations: AmplifyMigrationOperation[] = [];
@@ -151,7 +151,7 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
       describe: async () => [`Add environment variable '${GEN2_MIGRATION_ENVIRONMENT_NAME}' (value: ${this.gen1App.envName})`],
       execute: async () => {
         const app = await this.gen1App.clients.amplify.send(new GetAppCommand({ appId: this.gen1App.appId }));
-        const environmentVariables = { ...(app.app.environmentVariables ?? {}), [GEN2_MIGRATION_ENVIRONMENT_NAME]: this.gen1App.envName };
+        const environmentVariables = { ...(app.app!.environmentVariables ?? {}), [GEN2_MIGRATION_ENVIRONMENT_NAME]: this.gen1App.envName };
         await this.gen1App.clients.amplify.send(new UpdateAppCommand({ appId: this.gen1App.appId, environmentVariables }));
         this.logger.info(`Added '${GEN2_MIGRATION_ENVIRONMENT_NAME}' environment variable (value: ${this.gen1App.envName})`);
       },
@@ -232,7 +232,7 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
       describe: async () => [`Remove environment variable '${GEN2_MIGRATION_ENVIRONMENT_NAME}'`],
       execute: async () => {
         const app = await this.gen1App.clients.amplify.send(new GetAppCommand({ appId: this.gen1App.appId }));
-        const environmentVariables = app.app.environmentVariables ?? {};
+        const environmentVariables = app.app!.environmentVariables ?? {};
         delete environmentVariables[GEN2_MIGRATION_ENVIRONMENT_NAME];
         await this.gen1App.clients.amplify.send(new UpdateAppCommand({ appId: this.gen1App.appId, environmentVariables }));
         this.logger.info(`Removed ${GEN2_MIGRATION_ENVIRONMENT_NAME} environment variable`);
@@ -342,7 +342,7 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
   }
 
   private async fetchGraphQLModelTables(graphQLApiId: string): Promise<string[]> {
-    const tables = [];
+    const tables: string[] = [];
     for await (const page of paginateListTables({ client: this.gen1App.clients.dynamoDB }, {})) {
       for (const tableName of page.TableNames ?? []) {
         if (tableName.includes(`-${graphQLApiId}-${this.gen1App.envName}`)) {
@@ -488,7 +488,8 @@ export class AmplifyMigrationLockStep extends AmplifyMigrationStep {
         return `${rc.Action ?? 'Unknown'} ${rc.ResourceType ?? 'Unknown'} (${rc.LogicalResourceId ?? 'Unknown'})`;
       });
 
-      void this.gen1App.clients.cloudFormation.send(new DeleteChangeSetCommand({ StackName: stackId, ChangeSetName: changeSetName }))
+      void this.gen1App.clients.cloudFormation
+        .send(new DeleteChangeSetCommand({ StackName: stackId, ChangeSetName: changeSetName }))
         .catch((e: any) => this.logger.debug(`Failed to clean up changeset ${changeSetName}: ${e.message}`));
 
       throw new AmplifyError('MigrationError', {

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor/cfn.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor/cfn.ts
@@ -99,7 +99,7 @@ export class Cfn {
         StackName: stackName,
         Capabilities: [CFN_IAM_CAPABILITY],
       };
-      writeUpdateSnapshot({ stackName, templateBody: input.TemplateBody, parameters });
+      writeUpdateSnapshot({ stackName, templateBody: input.TemplateBody!, parameters });
       this.info(`Updating stack: ${extractStackNameFromId(stackName)}`, resource);
       await this.client.send(new UpdateStackCommand(input));
     } catch (e) {
@@ -117,8 +117,8 @@ export class Cfn {
    * Throws on failure.
    */
   public async refactor(resourceMappings: ResourceMapping[], resource?: DiscoveredResource): Promise<void> {
-    const sourceStackId = resourceMappings[0].Source.StackName;
-    const targetStackId = resourceMappings[0].Destination.StackName;
+    const sourceStackId = resourceMappings[0].Source!.StackName!;
+    const targetStackId = resourceMappings[0].Destination!.StackName!;
 
     const sourceStackName = extractStackNameFromId(sourceStackId);
     const targetStackName = extractStackNameFromId(targetStackId);
@@ -144,14 +144,16 @@ export class Cfn {
     const targetTemplate = targetStack ? await this.fetchTemplate(targetStackId) : JSON.parse(JSON.stringify(EMPTY_HOLDING_TEMPLATE));
 
     for (const mapping of resourceMappings) {
-      if (mapping.Destination.LogicalResourceId in targetTemplate.Resources) {
+      if (mapping.Destination!.LogicalResourceId! in targetTemplate.Resources) {
         // our refactoring is expected to move resources into vacancies, not override
         throw new AmplifyError('MigrationError', {
-          message: `Unable to create stack refactor. Resource ${mapping.Destination.LogicalResourceId} already exists in stack ${targetStackName}`,
+          message: `Unable to create stack refactor. Resource ${
+            mapping.Destination!.LogicalResourceId
+          } already exists in stack ${targetStackName}`,
         });
       }
-      targetTemplate.Resources[mapping.Destination.LogicalResourceId] = sourceTemplate.Resources[mapping.Source.LogicalResourceId];
-      delete sourceTemplate.Resources[mapping.Source.LogicalResourceId];
+      targetTemplate.Resources[mapping.Destination!.LogicalResourceId!] = sourceTemplate.Resources[mapping.Source!.LogicalResourceId!];
+      delete sourceTemplate.Resources[mapping.Source!.LogicalResourceId!];
     }
 
     if (Object.keys(sourceTemplate.Resources).length === 0) {
@@ -264,10 +266,10 @@ export class Cfn {
     readonly resource?: DiscoveredResource;
   }): Promise<void> {
     const { changeSet, templateBody, resource } = params;
-    const displayName = extractStackNameFromId(changeSet.StackName);
+    const displayName = extractStackNameFromId(changeSet.StackName!);
 
     writeUpdateSnapshot({
-      stackName: changeSet.StackName,
+      stackName: changeSet.StackName!,
       templateBody: JSON.stringify(templateBody),
       parameters: changeSet.Parameters ?? [],
     });
@@ -383,7 +385,7 @@ export class Cfn {
       const propDetails = details.filter((d) => d.Target?.Attribute === 'Properties' && d.Target?.Name);
 
       for (const detail of propDetails) {
-        const target = detail.Target;
+        const target = detail.Target!;
         const propertyPath = target.Path;
         const before = target.BeforeValue;
         const after = target.AfterValue;
@@ -415,9 +417,9 @@ export class Cfn {
 }
 
 function buildRefactorDescription(input: CreateStackRefactorCommandInput): string {
-  const logicalIds = input.ResourceMappings.map((m) => m.Source?.LogicalResourceId).join(', ');
-  const source = extractStackNameFromId(input.StackDefinitions[0].StackName);
-  const dest = extractStackNameFromId(input.StackDefinitions[1].StackName);
+  const logicalIds = input.ResourceMappings!.map((m) => m.Source?.LogicalResourceId).join(', ');
+  const source = extractStackNameFromId(input.StackDefinitions![0].StackName!);
+  const dest = extractStackNameFromId(input.StackDefinitions![1].StackName!);
   return `Move [${logicalIds}] from ${source} to ${dest}`;
 }
 
@@ -438,14 +440,14 @@ function writeUpdateSnapshot(input: WriteUpdateSnapshotInput): void {
 }
 
 function writeRefactorSnapshot(input: CreateStackRefactorCommandInput): void {
-  const source = input.StackDefinitions[0];
-  const target = input.StackDefinitions[1];
-  const sourceStackName = extractStackNameFromId(source.StackName);
-  const targetStackName = extractStackNameFromId(target.StackName);
+  const source = input.StackDefinitions![0];
+  const target = input.StackDefinitions![1];
+  const sourceStackName = extractStackNameFromId(source.StackName!);
+  const targetStackName = extractStackNameFromId(target.StackName!);
   const description = `refactor.__from__.${sourceStackName}.__to__.${targetStackName}`;
   const basePath = path.join(OUTPUT_DIRECTORY, description);
-  fs.writeFileSync(`${basePath}.source.template.json`, formatTemplateBody(source.TemplateBody));
-  fs.writeFileSync(`${basePath}.target.template.json`, formatTemplateBody(target.TemplateBody));
+  fs.writeFileSync(`${basePath}.source.template.json`, formatTemplateBody(source.TemplateBody!));
+  fs.writeFileSync(`${basePath}.target.template.json`, formatTemplateBody(target.TemplateBody!));
   fs.writeFileSync(
     path.join(OUTPUT_DIRECTORY, `${description}.mappings.json`),
     JSON.stringify(input.ResourceMappings ?? [], null, 2) + '\n',

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor/workflow/category-refactorer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor/workflow/category-refactorer.ts
@@ -291,7 +291,7 @@ export abstract class CategoryRefactorer implements Planner {
       style: { head: [] },
     });
     for (const m of mappings) {
-      table.push([m.Source.LogicalResourceId, m.Destination.LogicalResourceId]);
+      table.push([m.Source!.LogicalResourceId, m.Destination!.LogicalResourceId]);
     }
     return `${table.toString()}`;
   }

--- a/packages/amplify-cli/tsconfig.json
+++ b/packages/amplify-cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strict": false,
+    "strict": true,
     "noImplicitAny": false,
     "rootDir": "src",
     "outDir": "lib",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Turn strict mode back on in `packages/amplify-cli`.

#### Issue #14564 

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
https://tiny.amazon.com/7q8zqcl9/IsenLink

Created a new branch that contains Gen 2 Migration E2E CodeBuild running logic, and rebased from this commit to bring in the changes. Then, ran `yarn cloud-gen2-migration` to validate that the migration tool still works for all apps we are testing it on.


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are changed(https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
