### PR TITLE
fix(amplify-category-function): pin jstreemap to 1.28.2 (self is not …

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "istanbul/async": "^2.6.4",
     "jake/async": "^2.6.4",
     "json5": "^2.2.3",
+    "jstreemap": "1.28.2",
     "mysql2": "^3.9.8",
     "nth-check": "^2.0.1",
     "undici": "^5.28.3",

--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -41,7 +41,7 @@
     "graphql-transformer-core": "^8.2.18",
     "inquirer": "^7.3.3",
     "inquirer-datepicker": "^2.0.0",
-    "jstreemap": "^1.28.2",
+    "jstreemap": "1.28.2",
     "lodash": "^4.17.21",
     "promise-sequential": "^1.1.1",
     "uuid": "^8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,7 +276,7 @@ __metadata:
     inquirer: ^7.3.3
     inquirer-datepicker: ^2.0.0
     jest: ^29.7.0
-    jstreemap: ^1.28.2
+    jstreemap: 1.28.2
     lodash: ^4.17.21
     promise-sequential: ^1.1.1
     uuid: ^8.3.2
@@ -26090,7 +26090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jstreemap@npm:^1.28.2":
+"jstreemap@npm:1.28.2":
   version: 1.28.2
   resolution: "jstreemap@npm:1.28.2"
   checksum: d7f55ff23c3bc1f54a7b92675fd785ab4f069052b25137b2d1d47a10722dd8f8442d1a710d0d3144322412e654e3f3f71f4326f7126d7287497d4cdbd94c9f80


### PR DESCRIPTION
jstreemap 1.29.1/1.29.2/1.29.3 (published 2026-06-19) ships a broken UMD bundle that references bare `self` — undefined in Node.js — causing a ReferenceError at require('jstreemap') time. This crashes amplify-category- function during `amplify init` on every Node version (18 and 22 confirmed).

Root cause: jstreemap changed their UMD guard from the safe pattern
  typeof self !== 'undefined' ? self : this
to bare `self`, which is only defined in browser/ServiceWorker contexts.

Impact: Every `amplify init` that loads the function category throws
  ReferenceError: self is not defined
making the Gen1 CLI completely unusable for function workflows. Canary SEV-2s: P457496122 / P457522624 / P457523805 Timeline: jstreemap 1.29.1 published 15:44 UTC June 19; canaries red by 16:00 UTC.

Fix:
- Pin jstreemap to 1.28.2 (last known-good version) in packages/amplify-category-function/package.json
- Add root-level yarn resolutions entry to force 1.28.2 everywhere transitively, preventing any future accidental upgrade
- Update yarn.lock to reflect exact-version key alongside caret key

The upstream jstreemap package should guard `self` with typeof before accessing it; a separate upstream issue should be filed.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
