### PR TITLE
fix(gen2-migration): handle secrets in function definitions

### DIFF
--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/lowstockproducts/resource.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/lowstockproducts/resource.ts
@@ -1,4 +1,4 @@
-import { defineFunction } from '@aws-amplify/backend';
+import { defineFunction, secret } from '@aws-amplify/backend';
 import type { Backend } from '../../backend';
 
 const branchName = process.env.AWS_BRANCH ?? 'sandbox';
@@ -12,8 +12,7 @@ export const lowstockproducts = defineFunction({
     ENV: `${branchName}`,
     REGION: 'us-east-1',
     LOW_STOCK_THRESHOLD: '5',
-    PRODUCT_CATALOG_SECRET:
-      '/amplify/productcatalog/x/AMPLIFY_lowstockproducts_PRODUCT_CATALOG_SECRET',
+    PRODUCT_CATALOG_SECRET: secret('PRODUCT_CATALOG_SECRET'),
   },
   runtime: 22,
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
@@ -445,6 +445,66 @@ describe('FunctionGenerator', () => {
     `);
   });
 
+  it('renders SSM secret env vars as secret() calls', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      function: {
+        myFunc: {
+          service: 'Lambda',
+          output: { Name: 'myFunc-main-abc', Arn: 'arn:aws:lambda:us-east-1:123:function:myFunc-main-abc' },
+        },
+      },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('myFunc-main-abc');
+    jest.spyOn(gen1App, 'json').mockReturnValue({ Resources: {} });
+    jest.spyOn(gen1App, 'file').mockReturnValue('{}');
+    jest.spyOn(gen1App, 'fileExists').mockReturnValue(false);
+    jest.spyOn(gen1App.aws, 'fetchFunctionConfig').mockResolvedValue({
+      FunctionName: 'myFunc-main-abc',
+      Handler: 'index.handler',
+      Timeout: 3,
+      MemorySize: 128,
+      Runtime: 'nodejs18.x',
+      Environment: {
+        Variables: {
+          MY_SECRET: '/amplify/test-app-id/main/AMPLIFY_myFunc_MY_SECRET',
+          ANOTHER_SECRET: '/amplify/test-app-id/main/AMPLIFY_myFunc_ANOTHER_SECRET',
+          DB_HOST: 'localhost',
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchFunctionSchedule').mockResolvedValue(undefined);
+
+    const generator = createFunctionGenerator({ gen1App, backendGenerator, packageJsonGenerator, outputDir });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
+      "import { defineFunction, secret } from '@aws-amplify/backend';
+      import type { Backend } from '../../backend';
+
+      const branchName = process.env.AWS_BRANCH ?? 'sandbox';
+
+      export const myFunc = defineFunction({
+        entry: './index.js',
+        name: \`myFunc-\${branchName}\`,
+        timeoutSeconds: 3,
+        memoryMB: 128,
+        environment: {
+          MY_SECRET: secret('MY_SECRET'),
+          ANOTHER_SECRET: secret('ANOTHER_SECRET'),
+          DB_HOST: 'localhost',
+        },
+        runtime: 18,
+      });
+
+      export function applyEscapeHatches(backend: Backend) {
+        backend.myFunc.resources.cfnResources.cfnFunction.functionName = \`myFunc-\${branchName}\`;
+      }
+      "
+    `);
+  });
+
   it('renders environment variables', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.renderer.ts
@@ -308,12 +308,14 @@ export class FunctionRenderer {
   ): void {
     if (!opts.literalEnvVars || Object.keys(opts.literalEnvVars).length === 0) return;
 
+    const ssmSecretPrefix = `/amplify/${this.appId}/${this.backendEnvironmentName}/`;
+
     const envProps = Object.entries(opts.literalEnvVars).map(([key, value]) => {
-      if (key === 'API_KEY' && value.startsWith(`/amplify/${this.appId}/${this.backendEnvironmentName}`)) {
+      if (value.startsWith(ssmSecretPrefix)) {
         namedImports['@aws-amplify/backend'].add('secret');
         return factory.createPropertyAssignment(
           key,
-          factory.createCallExpression(factory.createIdentifier('secret'), undefined, [factory.createStringLiteral('API_KEY')]),
+          factory.createCallExpression(factory.createIdentifier('secret'), undefined, [factory.createStringLiteral(key)]),
         );
       }
 


### PR DESCRIPTION
Solves #14517.

## Issue Summary

When a Gen 1 function has secrets stored as SSM `SecureString` parameters, the `generate` command outputs the raw SSM path as a string literal in the `environment` block instead of using Gen 2's `secret()` API. The fix generalizes the existing `API_KEY`-only secret detection to recognize any env var whose value matches the SSM secret path pattern.

## Reasoning

1. In Gen 1, secrets are stored as SSM SecureString parameters at `/amplify/{appId}/{env}/AMPLIFY_{funcName}_{KEY}`. The path is set as the env var value, and the function fetches it at runtime via `@aws-sdk/client-ssm`.
2. In Gen 2, `secret('KEY')` handles this automatically — the value is fetched at function load time and available via `process.env.KEY`.
3. Read `function.renderer.ts` — found `renderEnvironment()` which already had a special case for `API_KEY` that checked if the value starts with the SSM prefix and emits `secret('API_KEY')`. But it was hardcoded to only match the key `API_KEY`.
4. The fix generalizes the condition: any env var whose value starts with `/amplify/{appId}/{envName}/` is treated as a secret, using the env var's own key name in the `secret()` call.

## Solution

- **`function.renderer.ts`** — Changed the secret detection from `key === 'API_KEY' && value.startsWith(...)` to just `value.startsWith(ssmSecretPrefix)`. The `secret()` call now uses the actual key name instead of hardcoded `'API_KEY'`.
- **`function.generator.test.ts`** — Added test `'renders SSM secret env vars as secret() calls'` that mocks a function with two SSM-path env vars and one regular env var, verifying the output uses `secret('MY_SECRET')` and `secret('ANOTHER_SECRET')` while keeping `DB_HOST: 'localhost'` as a literal.
- **product-catalog snapshot** — Updated `lowstockproducts/resource.ts` golden snapshot (the function had an SSM-path env var that now renders as `secret()`).

## Example

**Input (Gen 1 — deployed function config):**
```json
{
  "Environment": {
    "Variables": {
      "MY_SECRET": "/amplify/d1abc2def3/main/AMPLIFY_myFunc_MY_SECRET",
      "DB_HOST": "localhost"
    }
  }
}
```

**Output — before fix (resource.ts):**
```ts
import { defineFunction } from '@aws-amplify/backend';

export const myFunc = defineFunction({
  environment: {
    MY_SECRET: '/amplify/d1abc2def3/main/AMPLIFY_myFunc_MY_SECRET',
    DB_HOST: 'localhost',
  },
});
```

**Output — after fix (resource.ts):**
```ts
import { defineFunction, secret } from '@aws-amplify/backend';

export const myFunc = defineFunction({
  environment: {
    MY_SECRET: secret('MY_SECRET'),
    DB_HOST: 'localhost',
  },
});
```
