### PR TITLE
fix(cli): relax auth trigger drift filter to match prefixed policy names

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/drift/detect-stack-drift.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/drift/detect-stack-drift.test.ts
@@ -81,6 +81,25 @@ describe('isAmplifyTriggerPolicyDrift', () => {
     expect(isAmplifyTriggerPolicyDrift(drift, propDiff, mockPrinter)).toBe(true);
   });
 
+  it('filters Cognito trigger policy drift with prefixed policy name (breakCircularDependency=false)', () => {
+    const drift = makeDrift({ ResourceType: 'AWS::IAM::Role', LogicalResourceId: 'LambdaExecutionRole' });
+    const policyValue = JSON.stringify({
+      PolicyDocument: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: ['cognito-idp:AdminAddUserToGroup', 'cognito-idp:GetGroup', 'cognito-idp:CreateGroup'],
+            Resource: 'arn:aws:cognito-idp:us-east-1:728254692372:userpool/us-east-1_74MJs6tyH',
+          },
+        ],
+      }),
+      PolicyName: 'bpedsysauthPostConfirmationAddToGroupCognito',
+    });
+    const propDiff = makePropDiff({ PropertyPath: '/Policies/0', ExpectedValue: 'null', ActualValue: policyValue });
+    expect(isAmplifyTriggerPolicyDrift(drift, propDiff, mockPrinter)).toBe(true);
+  });
+
   it('filters S3 storage trigger policy drift', () => {
     const drift = makeDrift({ ResourceType: 'AWS::IAM::Role', LogicalResourceId: 'LambdaExecutionRole' });
     const policyValue = JSON.stringify({

--- a/packages/amplify-cli/src/commands/drift/detect-stack-drift.ts
+++ b/packages/amplify-cli/src/commands/drift/detect-stack-drift.ts
@@ -207,7 +207,7 @@ export function isAmplifyTriggerPolicyDrift(drift: StackResourceDrift, propDiff:
 
     // Auth trigger policies: known Cognito trigger policy pattern
     const cognitoActions = ['cognito-idp:AdminAddUserToGroup', 'cognito-idp:GetGroup', 'cognito-idp:CreateGroup'];
-    const isCognitoTriggerPolicy = policyName === 'AddToGroupCognito' && cognitoActions.every((a) => actions.has(a));
+    const isCognitoTriggerPolicy = policyName.endsWith('AddToGroupCognito') && cognitoActions.every((a) => actions.has(a));
 
     // S3 storage trigger policies: known S3 trigger policy pattern
     const s3Actions = ['s3:ListBucket', 's3:PutObject', 's3:GetObject', 's3:DeleteObject'];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The `isAmplifyTriggerPolicyDrift` filter (added in #14669) checks for `policyName === 'AddToGroupCognito'` to suppress false-positive drift on PostConfirmation auth trigger policies. This works for projects with `breakCircularDependency: true` (new projects since May 2021), but fails for older projects where the flag is `false`.

  When `breakCircularDependency` is `false`, the policy is created through [`auth-cognito-stack-builder.ts:1155`](https://github.com/aws-amplify/amplify-cli/blob/bb2cb4005b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts#L1155-L1157) which constructs the policy name as `${resourceName}${trigger}${policyName}` resulting in something like `bpedsysauthPostConfirmationAddToGroupCognito`. The strict equality check misses this variant.

#### Example 

drift report:

```cli
 ✘ Drift

  AUTH LambdaExecutionRole
  CloudFormation Drift: Deployed resources do not match templates

  bpedsysauthPostConfirmation-dev
  ~ AWS::IAM::Role
  Property: /Policies/0
  Deployed: "{"PolicyDocument":"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["cognito-idp:AdminAddUserToGroup","cognito-idp:GetGroup","cognito-idp:CreateGroup"],"Resource":"arn:aws:cognito-idp:us-east-1:728254692372:userpool/us-east-1_74MJs6tyH"}]}","PolicyNam
  e":"bpedsysauthPostConfirmationAddToGroupCognito"}"
  Expected: "null"
```
`parameters.json`:

  ```json
  {
    "breakCircularDependency": false,
    "triggers": "{\"PostConfirmation\":[\"add-to-group\"]}",
    "permissions": ["{\"policyName\":\"AddToGroupCognito\",\"trigger\":\"PostConfirmation\",...}"]
  }
```
  The raw policyName is "AddToGroupCognito", but since breakCircularDependency: false, the old code path prefixes it with ${resourceName}${trigger} → "bpedsysauthPostConfirmationAddToGroupCognito". Our filter only matched the raw name.


  #### Fix

  Change `policyName === 'AddToGroupCognito'` → `policyName.endsWith('AddToGroupCognito')` so both the raw name (new path) and the prefixed name (old path) are filtered.

  #### Why both paths exist

  - `breakCircularDependency: true` (default for **new** projects) → `generate-auth-trigger-template.ts:228` → `policyName: "AddToGroupCognito"`
  - `breakCircularDependency: false` (default for **existing** projects) → [`auth-cognito-stack-builder.ts:1157`](https://github.com/aws-amplify/amplify-cli/blob/bb2cb4005b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts#L1157) → `policyName: "${resourceName}${trigger}${policyName}"`

  The flag was introduced in [#6968](https://github.com/aws-amplify/amplify-cli/pull/6968) (May 2021). Any project created before that (or existing projects that never flipped it) will hit the old path. This is still reproducible today with any existing project that adds a PostConfirmation trigger.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Added UT and ran `yarn test`

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
