### PR TITLE
fix(cli-internal): correct OIDC TTL conversion and handle clientId field

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -390,7 +390,7 @@ describe('DataGenerator', () => {
     `);
   });
 
-  it('renders OIDC auth mode', async () => {
+  it('renders OIDC auth mode with TTL converted from milliseconds to seconds', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
       api: {
@@ -412,8 +412,8 @@ describe('DataGenerator', () => {
                 name: 'MyOIDC',
                 issuerUrl: 'https://example.com',
                 clientId: 'client123',
-                authTTL: 3600,
-                iatTTL: 7200,
+                authTTL: 3600000,
+                iatTTL: 7200000,
               },
             },
           ],
@@ -457,6 +457,93 @@ describe('DataGenerator', () => {
       });
       "
     `);
+  });
+
+  it('renders OIDC auth mode without clientId when absent and supplements from live API', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        testApi: {
+          service: 'AppSync',
+          output: { GraphQLAPIIdOutput: 'api-123' },
+        },
+      },
+    });
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
+      if (key === 'GraphQLAPIIdOutput') return 'api-123';
+      if (key === 'authConfig')
+        return {
+          defaultAuthentication: {
+            authenticationType: 'OPENID_CONNECT',
+            openIDConnectConfig: {
+              name: 'NoClientIdProvider',
+              issuerUrl: 'https://idp.example.com',
+              authTTL: 1800000,
+              iatTTL: 3600000,
+            },
+          },
+        } as any;
+      return undefined as any;
+    });
+    jest.spyOn(gen1App.aws, 'fetchGraphqlApi').mockResolvedValue({
+      apiId: 'api-123',
+      name: 'testApi',
+      openIDConnectConfig: { issuer: 'https://idp.example.com', clientId: 'supplemented-client-id' },
+      additionalAuthenticationProviders: [],
+    });
+
+    const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).toContain("clientId: 'supplemented-client-id'");
+    expect(output).toContain('tokenExpiryFromAuthInSeconds: 1800');
+    expect(output).toContain('tokenExpireFromIssueInSeconds: 3600');
+  });
+
+  it('floors TTL values when not exact multiples of 1000', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      api: {
+        testApi: {
+          service: 'AppSync',
+          output: { GraphQLAPIIdOutput: 'api-123' },
+        },
+      },
+    });
+    mockSchema(gen1App, 'type Todo @model { id: ID! }', ['Todo']);
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockImplementation((_resource: DiscoveredResource, key: string) => {
+      if (key === 'GraphQLAPIIdOutput') return 'api-123';
+      if (key === 'authConfig')
+        return {
+          defaultAuthentication: {
+            authenticationType: 'OPENID_CONNECT',
+            openIDConnectConfig: {
+              name: 'Floored',
+              issuerUrl: 'https://idp.example.com',
+              clientId: 'abc',
+              authTTL: 3599999,
+              iatTTL: 7200500,
+            },
+          },
+        } as any;
+      return undefined as any;
+    });
+    jest.spyOn(gen1App.aws, 'fetchGraphqlApi').mockResolvedValue({
+      apiId: 'api-123',
+      name: 'testApi',
+      additionalAuthenticationProviders: [],
+    });
+
+    const generator = new DataGenerator(gen1App, backendGenerator, outputDir, dataResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+    expect(output).toContain('tokenExpiryFromAuthInSeconds: 3599');
+    expect(output).toContain('tokenExpireFromIssueInSeconds: 7200');
   });
 
   it('renders Lambda auth mode', async () => {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
@@ -169,7 +169,7 @@ export class DataGenerator implements Planner {
     const hasAdditionalAuthProviders =
       graphqlApi.additionalAuthenticationProviders !== undefined && graphqlApi.additionalAuthenticationProviders.length > 0;
     const hasAuth = this.gen1App.categoryMeta('auth') !== undefined;
-    const authorizationModes = this.gen1App.resourceMetaOutput(this.resource, 'authConfig');
+    const authorizationModes = supplementOidcConfig(this.gen1App.resourceMetaOutput(this.resource, 'authConfig'), graphqlApi);
     const hasIamAuth = this.detectIamAuth(authorizationModes, graphqlApi);
     const vtlFiles = this.findResolverVtlFiles(this.resource.resourceName);
     const hasResolvers = vtlFiles.length > 0;
@@ -274,4 +274,43 @@ export class DataGenerator implements Planner {
     if (defaultAuthType === 'AWS_IAM') return true;
     return graphqlApi.additionalAuthenticationProviders?.some((p) => p.authenticationType === 'AWS_IAM') ?? false;
   }
+}
+
+/**
+ * Supplements the authConfig from amplify-meta.json with OIDC clientId
+ * values from the live GraphQL API when they are missing in the local config.
+ *
+ * Gen1 amplify-meta.json may not include the `clientId` field for OIDC
+ * providers (depends on CLI version), but the live API always has it.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped authConfig from amplify-meta.json
+function supplementOidcConfig(authConfig: any, graphqlApi: GraphqlApi): any {
+  if (!authConfig) return authConfig;
+
+  const result = JSON.parse(JSON.stringify(authConfig));
+
+  if (
+    result.defaultAuthentication?.authenticationType === 'OPENID_CONNECT' &&
+    result.defaultAuthentication.openIDConnectConfig &&
+    !result.defaultAuthentication.openIDConnectConfig.clientId &&
+    graphqlApi.openIDConnectConfig?.clientId
+  ) {
+    result.defaultAuthentication.openIDConnectConfig.clientId = graphqlApi.openIDConnectConfig.clientId;
+  }
+
+  if (result.additionalAuthenticationProviders) {
+    for (const provider of result.additionalAuthenticationProviders) {
+      if (provider.authenticationType !== 'OPENID_CONNECT' || !provider.openIDConnectConfig || provider.openIDConnectConfig.clientId) {
+        continue;
+      }
+      const match = graphqlApi.additionalAuthenticationProviders?.find(
+        (p) => p.authenticationType === 'OPENID_CONNECT' && p.openIDConnectConfig?.issuer === provider.openIDConnectConfig.issuerUrl,
+      );
+      if (match?.openIDConnectConfig?.clientId) {
+        provider.openIDConnectConfig.clientId = match.openIDConnectConfig.clientId;
+      }
+    }
+  }
+
+  return result;
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.renderer.ts
@@ -489,9 +489,19 @@ export class DataRenderer {
     ];
     if (cfg.clientId) props.push(factory.createPropertyAssignment('clientId', factory.createStringLiteral(cfg.clientId)));
     if (cfg.authTTL)
-      props.push(factory.createPropertyAssignment('tokenExpiryFromAuthInSeconds', factory.createNumericLiteral(cfg.authTTL.toString())));
+      props.push(
+        factory.createPropertyAssignment(
+          'tokenExpiryFromAuthInSeconds',
+          factory.createNumericLiteral(Math.floor(Number(cfg.authTTL) / 1000).toString()),
+        ),
+      );
     if (cfg.iatTTL)
-      props.push(factory.createPropertyAssignment('tokenExpireFromIssueInSeconds', factory.createNumericLiteral(cfg.iatTTL.toString())));
+      props.push(
+        factory.createPropertyAssignment(
+          'tokenExpireFromIssueInSeconds',
+          factory.createNumericLiteral(Math.floor(Number(cfg.iatTTL) / 1000).toString()),
+        ),
+      );
     target.push(factory.createPropertyAssignment('oidcAuthorizationMode', factory.createObjectLiteralExpression(props)));
   }
 


### PR DESCRIPTION
## Description

Fixes #14812

The Gen1→Gen2 migration was incorrectly handling OIDC authorization mode configuration in two ways:

1. **TTL values copied without unit conversion** — Gen1's AppSync config stores `authTTL` and `iatTTL` in milliseconds (per the AppSync API contract), but the migration was writing them directly into Gen2's `tokenExpiryFromAuthInSeconds` and `tokenExpireFromIssueInSeconds` fields which expect seconds. This resulted in token validity periods being 1000× longer than intended (e.g., 1 hour becoming ~41 days).

2. **`clientId` not always preserved** — Depending on the Gen1 CLI version that created the project, `amplify-meta.json` may not include the `clientId` field in the OIDC provider config. The migration now supplements the local config with `clientId` from the live AppSync API response, ensuring the generated Gen2 code always includes the client identifier for JWT validation.

#### TTL conversion fix

In `data.renderer.ts`, the `addOidcConfig` method now divides `authTTL` and `iatTTL` by 1000 (using `Math.floor`) before emitting them as `tokenExpiryFromAuthInSeconds` and `tokenExpireFromIssueInSeconds`.

#### clientId supplementation

In `data.generator.ts`, a new `supplementOidcConfig()` function deep-copies the authConfig and fills in missing `clientId` values by matching OIDC providers against the live GraphQL API response (matched by issuer URL for additional providers).

## Testing

- Updated existing OIDC renderer test to use millisecond input values and verify second output values
- Added test for OIDC config without `clientId` present
- Added test for non-exact-multiple TTL values (verifies floor behavior)
- All 243 tests pass in the `gen2-migration/generate` suite (24 test suites)
- All integration snapshot tests pass unchanged (no OIDC in fixture apps)

## Checklist

- [x] Tests pass (`npx jest --testPathPattern='gen2-migration/generate' --no-coverage`)
- [x] No TypeScript compilation errors in changed files
- [x] Pre-push hooks pass (build-tests for changed packages)
