### PR TITLE
fix(gen2-migration): replace misleading drift detection fallback messages

### DIFF
--- a/packages/amplify-cli/src/commands/drift.ts
+++ b/packages/amplify-cli/src/commands/drift.ts
@@ -19,6 +19,8 @@ export interface DriftDetectionResult {
   readonly code: number;
   /** Human-readable drift report, undefined when no drift. */
   readonly report?: string;
+  /** True when one or more detection phases were skipped due to errors. */
+  readonly incomplete?: boolean;
 }
 
 /**
@@ -35,7 +37,11 @@ export const run = async (context: $TSContext): Promise<void> => {
   if (result.report) {
     printer.info(result.report);
     printer.info(chalk.yellow('Drift detected'));
-  } else {
+  }
+  if (result.incomplete) {
+    printer.info(chalk.yellow('Drift detection was incomplete'));
+  }
+  if (!result.report && !result.incomplete) {
     printer.info(chalk.green('No drift detected'));
   }
 
@@ -142,7 +148,7 @@ export class AmplifyDriftDetector {
         this.logger.warn(chalk.yellow(`Local drift error: ${phase3Results.skipReason}`));
       }
       this.logger.debug('Exit code 1: Incomplete drift detection - cannot guarantee no drift');
-      return { code: 1, report: driftReport ?? undefined };
+      return { code: 1, report: driftReport ?? undefined, incomplete: true };
     }
     return { code: driftReport ? 1 : 0, report: driftReport };
   }

--- a/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_infra/validations.ts
@@ -29,7 +29,7 @@ export class AmplifyGen2MigrationValidations {
     const result = await new AmplifyDriftDetector(this.context, this.logger).detect();
     if (result.code !== 0) {
       throw new AmplifyError('MigrationError', {
-        message: result.report?.trim() ?? 'Drift detected',
+        message: result.report?.trim() ?? 'Drift detection was incomplete',
         resolution: 'Inspect the drift report above and resolve the drift',
       });
     }


### PR DESCRIPTION
## Summary

When drift detection phases are skipped (e.g., nested stack changeset creation fails), the two callers of `detect()` displayed misleading messages because they couldn't distinguish "no drift found" from "detection couldn't complete."

### Before

**`amplify drift`**: prints "No drift detected" in green — even though detection failed and exit code is 1

**`amplify migrate` (validation)**: reports "Drift detected" — implying drift was found, when actually detection couldn't finish

### After

Both callers now correctly report **"Drift detection was incomplete"** when phases are skipped but no drift was found. When drift IS found and some phases are also skipped, both the drift report and the incomplete notice are shown.

## Changes

- Add `incomplete?: boolean` to `DriftDetectionResult` — set to `true` when any phase is skipped
- Update `run()` in `drift.ts` to handle all four states: clean, drift, incomplete, drift+incomplete
- Update `validateDrift()` in `validations.ts` to build a composite message from report and incomplete status