### PR TITLE
fix(cli): drift not showing up in help

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.rulers": [140],
   "files.exclude": {
     "**/.git": true,
-    "**/build": true
+    "**/build": false
   },
   "files.insertFinalNewline": true,
   "editor.formatOnSave": true,

--- a/packages/amplify-cli-core/src/help/commands-info.ts
+++ b/packages/amplify-cli-core/src/help/commands-info.ts
@@ -1336,6 +1336,13 @@ export const commandsInfo: Array<CommandInfo> = [
     ],
   },
   {
+    command: 'drift',
+    commandDescription: 'Detect drift between local, deployed, and actual cloud resource states',
+    commandUsage: 'amplify drift',
+    commandFlags: [],
+    subCommands: [],
+  },
+  {
     command: 'build',
     commandDescription: 'Builds all resources in the project',
     commandUsage: 'amplify build',

--- a/packages/amplify-cli/amplify-plugin.json
+++ b/packages/amplify-cli/amplify-plugin.json
@@ -7,6 +7,7 @@
     "console",
     "delete",
     "diagnose",
+    "drift",
     "env",
     "export",
     "gen2-migration",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Added `drift` command spec to `commands-info.ts`, which controls the help message.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

Run `amplify --help` locally:

```console
 ❯ /Users/epolon/dev/src/github.com/aws-amplify/amplify-cli/packages/amplify-cli/bin/amplify --help                                             [14:50:42]

⚠️  WARNING: AWS Amplify Gen 1 CLI is in maintenance mode and will reach end of life on May 1, 2027.
During maintenance mode, only critical bug fixes and security patches will be provided.
Migrate to Amplify Gen 2: https://docs.amplify.aws/react/start/migrate-to-gen2/

The Amplify Command Line Interface (CLI) is a unified toolchain to
create, integrate, and manage the AWS cloud services for your app.

USAGE
  amplify <command> <subcommand> [flags]

COMMANDS
  ...
  drift           Detect drift between local, deployed, and actual cloud resource states
  ...
```

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
