### PR TITLE
fix(gen2-migration): preserve user attribute read/write restrictions 

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -1703,6 +1703,69 @@ describe('AuthGenerator', () => {
       `);
   });
 
+  it('preserves user attribute read/write restrictions on NativeAppClient', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      SchemaAttributes: [
+        { Name: 'email', Required: true, Mutable: true },
+        { Name: 'birthdate', Required: false, Mutable: true },
+        { Name: 'address', Required: false, Mutable: true },
+      ],
+      Policies: {
+        PasswordPolicy: {
+          MinimumLength: 12,
+          RequireLowercase: true,
+          RequireNumbers: true,
+          RequireSymbols: true,
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: false,
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockImplementation((_poolId: string, clientId: string) => {
+      if (clientId === 'webclient123') {
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve({
+        RefreshTokenValidity: 30,
+        ReadAttributes: ['birthdate', 'email'],
+        WriteAttributes: ['address', 'email'],
+      });
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const resourceTs = writtenFile('auth/resource.ts');
+    // birthdate and address should be declared in userAttributes even though not required
+    expect(resourceTs).toContain('birthdate');
+    expect(resourceTs).toContain('address');
+    // readAttributes and writeAttributes should be on the NativeAppClient
+    expect(resourceTs).toContain('readAttributes');
+    expect(resourceTs).toContain('writeAttributes');
+    expect(resourceTs).toContain('ClientAttributes');
+  });
+
   it('emits aliasAttributes in escape hatch', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -255,7 +255,7 @@ export class AuthRenderer {
 
     defineAuthProperties.push(this.createLogInWithPropertyAssignment(options, loginFlags));
 
-    const clientAttributeNames = AuthRenderer.collectClientAttributeNames(options.userPoolClient);
+    const clientAttributeNames = options.userPoolClient ? AuthRenderer.collectClientAttributeNames(options.userPoolClient) : [];
     const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes, clientAttributeNames);
     const customAttributes = AuthRenderer.deriveCustomUserAttributes(options.userPool.SchemaAttributes);
     const hasStandard = Object.keys(standardAttributes).length > 0;
@@ -406,8 +406,7 @@ export class AuthRenderer {
    * Collects unique standard attribute names from a user pool client's
    * ReadAttributes and WriteAttributes lists.
    */
-  private static collectClientAttributeNames(client?: UserPoolClientType): string[] {
-    if (!client) return [];
+  private static collectClientAttributeNames(client: UserPoolClientType): string[] {
     const names = new Set<string>();
     for (const attr of client.ReadAttributes ?? []) {
       if (attr in MAPPED_USER_ATTRIBUTE_NAME) names.add(attr);

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -255,7 +255,8 @@ export class AuthRenderer {
 
     defineAuthProperties.push(this.createLogInWithPropertyAssignment(options, loginFlags));
 
-    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes);
+    const clientAttributeNames = AuthRenderer.collectClientAttributeNames(options.userPoolClient);
+    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes, clientAttributeNames);
     const customAttributes = AuthRenderer.deriveCustomUserAttributes(options.userPool.SchemaAttributes);
     const hasStandard = Object.keys(standardAttributes).length > 0;
     const hasCustom = Object.keys(customAttributes).length > 0;
@@ -402,15 +403,33 @@ export class AuthRenderer {
   }
 
   /**
+   * Collects unique standard attribute names from a user pool client's
+   * ReadAttributes and WriteAttributes lists.
+   */
+  private static collectClientAttributeNames(client?: UserPoolClientType): string[] {
+    if (!client) return [];
+    const names = new Set<string>();
+    for (const attr of client.ReadAttributes ?? []) {
+      if (attr in MAPPED_USER_ATTRIBUTE_NAME) names.add(attr);
+    }
+    for (const attr of client.WriteAttributes ?? []) {
+      if (attr in MAPPED_USER_ATTRIBUTE_NAME) names.add(attr);
+    }
+    return Array.from(names);
+  }
+
+  /**
    * Extracts standard user attributes from schema, keeping only required ones.
    */
   private static deriveStandardUserAttributes(
     schema?: readonly SchemaAttributeType[],
+    additionalAttributeNames?: readonly string[],
   ): Record<string, { readonly required?: boolean; readonly mutable?: boolean }> {
     if (!schema) return {};
     const result: Record<string, { readonly required?: boolean; readonly mutable?: boolean }> = {};
+    const additionalSet = new Set(additionalAttributeNames ?? []);
     for (const attribute of schema) {
-      if (attribute.Name && attribute.Name in MAPPED_USER_ATTRIBUTE_NAME && attribute.Required) {
+      if (attribute.Name && attribute.Name in MAPPED_USER_ATTRIBUTE_NAME && (attribute.Required || additionalSet.has(attribute.Name))) {
         result[MAPPED_USER_ATTRIBUTE_NAME[attribute.Name]] = {
           required: attribute.Required,
           mutable: attribute.Mutable,
@@ -905,6 +924,38 @@ export class AuthRenderer {
     return factory.createObjectLiteralExpression(properties, true);
   }
 
+  /**
+   * Creates a `new ClientAttributes().withStandardAttributes({...}).withCustomAttributes(...)` expression
+   * from a list of Cognito attribute names (e.g. ['email', 'birthdate', 'custom:dept']).
+   */
+  private static createClientAttributesExpression(attributes: string[]): ts.Expression {
+    const standardAttrs = attributes.filter((a) => a in MAPPED_USER_ATTRIBUTE_NAME);
+    const customAttrs = attributes.filter((a) => a.startsWith('custom:'));
+
+    let expr: ts.Expression = factory.createNewExpression(factory.createIdentifier('ClientAttributes'), undefined, []);
+
+    if (standardAttrs.length > 0) {
+      const props = standardAttrs.map((attr) =>
+        factory.createPropertyAssignment(factory.createIdentifier(MAPPED_USER_ATTRIBUTE_NAME[attr]), factory.createTrue()),
+      );
+      expr = factory.createCallExpression(
+        factory.createPropertyAccessExpression(expr, factory.createIdentifier('withStandardAttributes')),
+        undefined,
+        [factory.createObjectLiteralExpression(props, true)],
+      );
+    }
+
+    if (customAttrs.length > 0) {
+      expr = factory.createCallExpression(
+        factory.createPropertyAccessExpression(expr, factory.createIdentifier('withCustomAttributes')),
+        undefined,
+        customAttrs.map((a) => factory.createStringLiteral(a)),
+      );
+    }
+
+    return expr;
+  }
+
   private static createProviderConfig(
     config: Record<string, string>,
     attributeMapping: Record<string, string> | undefined,
@@ -1018,6 +1069,10 @@ export class AuthRenderer {
 
     if (options.userPoolClient) {
       imports['aws-cdk-lib'].add('Duration');
+      if (options.userPoolClient.ReadAttributes?.length || options.userPoolClient.WriteAttributes?.length) {
+        if (!imports['aws-cdk-lib/aws-cognito']) imports['aws-cdk-lib/aws-cognito'] = new Set();
+        imports['aws-cdk-lib/aws-cognito'].add('ClientAttributes');
+      }
     }
 
     if (hasIdentityProviders) {
@@ -1198,6 +1253,18 @@ export class AuthRenderer {
       }
 
       clientProps.push(factory.createPropertyAssignment('oAuth', factory.createObjectLiteralExpression(oAuthProps, true)));
+    }
+
+    if (userPoolClient.ReadAttributes?.length) {
+      clientProps.push(
+        factory.createPropertyAssignment('readAttributes', AuthRenderer.createClientAttributesExpression(userPoolClient.ReadAttributes)),
+      );
+    }
+
+    if (userPoolClient.WriteAttributes?.length) {
+      clientProps.push(
+        factory.createPropertyAssignment('writeAttributes', AuthRenderer.createClientAttributesExpression(userPoolClient.WriteAttributes)),
+      );
     }
 
     const hasOAuth = (userPoolClient.AllowedOAuthFlows?.length ?? 0) > 0;


### PR DESCRIPTION
Solves #14748

During Gen1→Gen2 migration, the generate step was not carrying over app client read/write attribute restrictions from cli-inputs.json. This resulted in:
  
  - Attributes like birthdate and address not being declared in userAttributes
  in resource.ts
  - The NativeAppClient in backend.ts missing readAttributes and writeAttributes
   configuration
  
Changes
  
  - auth.renderer.ts: Extract attribute names from
  ReadAttributes/WriteAttributes on the UserPoolClientType and include them in
  userAttributes even when not required for signup. Generate ClientAttributes
  expressions for readAttributes/writeAttributes on the NativeAppClient.
  - auth.generator.test.ts: Added test verifying read/write attribute
  restrictions are preserved on the generated app client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
