### PR TITLE
fix: amplify --version output warnings are interpreted as shell parameters

### DIFF
--- a/.circleci/local_publish_helpers_codebuild.sh
+++ b/.circleci/local_publish_helpers_codebuild.sh
@@ -28,7 +28,7 @@ function uploadPkgCliCodeBuild {
     set -e
 
     cd out/
-    export version=$(./amplify-pkg-linux-x64 --version)
+    export version=$(./amplify-pkg-linux-x64 --version 2>/dev/null | tail -1)
 
     # validate that version is uploaded in right build
     if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
See https://tiny.amazon.com/63vy03uy/IsenLink.

We get the following error:
```
Unknown options: following,official,plugins,are,missing,or,inactive:,core:,core,\|,@aws-amplify/cli-internal-gen2-migration-experimental-alpha@14.3.0-dev.ae14ef198858c6fd50b6ed0196badda11a265735.0,14.3.0-dev.ae14ef198858c6fd50b6ed0196badda11a265735.0/amplify-pkg-win-x64.tgz
```
in the package binary upload step, where the version number is used as an input to a shell command. When `--version` returns extra output, like a warning, we get the error above.

This change removes output except for the last line, in `uploadPkgCliCodeBuild`.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

<!-- Also, please reference any associated PRs for documentation updates. -->


#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
