### PR TITLE
fix(cli): handle unsupported S3 acceleration in migration

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
@@ -1,0 +1,51 @@
+import { GetBucketAccelerateConfigurationCommand, S3Client } from '@aws-sdk/client-s3';
+import nock from 'nock';
+import { AwsFetcher } from '../../../../commands/gen2-migration/_common/aws-fetcher';
+import { AwsClients } from '../../../../commands/gen2-migration/_common/aws-clients';
+
+describe('AwsFetcher', () => {
+  it('returns the bucket accelerate status when available', async () => {
+    const send = jest.fn();
+    const fetcher = new AwsFetcher({ s3: { send } } as unknown as AwsClients);
+    send.mockResolvedValueOnce({ Status: 'Enabled' });
+
+    await expect(fetcher.fetchBucketAccelerate('my-bucket')).resolves.toBe('Enabled');
+    expect(send).toHaveBeenCalledWith(expect.any(GetBucketAccelerateConfigurationCommand));
+  });
+
+  it('returns undefined for an SDK-deserialized MethodNotAllowed response', async () => {
+    const endpoint = 'https://s3.example.com';
+    const scope = nock(endpoint)
+      .get(/.*/)
+      .reply(
+        405,
+        '<?xml version="1.0" encoding="UTF-8"?><Error><Code>MethodNotAllowed</Code><Message>The specified method is not allowed against this resource.</Message></Error>',
+        { 'Content-Type': 'application/xml' },
+      );
+    const s3 = new S3Client({
+      region: 'us-east-1',
+      endpoint,
+      forcePathStyle: true,
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+    });
+    const fetcher = new AwsFetcher({ s3 } as unknown as AwsClients);
+
+    try {
+      await expect(fetcher.fetchBucketAccelerate('my-bucket')).resolves.toBeUndefined();
+      scope.done();
+    } finally {
+      s3.destroy();
+      nock.cleanAll();
+    }
+  });
+
+  it('propagates non-MethodNotAllowed errors', async () => {
+    const send = jest.fn();
+    const fetcher = new AwsFetcher({ s3: { send } } as unknown as AwsClients);
+    const error = new Error('Access denied');
+    error.name = 'AccessDenied';
+    send.mockRejectedValueOnce(error);
+
+    await expect(fetcher.fetchBucketAccelerate('my-bucket')).rejects.toBe(error);
+  });
+});

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
@@ -1,0 +1,37 @@
+import { GetBucketAccelerateConfigurationCommand } from '@aws-sdk/client-s3';
+import { AwsFetcher } from '../../../../commands/gen2-migration/_common/aws-fetcher';
+import { AwsClients } from '../../../../commands/gen2-migration/_common/aws-clients';
+
+describe('AwsFetcher', () => {
+  describe('fetchBucketAccelerate', () => {
+    const send = jest.fn();
+    const fetcher = new AwsFetcher({ s3: { send } } as unknown as AwsClients);
+
+    beforeEach(() => {
+      send.mockReset();
+    });
+
+    it('returns the bucket accelerate status when available', async () => {
+      send.mockResolvedValueOnce({ Status: 'Enabled' });
+
+      await expect(fetcher.fetchBucketAccelerate('my-bucket')).resolves.toBe('Enabled');
+      expect(send).toHaveBeenCalledWith(expect.any(GetBucketAccelerateConfigurationCommand));
+    });
+
+    it('returns undefined when bucket acceleration is not supported for the bucket', async () => {
+      const error = new Error('The specified method is not allowed against this resource.');
+      error.name = 'MethodNotAllowed';
+      send.mockRejectedValueOnce(error);
+
+      await expect(fetcher.fetchBucketAccelerate('my-bucket')).resolves.toBeUndefined();
+    });
+
+    it('propagates non-MethodNotAllowed errors', async () => {
+      const error = new Error('Access denied');
+      error.name = 'AccessDenied';
+      send.mockRejectedValueOnce(error);
+
+      await expect(fetcher.fetchBucketAccelerate('my-bucket')).rejects.toBe(error);
+    });
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
@@ -158,9 +158,19 @@ export class AwsFetcher {
     return this.clients.s3.send(new GetBucketNotificationConfigurationCommand({ Bucket: bucketName }));
   }
 
+  /**
+   * Returns the bucket acceleration status, or undefined when S3 does not support the operation.
+   */
   public async fetchBucketAccelerate(bucketName: string) {
-    const { Status } = await this.clients.s3.send(new GetBucketAccelerateConfigurationCommand({ Bucket: bucketName }));
-    return Status;
+    try {
+      const { Status } = await this.clients.s3.send(new GetBucketAccelerateConfigurationCommand({ Bucket: bucketName }));
+      return Status;
+    } catch (e: unknown) {
+      if (e instanceof Error && e.name === 'MethodNotAllowed') {
+        return undefined;
+      }
+      throw e;
+    }
   }
 
   public async fetchBucketVersioning(bucketName: string) {

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
@@ -152,8 +152,15 @@ export class AwsFetcher {
   }
 
   public async fetchBucketAccelerate(bucketName: string) {
-    const { Status } = await this.clients.s3.send(new GetBucketAccelerateConfigurationCommand({ Bucket: bucketName }));
-    return Status;
+    try {
+      const { Status } = await this.clients.s3.send(new GetBucketAccelerateConfigurationCommand({ Bucket: bucketName }));
+      return Status;
+    } catch (e: unknown) {
+      if (e instanceof Error && e.name === 'MethodNotAllowed') {
+        return undefined;
+      }
+      throw e;
+    }
   }
 
   public async fetchBucketVersioning(bucketName: string) {


### PR DESCRIPTION
#### Description of changes

Fixes #14876.

`amplify gen2-migration generate` currently fails when S3 returns `MethodNotAllowed` for `GetBucketAccelerateConfiguration`, which can happen for buckets where transfer acceleration is unsupported. This updates `AwsFetcher.fetchBucketAccelerate()` to treat only `MethodNotAllowed` as an unavailable acceleration state and return `undefined`, while still propagating other S3 errors.

The regression test uses a real `S3Client` against a mocked HTTP 405 REST-XML response. This exercises the AWS SDK deserializer and proves that `<Code>MethodNotAllowed</Code>` becomes an S3 service error whose `name` is `MethodNotAllowed`.

#### Description of how you validated changes

- Reproduced the failure through the real AWS SDK path before the patch: the HTTP 405 REST-XML response deserialized to `S3ServiceException` with `name === 'MethodNotAllowed'`, and `fetchBucketAccelerate()` rejected.
- Verified the same reproduction after the patch resolves to `undefined`.
- Focused AwsFetcher regression: 3/3 tests passed.
- S3 migration generator suite: 13/13 tests and 11/11 snapshots passed.
- Full `@aws-amplify/cli-internal` suite: 131/131 suites, 802/802 tests, and 138/138 snapshots passed.
- `@aws-amplify/cli-internal` build passed.
- ESLint, Prettier, and diff checks passed.
- Repository pre-commit and pre-push hooks passed without bypasses.

#### Checklist

- [x] PR description included
- [x] Tests are changed or added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.