### PR TITLE
fix(cli): dynamo table mappings are sometimes omitted in `gen2-migration generate` 

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -26,16 +26,13 @@ const dataResource: DiscoveredResource = {
   key: 'api:AppSync',
 };
 
-/** Generates a minimal build schema containing ModelXConnection types for each model name. */
-function buildSchemaFor(...modelNames: string[]): string {
-  return modelNames.map((m) => `type Model${m}Connection { items: [${m}]! nextToken: String }`).join('\n');
-}
-
 /**
- * Mocks gen1App.file() to return the build schema for the build path
- * and the raw schema for all other paths.
+ * Mocks gen1App.file() so it returns the raw schema for the source
+ * path and a synthetic build schema (with ModelXConnection types)
+ * for the build path.
  */
-function mockFiles(gen1App: Gen1App, rawSchema: string, buildSchema: string): void {
+function mockSchema(gen1App: Gen1App, rawSchema: string, modelNames: string[]): void {
+  const buildSchema = modelNames.map((m) => `type Model${m}Connection { items: [${m}]! nextToken: String }`).join('\n');
   jest.spyOn(gen1App, 'file').mockImplementation((p: string) => {
     if (p.includes('build/schema.graphql')) return buildSchema;
     return rawSchema;
@@ -63,7 +60,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
 
     const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource);
     await expect(generator.plan()).rejects.toThrow('GraphQLAPIIdOutput');
@@ -79,7 +76,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App.aws, 'fetchGraphqlApi').mockResolvedValue(undefined);
 
     const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource);
@@ -96,7 +93,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -125,7 +122,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -158,7 +155,7 @@ describe('DataGenerator', () => {
       },
       auth: { myAuth: { service: 'Cognito' } },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -188,7 +185,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -219,7 +216,7 @@ describe('DataGenerator', () => {
       },
       auth: { myAuth: { service: 'Cognito' } },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -249,7 +246,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! title: String! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! title: String! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc123';
       return undefined as any;
@@ -294,7 +291,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       if (key === 'authConfig') return { defaultAuthentication: { authenticationType: 'AWS_IAM' } } as any;
@@ -339,7 +336,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -395,7 +392,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -464,7 +461,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -521,7 +518,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -566,7 +563,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { env: String @default(value: "${env}") }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { env: String @default(value: "${env}") }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -614,7 +611,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -642,7 +639,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    mockFiles(gen1App, 'type Todo @model { id: ID! } type Post @model { id: ID! }', buildSchemaFor('Todo', 'Post'));
+    mockSchema(gen1App, 'type Todo @model { id: ID! } type Post @model { id: ID! }', ['Todo', 'Post']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       return undefined as any;
@@ -687,7 +684,7 @@ describe('DataGenerator', () => {
       },
     });
     const rawSchema = 'type Todo @auth(rules: [{ allow: public }]) @model { id: ID! } type Post @key(name: "byUser") @model { id: ID! }';
-    mockFiles(gen1App, rawSchema, buildSchemaFor('Todo', 'Post'));
+    mockSchema(gen1App, rawSchema, ['Todo', 'Post']);
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       return undefined as any;

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -659,4 +659,59 @@ describe('DataGenerator', () => {
       "
     `);
   });
+
+  it('renders table mappings when @model is not the first directive', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        testApi: {
+          service: 'AppSync',
+          output: { GraphQLAPIIdOutput: 'abc' },
+        },
+      },
+    });
+    const rawSchema = 'type Todo @auth(rules: [{ allow: public }]) @model { id: ID! } type Post @key(name: "byUser") @model { id: ID! }';
+    const buildSchema = [
+      'type Todo { id: ID! createdAt: AWSDateTime! updatedAt: AWSDateTime! }',
+      'type Post { id: ID! createdAt: AWSDateTime! updatedAt: AWSDateTime! }',
+      'type ModelTodoConnection { items: [Todo]! nextToken: String }',
+      'type ModelPostConnection { items: [Post]! nextToken: String }',
+    ].join('\n');
+    jest.spyOn(gen1App, 'fileExists').mockImplementation((p: string) => p.includes('build/schema.graphql'));
+    jest.spyOn(gen1App, 'file').mockImplementation((p: string) => {
+      if (p.includes('build/schema.graphql')) return buildSchema;
+      return rawSchema;
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
+      if (key === 'GraphQLAPIIdOutput') return 'abc';
+      return undefined as any;
+    });
+    jest.spyOn(gen1App.aws, 'fetchGraphqlApi').mockResolvedValue({ apiId: 'abc', name: 'testApi', additionalAuthenticationProviders: [] });
+
+    const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
+      "import { defineData } from '@aws-amplify/backend';
+      import type { Backend } from '../backend';
+
+      const schema = \`type Todo @auth(rules: [{ allow: public }]) @model { id: ID! } type Post @key(name: "byUser") @model { id: ID! }\`;
+
+      export const data = defineData({
+        migratedAmplifyGen1DynamoDbTableMappings: [
+          {
+            //The "branchName" variable needs to be the same as your deployment branch if you want to reuse your Gen1 app tables
+            branchName: 'main',
+            modelNameToTableNameMapping: {
+              Todo: 'Todo-abc-main',
+              Post: 'Post-abc-main',
+            },
+          },
+        ],
+        schema,
+      });
+      "
+    `);
+  });
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -27,15 +27,15 @@ const dataResource: DiscoveredResource = {
 };
 
 /**
- * Mocks gen1App.file() so it returns the raw schema for the source
- * path and a synthetic build schema (with ModelXConnection types)
- * for the build path.
+ * Mocks gen1App.file() to return the appropriate schema content
+ * based on the requested path. Throws on unexpected paths.
  */
 function mockSchema(gen1App: Gen1App, rawSchema: string, modelNames: string[]): void {
   const buildSchema = modelNames.map((m) => `type Model${m}Connection { items: [${m}]! nextToken: String }`).join('\n');
   jest.spyOn(gen1App, 'file').mockImplementation((p: string) => {
     if (p.includes('build/schema.graphql')) return buildSchema;
-    return rawSchema;
+    if (p.endsWith('schema.graphql')) return rawSchema;
+    throw new Error(`Unexpected file() call with path: ${p}`);
   });
 }
 

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -1,7 +1,7 @@
 import { GraphqlApi } from '@aws-sdk/client-appsync';
 import { DataGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/data/data.generator';
 import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
-import { DiscoveredResource } from '../../../../../../commands/gen2-migration/_common/gen1-app';
+import { DiscoveredResource, Gen1App } from '../../../../../../commands/gen2-migration/_common/gen1-app';
 import { createGen1App } from '../../_helpers/create-gen1-app';
 
 jest.unmock('fs-extra');
@@ -26,6 +26,22 @@ const dataResource: DiscoveredResource = {
   key: 'api:AppSync',
 };
 
+/** Generates a minimal build schema containing ModelXConnection types for each model name. */
+function buildSchemaFor(...modelNames: string[]): string {
+  return modelNames.map((m) => `type Model${m}Connection { items: [${m}]! nextToken: String }`).join('\n');
+}
+
+/**
+ * Mocks gen1App.file() to return the build schema for the build path
+ * and the raw schema for all other paths.
+ */
+function mockFiles(gen1App: Gen1App, rawSchema: string, buildSchema: string): void {
+  jest.spyOn(gen1App, 'file').mockImplementation((p: string) => {
+    if (p.includes('build/schema.graphql')) return buildSchema;
+    return rawSchema;
+  });
+}
+
 describe('DataGenerator', () => {
   let backendGenerator: BackendGenerator;
   const outputDir = '/fake/output';
@@ -47,7 +63,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
 
     const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource);
     await expect(generator.plan()).rejects.toThrow('GraphQLAPIIdOutput');
@@ -63,7 +79,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App.aws, 'fetchGraphqlApi').mockResolvedValue(undefined);
 
     const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource);
@@ -80,7 +96,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -109,7 +125,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -142,7 +158,7 @@ describe('DataGenerator', () => {
       },
       auth: { myAuth: { service: 'Cognito' } },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -172,7 +188,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -203,7 +219,7 @@ describe('DataGenerator', () => {
       },
       auth: { myAuth: { service: 'Cognito' } },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -233,7 +249,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! title: String! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! title: String! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc123';
       return undefined as any;
@@ -278,7 +294,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       if (key === 'authConfig') return { defaultAuthentication: { authenticationType: 'AWS_IAM' } } as any;
@@ -323,7 +339,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -379,7 +395,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -448,7 +464,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       if (key === 'authConfig')
@@ -505,7 +521,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -550,7 +566,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { env: String @default(value: "${env}") }');
+    mockFiles(gen1App, 'type Todo @model { env: String @default(value: "${env}") }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -598,7 +614,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! }', buildSchemaFor('Todo'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'api-123';
       return undefined as any;
@@ -626,7 +642,7 @@ describe('DataGenerator', () => {
         },
       },
     });
-    jest.spyOn(gen1App, 'file').mockReturnValue('type Todo @model { id: ID! } type Post @model { id: ID! }');
+    mockFiles(gen1App, 'type Todo @model { id: ID! } type Post @model { id: ID! }', buildSchemaFor('Todo', 'Post'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       return undefined as any;
@@ -671,17 +687,7 @@ describe('DataGenerator', () => {
       },
     });
     const rawSchema = 'type Todo @auth(rules: [{ allow: public }]) @model { id: ID! } type Post @key(name: "byUser") @model { id: ID! }';
-    const buildSchema = [
-      'type Todo { id: ID! createdAt: AWSDateTime! updatedAt: AWSDateTime! }',
-      'type Post { id: ID! createdAt: AWSDateTime! updatedAt: AWSDateTime! }',
-      'type ModelTodoConnection { items: [Todo]! nextToken: String }',
-      'type ModelPostConnection { items: [Post]! nextToken: String }',
-    ].join('\n');
-    jest.spyOn(gen1App, 'fileExists').mockImplementation((p: string) => p.includes('build/schema.graphql'));
-    jest.spyOn(gen1App, 'file').mockImplementation((p: string) => {
-      if (p.includes('build/schema.graphql')) return buildSchema;
-      return rawSchema;
-    });
+    mockFiles(gen1App, rawSchema, buildSchemaFor('Todo', 'Post'));
     jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
       if (key === 'GraphQLAPIIdOutput') return 'abc';
       return undefined as any;

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
@@ -36,7 +36,7 @@ export class DataGenerator implements Planner {
     const schema = this.gen1App.file(path.join('api', this.resource.resourceName, 'schema.graphql'));
     const apiId = this.gen1App.resourceMetaOutput(this.resource, 'GraphQLAPIIdOutput');
 
-    const tableMappings = this.createTableMappings(schema, apiId);
+    const tableMappings = this.createTableMappings(apiId);
 
     const graphqlApi = await this.gen1App.aws.fetchGraphqlApi(apiId);
     if (!graphqlApi) {
@@ -88,26 +88,14 @@ export class DataGenerator implements Planner {
    * transformer expands each @model type into a `Model<Name>Connection`
    * type. This is more reliable than regex-matching `@model` in the
    * raw schema, which is sensitive to directive ordering.
-   *
-   * Falls back to the raw schema regex when build/schema.graphql is
-   * absent.
    */
-  private createTableMappings(schema: string, apiId: string): Record<string, string> {
+  private createTableMappings(apiId: string): Record<string, string> {
     const buildSchemaPath = path.join('api', this.resource.resourceName, 'build', 'schema.graphql');
-    if (this.gen1App.fileExists(buildSchemaPath)) {
-      const buildSchema = this.gen1App.file(buildSchemaPath);
-      const connectionRegex = /type\s+Model(\w+)Connection\b/g;
-      const mapping: Record<string, string> = {};
-      let match: RegExpExecArray | null;
-      while ((match = connectionRegex.exec(buildSchema)) !== null) {
-        mapping[match[1]] = [match[1], apiId, this.gen1App.envName].join('-');
-      }
-      return mapping;
-    }
-    const modelRegex = /type\s+(\w+)\s+@model/g;
+    const buildSchema = this.gen1App.file(buildSchemaPath);
+    const connectionRegex = /type\s+Model(\w+)Connection\b/g;
     const mapping: Record<string, string> = {};
     let match: RegExpExecArray | null;
-    while ((match = modelRegex.exec(schema)) !== null) {
+    while ((match = connectionRegex.exec(buildSchema)) !== null) {
       mapping[match[1]] = [match[1], apiId, this.gen1App.envName].join('-');
     }
     return mapping;

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
@@ -80,7 +80,30 @@ export class DataGenerator implements Planner {
     ];
   }
 
+  /**
+   * Extracts @model type names and maps each to its DynamoDB table
+   * name ({ModelName}-{apiId}-{envName}).
+   *
+   * Reads the compiled build/schema.graphql where the Amplify
+   * transformer expands each @model type into a `Model<Name>Connection`
+   * type. This is more reliable than regex-matching `@model` in the
+   * raw schema, which is sensitive to directive ordering.
+   *
+   * Falls back to the raw schema regex when build/schema.graphql is
+   * absent.
+   */
   private createTableMappings(schema: string, apiId: string): Record<string, string> {
+    const buildSchemaPath = path.join('api', this.resource.resourceName, 'build', 'schema.graphql');
+    if (this.gen1App.fileExists(buildSchemaPath)) {
+      const buildSchema = this.gen1App.file(buildSchemaPath);
+      const connectionRegex = /type\s+Model(\w+)Connection\b/g;
+      const mapping: Record<string, string> = {};
+      let match: RegExpExecArray | null;
+      while ((match = connectionRegex.exec(buildSchema)) !== null) {
+        mapping[match[1]] = [match[1], apiId, this.gen1App.envName].join('-');
+      }
+      return mapping;
+    }
     const modelRegex = /type\s+(\w+)\s+@model/g;
     const mapping: Record<string, string> = {};
     let match: RegExpExecArray | null;


### PR DESCRIPTION
Fixes #14487.

## Issue Summary

The `generate` command sometimes omits `migratedAmplifyGen1DynamoDbTableMappings` from the data resource. This is caused by the model-detection regex `type\s+(\w+)\s+@model` failing when `@model` is not the first directive on a type (e.g., `type Todo @auth(...) @model`).

## Reasoning

1. The issue describes the bug as "sporadic," but investigation revealed it's actually deterministic based on directive ordering in the GraphQL schema.
2. Read `data.generator.ts` — found `createTableMappings()` which uses `type\s+(\w+)\s+@model` to find model types. This regex requires `@model` to immediately follow the type name, so `type Todo @auth(...) @model` doesn't match.
3. The compiled `build/schema.graphql` (produced by the Amplify transformer) is more reliable — it expands each `@model` type into a `Model<Name>Connection` type. Matching `type Model(\w+)Connection` against the build schema is directive-order-independent.
4. The fix reads `build/schema.graphql` when available and falls back to the raw schema regex when it's not.

## Solution

- **`data.generator.ts`** — `createTableMappings()` now first checks for `build/schema.graphql` in the API resource directory. If present, it extracts model names by matching `type Model(\w+)Connection` patterns. Falls back to the original `@model` regex when the build schema is absent.
- **`data.generator.test.ts`** — Added test `'renders table mappings when @model is not the first directive'` with a schema where `@auth` and `@key` precede `@model`, verifying both types are correctly mapped.

## Example

**Input (Gen 1 — schema.graphql):**
```graphql
type Todo @auth(rules: [{ allow: public }]) @model {
  id: ID!
}
type Post @key(name: "byUser") @model {
  id: ID!
}
```

**Output — before fix (resource.ts):**
```ts
export const data = defineData({
  // migratedAmplifyGen1DynamoDbTableMappings is MISSING
  schema,
});
```

**Output — after fix (resource.ts):**
```ts
export const data = defineData({
  migratedAmplifyGen1DynamoDbTableMappings: [
    {
      branchName: 'main',
      modelNameToTableNameMapping: {
        Todo: 'Todo-abc-main',
        Post: 'Post-abc-main',
      },
    },
  ],
  schema,
});
```
