### PR TITLE
fix(gen2-migration): grant additional policies for REST API read access

### DIFF
--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/api/adminapi/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/api/adminapi/resource.ts
@@ -110,6 +110,32 @@ export function defineAdminapiApi(backend: Backend) {
       ],
     })
   );
+  // Gen1 read access policies not natively supported by Gen2
+  backend.auth.resources.groups['Admin'].role.attachInlinePolicy(
+    new Policy(stack, 'adminapiAdminReadPolicy', {
+      statements: [
+        new PolicyStatement({
+          actions: [
+            'cognito-identity:Describe*',
+            'cognito-identity:Get*',
+            'cognito-identity:List*',
+            'cognito-idp:Describe*',
+            'cognito-idp:AdminGetDevice',
+            'cognito-idp:AdminGetUser',
+            'cognito-idp:AdminList*',
+            'cognito-idp:List*',
+            'cognito-sync:Describe*',
+            'cognito-sync:Get*',
+            'cognito-sync:List*',
+            'iam:ListOpenIdConnectProviders',
+            'iam:ListRoles',
+            'sns:ListPlatformApplications',
+          ],
+          resources: ['*'],
+        }),
+      ],
+    })
+  );
   backend.addOutput({
     custom: {
       API: {

--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/api/nutritionapi/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/api/nutritionapi/resource.ts
@@ -149,6 +149,58 @@ export function defineNutritionapiApi(backend: Backend) {
       ],
     })
   );
+  // Gen1 read access policies not natively supported by Gen2
+  backend.auth.resources.authenticatedUserIamRole.attachInlinePolicy(
+    new Policy(stack, 'nutritionapiAuthReadPolicy', {
+      statements: [
+        new PolicyStatement({
+          actions: [
+            'cognito-identity:Describe*',
+            'cognito-identity:Get*',
+            'cognito-identity:List*',
+            'cognito-idp:Describe*',
+            'cognito-idp:AdminGetDevice',
+            'cognito-idp:AdminGetUser',
+            'cognito-idp:AdminList*',
+            'cognito-idp:List*',
+            'cognito-sync:Describe*',
+            'cognito-sync:Get*',
+            'cognito-sync:List*',
+            'iam:ListOpenIdConnectProviders',
+            'iam:ListRoles',
+            'sns:ListPlatformApplications',
+          ],
+          resources: ['*'],
+        }),
+      ],
+    })
+  );
+  // Gen1 read access policies not natively supported by Gen2
+  backend.auth.resources.groups['Admin'].role.attachInlinePolicy(
+    new Policy(stack, 'nutritionapiAdminReadPolicy', {
+      statements: [
+        new PolicyStatement({
+          actions: [
+            'cognito-identity:Describe*',
+            'cognito-identity:Get*',
+            'cognito-identity:List*',
+            'cognito-idp:Describe*',
+            'cognito-idp:AdminGetDevice',
+            'cognito-idp:AdminGetUser',
+            'cognito-idp:AdminList*',
+            'cognito-idp:List*',
+            'cognito-sync:Describe*',
+            'cognito-sync:Get*',
+            'cognito-sync:List*',
+            'iam:ListOpenIdConnectProviders',
+            'iam:ListRoles',
+            'sns:ListPlatformApplications',
+          ],
+          resources: ['*'],
+        }),
+      ],
+    })
+  );
   backend.addOutput({
     custom: {
       API: {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/rest-api/rest-api.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/rest-api/rest-api.generator.test.ts
@@ -635,6 +635,32 @@ describe('RestApiGenerator', () => {
             ],
           })
         );
+        // Gen1 read access policies not natively supported by Gen2
+        backend.auth.resources.authenticatedUserIamRole.attachInlinePolicy(
+          new Policy(stack, 'myApiAuthReadPolicy', {
+            statements: [
+              new PolicyStatement({
+                actions: [
+                  'cognito-identity:Describe*',
+                  'cognito-identity:Get*',
+                  'cognito-identity:List*',
+                  'cognito-idp:Describe*',
+                  'cognito-idp:AdminGetDevice',
+                  'cognito-idp:AdminGetUser',
+                  'cognito-idp:AdminList*',
+                  'cognito-idp:List*',
+                  'cognito-sync:Describe*',
+                  'cognito-sync:Get*',
+                  'cognito-sync:List*',
+                  'iam:ListOpenIdConnectProviders',
+                  'iam:ListRoles',
+                  'sns:ListPlatformApplications',
+                ],
+                resources: ['*'],
+              }),
+            ],
+          })
+        );
         backend.addOutput({
           custom: {
             API: {
@@ -784,6 +810,32 @@ describe('RestApiGenerator', () => {
                   gen1myApiApi.arnForExecuteApi('GET', '/admin'),
                   gen1myApiApi.arnForExecuteApi('GET', '/admin/*'),
                 ],
+              }),
+            ],
+          })
+        );
+        // Gen1 read access policies not natively supported by Gen2
+        backend.auth.resources.groups['admins'].role.attachInlinePolicy(
+          new Policy(stack, 'myApiadminsReadPolicy', {
+            statements: [
+              new PolicyStatement({
+                actions: [
+                  'cognito-identity:Describe*',
+                  'cognito-identity:Get*',
+                  'cognito-identity:List*',
+                  'cognito-idp:Describe*',
+                  'cognito-idp:AdminGetDevice',
+                  'cognito-idp:AdminGetUser',
+                  'cognito-idp:AdminList*',
+                  'cognito-idp:List*',
+                  'cognito-sync:Describe*',
+                  'cognito-sync:Get*',
+                  'cognito-sync:List*',
+                  'iam:ListOpenIdConnectProviders',
+                  'iam:ListRoles',
+                  'sns:ListPlatformApplications',
+                ],
+                resources: ['*'],
               }),
             ],
           })
@@ -1004,5 +1056,157 @@ describe('RestApiGenerator', () => {
 
     const output = writtenFile('resource.ts');
     expect(output).toContain('myapiApi');
+  });
+
+  it('renders additional read access policies for auth users with read permission', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        myApi: {
+          service: 'API Gateway',
+          output: { RootUrl: 'https://abc123.execute-api.us-east-1.amazonaws.com/main' },
+        },
+      },
+      auth: { myAuth: { service: 'Cognito' } },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('abc123');
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      paths: {
+        '/items': {
+          lambdaFunction: 'myFunc',
+          permissions: { setting: 'private', auth: ['read'] },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchRestApiRootResourceId').mockResolvedValue('root-resource-id');
+
+    const generator = new RestApiGenerator(gen1App, backendGenerator, outputDir, {
+      category: 'api',
+      resourceName: 'myApi',
+      service: 'API Gateway',
+      key: 'api:API Gateway',
+    });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).toContain('Gen1 read access policies not natively supported by Gen2');
+    expect(output).toContain('myApiAuthReadPolicy');
+    expect(output).toContain('cognito-identity:Describe*');
+    expect(output).toContain('cognito-idp:AdminGetUser');
+    expect(output).toContain('cognito-sync:Get*');
+    expect(output).toContain('iam:ListOpenIdConnectProviders');
+    expect(output).toContain('iam:ListRoles');
+    expect(output).toContain('sns:ListPlatformApplications');
+    expect(output).toContain("resources: ['*']");
+    expect(output).toContain('authenticatedUserIamRole');
+  });
+
+  it('does not render read access policies when no read permission', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        myApi: {
+          service: 'API Gateway',
+          output: { RootUrl: 'https://abc123.execute-api.us-east-1.amazonaws.com/main' },
+        },
+      },
+      auth: { myAuth: { service: 'Cognito' } },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('abc123');
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      paths: {
+        '/items': {
+          lambdaFunction: 'myFunc',
+          permissions: { setting: 'private', auth: ['create', 'update'] },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchRestApiRootResourceId').mockResolvedValue('root-resource-id');
+
+    const generator = new RestApiGenerator(gen1App, backendGenerator, outputDir, {
+      category: 'api',
+      resourceName: 'myApi',
+      service: 'API Gateway',
+      key: 'api:API Gateway',
+    });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).not.toContain('ReadPolicy');
+    expect(output).not.toContain('cognito-identity:Describe*');
+  });
+
+  it('renders read access policies for group with read permission', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        myApi: {
+          service: 'API Gateway',
+          output: { RootUrl: 'https://abc123.execute-api.us-east-1.amazonaws.com/main' },
+        },
+      },
+      auth: { myAuth: { service: 'Cognito' } },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('abc123');
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      paths: {
+        '/admin': {
+          lambdaFunction: 'myFunc',
+          permissions: { setting: 'protected', groups: { admins: ['read', 'create'] } },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchRestApiRootResourceId').mockResolvedValue('root-resource-id');
+
+    const generator = new RestApiGenerator(gen1App, backendGenerator, outputDir, {
+      category: 'api',
+      resourceName: 'myApi',
+      service: 'API Gateway',
+      key: 'api:API Gateway',
+    });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).toContain('myApiadminsReadPolicy');
+    expect(output).toContain('cognito-identity:Describe*');
+    expect(output).toContain("groups['admins'].role.attachInlinePolicy");
+  });
+
+  it('does not render read access policies when no auth category', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        myApi: {
+          service: 'API Gateway',
+          output: { RootUrl: 'https://abc123.execute-api.us-east-1.amazonaws.com/main' },
+        },
+      },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('abc123');
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      paths: {
+        '/items': {
+          lambdaFunction: 'myFunc',
+          permissions: { setting: 'private', auth: ['read'] },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchRestApiRootResourceId').mockResolvedValue('root-resource-id');
+
+    const generator = new RestApiGenerator(gen1App, backendGenerator, outputDir, {
+      category: 'api',
+      resourceName: 'myApi',
+      service: 'API Gateway',
+      key: 'api:API Gateway',
+    });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).not.toContain('ReadPolicy');
+    expect(output).not.toContain('cognito-identity:Describe*');
   });
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/rest-api/rest-api.renderer.ts
@@ -4,6 +4,33 @@ import { newLineIdentifier, TS } from '../../ts';
 const factory = ts.factory;
 
 /**
+ * Gen1 IAM actions granted for the `read` CRUD option on auth resources.
+ *
+ * Gen2's `iamActionMap` only covers specific `cognito-idp:*` actions.
+ * These additional actions (cognito-identity, cognito-sync, iam, sns)
+ * must be escape-hatched as inline policies when a REST API path has
+ * `read` access configured.
+ *
+ * Source: `getIAMPolicies` in Gen1 `auth-questions.ts`, `case 'read'`.
+ */
+const GEN1_AUTH_READ_ACTIONS: readonly string[] = [
+  'cognito-identity:Describe*',
+  'cognito-identity:Get*',
+  'cognito-identity:List*',
+  'cognito-idp:Describe*',
+  'cognito-idp:AdminGetDevice',
+  'cognito-idp:AdminGetUser',
+  'cognito-idp:AdminList*',
+  'cognito-idp:List*',
+  'cognito-sync:Describe*',
+  'cognito-sync:Get*',
+  'cognito-sync:List*',
+  'iam:ListOpenIdConnectProviders',
+  'iam:ListRoles',
+  'sns:ListPlatformApplications',
+];
+
+/**
  * Complete definition of a REST API extracted from Gen1 cli-inputs.json.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any -- paths are untyped Gen1 cli-inputs.json */
@@ -88,6 +115,7 @@ export class RestApiRenderer {
 
     statements.push(...this.renderPaths(restApi, apiVarName, integrations.map));
     statements.push(...this.renderPathPolicies(restApi, apiVarName, 'stack', gen1ApiVarName));
+    statements.push(...this.renderReadAccessPolicies(restApi, 'stack'));
     statements.push(this.renderOutput(apiVarName));
 
     return statements;
@@ -847,6 +875,123 @@ export class RestApiRenderer {
         ],
       ),
     );
+  }
+
+  /**
+   * Renders additional IAM policies for paths with `read` access.
+   *
+   * Gen1 grants broad Cognito/IAM/SNS read policies when a REST API
+   * path has `read` permission. Gen2 does not natively support these,
+   * so they are escape-hatched as inline policies on the authenticated
+   * user role or group role.
+   */
+  private renderReadAccessPolicies(restApi: RestApiRenderOptions, stackVarName: string): ts.Statement[] {
+    if (!this.hasAuth) return [];
+
+    const statements: ts.Statement[] = [];
+    let authReadEmitted = false;
+
+    for (const [, pathConfig] of Object.entries(restApi.paths)) {
+      if (!authReadEmitted && this.pathHasReadPermission(pathConfig.permissions?.auth)) {
+        statements.push(
+          ...this.renderReadPolicyForRole(
+            restApi.apiName,
+            stackVarName,
+            'AuthReadPolicy',
+            TS.propAccess('backend', 'auth', 'resources', 'authenticatedUserIamRole') as ts.Expression,
+          ),
+        );
+        authReadEmitted = true;
+      }
+
+      if (pathConfig.permissions?.groups) {
+        for (const [groupName, permissions] of Object.entries(pathConfig.permissions.groups) as [string, string[]][]) {
+          if (this.pathHasReadPermission(permissions)) {
+            statements.push(
+              ...this.renderReadPolicyForRole(
+                restApi.apiName,
+                stackVarName,
+                `${groupName}ReadPolicy`,
+                factory.createPropertyAccessExpression(
+                  factory.createElementAccessExpression(
+                    TS.propAccess('backend', 'auth', 'resources', 'groups') as ts.Expression,
+                    factory.createStringLiteral(groupName),
+                  ),
+                  factory.createIdentifier('role'),
+                ),
+              ),
+            );
+          }
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  /**
+   * Renders a single read-access policy and attaches it to the given IAM role.
+   */
+  private renderReadPolicyForRole(
+    apiName: string,
+    stackVarName: string,
+    policyName: string,
+    roleExpression: ts.Expression,
+  ): ts.Statement[] {
+    const comment = factory.createNotEmittedStatement(factory.createStringLiteral(''));
+    ts.addSyntheticLeadingComment(
+      comment,
+      ts.SyntaxKind.SingleLineCommentTrivia,
+      ' Gen1 read access policies not natively supported by Gen2',
+      true,
+    );
+
+    const attachCall = factory.createExpressionStatement(
+      factory.createCallExpression(
+        factory.createPropertyAccessExpression(roleExpression, factory.createIdentifier('attachInlinePolicy')),
+        undefined,
+        [
+          factory.createNewExpression(factory.createIdentifier('Policy'), undefined, [
+            factory.createIdentifier(stackVarName),
+            factory.createStringLiteral(`${apiName}${policyName}`),
+            factory.createObjectLiteralExpression(
+              [
+                factory.createPropertyAssignment(
+                  'statements',
+                  factory.createArrayLiteralExpression([
+                    factory.createNewExpression(factory.createIdentifier('PolicyStatement'), undefined, [
+                      factory.createObjectLiteralExpression(
+                        [
+                          factory.createPropertyAssignment(
+                            'actions',
+                            factory.createArrayLiteralExpression(
+                              GEN1_AUTH_READ_ACTIONS.map((action) => factory.createStringLiteral(action)),
+                            ),
+                          ),
+                          factory.createPropertyAssignment(
+                            'resources',
+                            factory.createArrayLiteralExpression([factory.createStringLiteral('*')]),
+                          ),
+                        ],
+                        true,
+                      ),
+                    ]),
+                  ]),
+                ),
+              ],
+              true,
+            ),
+          ]),
+        ],
+      ),
+    );
+
+    return [comment as unknown as ts.Statement, attachCall];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw cli-inputs permissions array
+  private pathHasReadPermission(permissions: any): boolean {
+    return Array.isArray(permissions) && permissions.includes('read');
   }
 
   private hasPathAuth(restApi: RestApiRenderOptions): boolean {


### PR DESCRIPTION
Solves #14610.

## Issue Summary

When REST APIs are configured in a Gen1 app with `read` access on auth resources, Gen1's `getIAMPolicies` (in `auth-questions.ts`) grants 14 IAM actions spanning `cognito-identity`, `cognito-idp`, `cognito-sync`, `iam`, and `sns`. After migration, these policies are lost because the REST API renderer only generates `execute-api:Invoke` policies.

However, not all 14 actions need to be escape-hatched. Gen2's `iamActionMap` (in `userpool_access_policy_factory.ts`) already covers the `cognito-idp` subset — actions like `AdminGetDevice`, `AdminGetUser`, and the wildcards `AdminList*` / `List*` that PR #14600 expanded. Only the actions that Gen2 has **no mechanism** to grant need escape-hatching.

## What changed

#### REST API renderer

`renderReadAccessPolicies()` detects paths with `read` permission on auth/groups and emits inline IAM policies. The escape-hatched action list (`GEN1_READ_ACTIONS_NOT_IN_GEN2`) contains only the 10 actions Gen2 cannot grant through its own APIs:

| Service            | Actions                                   | Why escape-hatched                            |
| ------------------ | ----------------------------------------- | --------------------------------------------- |
| `cognito-identity` | `Describe*`, `Get*`, `List*`              | Gen2 has no identity pool action mapping      |
| `cognito-idp`      | `Describe*`                               | Gen2's `iamActionMap` has no Describe actions |
| `cognito-sync`     | `Describe*`, `Get*`, `List*`              | Gen2 has no sync action mapping               |
| `iam`              | `ListOpenIdConnectProviders`, `ListRoles` | Outside Cognito scope                         |
| `sns`              | `ListPlatformApplications`                | Outside Cognito scope                         |

The following Gen1 `read` actions are intentionally **excluded** because Gen2 already covers them via `iamActionMap`:

- `cognito-idp:AdminGetDevice` → Gen2 `getDevice`
- `cognito-idp:AdminGetUser` → Gen2 `getUser`
- `cognito-idp:AdminList*` → Gen2 `listDevices`, `listGroupsForUser` (expanded by PR #14600)
- `cognito-idp:List*` → Gen2 `listUsers`, `listUsersInGroup`, `listGroups` (expanded by PR #14600)

#### Tests

Added 4 test cases: auth users with read permission (verifies correct actions present AND Gen2-covered actions absent), no read permission, group with read permission, and no auth category.

#### Snapshots

Updated fitness-tracker golden snapshots (`adminapi/resource.ts`, `nutritionapi/resource.ts`) to reflect the trimmed action list.

## Example

**Gen1 cli-inputs.json:**

```json
{
  "/items": {
    "permissions": { "setting": "private", "auth": ["read", "create"] }
  }
}
```

**Generated output (backend.ts):**

```ts
// Gen1 read access policies not natively supported by Gen2
backend.auth.resources.authenticatedUserIamRole.attachInlinePolicy(
  new Policy(stack, 'myApiAuthReadPolicy', {
    statements: [
      new PolicyStatement({
        actions: [
          'cognito-identity:Describe*',
          'cognito-identity:Get*',
          'cognito-identity:List*',
          'cognito-idp:Describe*',
          'cognito-sync:Describe*',
          'cognito-sync:Get*',
          'cognito-sync:List*',
          'iam:ListOpenIdConnectProviders',
          'iam:ListRoles',
          'sns:ListPlatformApplications',
        ],
        resources: ['*'],
      }),
    ],
  }),
);
```

Note: `cognito-idp:AdminGetDevice`, `AdminGetUser`, `AdminList*`, and `List*` are **not** included — Gen2 handles those natively through its auth access block.
