### PR TITLE
feat(gen2-migration): skip imported storage resources in gen2-migration

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/__snapshots__/assessment.test.ts.snap
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/__snapshots__/assessment.test.ts.snap
@@ -34,6 +34,8 @@ Resources
 │ geo      │ Location │ map      │ ✘ Any    │ ✘ Any    │
 └──────────┴──────────┴──────────┴──────────┴──────────┘
 
+During migration, unsupported resources/features can be skipped by passing --skip-validations to the command.
+
 ⚠️ Some features may not be reported by this assessment. More details are available in the migration guide.
 
 https://github.com/aws-amplify/amplify-cli/blob/gen2-migration/GEN2_MIGRATION_GUIDE.md#feature-coverage

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/storage/dynamodb.assessor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/storage/dynamodb.assessor.test.ts
@@ -2,12 +2,16 @@ import { DynamoDBAssessor } from '../../../../../commands/gen2-migration/assess/
 import { Assessment } from '../../../../../commands/gen2-migration/assess/assessment';
 import { Gen1App, DiscoveredResource } from '../../../../../commands/gen2-migration/generate/_infra/gen1-app';
 
+function mockGen1App(meta: Gen1App['meta'] = () => undefined): Gen1App {
+  return { fileExists: () => false, ensureCliInputs: () => undefined, meta } as unknown as Gen1App;
+}
+
 const RESOURCE: DiscoveredResource = { category: 'storage', resourceName: 'myTable', service: 'DynamoDB', key: 'storage:DynamoDB' };
 
 describe('DynamoDBAssessor', () => {
   it('records resource as supported', () => {
     const assessment = new Assessment('app', 'dev');
-    new DynamoDBAssessor({ fileExists: () => false, ensureCliInputs: () => undefined } as unknown as Gen1App, RESOURCE).record(assessment);
+    new DynamoDBAssessor(mockGen1App(), RESOURCE).record(assessment);
 
     const entry = assessment.resources[0];
     expect(entry!.generate.level).toBe('supported');
@@ -16,8 +20,18 @@ describe('DynamoDBAssessor', () => {
 
   it('records no features', () => {
     const assessment = new Assessment('app', 'dev');
-    new DynamoDBAssessor({ fileExists: () => false, ensureCliInputs: () => undefined } as unknown as Gen1App, RESOURCE).record(assessment);
+    new DynamoDBAssessor(mockGen1App(), RESOURCE).record(assessment);
 
     expect(assessment.features).toHaveLength(0);
+  });
+
+  it('records imported resource as unsupported', () => {
+    const assessment = new Assessment('app', 'dev');
+    const meta = (category: string) => (category === 'storage' ? { myTable: { service: 'DynamoDB', serviceType: 'imported' } } : undefined);
+    new DynamoDBAssessor(mockGen1App(meta), RESOURCE).record(assessment);
+
+    const entry = assessment.resources[0];
+    expect(entry!.generate.level).toBe('unsupported');
+    expect(entry!.refactor.level).toBe('unsupported');
   });
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/storage/s3.assessor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/storage/s3.assessor.test.ts
@@ -2,9 +2,9 @@ import { S3Assessor } from '../../../../../commands/gen2-migration/assess/storag
 import { Assessment } from '../../../../../commands/gen2-migration/assess/assessment';
 import { Gen1App, DiscoveredResource } from '../../../../../commands/gen2-migration/generate/_infra/gen1-app';
 
-function mockGen1App(existingFiles: string[] = []): Gen1App {
+function mockGen1App(existingFiles: string[] = [], meta: Gen1App['meta'] = () => undefined): Gen1App {
   const fileSet = new Set(existingFiles);
-  return { fileExists: (path: string) => fileSet.has(path), ensureCliInputs: () => undefined } as unknown as Gen1App;
+  return { fileExists: (path: string) => fileSet.has(path), ensureCliInputs: () => undefined, meta } as unknown as Gen1App;
 }
 
 const RESOURCE: DiscoveredResource = { category: 'storage', resourceName: 'myBucket', service: 'S3', key: 'storage:S3' };
@@ -17,6 +17,17 @@ describe('S3Assessor', () => {
     const entry = assessment.resources[0];
     expect(entry!.generate.level).toBe('supported');
     expect(entry!.refactor.level).toBe('supported');
+  });
+
+  it('records imported resource as unsupported and skips feature detection', () => {
+    const assessment = new Assessment('app', 'dev');
+    const meta = (category: string) => (category === 'storage' ? { myBucket: { service: 'S3', serviceType: 'imported' } } : undefined);
+    new S3Assessor(mockGen1App(['storage/myBucket/override.ts'], meta), RESOURCE).record(assessment);
+
+    const entry = assessment.resources[0];
+    expect(entry!.generate.level).toBe('unsupported');
+    expect(entry!.refactor.level).toBe('unsupported');
+    expect(assessment.features).toHaveLength(0);
   });
 
   it('detects override.ts', () => {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/refactor.test.ts
@@ -207,6 +207,27 @@ describe('AmplifyMigrationRefactorStep', () => {
       const plan = await step.forward();
       await plan.describe();
     });
+
+    it('skips imported storage resources', async () => {
+      infraSpy = mockCreateInfrastructure();
+      const gen1 = mockGen1App({
+        discover: () => [
+          { category: 'storage', resourceName: 'myImportedBucket', service: 'S3', key: 'storage:S3' },
+          { category: 'storage', resourceName: 'myImportedTable', service: 'DynamoDB', key: 'storage:DynamoDB' },
+        ],
+        meta: (category: string) =>
+          category === 'storage'
+            ? {
+                myImportedBucket: { service: 'S3', serviceType: 'imported' },
+                myImportedTable: { service: 'DynamoDB', serviceType: 'imported' },
+              }
+            : undefined,
+      });
+
+      const step = createStep(gen1);
+      const plan = await step.forward();
+      await plan.describe();
+    });
   });
 
   describe('rollback()', () => {
@@ -242,6 +263,27 @@ describe('AmplifyMigrationRefactorStep', () => {
       const gen1 = mockGen1App({
         discover: () => [{ category: 'auth', resourceName: 'myImportedPool', service: 'Cognito', key: 'auth:Cognito' }],
         meta: (category: string) => (category === 'auth' ? { myImportedPool: { service: 'Cognito', serviceType: 'imported' } } : undefined),
+      });
+
+      const step = createStep(gen1);
+      const plan = await step.rollback();
+      await plan.describe();
+    });
+
+    it('skips imported storage resources', async () => {
+      infraSpy = mockCreateInfrastructure();
+      const gen1 = mockGen1App({
+        discover: () => [
+          { category: 'storage', resourceName: 'myImportedBucket', service: 'S3', key: 'storage:S3' },
+          { category: 'storage', resourceName: 'myImportedTable', service: 'DynamoDB', key: 'storage:DynamoDB' },
+        ],
+        meta: (category: string) =>
+          category === 'storage'
+            ? {
+                myImportedBucket: { service: 'S3', serviceType: 'imported' },
+                myImportedTable: { service: 'DynamoDB', serviceType: 'imported' },
+              }
+            : undefined,
       });
 
       const step = createStep(gen1);

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
@@ -210,7 +210,7 @@ export class Assessment {
       case 'unsupported':
         return support.note ? `✘ ${support.note}` : '✘';
       case 'not-applicable':
-        return '—';
+        return '— (not needed)';
     }
   }
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
@@ -162,12 +162,26 @@ export class Assessment {
       lines.push('');
     }
 
+    if (this.hasUnsupported()) {
+      lines.push(
+        chalk.yellow('During migration, unsupported resources/features can be skipped by passing --skip-validations to the command.'),
+      );
+      lines.push('');
+    }
+
     lines.push(chalk.yellow('⚠️ Some features may not be reported by this assessment. More details are available in the migration guide.'));
     lines.push('');
     lines.push(chalk.yellow(GUIDE_LINK));
     lines.push('');
 
     return lines.join('\n');
+  }
+
+  private hasUnsupported(): boolean {
+    return (
+      this._resources.some((ra) => ra.generate.level === 'unsupported' || ra.refactor.level === 'unsupported') ||
+      this._features.some((fr) => fr.generate.level === 'unsupported' || fr.refactor.level === 'unsupported')
+    );
   }
 
   private renderResourceTable(): string {

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
@@ -24,9 +24,9 @@ export interface Support {
 export const supported = (): Support => ({ level: 'supported' });
 
 /**
- * Shorthand for an unsupported entry, optionally with an explanatory note.
+ * Shorthand for an unsupported entry with a note.
  */
-export const unsupported = (note?: string): Support => (note !== undefined ? { level: 'unsupported', note } : { level: 'unsupported' });
+export const unsupported = (note: string): Support => ({ level: 'unsupported', note });
 
 /**
  * Shorthand for a not-applicable entry.

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/assessment.ts
@@ -24,9 +24,9 @@ export interface Support {
 export const supported = (): Support => ({ level: 'supported' });
 
 /**
- * Shorthand for an unsupported entry with a note.
+ * Shorthand for an unsupported entry, optionally with an explanatory note.
  */
-export const unsupported = (note: string): Support => ({ level: 'unsupported', note });
+export const unsupported = (note?: string): Support => (note !== undefined ? { level: 'unsupported', note } : { level: 'unsupported' });
 
 /**
  * Shorthand for a not-applicable entry.

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
@@ -16,8 +16,8 @@ export class DynamoDBAssessor implements Assessor {
     if (meta?.serviceType === 'imported') {
       assessment.recordResource({
         resource: this.resource,
-        generate: unsupported('imported resource - skipped'),
-        refactor: unsupported('imported resource - skipped'),
+        generate: unsupported(),
+        refactor: unsupported(),
       });
       return;
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
@@ -16,8 +16,8 @@ export class DynamoDBAssessor implements Assessor {
     if (meta?.serviceType === 'imported') {
       assessment.recordResource({
         resource: this.resource,
-        generate: unsupported(),
-        refactor: unsupported(),
+        generate: unsupported('(imported)'),
+        refactor: unsupported('(imported)'),
       });
       return;
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/dynamodb.assessor.ts
@@ -12,6 +12,16 @@ export class DynamoDBAssessor implements Assessor {
    * Records resource-level support for this DynamoDB resource.
    */
   public record(assessment: Assessment): void {
+    const meta = (this.gen1App.meta('storage') ?? {})[this.resource.resourceName] as Record<string, unknown> | undefined;
+    if (meta?.serviceType === 'imported') {
+      assessment.recordResource({
+        resource: this.resource,
+        generate: unsupported('imported resource - skipped'),
+        refactor: unsupported('imported resource - skipped'),
+      });
+      return;
+    }
+
     this.gen1App.ensureCliInputs(this.resource.category, this.resource.resourceName);
     assessment.recordResource({ resource: this.resource, generate: supported(), refactor: supported() });
 

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
@@ -17,8 +17,8 @@ export class S3Assessor implements Assessor {
     if (meta?.serviceType === 'imported') {
       assessment.recordResource({
         resource: this.resource,
-        generate: unsupported('imported resource - skipped'),
-        refactor: unsupported('imported resource - skipped'),
+        generate: unsupported(),
+        refactor: unsupported(),
       });
       return;
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
@@ -13,6 +13,16 @@ export class S3Assessor implements Assessor {
    * Records resource-level and feature-level support for this S3 resource.
    */
   public record(assessment: Assessment): void {
+    const meta = (this.gen1App.meta('storage') ?? {})[this.resource.resourceName] as Record<string, unknown> | undefined;
+    if (meta?.serviceType === 'imported') {
+      assessment.recordResource({
+        resource: this.resource,
+        generate: unsupported('imported resource - skipped'),
+        refactor: unsupported('imported resource - skipped'),
+      });
+      return;
+    }
+
     this.gen1App.ensureCliInputs(this.resource.category, this.resource.resourceName);
     assessment.recordResource({ resource: this.resource, generate: supported(), refactor: supported() });
 

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/storage/s3.assessor.ts
@@ -17,8 +17,8 @@ export class S3Assessor implements Assessor {
     if (meta?.serviceType === 'imported') {
       assessment.recordResource({
         resource: this.resource,
-        generate: unsupported(),
-        refactor: unsupported(),
+        generate: unsupported('(imported)'),
+        refactor: unsupported('(imported)'),
       });
       return;
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
@@ -54,12 +54,18 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
             new AuthUserPoolGroupsForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),
           );
           break;
-        case 'storage:S3':
+        case 'storage:S3': {
+          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
+          if (meta?.serviceType === 'imported') break;
           refactorers.push(new StorageS3ForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        case 'storage:DynamoDB':
+        }
+        case 'storage:DynamoDB': {
+          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
+          if (meta?.serviceType === 'imported') break;
           refactorers.push(new StorageDynamoForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
+        }
         case 'analytics:Kinesis':
           refactorers.push(new AnalyticsKinesisForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
@@ -135,12 +141,18 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
             new AuthUserPoolGroupsRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),
           );
           break;
-        case 'storage:S3':
+        case 'storage:S3': {
+          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
+          if (meta?.serviceType === 'imported') break;
           refactorers.push(new StorageS3RollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        case 'storage:DynamoDB':
+        }
+        case 'storage:DynamoDB': {
+          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
+          if (meta?.serviceType === 'imported') break;
           refactorers.push(new StorageDynamoRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
+        }
         case 'analytics:Kinesis':
           refactorers.push(
             new AnalyticsKinesisRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
@@ -36,6 +36,12 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
     const discovered = this.gen1App.discover();
 
     for (const resource of discovered) {
+      // skip resources the assessment did not mark as supported.
+      // these will show up as validation errors the user has to acknowledge.
+      if (assessment.of(resource, 'refactor').level !== 'supported') {
+        continue;
+      }
+
       switch (resource.key) {
         case 'auth:Cognito': {
           const isReferenceAuth = discovered
@@ -54,18 +60,12 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
             new AuthUserPoolGroupsForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),
           );
           break;
-        case 'storage:S3': {
-          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
-          if (meta?.serviceType === 'imported') break;
+        case 'storage:S3':
           refactorers.push(new StorageS3ForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        }
-        case 'storage:DynamoDB': {
-          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
-          if (meta?.serviceType === 'imported') break;
+        case 'storage:DynamoDB':
           refactorers.push(new StorageDynamoForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        }
         case 'analytics:Kinesis':
           refactorers.push(new AnalyticsKinesisForwardRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
@@ -122,6 +122,12 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
     const discovered = this.gen1App.discover();
 
     for (const resource of discovered) {
+      // skip resources the assessment did not mark as supported.
+      // these will show up as validation errors the user has to acknowledge.
+      if (assessment.of(resource, 'refactor').level !== 'supported') {
+        continue;
+      }
+
       switch (resource.key) {
         case 'auth:Cognito': {
           // Imported auth resources have no CloudFormation stack to move — skip.
@@ -141,18 +147,12 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
             new AuthUserPoolGroupsRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),
           );
           break;
-        case 'storage:S3': {
-          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
-          if (meta?.serviceType === 'imported') break;
+        case 'storage:S3':
           refactorers.push(new StorageS3RollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        }
-        case 'storage:DynamoDB': {
-          const meta = (this.gen1App.meta('storage') ?? {})[resource.resourceName] as Record<string, unknown> | undefined;
-          if (meta?.serviceType === 'imported') break;
+        case 'storage:DynamoDB':
           refactorers.push(new StorageDynamoRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn));
           break;
-        }
         case 'analytics:Kinesis':
           refactorers.push(
             new AnalyticsKinesisRollbackRefactorer(gen1Env, gen2Branch, this.gen1App, accountId, this.logger, resource, cfn),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

Fixes #14781

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Imported S3 and DynamoDB resources were being treated as Amplify-managed by the gen2-migration tool, causing `assess` to crash with a misleading error and `generate` / `refactor` to codegen and move resources the user owns outside Amplify. Only imported auth was handled before.

- `S3Assessor` and `DynamoDBAssessor` now short-circuit on `serviceType: "imported"` and record the resource as `unsupported()`.
- `refactor.ts` now gates its loop on the assessment (same pattern `generate.ts` already uses) instead of embedding inline imported checks. Storage skip happens transitively.
- `generate.ts` needed no change — it already gates on the assessment.

While here, small report tweaks:
- `—` (not-applicable) renders as `— (not needed)` so users know the empty cell is intentional.
- Assessment report footer adds a one-liner about `--skip-validations`, shown only when unsupported rows exist.


Running `assess` on gen1 app with an imported s3 sbucket:

Before:

```console
amplify gen2-migration assess
```

```cli
🛑 Unable to find storage/exp3773ad55/cli-inputs.json. Your app was created with an old Gen1 CLI version (<=v6) that did not produce this file.
```
After:

```console
Assessment For Migrating "exp" (env: main)

Resources

┌───────────┬─────────────────────────┬────────────────────────────┬──────────────┬────────────────────────────────────┐
│ Category  │ Service                 │ Resource                   │ Generate     │ Refactor                           │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ auth      │ Cognito                 │ exp3b384952                │ ✔            │ ✔                                  │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ auth      │ Cognito-UserPool-Groups │ userPoolGroups             │ ✔            │ ✔                                  │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ geo       │ Map                     │ map7c2057b4                │ ✔            │ ✔                                  │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ geo       │ GeofenceCollection      │ geofenceCollection1f728878 │ ✔            │ ✘ requires manual data replication │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ geo       │ PlaceIndex              │ placeIndex4173f677         │ ✔            │ ✔                                  │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ function  │ Lambda                  │ exp53ff4263                │ ✔            │ — (not needed)                     │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ analytics │ Kinesis                 │ expKinesis                 │ ✔            │ ✔                                  │
├───────────┼─────────────────────────┼────────────────────────────┼──────────────┼────────────────────────────────────┤
│ storage   │ S3                      │ exp3773ad55                │ ✘ (imported) │ ✘ (imported)                       │
└───────────┴─────────────────────────┴────────────────────────────┴──────────────┴────────────────────────────────────┘

During migration, unsupported resources/features can be skipped by passing --skip-validations to the command.

⚠️ Some features may not be reported by this assessment. More details are available in the migration guide.

https://github.com/aws-amplify/amplify-cli/blob/gen2-migration/GEN2_MIGRATION_GUIDE.md#feature-coverage

```


#### Issue #, if available

#14781

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- - New unit tests in `S3Assessor`, `DynamoDBAssessor`, and `AmplifyMigrationRefactorStep` (forward + rollback) covering imported storage skip.
- Verified against a live Gen1 app with an imported S3 bucket.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
