### PR TITLE
fix(gen2-migration): preserve email verification disabled setting (#14810)

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -224,6 +224,86 @@ describe('AuthGenerator', () => {
       `);
   });
 
+  it('generates phone login when email verification is disabled', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      AutoVerifiedAttributes: ['phone_number'],
+      UsernameAttributes: ['phone_number'],
+      SchemaAttributes: [{ Name: 'email', Required: true, Mutable: true }],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    expect(writtenFile('auth/resource.ts')).toMatchInlineSnapshot(`
+        "import { defineAuth } from '@aws-amplify/backend';
+        import { CfnResource } from 'aws-cdk-lib';
+        import type { Backend } from '../backend';
+
+        export const auth = defineAuth({
+          loginWith: {
+            phone: true,
+          },
+          userAttributes: {
+            email: {
+              required: true,
+              mutable: true,
+            },
+          },
+          multifactor: {
+            mode: 'OFF',
+          },
+        });
+
+        export function applyEscapeHatches(backend: Backend) {
+          const cfnUserPool = backend.auth.resources.cfnResources.cfnUserPool;
+          cfnUserPool.usernameAttributes = ['phone_number'];
+          cfnUserPool.policies = {
+            passwordPolicy: {},
+          };
+          for (const cfnResource of backend.auth.stack.node
+            .findAll()
+            .filter(
+              (c) =>
+                CfnResource.isCfnResource(c) &&
+                [
+                  'AWS::Cognito::UserPool',
+                  'AWS::Cognito::IdentityPool',
+                  'AWS::Cognito::UserPoolClient',
+                  'AWS::Cognito::IdentityPoolRoleAttachment',
+                  'AWS::Cognito::UserPoolGroup',
+                ].includes(c.cfnResourceType)
+            )) {
+            (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
+            (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
+          }
+        }
+        "
+      `);
+  });
+
   it('generates email with verification options', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -641,18 +641,27 @@ export class AuthRenderer {
     const logInWith = factory.createIdentifier('loginWith');
     const assignments: ts.ObjectLiteralElementLike[] = [];
 
-    const emailOptions =
-      options.userPool.EmailVerificationMessage || options.userPool.EmailVerificationSubject
-        ? {
-            emailVerificationBody: options.userPool.EmailVerificationMessage ?? '',
-            emailVerificationSubject: options.userPool.EmailVerificationSubject ?? '',
-          }
-        : undefined;
+    const autoVerified = options.userPool.AutoVerifiedAttributes ?? [];
+    const isPhoneOnlyVerification = autoVerified.includes('phone_number') && !autoVerified.includes('email');
 
-    if (emailOptions) {
-      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), this.createEmailDefinitionObject(emailOptions)));
+    if (isPhoneOnlyVerification) {
+      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('phone'), factory.createTrue()));
     } else {
-      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), factory.createTrue()));
+      const emailOptions =
+        options.userPool.EmailVerificationMessage || options.userPool.EmailVerificationSubject
+          ? {
+              emailVerificationBody: options.userPool.EmailVerificationMessage ?? '',
+              emailVerificationSubject: options.userPool.EmailVerificationSubject ?? '',
+            }
+          : undefined;
+
+      if (emailOptions) {
+        assignments.push(
+          factory.createPropertyAssignment(factory.createIdentifier('email'), this.createEmailDefinitionObject(emailOptions)),
+        );
+      } else {
+        assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), factory.createTrue()));
+      }
     }
 
     const externalProviders = AuthRenderer.deriveExternalProviders(options.identityProviders);


### PR DESCRIPTION
Solves #14810.

## Issue Summary

The `generate` step does not preserve the "Email based user registration/forgot password: Disabled" setting from Gen 1. When `autoVerifiedAttributes` is `["phone_number"]` (not `["email"]`), the migration tool incorrectly generates `loginWith: { email: true }` instead of `loginWith: { phone: true }`, switching verification from SMS to email.

## Reasoning

1. The issue reports that Gen 1 apps configured with `autoVerifiedAttributes: ["phone_number"]` get migrated to `loginWith: { email: true }`, which changes the verification channel from SMS to email.
2. Read `auth.renderer.ts` — found the `buildLoginWith` method which unconditionally emits either `email: true` or an email options object. It never checks `autoVerifiedAttributes` to determine whether phone-based verification was configured.
3. The fix needs to check `AutoVerifiedAttributes` from the fetched user pool config: if it contains `phone_number` but not `email`, the user had email verification disabled and we should emit `phone: true` instead.
4. The `options.userPool.AutoVerifiedAttributes` array is already available in the render options passed to `buildLoginWith`.

## Solution

- **`auth.renderer.ts`** — In `buildLoginWith`, added a check for `isPhoneOnlyVerification` (autoVerified includes `phone_number` but not `email`). When true, emits `loginWith: { phone: true }` instead of `loginWith: { email: true }`. The existing email verification message/subject logic is preserved in the `else` branch.
- **`auth.generator.test.ts`** — Added a new test case `'generates phone login when email verification is disabled'` that mocks a user pool with `AutoVerifiedAttributes: ['phone_number']` and `UsernameAttributes: ['phone_number']`, and asserts the generated `resource.ts` contains `loginWith: { phone: true }` with `email` as a required-but-not-verified user attribute.

## Example

**Input (Gen 1 — cli-inputs.json):**
```json
{
  "cognitoConfig": {
    "autoVerifiedAttributes": ["phone_number"],
    "requiredAttributes": ["email"]
  }
}
```

**Output — before fix (resource.ts):**
```ts
loginWith: {
  email: true,
},
```

**Output — after fix (resource.ts):**
```ts
loginWith: {
  phone: true,
},
userAttributes: {
  email: {
    required: true,
    mutable: true,
  },
},
```
