### PR TITLE
fix(cli-internal): handle ResourceNotFoundException in fetchFunctionSchedule

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/_infra/aws-fetcher.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/_infra/aws-fetcher.test.ts
@@ -1,0 +1,129 @@
+import { AwsFetcher } from '../../../../../commands/gen2-migration/generate/_infra/aws-fetcher';
+import { AwsClients } from '../../../../../commands/gen2-migration/_infra/aws-clients';
+
+function createMockClients(overrides: { lambdaSend?: jest.Mock; cloudWatchEventsSend?: jest.Mock }): AwsClients {
+  return {
+    lambda: { send: overrides.lambdaSend ?? jest.fn() },
+    cloudWatchEvents: { send: overrides.cloudWatchEventsSend ?? jest.fn() },
+  } as unknown as AwsClients;
+}
+
+describe('AwsFetcher', () => {
+  describe('fetchFunctionSchedule()', () => {
+    it('returns the schedule expression when the rule exists', async () => {
+      const policy = {
+        Statement: [
+          {
+            Condition: {
+              ArnLike: {
+                'AWS:SourceArn': 'arn:aws:events:us-east-1:123456789:rule/myFunc-schedule',
+              },
+            },
+          },
+        ],
+      };
+      const lambdaSend = jest.fn().mockResolvedValue({ Policy: JSON.stringify(policy) });
+      const cloudWatchEventsSend = jest.fn().mockResolvedValue({ ScheduleExpression: 'rate(1 hour)' });
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend, cloudWatchEventsSend }));
+      const result = await fetcher.fetchFunctionSchedule('myFunc');
+
+      expect(result).toBe('rate(1 hour)');
+    });
+
+    it('returns undefined when GetPolicy throws ResourceNotFoundException', async () => {
+      const error = new Error('Resource not found');
+      error.name = 'ResourceNotFoundException';
+      const lambdaSend = jest.fn().mockRejectedValue(error);
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend }));
+      const result = await fetcher.fetchFunctionSchedule('myFunc');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when DescribeRule throws ResourceNotFoundException', async () => {
+      const policy = {
+        Statement: [
+          {
+            Condition: {
+              ArnLike: {
+                'AWS:SourceArn': 'arn:aws:events:us-east-1:123456789:rule/myFunc-schedule',
+              },
+            },
+          },
+        ],
+      };
+      const lambdaSend = jest.fn().mockResolvedValue({ Policy: JSON.stringify(policy) });
+      const error = new Error('Rule myFunc-schedule does not exist on EventBus default.');
+      error.name = 'ResourceNotFoundException';
+      const cloudWatchEventsSend = jest.fn().mockRejectedValue(error);
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend, cloudWatchEventsSend }));
+      const result = await fetcher.fetchFunctionSchedule('myFunc');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('propagates non-ResourceNotFoundException errors from GetPolicy', async () => {
+      const error = new Error('Access denied');
+      error.name = 'AccessDeniedException';
+      const lambdaSend = jest.fn().mockRejectedValue(error);
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend }));
+
+      await expect(fetcher.fetchFunctionSchedule('myFunc')).rejects.toThrow('Access denied');
+    });
+
+    it('propagates non-ResourceNotFoundException errors from DescribeRule', async () => {
+      const policy = {
+        Statement: [
+          {
+            Condition: {
+              ArnLike: {
+                'AWS:SourceArn': 'arn:aws:events:us-east-1:123456789:rule/myFunc-schedule',
+              },
+            },
+          },
+        ],
+      };
+      const lambdaSend = jest.fn().mockResolvedValue({ Policy: JSON.stringify(policy) });
+      const error = new Error('Internal failure');
+      error.name = 'InternalException';
+      const cloudWatchEventsSend = jest.fn().mockRejectedValue(error);
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend, cloudWatchEventsSend }));
+
+      await expect(fetcher.fetchFunctionSchedule('myFunc')).rejects.toThrow('Internal failure');
+    });
+
+    it('returns undefined when the policy has no schedule rule reference', async () => {
+      const policy = {
+        Statement: [
+          {
+            Condition: {
+              ArnLike: {
+                'AWS:SourceArn': 'arn:aws:execute-api:us-east-1:123456789:abc/*/GET/',
+              },
+            },
+          },
+        ],
+      };
+      const lambdaSend = jest.fn().mockResolvedValue({ Policy: JSON.stringify(policy) });
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend }));
+      const result = await fetcher.fetchFunctionSchedule('myFunc');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the policy response has no Policy field', async () => {
+      const lambdaSend = jest.fn().mockResolvedValue({});
+
+      const fetcher = new AwsFetcher(createMockClients({ lambdaSend }));
+      const result = await fetcher.fetchFunctionSchedule('myFunc');
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/_infra/aws-fetcher.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/_infra/aws-fetcher.test.ts
@@ -1,5 +1,5 @@
-import { AwsFetcher } from '../../../../../commands/gen2-migration/generate/_infra/aws-fetcher';
-import { AwsClients } from '../../../../../commands/gen2-migration/_infra/aws-clients';
+import { AwsFetcher } from '../../../../../commands/gen2-migration/_common/aws-fetcher';
+import { AwsClients } from '../../../../../commands/gen2-migration/_common/aws-clients';
 
 function createMockClients(overrides: { lambdaSend?: jest.Mock; cloudWatchEventsSend?: jest.Mock }): AwsClients {
   return {

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
@@ -141,8 +141,15 @@ export class AwsFetcher {
       throw e;
     }
     if (!ruleName) return undefined;
-    const ruleResponse = await this.clients.cloudWatchEvents.send(new DescribeRuleCommand({ Name: ruleName }));
-    return ruleResponse.ScheduleExpression;
+    try {
+      const ruleResponse = await this.clients.cloudWatchEvents.send(new DescribeRuleCommand({ Name: ruleName }));
+      return ruleResponse.ScheduleExpression;
+    } catch (e: unknown) {
+      if (e instanceof Error && e.name === 'ResourceNotFoundException') {
+        return undefined;
+      }
+      throw e;
+    }
   }
 
   // ── Storage (S3) ────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes #14883.

When a Lambda function has no CloudWatch Events rule (i.e., it is not a scheduled function), the `DescribeRuleCommand` API throws `ResourceNotFoundException`. Previously, this call was not wrapped in error handling, causing the entire `amplify gen2-migration generate` command to crash.

#### Fix

Wrap the `DescribeRuleCommand` call in a targeted try-catch that catches only `ResourceNotFoundException` and returns `undefined` (no schedule found). This matches the existing error-handling pattern already used for `GetPolicyCommand` in the same method. Non-`ResourceNotFoundException` errors (permissions, network) still propagate.

#### Testing

- Added `aws-fetcher.test.ts` with 7 test cases covering:
  - Happy path (rule exists → returns schedule expression)
  - `GetPolicyCommand` throws `ResourceNotFoundException` → returns `undefined`  
  - `DescribeRuleCommand` throws `ResourceNotFoundException` → returns `undefined` (the bug scenario)
  - Non-`ResourceNotFoundException` errors propagate from both API calls
  - Policy has no schedule rule reference → returns `undefined`
  - Policy response has no `Policy` field → returns `undefined`
- All existing snapshot tests (12/12) and function generator tests (7/7) continue to pass.
