### PR TITLE
chore: set all resources to delete in gen2-migration e2e teardown

### DIFF
--- a/packages/amplify-e2e-gen2-migration/src/core/teardown.ts
+++ b/packages/amplify-e2e-gen2-migration/src/core/teardown.ts
@@ -24,19 +24,6 @@ const DELETE_WAIT_SECONDS = 300;
 /** Seconds between polls when waiting for stack deletion. */
 const DELETE_POLL_INTERVAL_SECONDS = 10;
 
-// these will have removal policy of retain because the migration tool
-// sets it.
-export const REFACTORED_RESOURCES = [
-  'AWS::Cognito::UserPool',
-  'AWS::Cognito::IdentityPool',
-  'AWS::Cognito::UserPoolClient',
-  'AWS::Cognito::IdentityPoolRoleAttachment',
-  'AWS::Cognito::UserPoolGroup',
-  'AWS::DynamoDB::Table',
-  'AWS::S3::Bucket',
-  'AWS::Kinesis::Stream',
-];
-
 /**
  * Deletes all AWS resources deployed by an `App` instance.
  *
@@ -183,10 +170,6 @@ export class Teardown {
 
       let modified = false;
       for (const [logicalId, resource] of Object.entries(resources)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-        if (!REFACTORED_RESOURCES.includes((resource as any).Type)) {
-          continue;
-        }
         if (resource.DeletionPolicy && resource.DeletionPolicy !== 'Delete') {
           this.logger.info(`Updating ${logicalId}.DeletionPolicy: ${resource.DeletionPolicy} -> Delete`);
           resource.DeletionPolicy = 'Delete';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently we only set a select few resource types to `Delete` - this is not needed, teardown should make every attempt to delete everything. 

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
