### PR TITLE
fix(cli): assess transformer version in data assessor

### DIFF
--- a/docs/packages/amplify-cli/src/commands/gen2-migration/assess.md
+++ b/docs/packages/amplify-cli/src/commands/gen2-migration/assess.md
@@ -76,7 +76,7 @@ Produced by `Gen1App.discover()`. The `key` field is a typed `category:service` 
 | auth      | Cognito-UserPool-Groups | ✔                | ✔           |
 | storage   | S3                      | ✔                | ✔           |
 | storage   | DynamoDB                | ✔                | ✔           |
-| api       | AppSync                 | ✔                | n/a         |
+| api       | AppSync                 | ✔ (V2 only)      | n/a         |
 | api       | API Gateway             | ✔                | n/a         |
 | analytics | Kinesis                 | ✔                | ✔           |
 | function  | Lambda                  | ✔ (Node.js only) | n/a         |
@@ -89,5 +89,5 @@ Produced by `Gen1App.discover()`. The `key` field is a typed `category:service` 
 - Adding a new resource type: add the pair to `KNOWN_RESOURCE_KEYS` in `gen1-app.ts`, create an assessor, handle the case in `assess.ts`, and in the generate/refactor steps. The compiler enforces exhaustiveness.
 - The `Assessment` is also used by generate and refactor steps for validation — `validFor(step)` returns false if any resource or feature is unsupported for that step. The `of(resource, step)` method returns the `Support` for a specific resource, used by the generate orchestrator to skip unsupported resources before instantiating generators.
 - Feature detection (overrides, custom policies, conflict resolution) is assessor-specific. Each assessor checks for files in the cloud backend directory via `gen1App.fileExists()` or reads `cli-inputs.json` via `gen1App.cliInputs()`.
-- `DataAssessor` detects conflict resolution (DataStore) by reading `cli-inputs.json` for the API resource. If `serviceConfiguration.conflictResolution` is present and non-empty, both generate and refactor are marked unsupported because Gen2 does not support DataStore conflict resolution.
+- `DataAssessor` checks the GraphQL transformer version via `FeatureFlags.getNumber('graphQLTransformer.transformerVersion')`. If the version is not 2 (i.e., Transformer V1), the resource is marked unsupported for generate. It also detects conflict resolution (DataStore) by reading `cli-inputs.json` for the API resource. If `serviceConfiguration.conflictResolution` is present and non-empty, both generate and refactor are marked unsupported because Gen2 does not support DataStore conflict resolution.
 - `FunctionAssessor` reads the Lambda runtime from the local CloudFormation template (`function/<name>/<name>-cloudformation-template.json`). Non-Node.js runtimes are marked as unsupported for generate. Function refactor is always not-applicable since functions are stateless.

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
@@ -7,7 +7,7 @@ import { SpinningLogger } from '../../../../commands/gen2-migration/_common/spin
 import { Gen1App } from '../../../../commands/gen2-migration/_common/gen1-app';
 import { AwsFetcher } from '../../../../commands/gen2-migration/_common/aws-fetcher';
 import { AwsClients } from '../../../../commands/gen2-migration/_common/aws-clients';
-import { JSONUtilities } from '@aws-amplify/amplify-cli-core';
+import { JSONUtilities, FeatureFlags } from '@aws-amplify/amplify-cli-core';
 import { Snapshot } from './snapshot';
 import { DEFAULT_STATEFUL_RESOURCES } from '../../../../commands/gen2-migration/_common/resource-types';
 
@@ -398,6 +398,7 @@ export class MigrationApp {
 
     process.chdir(workDir);
     try {
+      await FeatureFlags.initialize({ getCurrentEnvName: () => app.environmentName });
       await callback(app);
     } finally {
       process.chdir(cwd);

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/api/data.assessor.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/assess/api/data.assessor.test.ts
@@ -1,6 +1,7 @@
 import { DataAssessor } from '../../../../../commands/gen2-migration/assess/api/data.assessor';
 import { Assessment } from '../../../../../commands/gen2-migration/assess/assessment';
 import { Gen1App, DiscoveredResource } from '../../../../../commands/gen2-migration/_common/gen1-app';
+import { FeatureFlags } from '@aws-amplify/amplify-cli-core';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper for untyped cli-inputs.json
 function mockGen1App(existingFiles: string[] = [], cliInputsData: any = {}): Gen1App {
@@ -12,10 +13,22 @@ function mockGen1App(existingFiles: string[] = [], cliInputsData: any = {}): Gen
   } as unknown as Gen1App;
 }
 
+function mockTransformerVersion(version: number): void {
+  jest.spyOn(FeatureFlags, 'getNumber').mockImplementation((flagName: string) => {
+    if (flagName === 'graphQLTransformer.transformerVersion') return version;
+    throw new Error(`Unexpected FeatureFlags.getNumber call: ${flagName}`);
+  });
+}
+
 const RESOURCE: DiscoveredResource = { category: 'api', resourceName: 'myApi', service: 'AppSync', key: 'api:AppSync' };
 
 describe('DataAssessor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('records resource as supported', () => {
+    mockTransformerVersion(2);
     const assessment = new Assessment('app', 'dev');
     new DataAssessor(mockGen1App(), RESOURCE).record(assessment);
 
@@ -25,6 +38,7 @@ describe('DataAssessor', () => {
   });
 
   it('detects override.ts', () => {
+    mockTransformerVersion(2);
     const assessment = new Assessment('app', 'dev');
     new DataAssessor(mockGen1App(['api/myApi/override.ts']), RESOURCE).record(assessment);
 
@@ -37,6 +51,7 @@ describe('DataAssessor', () => {
   });
 
   it('records no features when override.ts is absent', () => {
+    mockTransformerVersion(2);
     const assessment = new Assessment('app', 'dev');
     new DataAssessor(mockGen1App(), RESOURCE).record(assessment);
 
@@ -44,6 +59,7 @@ describe('DataAssessor', () => {
   });
 
   it('detects conflict resolution (DataStore) as unsupported', () => {
+    mockTransformerVersion(2);
     const cliInputs = {
       version: 1,
       serviceConfiguration: {
@@ -66,6 +82,7 @@ describe('DataAssessor', () => {
   });
 
   it('does not record conflict resolution when it is absent from cli-inputs.json', () => {
+    mockTransformerVersion(2);
     const cliInputs = {
       version: 1,
       serviceConfiguration: {
@@ -81,6 +98,7 @@ describe('DataAssessor', () => {
   });
 
   it('does not record conflict resolution when conflictResolution is an empty object', () => {
+    mockTransformerVersion(2);
     const cliInputs = {
       version: 1,
       serviceConfiguration: {
@@ -93,5 +111,26 @@ describe('DataAssessor', () => {
     new DataAssessor(mockGen1App([], cliInputs), RESOURCE).record(assessment);
 
     expect(assessment.features).toHaveLength(0);
+  });
+
+  it('records resource as unsupported when transformer version is not 2', () => {
+    mockTransformerVersion(1);
+    const assessment = new Assessment('app', 'dev');
+    new DataAssessor(mockGen1App(), RESOURCE).record(assessment);
+
+    const entry = assessment.resources[0];
+    expect(entry!.generate.level).toBe('unsupported');
+    expect(entry!.generate).toHaveProperty('note', 'Transformer V1 is not supported in Gen2');
+    expect(entry!.refactor.level).toBe('not-applicable');
+  });
+
+  it('records resource as supported when transformer version is 2', () => {
+    mockTransformerVersion(2);
+    const assessment = new Assessment('app', 'dev');
+    new DataAssessor(mockGen1App(), RESOURCE).record(assessment);
+
+    const entry = assessment.resources[0];
+    expect(entry!.generate.level).toBe('supported');
+    expect(entry!.refactor.level).toBe('not-applicable');
   });
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/assess/api/data.assessor.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/assess/api/data.assessor.ts
@@ -1,10 +1,11 @@
 import { Assessor } from '../assessor';
 import { Assessment, supported, unsupported, notApplicable } from '../assessment';
 import { Gen1App, DiscoveredResource, KNOWN_FEATURES } from '../../_common/gen1-app';
+import { FeatureFlags } from '@aws-amplify/amplify-cli-core';
 
 /**
  * Assesses migration readiness for an AppSync GraphQL API resource.
- * Detects overrides.ts usage and conflict resolution (DataStore).
+ * Rejects Transformer V1 projects, detects overrides.ts usage and conflict resolution (DataStore).
  */
 export class DataAssessor implements Assessor {
   public constructor(private readonly gen1App: Gen1App, private readonly resource: DiscoveredResource) {}
@@ -14,7 +15,17 @@ export class DataAssessor implements Assessor {
    */
   public record(assessment: Assessment): void {
     this.gen1App.ensureCliInputs(this.resource.category, this.resource.resourceName);
-    assessment.recordResource({ resource: this.resource, generate: supported(), refactor: notApplicable() });
+
+    const transformerVersion = FeatureFlags.getNumber('graphQLTransformer.transformerVersion');
+    if (transformerVersion !== 2) {
+      assessment.recordResource({
+        resource: this.resource,
+        generate: unsupported('Transformer V1 is not supported in Gen2'),
+        refactor: notApplicable(),
+      });
+    } else {
+      assessment.recordResource({ resource: this.resource, generate: supported(), refactor: notApplicable() });
+    }
 
     const overridesPath = `api/${this.resource.resourceName}/override.ts`;
 


### PR DESCRIPTION
#### Description of changes

Adds a Transformer V1 gate to the `DataAssessor`. Before assessing
features (overrides, conflict resolution), the assessor now reads
`graphQLTransformer.transformerVersion` from `FeatureFlags`. If the
version is not 2, the resource is immediately marked unsupported with a
clear note, preventing Gen2 migration from proceeding on V1 projects **without explicit acknowledgment**.

Note that the `generate` step will automatically skip this resource since it will now be marked unsupported.

#### Issue #, if available

N/A

#### Description of how you validated changes

- `npx jest --testPathPattern="data.assessor.test"` — 8/8 pass
- `npx jest --testPathPattern="generate.test" -t "fitness-tracker|backend-only|product-catalog"` — 3/3 pass
- `npx jest --testPathPattern="refactor.test" -t "fitness-tracker"` — pass

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are changed or added
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [x] Pull request labels are added

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
