### PR TITLE
fix(cli-internal): add lambda authorizer import and use dynamic region in data resource

### DIFF
--- a/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/function/quotegeneratorbe/resource.ts
+++ b/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/function/quotegeneratorbe/resource.ts
@@ -8,10 +8,14 @@ export const quotegeneratorbe = defineFunction({
   name: `quotegeneratorbe-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
 export function applyEscapeHatches(backend: Backend) {
   backend.quotegeneratorbe.resources.cfnResources.cfnFunction.functionName = `quotegeneratorbe-${branchName}`;
+  backend.quotegeneratorbe.addEnvironment(
+    'REGION',
+    backend.quotegeneratorbe.stack.region
+  );
 }

--- a/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/activityTrigger/resource.ts
+++ b/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/activityTrigger/resource.ts
@@ -11,7 +11,7 @@ export const activityTrigger = defineFunction({
   name: `activityTrigger-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -28,6 +28,10 @@ export function applyEscapeHatches(backend: Backend, activity: Table) {
   backend.activityTrigger.addEnvironment(
     'STORAGE_ACTIVITY_NAME',
     activity.tableName
+  );
+  backend.activityTrigger.addEnvironment(
+    'REGION',
+    backend.activityTrigger.stack.region
   );
   activity.grant(
     backend.activityTrigger.resources.lambda,

--- a/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/fetchuseractivity/resource.ts
+++ b/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/fetchuseractivity/resource.ts
@@ -9,7 +9,7 @@ export const fetchuseractivity = defineFunction({
   name: `fetchuseractivity-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -26,6 +26,10 @@ export function applyEscapeHatches(backend: Backend, activity: Table) {
   backend.fetchuseractivity.addEnvironment(
     'STORAGE_ACTIVITY_NAME',
     activity.tableName
+  );
+  backend.fetchuseractivity.addEnvironment(
+    'REGION',
+    backend.fetchuseractivity.stack.region
   );
   activity.grant(
     backend.fetchuseractivity.resources.lambda,

--- a/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/recorduseractivity/resource.ts
+++ b/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/function/recorduseractivity/resource.ts
@@ -11,7 +11,7 @@ export const recorduseractivity = defineFunction({
   name: `recorduseractivity-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -28,6 +28,10 @@ export function applyEscapeHatches(backend: Backend, activity: Table) {
   backend.recorduseractivity.addEnvironment(
     'STORAGE_ACTIVITY_NAME',
     activity.tableName
+  );
+  backend.recorduseractivity.addEnvironment(
+    'REGION',
+    backend.recorduseractivity.stack.region
   );
   activity.grant(
     backend.recorduseractivity.resources.lambda,

--- a/amplify-migration-apps/finance-tracker/_snapshot.post.generate/amplify/function/financetracker/resource.ts
+++ b/amplify-migration-apps/finance-tracker/_snapshot.post.generate/amplify/function/financetracker/resource.ts
@@ -10,7 +10,6 @@ export const financetracker = defineFunction({
   memoryMB: 128,
   environment: {
     ENV: `${branchName}`,
-    REGION: 'us-east-1',
     BUDGET_ALERT_TOPIC_ARN:
       'arn:aws:sns:us-east-1:123456789012:amplify-financetracker-x-x-customcustomfinance-x-BudgetAlertTopicF20DF526-DFMxF2RX1UKQ',
     MONTHLY_REPORT_TOPIC_ARN:
@@ -32,6 +31,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.financetracker.addEnvironment(
     'API_FINANCETRACKER_TRANSACTIONTABLE_NAME',
     backend.data.resources.tables['Transaction'].tableName
+  );
+  backend.financetracker.addEnvironment(
+    'REGION',
+    backend.financetracker.stack.region
   );
   backend.data.resources.tables['Transaction'].grant(
     backend.financetracker.resources.lambda,

--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/admin/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/admin/resource.ts
@@ -9,7 +9,7 @@ export const admin = defineFunction({
   name: `admin-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -19,6 +19,7 @@ export function applyEscapeHatches(backend: Backend) {
     'AUTH_FITNESSTRACKER33F5545533F55455_USERPOOLID',
     backend.auth.resources.userPool.userPoolId
   );
+  backend.admin.addEnvironment('REGION', backend.admin.stack.region);
   new aws_iam.Policy(
     backend.admin.resources.lambda,
     'UnmappedCognitoActionsPolicy',

--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/fitnesstracker33f5545533f55455PreSignup/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/fitnesstracker33f5545533f55455PreSignup/resource.ts
@@ -11,7 +11,6 @@ export const fitnesstracker33f5545533f55455PreSignup = defineFunction({
   environment: {
     ENV: `${branchName}`,
     MODULES: 'email-filter-allowlist',
-    REGION: 'us-east-1',
     DOMAINALLOWLIST: 'amazon.com',
     DOMAINBLACKLIST: '',
   },
@@ -20,4 +19,8 @@ export const fitnesstracker33f5545533f55455PreSignup = defineFunction({
 
 export function applyEscapeHatches(backend: Backend) {
   backend.fitnesstracker33f5545533f55455PreSignup.resources.cfnResources.cfnFunction.functionName = `fitnesstracker33f5545533f55455PreSignup-${branchName}`;
+  backend.fitnesstracker33f5545533f55455PreSignup.addEnvironment(
+    'REGION',
+    backend.fitnesstracker33f5545533f55455PreSignup.stack.region
+  );
 }

--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/lognutrition/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/function/lognutrition/resource.ts
@@ -8,7 +8,7 @@ export const lognutrition = defineFunction({
   name: `lognutrition-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -25,6 +25,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.lognutrition.addEnvironment(
     'API_FITNESSTRACKER_MEALTABLE_NAME',
     backend.data.resources.tables['Meal'].tableName
+  );
+  backend.lognutrition.addEnvironment(
+    'REGION',
+    backend.lognutrition.stack.region
   );
   backend.data.resources.tables['Meal'].grant(
     backend.lognutrition.resources.lambda,

--- a/amplify-migration-apps/imported-resources/_snapshot.post.generate/amplify/function/importedresourcequotegenerator/resource.ts
+++ b/amplify-migration-apps/imported-resources/_snapshot.post.generate/amplify/function/importedresourcequotegenerator/resource.ts
@@ -8,10 +8,14 @@ export const importedresourcequotegenerator = defineFunction({
   name: `importedresourcequotegenerator-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
 export function applyEscapeHatches(backend: Backend) {
   backend.importedresourcequotegenerator.resources.cfnResources.cfnFunction.functionName = `importedresourcequotegenerator-${branchName}`;
+  backend.importedresourcequotegenerator.addEnvironment(
+    'REGION',
+    backend.importedresourcequotegenerator.stack.region
+  );
 }

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/addusertogroup/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/addusertogroup/resource.ts
@@ -9,7 +9,7 @@ export const addusertogroup = defineFunction({
   name: `addusertogroup-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -18,6 +18,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.addusertogroup.addEnvironment(
     'AUTH_MEDIAVAULT1F08412D_USERPOOLID',
     backend.auth.resources.userPool.userPoolId
+  );
+  backend.addusertogroup.addEnvironment(
+    'REGION',
+    backend.addusertogroup.stack.region
   );
   new aws_iam.Policy(
     backend.addusertogroup.resources.lambda,

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/removeuserfromgroup/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/removeuserfromgroup/resource.ts
@@ -9,7 +9,7 @@ export const removeuserfromgroup = defineFunction({
   name: `removeuserfromgroup-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -18,6 +18,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.removeuserfromgroup.addEnvironment(
     'AUTH_MEDIAVAULT1F08412D_USERPOOLID',
     backend.auth.resources.userPool.userPoolId
+  );
+  backend.removeuserfromgroup.addEnvironment(
+    'REGION',
+    backend.removeuserfromgroup.stack.region
   );
   new aws_iam.Policy(
     backend.removeuserfromgroup.resources.lambda,

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/thumbnailgen/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/function/thumbnailgen/resource.ts
@@ -8,7 +8,7 @@ export const thumbnailgen = defineFunction({
   name: `thumbnailgen-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -17,5 +17,9 @@ export function applyEscapeHatches(backend: Backend) {
   backend.thumbnailgen.addEnvironment(
     'STORAGE_MEDIAVAULT_BUCKETNAME',
     backend.storage.resources.bucket.bucketName
+  );
+  backend.thumbnailgen.addEnvironment(
+    'REGION',
+    backend.thumbnailgen.stack.region
   );
 }

--- a/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardGetRandomEmoji/resource.ts
+++ b/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardGetRandomEmoji/resource.ts
@@ -8,10 +8,14 @@ export const moodboardGetRandomEmoji = defineFunction({
   name: `moodboardGetRandomEmoji-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
 export function applyEscapeHatches(backend: Backend) {
   backend.moodboardGetRandomEmoji.resources.cfnResources.cfnFunction.functionName = `moodboardGetRandomEmoji-${branchName}`;
+  backend.moodboardGetRandomEmoji.addEnvironment(
+    'REGION',
+    backend.moodboardGetRandomEmoji.stack.region
+  );
 }

--- a/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardKinesisReader/resource.ts
+++ b/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardKinesisReader/resource.ts
@@ -10,7 +10,7 @@ export const moodboardKinesisReader = defineFunction({
   name: `moodboardKinesisReader-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -22,6 +22,10 @@ export function applyEscapeHatches(
   backend.moodboardKinesisReader.addEnvironment(
     'ANALYTICS_MOODBOARDKINESIS_KINESISSTREAMARN',
     analytics.kinesisStreamArn
+  );
+  backend.moodboardKinesisReader.addEnvironment(
+    'REGION',
+    backend.moodboardKinesisReader.stack.region
   );
   backend.moodboardKinesisReader.resources.lambda.addToRolePolicy(
     new aws_iam.PolicyStatement({

--- a/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardKinesisTrigger/resource.ts
+++ b/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/function/moodboardKinesisTrigger/resource.ts
@@ -12,7 +12,7 @@ export const moodboardKinesisTrigger = defineFunction({
   name: `moodboardKinesisTrigger-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -32,6 +32,10 @@ export function applyEscapeHatches(
   backend.moodboardKinesisTrigger.addEnvironment(
     'API_MOODBOARD_GRAPHQLAPIIDOUTPUT',
     backend.data.apiId
+  );
+  backend.moodboardKinesisTrigger.addEnvironment(
+    'REGION',
+    backend.moodboardKinesisTrigger.stack.region
   );
   backend.data.resources.graphqlApi.grantMutation(
     backend.moodboardKinesisTrigger.resources.lambda

--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/S3Trigger1ef46783/resource.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/S3Trigger1ef46783/resource.ts
@@ -8,7 +8,7 @@ export const S3Trigger1ef46783 = defineFunction({
   name: `S3Trigger1ef46783-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
@@ -25,6 +25,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.S3Trigger1ef46783.addEnvironment(
     'API_PRODUCTCATALOG_GRAPHQLAPIIDOUTPUT',
     backend.data.apiId
+  );
+  backend.S3Trigger1ef46783.addEnvironment(
+    'REGION',
+    backend.S3Trigger1ef46783.stack.region
   );
   backend.data.resources.graphqlApi.grantMutation(
     backend.S3Trigger1ef46783.resources.lambda

--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/lowstockproducts/resource.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/function/lowstockproducts/resource.ts
@@ -10,7 +10,6 @@ export const lowstockproducts = defineFunction({
   memoryMB: 128,
   environment: {
     ENV: `${branchName}`,
-    REGION: 'us-east-1',
     LOW_STOCK_THRESHOLD: '5',
     PRODUCT_CATALOG_SECRET:
       '/amplify/productcatalog/x/AMPLIFY_lowstockproducts_PRODUCT_CATALOG_SECRET',
@@ -31,6 +30,10 @@ export function applyEscapeHatches(backend: Backend) {
   backend.lowstockproducts.addEnvironment(
     'API_PRODUCTCATALOG_GRAPHQLAPIIDOUTPUT',
     backend.data.apiId
+  );
+  backend.lowstockproducts.addEnvironment(
+    'REGION',
+    backend.lowstockproducts.stack.region
   );
   backend.data.resources.graphqlApi.grantQuery(
     backend.lowstockproducts.resources.lambda

--- a/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/function/quotegenerator/resource.ts
+++ b/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/function/quotegenerator/resource.ts
@@ -8,10 +8,14 @@ export const quotegenerator = defineFunction({
   name: `quotegenerator-${branchName}`,
   timeoutSeconds: 25,
   memoryMB: 128,
-  environment: { ENV: `${branchName}`, REGION: 'us-east-1' },
+  environment: { ENV: `${branchName}` },
   runtime: 22,
 });
 
 export function applyEscapeHatches(backend: Backend) {
   backend.quotegenerator.resources.cfnResources.cfnFunction.functionName = `quotegenerator-${branchName}`;
+  backend.quotegenerator.addEnvironment(
+    'REGION',
+    backend.quotegenerator.stack.region
+  );
 }

--- a/amplify-migration-apps/store-locator/_snapshot.post.generate/amplify/function/storelocator41a9495f41a9495fPostConfirmation/resource.ts
+++ b/amplify-migration-apps/store-locator/_snapshot.post.generate/amplify/function/storelocator41a9495f41a9495fPostConfirmation/resource.ts
@@ -11,7 +11,6 @@ export const storelocator41a9495f41a9495fPostConfirmation = defineFunction({
   environment: {
     ENV: `${branchName}`,
     MODULES: 'add-to-group',
-    REGION: 'us-east-1',
     GROUP: 'storeLocatorAdmin',
   },
   runtime: 22,
@@ -19,4 +18,8 @@ export const storelocator41a9495f41a9495fPostConfirmation = defineFunction({
 
 export function applyEscapeHatches(backend: Backend) {
   backend.storelocator41a9495f41a9495fPostConfirmation.resources.cfnResources.cfnFunction.functionName = `storelocator41a9495f41a9495fPostConfirmation-${branchName}`;
+  backend.storelocator41a9495f41a9495fPostConfirmation.addEnvironment(
+    'REGION',
+    backend.storelocator41a9495f41a9495fPostConfirmation.stack.region
+  );
 }

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/data/data.generator.test.ts
@@ -583,6 +583,7 @@ describe('DataGenerator', () => {
     expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
       "import { defineData } from '@aws-amplify/backend';
       import type { Backend } from '../backend';
+      import { myAuthFn } from '../function/myAuthFn/resource';
 
       const schema = \`type Todo @model { id: ID! }\`;
 

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
@@ -1237,6 +1237,44 @@ describe('FunctionGenerator', () => {
     expect(output).toContain('KinesisEventSource');
   });
 
+  it('moves REGION from literal env vars to dynamic addEnvironment using stack.region', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      function: {
+        myFunc: {
+          service: 'Lambda',
+          output: { Name: 'myFunc-main-abc', Arn: 'arn:aws:lambda:us-east-1:123:function:myFunc-main-abc' },
+        },
+      },
+    });
+    jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue('myFunc-main-abc');
+    jest.spyOn(gen1App, 'json').mockReturnValue({ Resources: {} });
+    jest.spyOn(gen1App, 'file').mockReturnValue('{}');
+    jest.spyOn(gen1App, 'fileExists').mockReturnValue(false);
+    jest.spyOn(gen1App.aws, 'fetchFunctionConfig').mockResolvedValue({
+      FunctionName: 'myFunc-main-abc',
+      Handler: 'index.handler',
+      Timeout: 3,
+      MemorySize: 128,
+      Runtime: 'nodejs18.x',
+      Environment: { Variables: { REGION: 'us-east-1', MY_VAR: 'hello' } },
+    });
+    jest.spyOn(gen1App.aws, 'fetchFunctionSchedule').mockResolvedValue(undefined);
+
+    const generator = createFunctionGenerator({ gen1App, backendGenerator, packageJsonGenerator, outputDir });
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const output = writtenFile('resource.ts');
+
+    // REGION should NOT appear as a literal environment variable
+    expect(output).not.toMatch(/environment:.*REGION/);
+    // MY_VAR should still be a literal env var
+    expect(output).toContain("MY_VAR: 'hello'");
+    // REGION should be set dynamically via addEnvironment using the stack region token
+    expect(output).toContain("backend.myFunc.addEnvironment('REGION', backend.myFunc.stack.region)");
+  });
+
   it('throws for non-nodejs runtime', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.generator.ts
@@ -9,7 +9,7 @@ import { AmplifyMigrationOperation } from '../../../_common/operation';
 import { BackendGenerator } from '../backend.generator';
 import { Gen1App, DiscoveredResource } from '../../../_common/gen1-app';
 import { TS } from '../../ts';
-import { DataRenderer } from './data.renderer';
+import { DataRenderer, LambdaAuthFunctionRef } from './data.renderer';
 import { SpinningLogger } from '../../../_common/spinning-logger';
 
 // ── Resolver Utility Types ─────────────────────────────────────────────
@@ -170,6 +170,7 @@ export class DataGenerator implements Planner {
       graphqlApi.additionalAuthenticationProviders !== undefined && graphqlApi.additionalAuthenticationProviders.length > 0;
     const hasAuth = this.gen1App.categoryMeta('auth') !== undefined;
     const authorizationModes = supplementOidcConfig(this.gen1App.resourceMetaOutput(this.resource, 'authConfig'), graphqlApi);
+    const lambdaAuthFunction = extractLambdaAuthFunction(authorizationModes);
     const hasIamAuth = this.detectIamAuth(authorizationModes, graphqlApi);
     const vtlFiles = this.findResolverVtlFiles(this.resource.resourceName);
     const hasResolvers = vtlFiles.length > 0;
@@ -191,6 +192,7 @@ export class DataGenerator implements Planner {
             hasAuth,
             apiId,
             classifiedResolvers,
+            lambdaAuthFunction,
           });
 
           const content = TS.printNodes(nodes);
@@ -313,4 +315,44 @@ function supplementOidcConfig(authConfig: any, graphqlApi: GraphqlApi): any {
   }
 
   return result;
+}
+
+/**
+ * Extracts the Lambda authorizer function reference from the authConfig.
+ * Searches both defaultAuthentication and additionalAuthenticationProviders.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped authConfig from amplify-meta.json
+function extractLambdaAuthFunction(authorizationModes: any): LambdaAuthFunctionRef | undefined {
+  if (!authorizationModes) return undefined;
+
+  const lambdaFunctionName =
+    findLambdaFunctionName(authorizationModes.defaultAuthentication) ??
+    findLambdaFunctionNameInProviders(authorizationModes.additionalAuthenticationProviders);
+
+  if (!lambdaFunctionName) return undefined;
+
+  return {
+    name: lambdaFunctionName,
+    importPath: `../function/${lambdaFunctionName}/resource`,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped authConfig provider
+function findLambdaFunctionName(provider: any): string | undefined {
+  if (provider?.authenticationType === 'AWS_LAMBDA' && provider.lambdaAuthorizerConfig?.lambdaFunction) {
+    return provider.lambdaAuthorizerConfig.lambdaFunction;
+  }
+  return undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped authConfig providers array
+function findLambdaFunctionNameInProviders(providers: any[] | undefined): string | undefined {
+  if (!providers) return undefined;
+  // AppSync supports only one Lambda authorizer per API, but we iterate defensively
+  // in case the config structure has multiple providers listed
+  for (const provider of providers) {
+    const name = findLambdaFunctionName(provider);
+    if (name) return name;
+  }
+  return undefined;
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/data/data.renderer.ts
@@ -201,6 +201,15 @@ export function computeSpliceIndexes(
  * Options for rendering a defineData() resource file.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any -- authorizationModes is untyped JSON */
+/**
+ * Describes a Lambda authorizer function that needs to be imported
+ * into data/resource.ts for the lambdaAuthorizationMode config.
+ */
+export interface LambdaAuthFunctionRef {
+  readonly name: string;
+  readonly importPath: string;
+}
+
 export interface DataRenderOptions {
   readonly schema: string;
   readonly tableMappings: Record<string, string>;
@@ -209,6 +218,7 @@ export interface DataRenderOptions {
   readonly hasAuth?: boolean;
   readonly apiId?: string;
   readonly classifiedResolvers?: ClassifiedVtlFiles;
+  readonly lambdaAuthFunction?: LambdaAuthFunctionRef;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -240,6 +250,10 @@ export class DataRenderer {
     const { schema, preSchemaStatements } = this.prepareSchema(opts.schema);
 
     const nodes: ts.Node[] = [this.renderNamedImport('defineData', '@aws-amplify/backend'), this.renderBackendTypeImport()];
+
+    if (opts.lambdaAuthFunction) {
+      nodes.push(this.renderNamedImport(opts.lambdaAuthFunction.name, opts.lambdaAuthFunction.importPath));
+    }
 
     const escapeHatchResult = this.renderApplyEscapeHatches(opts);
     for (const imp of escapeHatchResult.additionalImports) {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.generator.ts
@@ -78,6 +78,19 @@ export class FunctionGenerator implements Planner {
     const entry = TS.extractFilePathFromHandler(config.Handler ?? 'index.js');
     const { literalEnvVars, dynamicEnvVars } = classifyEnvVars(config.Environment?.Variables ?? {});
 
+    // REGION should resolve dynamically to the deployment region rather than
+    // being hardcoded. Move it from retained env vars to an escape hatch that
+    // uses the CDK stack region token.
+    const finalLiteralEnvVars = { ...literalEnvVars };
+    const finalDynamicEnvVars = [...dynamicEnvVars];
+    if ('REGION' in finalLiteralEnvVars) {
+      delete finalLiteralEnvVars.REGION;
+      finalDynamicEnvVars.push({
+        name: 'REGION',
+        expression: TS.propAccess('backend', this.resource.resourceName, 'stack', 'region'),
+      });
+    }
+
     const dynamoActions = this.extractDynamoActions();
     const kinesisActions = this.extractKinesisActions();
     const appSyncPermissions = this.extractAppSyncPermissions();
@@ -97,8 +110,8 @@ export class FunctionGenerator implements Planner {
       memoryMB: config.MemorySize,
       runtime,
       schedule,
-      literalEnvVars,
-      dynamicEnvVars,
+      literalEnvVars: finalLiteralEnvVars,
+      dynamicEnvVars: finalDynamicEnvVars,
       dynamoActions,
       appSyncPermissions,
       dataTriggerModels,


### PR DESCRIPTION
## Description

Fixes #14813.

Two bugs in the gen2-migration code generator that caused build failures when migrating Gen1 apps with Lambda authorizer auth modes:

1. **Missing import for Lambda authorizer function** — The generated `data/resource.ts` referenced the Lambda function identifier (e.g., `myAuthFn`) without emitting an import statement, producing a TypeScript compilation error.

2. **Hardcoded REGION environment variable** — The `REGION` env var was placed in `defineFunction()`'s static `environment` object with the Gen1 deployment region (e.g., `us-east-1`). This is incorrect for Gen2 where the deployment region may differ from the original Gen1 region.

## Changes

#### Data resource generation

`DataRenderer` now accepts an optional `lambdaAuthFunction` reference describing the function name and relative import path. When present, it adds the import to the generated `data/resource.ts`.

`DataGenerator` extracts the Lambda function name from `authorizationModes` (searching both `defaultAuthentication` and `additionalAuthenticationProviders`) and passes it to the renderer.

#### Dynamic REGION resolution

`FunctionGenerator.resolve()` now intercepts the `REGION` key after `classifyEnvVars()` runs. Instead of leaving it as a retained (hardcoded) env var, it moves REGION to an escape hatch that emits `backend.{funcName}.stack.region` — the CDK token that resolves to the actual deployment region at synth time.

## Testing

- Unit tests: `data.renderer.test.ts` updated with Lambda auth import assertion
- Integration snapshots: All 9 fixture apps regenerated and verified (12 snapshot tests pass)
- Function generator tests: 19 tests pass
- Full test suite: 55 tests across 5 suites pass
