### PR TITLE
fix(gen2-migration): preserve user attribute read/write restrictions

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -2051,7 +2051,7 @@ describe('AuthGenerator', () => {
       AllowUnauthenticatedIdentities: false,
     });
     jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockImplementation((_poolId: string, clientId: string) => {
-      if (clientId === 'webclient123') return Promise.resolve(undefined);
+      if (clientId === 'webclient123') return Promise.resolve({});
       return Promise.resolve({
         RefreshTokenValidity: 30,
         EnableTokenRevocation: true,
@@ -2060,7 +2060,7 @@ describe('AuthGenerator', () => {
       });
     });
 
-    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource);
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
     const ops = await generator.plan();
     await ops[0].execute();
     expect(writtenFile('auth/resource.ts')).toMatchInlineSnapshot(`
@@ -2079,9 +2079,11 @@ describe('AuthGenerator', () => {
             mutable: true,
           },
           birthdate: {
+            required: false,
             mutable: true,
           },
           address: {
+            required: false,
             mutable: true,
           },
         },
@@ -2099,7 +2101,7 @@ describe('AuthGenerator', () => {
         const cfnIdentityPool = backend.auth.resources.cfnResources.cfnIdentityPool;
         cfnIdentityPool.allowUnauthenticatedIdentities = false;
         const userPool = backend.auth.resources.userPool;
-        userPool.addClient('NativeAppClient', {
+        const nativeUserPoolClient = userPool.addClient('NativeAppClient', {
           refreshTokenValidity: Duration.days(30),
           enableTokenRevocation: true,
           disableOAuth: true,
@@ -2113,6 +2115,15 @@ describe('AuthGenerator', () => {
             email: true,
           }),
         });
+        const cognitoProviders =
+          backend.auth.resources.cfnResources.cfnIdentityPool
+            .cognitoIdentityProviders;
+        if (cognitoProviders && Array.isArray(cognitoProviders)) {
+          cognitoProviders.push({
+            clientId: nativeUserPoolClient.userPoolClientId,
+            providerName: \`cognito-idp.\${backend.auth.stack.region}.amazonaws.com/\${userPool.userPoolId}\`,
+          });
+        }
         for (const cfnResource of backend.auth.stack.node
           .findAll()
           .filter(

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -2019,4 +2019,118 @@ describe('AuthGenerator', () => {
       "
     `);
   });
+
+  it('generates read/write attribute restrictions on NativeAppClient', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      SchemaAttributes: [
+        { Name: 'email', Required: true, Mutable: true },
+        { Name: 'birthdate', Required: false, Mutable: true },
+        { Name: 'address', Required: false, Mutable: true },
+      ],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: false,
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockImplementation((_poolId: string, clientId: string) => {
+      if (clientId === 'webclient123') return Promise.resolve(undefined);
+      return Promise.resolve({
+        RefreshTokenValidity: 30,
+        EnableTokenRevocation: true,
+        ReadAttributes: ['birthdate', 'email'],
+        WriteAttributes: ['address', 'email'],
+      });
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    expect(writtenFile('auth/resource.ts')).toMatchInlineSnapshot(`
+      "import { defineAuth } from '@aws-amplify/backend';
+      import { CfnResource, Duration } from 'aws-cdk-lib';
+      import { ClientAttributes } from 'aws-cdk-lib/aws-cognito';
+      import type { Backend } from '../backend';
+
+      export const auth = defineAuth({
+        loginWith: {
+          email: true,
+        },
+        userAttributes: {
+          email: {
+            required: true,
+            mutable: true,
+          },
+          birthdate: {
+            mutable: true,
+          },
+          address: {
+            mutable: true,
+          },
+        },
+        multifactor: {
+          mode: 'OFF',
+        },
+      });
+
+      export function applyEscapeHatches(backend: Backend) {
+        const cfnUserPool = backend.auth.resources.cfnResources.cfnUserPool;
+        cfnUserPool.usernameAttributes = undefined;
+        cfnUserPool.policies = {
+          passwordPolicy: {},
+        };
+        const cfnIdentityPool = backend.auth.resources.cfnResources.cfnIdentityPool;
+        cfnIdentityPool.allowUnauthenticatedIdentities = false;
+        const userPool = backend.auth.resources.userPool;
+        userPool.addClient('NativeAppClient', {
+          refreshTokenValidity: Duration.days(30),
+          enableTokenRevocation: true,
+          disableOAuth: true,
+          generateSecret: false,
+          readAttributes: new ClientAttributes().withStandardAttributes({
+            birthdate: true,
+            email: true,
+          }),
+          writeAttributes: new ClientAttributes().withStandardAttributes({
+            address: true,
+            email: true,
+          }),
+        });
+        for (const cfnResource of backend.auth.stack.node
+          .findAll()
+          .filter(
+            (c) =>
+              CfnResource.isCfnResource(c) &&
+              [
+                'AWS::Cognito::UserPool',
+                'AWS::Cognito::IdentityPool',
+                'AWS::Cognito::UserPoolClient',
+                'AWS::Cognito::IdentityPoolRoleAttachment',
+                'AWS::Cognito::UserPoolGroup',
+              ].includes(c.cfnResourceType)
+          )) {
+          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
+          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
+        }
+      }
+      "
+    `);
+  });
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -252,8 +252,7 @@ export class AuthRenderer {
 
     defineAuthProperties.push(this.createLogInWithPropertyAssignment(options, loginFlags));
 
-    const clientAttributeNames = AuthRenderer.collectClientAttributeNames(options.userPoolClient);
-    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes, clientAttributeNames);
+    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes);
     const customAttributes = AuthRenderer.deriveCustomUserAttributes(options.userPool.SchemaAttributes);
     const hasStandard = Object.keys(standardAttributes).length > 0;
     const hasCustom = Object.keys(customAttributes).length > 0;
@@ -405,18 +404,15 @@ export class AuthRenderer {
    */
   private static deriveStandardUserAttributes(
     schema?: readonly SchemaAttributeType[],
-    clientAttributeNames?: ReadonlySet<string>,
   ): Record<string, { readonly required?: boolean; readonly mutable?: boolean }> {
     if (!schema) return {};
     const result: Record<string, { readonly required?: boolean; readonly mutable?: boolean }> = {};
     for (const attribute of schema) {
       if (!attribute.Name || !(attribute.Name in MAPPED_USER_ATTRIBUTE_NAME)) continue;
-      if (attribute.Required || clientAttributeNames?.has(attribute.Name)) {
-        result[MAPPED_USER_ATTRIBUTE_NAME[attribute.Name]] = {
-          ...(attribute.Required ? { required: true } : {}),
-          mutable: attribute.Mutable,
-        };
-      }
+      result[MAPPED_USER_ATTRIBUTE_NAME[attribute.Name]] = {
+        required: attribute.Required,
+        mutable: attribute.Mutable,
+      };
     }
     return result;
   }
@@ -1032,7 +1028,7 @@ export class AuthRenderer {
       imports['aws-cdk-lib/aws-cognito'].add('UserPoolClientIdentityProvider');
     }
 
-    if (options.userPoolClient?.ReadAttributes?.length || options.userPoolClient?.WriteAttributes?.length) {
+    if (options.nativeClient?.ReadAttributes?.length || options.nativeClient?.WriteAttributes?.length) {
       if (!imports['aws-cdk-lib/aws-cognito']) imports['aws-cdk-lib/aws-cognito'] = new Set();
       imports['aws-cdk-lib/aws-cognito'].add('ClientAttributes');
     }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -418,18 +418,6 @@ export class AuthRenderer {
   }
 
   /**
-   * Collects all attribute names referenced in the app client's
-   * ReadAttributes and WriteAttributes lists.
-   */
-  private static collectClientAttributeNames(client?: UserPoolClientType): ReadonlySet<string> | undefined {
-    if (!client?.ReadAttributes?.length && !client?.WriteAttributes?.length) return undefined;
-    const names = new Set<string>();
-    for (const attr of client?.ReadAttributes ?? []) names.add(attr);
-    for (const attr of client?.WriteAttributes ?? []) names.add(attr);
-    return names;
-  }
-
-  /**
    * Extracts custom user attributes from schema.
    */
   private static deriveCustomUserAttributes(schema?: readonly SchemaAttributeType[]): Record<

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -252,7 +252,8 @@ export class AuthRenderer {
 
     defineAuthProperties.push(this.createLogInWithPropertyAssignment(options, loginFlags));
 
-    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes);
+    const clientAttributeNames = AuthRenderer.collectClientAttributeNames(options.userPoolClient);
+    const standardAttributes = AuthRenderer.deriveStandardUserAttributes(options.userPool.SchemaAttributes, clientAttributeNames);
     const customAttributes = AuthRenderer.deriveCustomUserAttributes(options.userPool.SchemaAttributes);
     const hasStandard = Object.keys(standardAttributes).length > 0;
     const hasCustom = Object.keys(customAttributes).length > 0;
@@ -399,22 +400,37 @@ export class AuthRenderer {
   }
 
   /**
-   * Extracts standard user attributes from schema, keeping only required ones.
+   * Extracts standard user attributes from schema, keeping required ones
+   * and any that appear in the app client read/write attribute lists.
    */
   private static deriveStandardUserAttributes(
     schema?: readonly SchemaAttributeType[],
+    clientAttributeNames?: ReadonlySet<string>,
   ): Record<string, { readonly required?: boolean; readonly mutable?: boolean }> {
     if (!schema) return {};
     const result: Record<string, { readonly required?: boolean; readonly mutable?: boolean }> = {};
     for (const attribute of schema) {
-      if (attribute.Name && attribute.Name in MAPPED_USER_ATTRIBUTE_NAME && attribute.Required) {
+      if (!attribute.Name || !(attribute.Name in MAPPED_USER_ATTRIBUTE_NAME)) continue;
+      if (attribute.Required || clientAttributeNames?.has(attribute.Name)) {
         result[MAPPED_USER_ATTRIBUTE_NAME[attribute.Name]] = {
-          required: attribute.Required,
+          ...(attribute.Required ? { required: true } : {}),
           mutable: attribute.Mutable,
         };
       }
     }
     return result;
+  }
+
+  /**
+   * Collects all attribute names referenced in the app client's
+   * ReadAttributes and WriteAttributes lists.
+   */
+  private static collectClientAttributeNames(client?: UserPoolClientType): ReadonlySet<string> | undefined {
+    if (!client?.ReadAttributes?.length && !client?.WriteAttributes?.length) return undefined;
+    const names = new Set<string>();
+    for (const attr of client?.ReadAttributes ?? []) names.add(attr);
+    for (const attr of client?.WriteAttributes ?? []) names.add(attr);
+    return names;
   }
 
   /**
@@ -1016,6 +1032,11 @@ export class AuthRenderer {
       imports['aws-cdk-lib/aws-cognito'].add('UserPoolClientIdentityProvider');
     }
 
+    if (options.userPoolClient?.ReadAttributes?.length || options.userPoolClient?.WriteAttributes?.length) {
+      if (!imports['aws-cdk-lib/aws-cognito']) imports['aws-cdk-lib/aws-cognito'] = new Set();
+      imports['aws-cdk-lib/aws-cognito'].add('ClientAttributes');
+    }
+
     return imports;
   }
 
@@ -1207,6 +1228,18 @@ export class AuthRenderer {
       factory.createPropertyAssignment('generateSecret', userPoolClient.ClientSecret ? factory.createTrue() : factory.createFalse()),
     );
 
+    if (userPoolClient.ReadAttributes?.length) {
+      clientProps.push(
+        factory.createPropertyAssignment('readAttributes', AuthRenderer.buildClientAttributesExpression(userPoolClient.ReadAttributes)),
+      );
+    }
+
+    if (userPoolClient.WriteAttributes?.length) {
+      clientProps.push(
+        factory.createPropertyAssignment('writeAttributes', AuthRenderer.buildClientAttributesExpression(userPoolClient.WriteAttributes)),
+      );
+    }
+
     const addClientCall = factory.createCallExpression(
       factory.createPropertyAccessExpression(factory.createIdentifier('userPool'), factory.createIdentifier('addClient')),
       undefined,
@@ -1296,6 +1329,45 @@ export class AuthRenderer {
     statements.push(ifStatement);
 
     return statements;
+  }
+
+  /**
+   * Builds a `new ClientAttributes().withStandardAttributes({...}).withCustomAttributes(...)` expression
+   * from a list of Cognito attribute names (e.g. `['email', 'birthdate', 'custom:foo']`).
+   */
+  private static buildClientAttributesExpression(attributes: readonly string[]): ts.Expression {
+    const standardProps: ts.PropertyAssignment[] = [];
+    const customNames: string[] = [];
+
+    for (const attr of attributes) {
+      if (attr.startsWith('custom:')) {
+        customNames.push(attr);
+      } else if (attr in MAPPED_USER_ATTRIBUTE_NAME) {
+        standardProps.push(
+          factory.createPropertyAssignment(factory.createIdentifier(MAPPED_USER_ATTRIBUTE_NAME[attr]), factory.createTrue()),
+        );
+      }
+    }
+
+    let expr: ts.Expression = factory.createNewExpression(factory.createIdentifier('ClientAttributes'), undefined, []);
+
+    if (standardProps.length > 0) {
+      expr = factory.createCallExpression(
+        factory.createPropertyAccessExpression(expr, factory.createIdentifier('withStandardAttributes')),
+        undefined,
+        [factory.createObjectLiteralExpression(standardProps, true)],
+      );
+    }
+
+    if (customNames.length > 0) {
+      expr = factory.createCallExpression(
+        factory.createPropertyAccessExpression(expr, factory.createIdentifier('withCustomAttributes')),
+        undefined,
+        customNames.map((name) => factory.createStringLiteral(name)),
+      );
+    }
+
+    return expr;
   }
 
   /** Builds the providerSetupResult code and commented tryRemoveChild. */


### PR DESCRIPTION
Fixes #14748

When migrating from Gen 1 to Gen 2, the generate step now preserves app client read/write attribute restrictions on the NativeAppClient in backend.ts, and declares non-required standard attributes (e.g. birthdate, address) in userAttributes when they appear in the client's read or write attribute lists.

Changes in auth.renderer.ts:
- deriveStandardUserAttributes now accepts an optional set of attribute names from the client's ReadAttributes and WriteAttributes, including them in userAttributes even when not required.
- buildUserPoolClientStatements emits readAttributes and writeAttributes using CDK ClientAttributes when the native app client has those restrictions configured.
- buildAdditionalImports adds the ClientAttributes import from aws-cdk-lib/aws-cognito when needed.

https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cognito.UserPoolClientOptions.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
