### PR TITLE
chore: enable long paths for windows smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,6 +31,10 @@ jobs:
     name: Smoke Tests ${{ matrix.os }} ${{ matrix.cli-version }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Enable long paths
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:


### PR DESCRIPTION
#### Description of changes

Followup to https://github.com/aws-amplify/amplify-cli/pull/14844 as we still have other files that are too long. Thankfully these are not files we create on customer machines so we can apply a git config to fix the smoke tests checkout process.

#### Issue #, if available

#### Description of how you validated changes

https://github.com/aws-amplify/amplify-cli/actions/runs/25220854475

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
