### PR TITLE
fix: write deprecation warning to stderr to avoid breaking E2E tests

### DIFF
--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -18,6 +18,7 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { printer, prompter } from '@aws-amplify/amplify-prompts';
+import chalk from 'chalk';
 import { saveAll as saveAllEnvParams, ServiceUploadHandler } from '@aws-amplify/amplify-environment-parameters';
 import { logInput } from './conditional-local-logging-init';
 import { attachUsageData, constructContext } from './context-manager';
@@ -63,11 +64,14 @@ const disableCDKDeprecationWarning = () => {
  * Command line entry point
  */
 export const run = async (startTime: number): Promise<void> => {
-  printer.blankLine();
-  printer.warn(
-    'AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
-      'During maintenance mode, only critical bug fixes and security patches will be provided.\n' +
-      'Migrate to Amplify Gen 2: https://docs.amplify.aws/react/start/migrate-to-gen2/\n',
+  process.stderr.write(
+    '\n' +
+      chalk.yellow(
+        '⚠️  WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
+          'During maintenance mode, only critical bug fixes and security patches will be provided.\n' +
+          'Migrate to Amplify Gen 2: https://docs.amplify.aws/react/start/migrate-to-gen2/',
+      ) +
+      '\n\n',
   );
 
   deleteOldVersion();

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -67,7 +67,7 @@ export const run = async (startTime: number): Promise<void> => {
   process.stderr.write(
     '\n' +
       chalk.yellow(
-        '⚠️ WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
+        '⚠️  WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
           'During maintenance mode, only critical bug fixes and security patches will be provided.\n' +
           'Migrate to Amplify Gen 2: https://docs.amplify.aws/react/start/migrate-to-gen2/',
       ) +

--- a/packages/amplify-cli/src/index.ts
+++ b/packages/amplify-cli/src/index.ts
@@ -67,7 +67,7 @@ export const run = async (startTime: number): Promise<void> => {
   process.stderr.write(
     '\n' +
       chalk.yellow(
-        '⚠️  WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
+        '⚠️ WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.\n' +
           'During maintenance mode, only critical bug fixes and security patches will be provided.\n' +
           'Migrate to Amplify Gen 2: https://docs.amplify.aws/react/start/migrate-to-gen2/',
       ) +


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
