### PR TITLE
fix(amplify-e2e-tests): stagger e2e batch fan-out into waves to prevent codebuild orchestrator fault

### DIFF
--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -496,84 +496,84 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init-special-case.test.ts|src/__tests__/function_3a_python.test.ts|src/__tests__/function_3a_nodejs.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_function_3a_go_function_3a_dotnet_export_pull_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_3a_go.test.ts|src/__tests__/function_3a_dotnet.test.ts|src/__tests__/export-pull-b.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_7b_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_7b.test.ts|src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_function_2_schema_auth_3_schema_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts|src/__tests__/schema-auth-12.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_iterative_update_3_schema_iterative_rollback_2_schema_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/schema-auth-5a.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_export_pull_d_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/export-pull-d.test.ts|src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_migration_push_pull_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts|src/__tests__/pull-2.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_pr_previews_multi_env_1_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pr-previews-multi-env-1.test.ts|src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_notifications_sms_update_notifications_multi_env_minify_cloudformation
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts|src/__tests__/minify-cloudformation.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_init_force_push_hooks_c_help
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-force-push.test.ts|src/__tests__/hooks-c.test.ts|src/__tests__/help.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_function_2d_function_15_function_14
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_2d.test.ts|src/__tests__/function_15.test.ts|src/__tests__/function_14.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_function_13_function_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_13.test.ts|src/__tests__/function_12.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_export_pull_c_custom_resource_with_storage
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -581,189 +581,189 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-c.test.ts|src/__tests__/custom-resource-with-storage.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_build_function_build_function_yarn_modern_auth_5g
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts|src/__tests__/auth_5g.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_2h_auth_2g_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_2h.test.ts|src/__tests__/auth_2g.test.ts|src/__tests__/auth_12.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_2b_api_2a_amplify_remove
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts|src/__tests__/amplify-remove.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_S3server_smoketest_smoketest_ios
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/storage-simulator/S3server.test.ts|src/__tests__/smoke-tests/smoketest.test.ts|src/__tests__/smoke-tests/smoketest-ios.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_javascript_notifications_pinpoint_config_javascript_analytics_pinpoint_config_ios_notifications_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/javascript-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/javascript-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/ios-notifications-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_ios_analytics_pinpoint_config_flutter_notifications_pinpoint_config_flutter_analytics_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/ios-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-analytics-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_android_notifications_pinpoint_config_android_analytics_pinpoint_config_opensearch_simulator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/android-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/android-analytics-pinpoint-config.test.ts|src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_general_config_headless_init_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/general-config/general-config-headless-init.test.ts|src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_user_groups_s3_access_hosted_ui_admin_api
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts|src/__tests__/auth/admin-api.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_iterative_update_locking_function_8_api_8
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/function_8.test.ts|src/__tests__/api_8.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_auth_13_layer_2_api_lambda_auth_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts|src/__tests__/layer-2.test.ts|src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_iterative_update_1_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_6_storage_1b_storage_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts|src/__tests__/storage-1a.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_iterative_update_2_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_9b_function_7_function_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_7.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_function_11_api_connection_migration2_storage_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/storage-4.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_containers_api_secrets_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/containers-api-secrets.test.ts|src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_key_resolvers_geo_multi_env
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/geo-multi-env.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_searchable_datastore_schema_searchable
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts|src/__tests__/schema-searchable.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_apigw_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts|src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_lambda_auth_1_schema_auth_14_api_key_migration1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts|src/__tests__/migration/api.key.migration1.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_6b_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_6b.test.ts|src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_storage_5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -771,7 +771,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/storage-5.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_datastore_modelgen
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -780,7 +780,7 @@ batch:
           TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -789,7 +789,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_uibuilder
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -797,7 +797,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/uibuilder.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -805,7 +805,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -813,7 +813,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_geo_remove_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -821,7 +821,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-3.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_geo_add_f
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -829,7 +829,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-f.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_geo_add_e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -837,7 +837,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-e.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_import_dynamodb_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -845,7 +845,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2c.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_env_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -853,7 +853,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -861,7 +861,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_geo_remove_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -869,7 +869,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-2.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_auth_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -877,7 +877,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2a.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_auth_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -885,7 +885,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1a.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_s3_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -893,7 +893,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2c.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_s3_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -901,7 +901,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2a.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -909,7 +909,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2b.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -917,7 +917,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -925,7 +925,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1b.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -933,7 +933,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_geo_update_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -941,7 +941,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-2.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_geo_update_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -949,7 +949,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-1.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_dynamodb_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -957,7 +957,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2b.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_smoketest_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -966,7 +966,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_store_locator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -975,7 +975,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-store-locator.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_project_boards
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -984,7 +984,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-project-boards.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_product_catalog
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -993,7 +993,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-product-catalog.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_mood_board
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1002,7 +1002,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-mood-board.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_media_vault
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1011,7 +1011,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-media-vault.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_fitness_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1020,7 +1020,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-fitness-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_finance_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1029,7 +1029,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-finance-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_discussions
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1038,7 +1038,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-discussions.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_gen2_migration_backend_only
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1047,7 +1047,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-backend-only.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1055,7 +1055,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1063,7 +1063,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_s3_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1071,7 +1071,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2b.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1079,7 +1079,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1087,7 +1087,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1095,7 +1095,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_auth_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1103,7 +1103,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_3.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_dynamodb_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1111,7 +1111,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2a.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1119,7 +1119,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1128,7 +1128,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1137,7 +1137,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1145,7 +1145,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - upb
+        - l_env_3
     - identifier: l_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1154,7 +1154,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_env_3
     - identifier: w_notifications_lifecycle_auth_2f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1663,8 +1663,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_9_c_schema_auth_9_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1673,8 +1672,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9-c.test.ts|src/__tests__/schema-auth-9-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1683,8 +1681,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_1a_geo_headless
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1693,8 +1690,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_9a_export_pull_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1703,8 +1699,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9a.test.ts|src/__tests__/export-pull-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_7_api_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1713,8 +1708,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_7.test.ts|src/__tests__/api_10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_key_migration5_schema_auth_9_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1723,8 +1717,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts|src/__tests__/schema-auth-9-b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_7b_schema_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1733,8 +1726,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7b.test.ts|src/__tests__/schema-auth-7a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1743,8 +1735,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_11_b_predictions
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1753,8 +1744,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_layer_3_hosting
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1763,8 +1753,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/layer-3.test.ts|src/__tests__/hosting.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_geo_import_3_geo_add_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1773,8 +1762,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-import-3.test.ts|src/__tests__/geo-add-d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_geo_add_c_delete
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1783,8 +1771,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-c.test.ts|src/__tests__/delete.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1793,8 +1780,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_predictions_migration_api_key_migration3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1803,8 +1789,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_connection_migration_init_special_case
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1813,8 +1798,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/init-special-case.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_export_pull_b_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1823,8 +1807,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/export-pull-b.test.ts|src/__tests__/auth_7b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1833,8 +1816,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_function_2_schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1843,8 +1825,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_12_schema_iterative_update_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1853,8 +1834,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts|src/__tests__/schema-iterative-update-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_auth_5a_export_pull_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1863,8 +1843,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5a.test.ts|src/__tests__/export-pull-d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1873,8 +1852,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_auth_migration_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1883,8 +1861,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1893,8 +1870,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_notifications_sms_update_notifications_multi_env
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1903,8 +1879,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_minify_cloudformation_init_force_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1913,8 +1888,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/minify-cloudformation.test.ts|src/__tests__/init-force-push.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_help_function_2d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1923,8 +1897,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/help.test.ts|src/__tests__/function_2d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_14_function_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1933,8 +1906,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_14.test.ts|src/__tests__/function_13.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_12_export_pull_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1943,8 +1915,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_12.test.ts|src/__tests__/export-pull-c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_build_function_build_function_yarn_modern
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1953,8 +1924,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_auth_5g_auth_2h
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1963,8 +1933,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5g.test.ts|src/__tests__/auth_2h.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1973,8 +1942,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_2b_api_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1983,8 +1951,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_amplify_remove_smoketest
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1993,8 +1960,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-remove.test.ts|src/__tests__/smoke-tests/smoketest.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_smoketest_ios_general_config_headless_init
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2003,8 +1969,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-ios.test.ts|src/__tests__/general-config/general-config-headless-init.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2013,8 +1978,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_user_groups_s3_access_hosted_ui
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2023,8 +1987,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_admin_api_schema_iterative_update_locking
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2033,8 +1996,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/admin-api.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_8_schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2043,8 +2005,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_8.test.ts|src/__tests__/schema-auth-13.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_lambda_auth_2_schema_iterative_update_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2053,8 +2014,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_2.test.ts|src/__tests__/schema-iterative-update-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2063,8 +2023,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2073,8 +2032,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_auth_6_storage_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2083,8 +2041,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_storage_1a_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2093,8 +2050,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-1a.test.ts|src/__tests__/schema-iterative-update-2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2103,8 +2059,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_9b_function_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2113,8 +2068,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_11_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2123,8 +2077,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_storage_4_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2133,8 +2086,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-4.test.ts|src/__tests__/containers-api-secrets.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2143,8 +2095,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_schema_key_resolvers
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2153,8 +2104,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_geo_multi_env_searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2163,8 +2113,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-multi-env.test.ts|src/__tests__/graphql-v2/searchable-datastore.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_schema_searchable_apigw
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2173,8 +2122,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts|src/__tests__/apigw.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2183,8 +2131,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_api_lambda_auth_1_schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2193,8 +2140,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_api_key_migration1_api_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2203,8 +2149,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts|src/__tests__/api_6b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2213,8 +2158,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2223,8 +2167,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2233,8 +2176,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2243,8 +2185,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2253,8 +2194,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_env_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2263,8 +2203,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2273,8 +2212,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2283,8 +2221,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2293,8 +2230,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2303,8 +2239,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2313,8 +2248,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2323,8 +2257,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2333,8 +2266,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2343,8 +2275,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2353,8 +2284,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2364,8 +2294,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2375,8 +2304,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2385,8 +2313,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: w_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2396,8 +2323,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_key_resolvers
     - identifier: aggregate_e2e_reports
       env:
         compute-type: BUILD_GENERAL1_MEDIUM

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -181,6 +181,14 @@ type ConfigBase = {
 };
 const MAX_WORKERS = 3;
 const MAX_WORKERS_WINDOWS = 2;
+/**
+ * Maximum number of e2e shards in a single dependency wave. Shards are chained
+ * wave-by-wave (see `staggerJobsIntoWaves`) so that at most this many builds
+ * start simultaneously. This avoids the CodeBuild batch orchestrator fault that
+ * occurs when a single gate (e.g. `upb`) releases all ~140 shards at once,
+ * producing a thundering herd of `StartBuild` calls.
+ */
+const E2E_WAVE_SIZE = 50;
 type OS_TYPE = 'w' | 'l';
 type CandidateJob = {
   region?: string;
@@ -198,6 +206,34 @@ const createRandomJob = (os: OS_TYPE): CandidateJob => {
     useParentAccount: false,
     disableCoverage: false,
   };
+};
+/**
+ * Staggers an ordered list of e2e shard jobs into waves so they do not all
+ * start at the same instant when their shared dependency completes.
+ *
+ * The first `E2E_WAVE_SIZE` shards (wave 1) keep their original dependency gate
+ * (e.g. `upb` for Linux, or `build_windows` + `upb` for Windows). Every later
+ * wave is re-pointed to depend solely on the last shard of the previous wave,
+ * so a wave only fans out once the previous wave is already underway. This caps
+ * the number of simultaneous CodeBuild `StartBuild` calls at roughly one wave
+ * instead of the full shard count, preventing the batch orchestrator from
+ * faulting under a thundering-herd fan-out of ~140 shards.
+ *
+ * Transitive ordering is preserved: because each wave depends on a shard from
+ * the previous wave (which itself depends on the original gate), every shard
+ * still runs strictly after the prebuilt binaries are uploaded. Jobs are
+ * mutated in place and their order is unchanged, so shard identities (and the
+ * build cache that keys off them) are preserved.
+ */
+const staggerJobsIntoWaves = (jobs: any[]): void => {
+  jobs.forEach((job, shardIndex) => {
+    if (shardIndex < E2E_WAVE_SIZE) {
+      // Wave 1 keeps its original gate (e.g. ['upb']).
+      return;
+    }
+    const previousWaveLastIndex = Math.floor(shardIndex / E2E_WAVE_SIZE) * E2E_WAVE_SIZE - 1;
+    job['depend-on'] = [jobs[previousWaveLastIndex].identifier];
+  });
 };
 const splitTestsV3 = (
   baseJobLinux: any,
@@ -292,7 +328,8 @@ const splitTestsV3 = (
     }
     return jobName;
   };
-  const result: any[] = [];
+  const linuxFormattedJobs: any[] = [];
+  const windowsFormattedJobs: any[] = [];
   const dependeeIdentifiers: string[] = [];
   linuxJobs.forEach((job) => {
     if (job.tests.length !== 0) {
@@ -322,7 +359,7 @@ const splitTestsV3 = (
       if (job.disableCoverage) {
         formattedJob.env.variables.DISABLE_COVERAGE = 1;
       }
-      result.push(formattedJob);
+      linuxFormattedJobs.push(formattedJob);
     }
   });
   windowsJobs.forEach((job) => {
@@ -347,10 +384,12 @@ const splitTestsV3 = (
       if (job.disableCoverage) {
         formattedJob.env.variables.DISABLE_COVERAGE = 1;
       }
-      result.push(formattedJob);
+      windowsFormattedJobs.push(formattedJob);
     }
   });
-  return result;
+  staggerJobsIntoWaves(linuxFormattedJobs);
+  staggerJobsIntoWaves(windowsFormattedJobs);
+  return [...linuxFormattedJobs, ...windowsFormattedJobs];
 };
 function main(): void {
   const configBase: any = loadConfigBase();


### PR DESCRIPTION
#### Description of changes

The generated CodeBuild batch workflow (`codebuild_specs/e2e_workflow_generated.yml`) has been FAULTing at the batch-orchestrator level ("Internal Service Error") roughly 25 minutes into every run since ~May 22. The batch reaches the e2e fan-out, then FAULTs and stops all downstream builds. Because the error is at the batch-orchestrator level (not an individual build), it is largely invisible in the per-build UI.

##### Root cause — single-gate thundering herd

The workflow funnels **every** e2e shard through one dependency gate:

- ~141 Linux shards each declare `depend-on: [upb]`
- ~124 Windows shards each declare `depend-on: [build_windows, upb]`

When `upb` completes, all ~141 Linux shards leave `INITIALIZED` within ~13s — a burst of hundreds of `StartBuild` calls in under a minute. That simultaneous-start burst trips the CodeBuild **batch orchestrator**. The individual builds are healthy (they reach `PROVISIONING` in seconds) and per-build concurrency quota is not the limiter. Setting the project `concurrentBuildLimit` does **not** fix it — batch builds are rejected (`AccountLimitExceededException`) rather than queued.

##### Fix — stagger the fan-out into waves

`scripts/split-e2e-tests-codebuild.ts` now groups the generated shards into **waves** of at most `E2E_WAVE_SIZE` (50):

- **Wave 1** keeps the original gate (`[upb]` for Linux, `[build_windows, upb]` for Windows).
- **Wave N (N > 1)** depends solely on the **last shard of wave N-1**.

A wave only fans out once the previous wave's anchor shard has completed, so the instantaneous `StartBuild` burst is capped at ~one wave (≤50) instead of the full shard count. Transitive ordering is preserved — every shard still runs strictly after `upb` (and `build_windows` for Windows), so artifact access is unchanged (shards download the prebuilt CLI from S3 at runtime; `depend-on` in a build-graph is ordering-only and does not pass artifacts). Linux and Windows are staggered independently. The regenerated `e2e_workflow_generated.yml` is committed alongside the generator change (it is a committed artifact).

##### Tradeoff for reviewer discussion (why this is a draft)

Chaining each wave on the previous wave's anchor shard means that if an **anchor shard fails**, CodeBuild does not run the dependent wave — downstream waves for that OS are skipped. e2e shards are occasionally flaky, so a flaky failure on an anchor shard could skip a wave. `fast-fail: false` is set so the rest of the batch still runs, and the e2e monitor already retries failed builds — but reviewers should confirm this tradeoff is acceptable versus, e.g., inserting always-succeeding barrier jobs between waves. Wave size is a single tunable constant.

This change complements a separate AWS Support case opened for the batch-orchestrator behavior; it is the robust, workflow-side mitigation that does not depend on a service-side fix.

#### Issue #, if available

N/A

#### Description of how you validated changes

- `yarn split-e2e-tests-codebuild` regenerates the workflow with **exit 0** (ts-node type-checks the script, confirming it compiles).
- The regenerated `e2e_workflow_generated.yml` now shows three waves per OS:
  - **Linux (136 shards):** 50 → `[upb]`; 50 → `[l_predictions_migration_..._api_connection_migration]` (wave-1 anchor); 36 → `[l_env_3]` (wave-2 anchor)
  - **Windows (124 shards):** 50 → `[build_windows, upb]`; 50 → `[w_auth_3b_auth_3a]` (wave-1 anchor); 24 → `[w_schema_key_resolvers]` (wave-2 anchor)
- No e2e anchor gate has more than 50 direct dependents. `upb` retains both OSes' wave-1 shards, but Windows wave 1 is additionally gated by `build_windows`, so `upb` completing releases at most ~50 same-OS (Linux) shards.
- `wait_for_ids.json` is unchanged — shard identifiers (and the cache that keys off them) are preserved; only `depend-on` edges changed.
- Commit passed the husky / lint-staged / commitlint hooks (prettier + eslint clean).

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes — n/a: no unit tests exist for the workflow generator; validated via the regenerated artifact
- [ ] Tests are changed or added — n/a: build-script change, verified via generated output
- [x] Relevant documentation is changed or added — n/a: no `docs/` file maps to this script
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
