### PR TITLE
chore(e2e): harden credential file writes

### DIFF
--- a/packages/amplify-cli-npm/index.ts
+++ b/packages/amplify-cli-npm/index.ts
@@ -16,4 +16,4 @@ export const install = async (): Promise<void> => {
   return binary.install();
 };
 
-// force version bump to 14.4.0
+// force version bump to 14.3.0

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -264,4 +264,4 @@ export const executeAmplifyCommand = async (context: Context): Promise<void> => 
   }
 };
 
-// bump version to 14.3.0
+// bump version to 14.4.0

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -264,4 +264,4 @@ export const executeAmplifyCommand = async (context: Context): Promise<void> => 
   }
 };
 
-// bump version to 14.4.0
+// bump version to 14.3.0

--- a/packages/amplify-e2e-gen2-migration/src/core/credentials.ts
+++ b/packages/amplify-e2e-gen2-migration/src/core/credentials.ts
@@ -94,16 +94,24 @@ export class CredentialManager {
     fs.mkdirSync(awsDir, { recursive: true });
 
     const credsFile = path.join(awsDir, 'credentials');
+    if (fs.existsSync(credsFile)) {
+      throw new Error(`Refusing to overwrite existing credentials file: ${credsFile}`);
+    }
+
+    const configFile = path.join(awsDir, 'config');
+    if (fs.existsSync(configFile)) {
+      throw new Error(`Refusing to overwrite existing config file: ${configFile}`);
+    }
+
     const credsContent =
       `[${this.generatedProfile}]\n` +
       `aws_access_key_id = ${accessKeyId}\n` +
       `aws_secret_access_key = ${secretAccessKey}\n` +
       `aws_session_token = ${sessionToken}\n`;
-    fs.writeFileSync(credsFile, credsContent, 'utf-8');
+    fs.writeFileSync(credsFile, credsContent, { encoding: 'utf-8', mode: 0o600 });
 
-    const configFile = path.join(awsDir, 'config');
     const configContent = `[profile ${this.generatedProfile}]\nregion = ${this.region}\noutput = json\n`;
-    fs.writeFileSync(configFile, configContent, 'utf-8');
+    fs.writeFileSync(configFile, configContent, { encoding: 'utf-8', mode: 0o600 });
   }
 }
 


### PR DESCRIPTION
#### Description of changes

Hardens the `CredentialManager.writeCredentialsFile` method in the gen2
migration e2e package:

1. Both `~/.aws/credentials` and `~/.aws/config` are now written with
   `0600` permissions (owner read/write only), preventing other users on
   the system from reading temporary session credentials.

2. If either file already exists before writing, the method throws an
   error instead of silently overwriting. This guards against
   accidentally clobbering a developer's existing AWS configuration
   during a test run.

#### Issue #, if available

N/A

#### Description of how you validated changes

The logic is straightforward — `mode` option on `writeFileSync` and `existsSync` guard before each write. Will be tested in E2Es once we add them to CI.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
