### PR TITLE
fix(cli): `amplify gen2-migration generate` fails on published package

### DIFF
--- a/codebuild_specs/run_gen2_migration_e2e.yml
+++ b/codebuild_specs/run_gen2_migration_e2e.yml
@@ -11,7 +11,7 @@ phases:
     commands:
       - export NODE_OPTIONS=--max-old-space-size=4096
       - export AMPLIFY_DIR=$CODEBUILD_SRC_DIR/out
-      - export AMPLIFY_PATH=$CODEBUILD_SRC_DIR/out/amplify
+      - export AMPLIFY_PATH=$CODEBUILD_SRC_DIR/out/amplify-pkg-linux-x64
       - echo "AMPLIFY_DIR=$AMPLIFY_DIR"
       - echo "AMPLIFY_PATH=$AMPLIFY_PATH"
       - echo "MIGRATION_APP=$MIGRATION_APP"

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -116,6 +116,7 @@
     "semver": "^7.5.4",
     "tar-fs": "^2.1.1",
     "treeify": "^1.1.0",
+    "typescript": "~4.9.5",
     "unzipper": "^0.10.14",
     "update-notifier": "^5.1.0",
     "uuid": "^8.3.2",
@@ -143,8 +144,7 @@
     "cloudform-types": "^4.2.0",
     "jest": "^29.7.0",
     "jest-diff": "^29.7.0",
-    "nock": "^13.5.0",
-    "typescript": "^4.9.5"
+    "nock": "^13.5.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,7 +1277,7 @@ __metadata:
     semver: ^7.5.4
     tar-fs: ^2.1.1
     treeify: ^1.1.0
-    typescript: ^4.9.5
+    typescript: ~4.9.5
     unzipper: ^0.10.14
     update-notifier: ^5.1.0
     uuid: ^8.3.2
@@ -33810,7 +33810,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4, typescript@npm:^4.9.5":
+"typescript@npm:^4.8.4, typescript@npm:^4.9.5, typescript@npm:~4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -33850,7 +33850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@~4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
   bin:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

`typescript` is now a production dependency because `gen2-migration generate` uses it. Also change from `^` to `~` since minor typescript bumps could be breaking (it is known). 

```console
Debug Failure. Unhandled SyntaxKind: Unknown.
Error: Debug Failure. Unhandled SyntaxKind: Unknown.
    at pipelineEmitWithHintWorker (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:107099:22)
    at pipelineEmitWithHint (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106647:17)
    at pipelineEmitWithComments (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:110129:13)
    at pipelineEmit (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106587:13)
    at emit (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106560:13)
    at emitFunctionDeclarationOrExpression (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:108226:13)
    at emitFunctionDeclaration (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:108220:13)
    at pipelineEmitWithHintWorker (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106821:32)
    at pipelineEmitWithHint (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106647:17)
    at pipelineEmitWithComments (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:110129:13)
    at pipelineEmit (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106587:13)
    at emit (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106560:13)
    at emitNodeList (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:109376:25)
    at emitList (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:109263:13)
    at writeList (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106388:13)
    at Object.printList (/snapshot/amplify-cli/build/node_modules/typescript/lib/typescript.js:106360:13)
    at TS.printNodes (/snapshot/amplify-cli/build/node_modules/@aws-amplify/cli-internal/lib/commands/gen2-migration/generate/ts.js:38:29)
    at Object.execute (/snapshot/amplify-cli/build/node_modules/@aws-amplify/cli-internal/lib/commands/gen2-migration/generate/amplify/auth/auth.generator.js:60
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
