### PR TITLE
fix(cli): classify migration categories by prefix

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/categories.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/categories.test.ts
@@ -1,0 +1,12 @@
+import { extractCategory } from '../../../../commands/gen2-migration/_common/categories';
+
+describe('extractCategory', () => {
+  it.each([
+    ['storageauthbackup', 'Storage'],
+    ['apiStorageResolver', 'Api'],
+    ['functionAuthHandler', 'Function'],
+    ['analyticsAuthStream', 'Analytics'],
+  ])('classifies %s using the category prefix', (logicalId, expectedCategory) => {
+    expect(extractCategory(logicalId)).toBe(expectedCategory);
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/categories.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/categories.ts
@@ -1,19 +1,24 @@
 /**
  * Extract Amplify category from a logical resource ID.
  */
+const CATEGORY_PREFIXES = [
+  ['auth', 'Auth'],
+  ['storage', 'Storage'],
+  ['function', 'Function'],
+  ['api', 'Api'],
+  ['analytics', 'Analytics'],
+  ['hosting', 'Hosting'],
+  ['notifications', 'Notifications'],
+  ['interactions', 'Interactions'],
+  ['predictions', 'Predictions'],
+  ['geo', 'Geo'],
+  ['custom', 'Custom'],
+] as const;
+
 export function extractCategory(logicalId: string): string {
   const idLower = logicalId.toLowerCase();
-  if (idLower.includes('auth')) return 'Auth';
-  if (idLower.includes('storage')) return 'Storage';
-  if (idLower.includes('function')) return 'Function';
-  if (idLower.includes('api')) return 'Api';
-  if (idLower.includes('analytics')) return 'Analytics';
-  if (idLower.includes('hosting')) return 'Hosting';
-  if (idLower.includes('notifications')) return 'Notifications';
-  if (idLower.includes('interactions')) return 'Interactions';
-  if (idLower.includes('predictions')) return 'Predictions';
-  if (idLower.includes('geo')) return 'Geo';
-  if (idLower.includes('custom')) return 'Custom';
-  if (idLower.includes('deployment') || idLower.includes('infrastructure') || idLower.includes('core')) return 'Core Infrastructure';
+  const category = CATEGORY_PREFIXES.find(([prefix]) => idLower.startsWith(prefix));
+  if (category) return category[1];
+  if (idLower.startsWith('deployment') || idLower.startsWith('infrastructure') || idLower.startsWith('core')) return 'Core Infrastructure';
   return 'Other';
 }


### PR DESCRIPTION
## Description

Fixes #14609.

`extractCategory()` previously classified logical IDs by checking whether category names appeared anywhere in the ID. That made the result order-dependent, so a storage resource such as `storageauthbackup` was reported as `Auth` because `auth` appeared later in the resource name.

This changes category detection to use known Amplify category prefixes and keeps core infrastructure detection prefix-based as well.

## Validation

- Reproduced the bug with a failing unit test before the fix: `storageauthbackup` returned `Auth` instead of `Storage`.
- `corepack yarn workspace @aws-amplify/cli-internal test src/__tests__/commands/gen2-migration/_common/categories.test.ts --runInBand --no-coverage`
- `corepack yarn workspace @aws-amplify/cli-internal test src/__tests__/commands/drift --runInBand --no-coverage`
- `corepack yarn workspace @aws-amplify/cli-internal test src/__tests__/commands/gen2-migration/_common/categories.test.ts src/__tests__/commands/drift/services/drift-formatter.test.ts --runInBand --no-coverage`
- `corepack yarn prettier --check packages/amplify-cli/src/commands/gen2-migration/_common/categories.ts packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/categories.test.ts`
- `corepack yarn eslint packages/amplify-cli/src/commands/gen2-migration/_common/categories.ts packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/categories.test.ts`
- `corepack yarn sanitize-migration-apps`
- `corepack yarn build-tests-changed`
- `git diff --check`