### PR TITLE
fix: eslint warnings above hardcoded threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "link-dev": "mkdir -p .bin/ && cd packages/amplify-cli && ln -s \"$(pwd)/bin/amplify\" ../../.bin/amplify-dev && cd ../../",
     "link-win": "node ./scripts/link-bin.js packages/amplify-cli/bin/amplify amplify-dev",
     "lint-check-package-json": "yarn eslint --no-eslintrc --config .eslint.package.json.js '**/package.json'",
-    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=750",
+    "lint-check": "yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=1500",
     "lint-fix-package-json": "yarn lint-check-package-json --fix",
     "lint-fix": "git diff --name-only --cached --diff-filter d | grep -E '\\.(js|jsx|ts|tsx)$' | xargs eslint --fix --quiet",
     "mergewords": "yarn ts-node ./scripts/handle-dict-conflicts.ts",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

In the `_lint` step of our `AmplifyCLI-E2E-Testing` CodeBuild job, we run `yarn lint-check`, which runs `yarn eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=750`.

With the inclusion of Gen 2 Migration changes, we are at 999 warnings, which is beyond the existing threshold. This change modifies the value passed to `--max-warnings` to 1500.

```

✖ 999 problems (0 errors, 999 warnings)
--
 
ESLint found too many warnings (maximum: 750).
 

```

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
