### PR TITLE
fix(cli): `gen2-migration assess` breaks on function custom policies that defined direct IAM policies

### DIFF
--- a/packages/amplify-cli-core/src/help/commands-info.ts
+++ b/packages/amplify-cli-core/src/help/commands-info.ts
@@ -804,6 +804,12 @@ export const commandsInfo: Array<CommandInfo> = [
         subCommandUsage: 'amplify gen2-migration refactor [--skip-validations] [--validations-only] [--rollback] [--no-rollback]',
         subCommandFlags: [],
       },
+      {
+        subCommand: 'retain',
+        subCommandDescription: 'Applies retention policies to Gen1 stack resources so they survive stack deletion',
+        subCommandUsage: 'amplify gen2-migration retain [--skip-validations] [--validations-only] [--rollback] [--no-rollback]',
+        subCommandFlags: [],
+      },
     ],
   },
   {

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -80,6 +80,7 @@
     "@aws-sdk/client-ssm": "^3.919.0",
     "@aws-sdk/client-sts": "^3.919.0",
     "@smithy/node-http-handler": "^4.4.3",
+    "@smithy/util-retry": "^4.2.0",
     "amplify-codegen": "^4.10.3",
     "amplify-dotnet-function-runtime-provider": "2.1.8",
     "amplify-go-function-runtime-provider": "2.3.55",

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess.test.ts
@@ -1,5 +1,6 @@
 import { AmplifyMigrationAssessor } from '../../../commands/gen2-migration/assess';
 import { Gen1App, DiscoveredResource } from '../../../commands/gen2-migration/_common/gen1-app';
+import { SpinningLogger } from '../../../commands/gen2-migration/_common/spinning-logger';
 
 function mockGen1App(resources: DiscoveredResource[], existingFiles: string[] = [], jsonFiles: Record<string, unknown> = {}): Gen1App {
   const fileSet = new Set(existingFiles);
@@ -22,7 +23,7 @@ describe('AmplifyMigrationAssessor', () => {
   describe('assess()', () => {
     it('returns empty assessment when no resources discovered', () => {
       const gen1App = mockGen1App([]);
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.resources).toHaveLength(0);
@@ -40,7 +41,7 @@ describe('AmplifyMigrationAssessor', () => {
           'function/myFunc/custom-policies.json': [{ Action: ['s3:GetObject'], Resource: ['arn:aws:s3:::my-bucket/*'] }],
         },
       );
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.features).toHaveLength(1);
@@ -52,7 +53,7 @@ describe('AmplifyMigrationAssessor', () => {
         [{ category: 'auth', resourceName: 'myPool', service: 'Cognito', key: 'auth:Cognito' }],
         ['auth/myPool/override.ts'],
       );
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.features).toHaveLength(1);
@@ -68,7 +69,7 @@ describe('AmplifyMigrationAssessor', () => {
           'function/myFunc/custom-policies.json': [{ Action: [], Resource: [] }],
         },
       );
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.features).toHaveLength(0);
@@ -76,7 +77,7 @@ describe('AmplifyMigrationAssessor', () => {
 
     it('marks UNKNOWN resources as unsupported', () => {
       const gen1App = mockGen1App([{ category: 'notifications', resourceName: 'push', service: 'Pinpoint', key: 'UNKNOWN' }]);
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.resources).toHaveLength(1);
@@ -94,7 +95,7 @@ describe('AmplifyMigrationAssessor', () => {
           },
         },
       );
-      const assessor = new AmplifyMigrationAssessor(gen1App);
+      const assessor = new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess'));
       const assessment = assessor.assess();
 
       expect(assessment.resources).toHaveLength(1);
@@ -116,7 +117,7 @@ describe('AmplifyMigrationAssessor', () => {
       const { printer } = require('@aws-amplify/amplify-prompts');
       const infoSpy = jest.spyOn(printer, 'info').mockImplementation(() => {});
 
-      new AmplifyMigrationAssessor(gen1App).run();
+      new AmplifyMigrationAssessor(gen1App, new SpinningLogger('assess')).run();
 
       expect(infoSpy).toHaveBeenCalled();
 

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/function/function.assessor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/function/function.assessor.test.ts
@@ -55,6 +55,21 @@ describe('FunctionAssessor', () => {
     expect(assessment.features).toHaveLength(0);
   });
 
+  it('detects direct IAM policy object in custom-policies.json', () => {
+    const gen1App = mockGen1App(['function/myFunc/custom-policies.json'], {
+      [NODEJS_TEMPLATE_PATH]: NODEJS_TEMPLATE,
+      'function/myFunc/custom-policies.json': {
+        Version: '2012-10-17',
+        Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:aws:s3:::bucket/*' }],
+      },
+    });
+    const assessment = new Assessment('app', 'dev');
+    new FunctionAssessor(gen1App, RESOURCE).record(assessment);
+
+    expect(assessment.features).toHaveLength(1);
+    expect(assessment.features[0]!.generate.level).toBe('unsupported');
+  });
+
   it('records no features when custom-policies.json is absent', () => {
     const gen1App = mockGen1App([], { [NODEJS_TEMPLATE_PATH]: NODEJS_TEMPLATE });
     const assessment = new Assessment('app', 'dev');

--- a/packages/amplify-cli/src/commands/gen2-migration.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration.ts
@@ -66,7 +66,7 @@ export const run = async (context: $TSContext) => {
 
   // Assess is not a migration step — handle it separately.
   if (stepName === 'assess') {
-    const assessor = new AmplifyMigrationAssessor(gen1App);
+    const assessor = new AmplifyMigrationAssessor(gen1App, logger);
     assessor.run();
     return;
   }

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/aws-clients.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/aws-clients.ts
@@ -15,6 +15,7 @@ import { NodeHttpHandler } from '@smithy/node-http-handler';
 import type { AmplifyClientConfig } from '@aws-sdk/client-amplify';
 import { ProxyAgent } from 'proxy-agent';
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
+import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 
 export const proxyAgent = () => {
   let httpAgent;
@@ -79,6 +80,8 @@ export class AwsClients {
     const config: ClientConfig = {
       ...cred,
       customUserAgent: provider.formUserAgentParam(context, 'gen2-migration'),
+      // https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html
+      retryStrategy: new ConfiguredRetryStrategy(10, (attempt) => 1000 * 2 ** attempt),
       requestHandler: new NodeHttpHandler({
         httpAgent: proxyAgent(),
         httpsAgent: proxyAgent(),

--- a/packages/amplify-cli/src/commands/gen2-migration/assess.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess.ts
@@ -14,6 +14,7 @@ import { GeoFenceCollectionAssessor } from './assess/geo/geo-geofence-collection
 import { GeoMapAssessor } from './assess/geo/geo-map.assessor';
 import { GeoPlaceIndexAssessor } from './assess/geo/geo-place-index.assessor';
 import { CustomCdkAssessor } from './assess/custom/custom-cdk.assessor';
+import { SpinningLogger } from './_common/spinning-logger';
 
 /**
  * Evaluates migration readiness by discovering resources and
@@ -21,7 +22,7 @@ import { CustomCdkAssessor } from './assess/custom/custom-cdk.assessor';
  * feature-level support detection.
  */
 export class AmplifyMigrationAssessor {
-  public constructor(private readonly gen1App: Gen1App) {}
+  public constructor(private readonly gen1App: Gen1App, private readonly logger: SpinningLogger) {}
 
   public assess(): Assessment {
     const discovered = this.gen1App.discover();
@@ -29,7 +30,7 @@ export class AmplifyMigrationAssessor {
 
     for (const resource of discovered) {
       const assessors: Assessor[] = [];
-
+      this.logger.debug(`Assessing resource: ${resource.category}/${resource.resourceName} (${resource.service})`);
       switch (resource.key) {
         case 'auth:Cognito':
           assessors.push(new AuthCognitoAssessor(this.gen1App, resource));

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/function/function.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/function/function.assessor.ts
@@ -49,7 +49,14 @@ export class FunctionAssessor implements Assessor {
     if (!this.gen1App.fileExists(filePath)) return false;
 
     const policies = this.gen1App.json(filePath);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped custom-policies.json
-    return policies.some((p: any) => p.Action.length > 0 || p.Resource.length > 0);
+
+    // default empty structure is array, so if its something else
+    // the user must have changed it.
+    if (!Array.isArray(policies)) return true;
+
+    return policies.some(
+      (p: { Action: string | string[]; Resource: string | string[] }) =>
+        (p.Action && p.Action.length > 0) || (p.Resource && p.Resource.length > 0),
+    );
   }
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/geo/geo-map.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/geo/geo-map.assessor.ts
@@ -1,5 +1,5 @@
 import { Assessor } from '../assessor';
-import { Assessment, supported } from '../assessment';
+import { Assessment, notApplicable, supported } from '../assessment';
 import { Gen1App, DiscoveredResource } from '../../_common/gen1-app';
 
 /**
@@ -12,6 +12,6 @@ export class GeoMapAssessor implements Assessor {
    * Records resource-level support for this Map resource.
    */
   public record(assessment: Assessment): void {
-    assessment.recordResource({ resource: this.resource, generate: supported(), refactor: supported() });
+    assessment.recordResource({ resource: this.resource, generate: supported(), refactor: notApplicable() });
   }
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/geo/geo-place-index.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/geo/geo-place-index.assessor.ts
@@ -1,5 +1,5 @@
 import { Assessor } from '../assessor';
-import { Assessment, supported } from '../assessment';
+import { Assessment, notApplicable, supported } from '../assessment';
 import { Gen1App, DiscoveredResource } from '../../_common/gen1-app';
 
 /**
@@ -12,6 +12,6 @@ export class GeoPlaceIndexAssessor implements Assessor {
    * Records resource-level support for this PlaceIndex resource.
    */
   public record(assessment: Assessment): void {
-    assessment.recordResource({ resource: this.resource, generate: supported(), refactor: supported() });
+    assessment.recordResource({ resource: this.resource, generate: supported(), refactor: notApplicable() });
   }
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate.ts
@@ -36,7 +36,7 @@ export class AmplifyMigrationGenerateStep extends AmplifyMigrationStep {
     const packageJsonGenerator = new RootPackageJsonGenerator(outputDir);
 
     const generators: Planner[] = [];
-    const assessor = new AmplifyMigrationAssessor(this.gen1App);
+    const assessor = new AmplifyMigrationAssessor(this.gen1App, this.logger);
     const assessment = assessor.assess();
 
     const operations: AmplifyMigrationOperation[] = [

--- a/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/refactor.ts
@@ -32,7 +32,7 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
     const { accountId, gen1Env, gen2Branch, cfn } = await this.createInfrastructure(toStack);
 
     const refactorers: Planner[] = [];
-    const assessor = new AmplifyMigrationAssessor(this.gen1App);
+    const assessor = new AmplifyMigrationAssessor(this.gen1App, this.logger);
     const assessment = assessor.assess();
 
     const discovered = this.gen1App.discover();
@@ -121,7 +121,7 @@ export class AmplifyMigrationRefactorStep extends AmplifyMigrationStep {
     const { accountId, gen1Env, gen2Branch, cfn } = await this.createInfrastructure(toStack);
 
     const refactorers: Planner[] = [];
-    const assessor = new AmplifyMigrationAssessor(this.gen1App);
+    const assessor = new AmplifyMigrationAssessor(this.gen1App, this.logger);
     const assessment = assessor.assess();
 
     const discovered = this.gen1App.discover();

--- a/packages/amplify-e2e-gen2-migration/src/core/teardown.ts
+++ b/packages/amplify-e2e-gen2-migration/src/core/teardown.ts
@@ -65,20 +65,26 @@ export class Teardown {
       StackStatus.REVIEW_IN_PROGRESS,
     ];
 
-    const stacks = await this.discoverStacks(cfnClient, allStatuses, (name) => name.startsWith(stackPrefix));
-    if (stacks.length === 0) {
+    const allStacks = await this.discoverStacks(cfnClient, allStatuses, (name) => name.startsWith(stackPrefix), false);
+    this.logger.info(`Discovered ${allStacks.length} total stack(s) matching prefix '${stackPrefix}'`);
+    for (const stackName of allStacks) {
+      await this.emptyStackBuckets(cfnClient, stackName);
+    }
+
+    const rootStacks = await this.discoverStacks(cfnClient, allStatuses, (name) => name.startsWith(stackPrefix), true);
+    if (rootStacks.length === 0) {
       this.logger.info('No stacks found. Nothing to tear down.');
       return;
     }
-    this.logger.info(`Discovered ${stacks.length} stack(s) matching prefix '${stackPrefix}'`);
+    this.logger.info(`Discovered ${rootStacks.length} root stack(s) matching prefix '${stackPrefix}'`);
 
-    await this.setDeletionPolicies(cfnClient, stacks);
-    await this.disableDeletionProtection(cfnClient, stacks);
+    await this.setDeletionPolicies(cfnClient, rootStacks);
+    await this.disableDeletionProtection(cfnClient, rootStacks);
 
-    await this.deleteGen1Stacks(cfnClient, stacks);
+    await this.deleteGen1Stacks(cfnClient, rootStacks);
     await this.deleteAmplifyApp();
-    await this.deleteGen2Sandbox(cfnClient, stacks);
-    await this.deleteHoldingStacks(cfnClient, stacks);
+    await this.deleteGen2Sandbox(cfnClient, rootStacks);
+    await this.deleteHoldingStacks(cfnClient, rootStacks);
 
     if (this.errors.length > 0) {
       const summary = this.errors.map((e, i) => `  ${i + 1}. ${e}`).join('\n');
@@ -277,11 +283,12 @@ export class Teardown {
     cfnClient: CloudFormationClient,
     statusFilter: StackStatus[],
     predicate: (name: string) => boolean,
+    ignoreNested: boolean,
   ): Promise<string[]> {
     const stacks: string[] = [];
     for await (const page of paginateListStacks({ client: cfnClient }, { StackStatusFilter: statusFilter })) {
       for (const stack of page.StackSummaries ?? []) {
-        if (stack.ParentId) {
+        if (ignoreNested && stack.ParentId) {
           // nested stacks are skipped because the parent will deleted them.
           continue;
         }
@@ -322,15 +329,11 @@ export class Teardown {
       StackStatus.REVIEW_IN_PROGRESS,
     ];
     for (let pass = 0; pass < MAX_DELETE_PASSES; pass++) {
-      const stacks = await this.discoverStacks(cfnClient, statusFilter, predicate);
+      const stacks = await this.discoverStacks(cfnClient, statusFilter, predicate, true);
       if (stacks.length === 0) return;
 
       if (pass > 0) {
         this.logger.info(`Delete pass ${pass + 1} for ${stacks.length} remaining stack(s)`);
-      }
-
-      for (const stackName of stacks) {
-        await this.emptyStackBuckets(cfnClient, stackName);
       }
 
       for (const stackName of stacks) {
@@ -359,7 +362,7 @@ export class Teardown {
     }
 
     // Final check: anything still around after all passes is an error.
-    const leftover = await this.discoverStacks(cfnClient, statusFilter, predicate);
+    const leftover = await this.discoverStacks(cfnClient, statusFilter, predicate, false);
     for (const stackName of leftover) {
       this.recordError('Stack delete', new Error(`${stackName} could not be deleted after ${MAX_DELETE_PASSES} passes`));
     }
@@ -420,7 +423,7 @@ export class Teardown {
     const s3 = new S3Client(this.clientConfig);
     for (const bucket of buckets) {
       try {
-        this.logger.info(`Emptying bucket: ${bucket}`);
+        this.logger.info(`Emptying bucket: ${bucket} (stack: ${stackName})`);
         for await (const page of paginateListObjectsV2({ client: s3 }, { Bucket: bucket })) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const objects = (page.Contents ?? []).filter((o) => o.Key).map((o) => ({ Key: o.Key! }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,7 @@ __metadata:
     "@aws-sdk/client-ssm": ^3.919.0
     "@aws-sdk/client-sts": ^3.919.0
     "@smithy/node-http-handler": ^4.4.3
+    "@smithy/util-retry": ^4.2.0
     "@types/archiver": ^5.3.1
     "@types/columnify": ^1.5.1
     "@types/folder-hash": ^4.0.1


### PR DESCRIPTION
#### Description of changes

Hardens the `FunctionAssessor`'s custom policy detection to handle
real-world `custom-policies.json` files that don't follow the default
array format. Previously, the assessor assumed the file was always an
array and used an untyped `any` cast. This broke on direct IAM policy
documents (e.g., `{Version: "2012-10-17", Statement: [...]}`) and
could crash on entries with missing `Action`/`Resource` fields.

#### Function assessor improvements

- Non-array policies (direct IAM policy objects) are now detected as
  custom policies, triggering the "unsupported" assessment.
- Null-safe checks on `Action` and `Resource` prevent crashes on
  malformed entries.
- Removed the `eslint-disable` for `@typescript-eslint/no-explicit-any`
  by using a proper type annotation.

#### Logger wiring

- `AmplifyMigrationAssessor` now accepts a `SpinningLogger` and logs
  each resource being assessed. All call sites (`gen2-migration.ts`,
  `generate.ts`, `refactor.ts`) pass the existing logger through.

#### Geo Assessors

Noticed that geo refactoring was marked as `supported`, when in fact it should be `notApplicable` since they are not stateful resources.

#### SDK Retries

In https://github.com/aws-amplify/amplify-cli/pull/14875 we introduced CloudControl based references resolution that recursively walk a CFN template and calls `GetResource`. We are seeing sporadic `Rate exceeded` issues because it so add a retry policy (which is good regardless) on our SDK clients.

#### E2E Teardown

Storage stacks were not being properly deleted since the bucket wasn't emptied. Fix this by first querying all stacks (including nested) and emptying all buckets.

#### Command Info

Add missing info about `gen2-migration retain`. Missed during https://github.com/aws-amplify/amplify-cli/pull/14843

#### Issue #, if available

N/A

#### Description of how you validated changes

- Unit test added: `detects direct IAM policy object in custom-policies.json`
- All existing `function.assessor.test.ts` tests pass (8/8)
- `tsc --noEmit` passes with no errors

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
