### PR TITLE
fix(storage-simulator): prevent path traversal in mock S3 server

### DIFF
--- a/packages/amplify-storage-simulator/src/server/S3server.ts
+++ b/packages/amplify-storage-simulator/src/server/S3server.ts
@@ -17,6 +17,18 @@ import { StorageSimulatorServerConfig } from '../index';
 
 import * as util from './utils';
 
+/**
+ * Validates that a resolved file path is contained within the storage root directory.
+ * Prevents path traversal attacks that could read/write/delete files outside the mock storage.
+ */
+function assertPathWithinRoot(resolvedPath: string, rootDir: string): void {
+  const normalizedRoot = path.resolve(rootDir) + path.sep;
+  const normalizedPath = path.resolve(resolvedPath);
+  if (!normalizedPath.startsWith(normalizedRoot) && normalizedPath !== path.resolve(rootDir)) {
+    throw new Error(`Access denied: path "${resolvedPath}" is outside the storage root`);
+  }
+}
+
 const LIST_CONTENT = 'Contents';
 const LIST_COMMOM_PREFIXES = 'CommonPrefixes';
 const EVENT_RECORDS = 'Records';
@@ -126,6 +138,7 @@ export class StorageServer extends EventEmitter {
 
   private async handleRequestGet(request, response) {
     const filePath = path.normalize(path.join(this.localDirectoryPath, request.params.path));
+    assertPathWithinRoot(filePath, this.localDirectoryPath);
     if (fs.existsSync(filePath) && !fs.statSync(filePath).isDirectory()) {
       fs.readFile(filePath, (err, data) => {
         if (err) {
@@ -173,6 +186,7 @@ export class StorageServer extends EventEmitter {
     let keyCount = 0;
     // getting folders recursively
     const dirPath = path.normalize(path.join(this.localDirectoryPath, request.params.path));
+    assertPathWithinRoot(dirPath, this.localDirectoryPath);
 
     const files = globSync('**/*', {
       cwd: dirPath,
@@ -228,6 +242,7 @@ export class StorageServer extends EventEmitter {
 
   private async handleRequestDelete(request, response) {
     const filePath = path.join(this.localDirectoryPath, request.params.path);
+    assertPathWithinRoot(filePath, this.localDirectoryPath);
     if (fs.existsSync(filePath)) {
       fs.unlink(filePath, (err) => {
         if (err) throw err;
@@ -241,6 +256,7 @@ export class StorageServer extends EventEmitter {
 
   private async handleRequestPut(request, response) {
     const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
+    assertPathWithinRoot(directoryPath, this.localDirectoryPath);
     fs.ensureFileSync(directoryPath);
     // strip signature in android , returns same buffer for other clients
     const new_data = util.stripChunkSignature(request.body);
@@ -259,6 +275,7 @@ export class StorageServer extends EventEmitter {
 
   private async handleRequestPost(request, response) {
     const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
+    assertPathWithinRoot(directoryPath, this.localDirectoryPath);
     if (request.query.uploads !== undefined) {
       const id = uuid();
       this.uploadIds.push(id);
@@ -300,6 +317,7 @@ export class StorageServer extends EventEmitter {
       this.emit('event', eventObj);
     } else {
       const directoryPath = path.normalize(path.join(String(this.localDirectoryPath), String(request.params.path)));
+      assertPathWithinRoot(directoryPath, this.localDirectoryPath);
       fs.ensureFileSync(directoryPath);
       const new_data = util.stripChunkSignature(request.body);
       fs.writeFileSync(directoryPath, new_data);

--- a/packages/amplify-storage-simulator/src/server/utils.ts
+++ b/packages/amplify-storage-simulator/src/server/utils.ts
@@ -3,7 +3,10 @@ import * as path from 'path';
 // parse the request url to get the path and storing in the request.params.path  with the prefix if present
 
 export function parseUrl(request, route: string) {
-  request.url = path.normalize(decodeURIComponent(request.url));
+  // Strip query string BEFORE normalizing the URL to prevent path.normalize
+  // from treating query parameter values (e.g. ?prefix=../../) as path segments
+  const urlWithoutQuery = request.url.split('?')[0];
+  request.url = path.normalize(decodeURIComponent(urlWithoutQuery));
   const temp = request.url.split(route);
   request.params.path = '';
 
@@ -20,6 +23,13 @@ export function parseUrl(request, route: string) {
 
   if (request.params.path[0] == '/' || request.params.path[0] == '.') {
     request.params.path = request.params.path.substring(1);
+  }
+
+  // Sanitize path traversal: reject any path that would escape the storage root.
+  // After all normalization, the path must not contain '..' segments.
+  const normalized = path.normalize(request.params.path);
+  if (normalized.startsWith('..') || path.isAbsolute(normalized)) {
+    request.params.path = path.basename(normalized);
   }
 
   // changing file path by removing invalid file path characters for windows


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in the mock storage simulator (`amplify-storage-simulator`) that allows arbitrary file read/write/delete outside the configured storage directory on a developer's workstation.

## Root Cause

`parseUrl()` in `utils.ts` called `path.normalize(decodeURIComponent(request.url))` on the full URL including the query string. This caused `../` sequences in query parameter values (e.g. `?prefix=../../`) to be resolved as filesystem path traversal by `path.normalize()`. Combined with the insufficient single-character strip of a leading `.` or `/`, an attacker with network access to the simulator (localhost:20005) could escape the storage root.

**Attack vector:** `PUT /test-bucket/ESCAPE/pwned.txt/?prefix=../..` writes a file one level above the configured storage directory.

## Fix

1. **Strip query string before normalize** - `request.url.split('?')[0]` before passing to `path.normalize()`
2. **Post-normalization traversal check** - reject any `params.path` that starts with `..` or is absolute after all normalization (falls back to `path.basename()`)
3. **Defense-in-depth `assertPathWithinRoot()` checks** - added to every handler (GET, PUT, POST, DELETE, LIST) that performs filesystem operations, validating that the resolved path stays within the storage root

## Testing

- Verified with a live PoC that the exploit is blocked after the fix
- Regression tested: normal PUT, GET, DELETE, POST, multipart upload, nested paths all work correctly
- 17/17 passed in regression suite

## Impact

Limited to developers running `amplify mock storage` who also have port 20005 reachable from untrusted networks or processes. No AWS production infrastructure affected.
