### PR TITLE
fix(cli-internal): avoid duplicate Construct import for double-quoted sources

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.construct-import-dedup.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.construct-import-dedup.test.ts
@@ -1,66 +1,82 @@
-import path from 'node:path';
-import fs from 'node:fs/promises';
-import os from 'node:os';
 import { CustomResourceGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/custom-resources/custom.generator';
 import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
 import { RootPackageJsonGenerator } from '../../../../../../commands/gen2-migration/generate/package.json.generator';
 import { SpinningLogger } from '../../../../../../commands/gen2-migration/_common/spinning-logger';
+import { Gen1App } from '../../../../../../commands/gen2-migration/_common/gen1-app';
 import { DEFAULT_STATEFUL_RESOURCES } from '../../../../../../commands/gen2-migration/_common/resource-types';
 
+jest.unmock('fs-extra');
+
+jest.mock('@aws-amplify/amplify-cli-core', () => {
+  const actual = jest.requireActual('@aws-amplify/amplify-cli-core');
+  return {
+    ...actual,
+    JSONUtilities: {
+      ...actual.JSONUtilities,
+      readJson: jest.fn().mockImplementation((filePath: string, opts?: unknown) => {
+        if (typeof filePath === 'string' && filePath.endsWith('package.json')) {
+          return { dependencies: {}, devDependencies: {} };
+        }
+        if (typeof filePath === 'string' && filePath.endsWith('project-config.json')) {
+          return { projectName: 'testProject' };
+        }
+        return actual.JSONUtilities.readJson(filePath, opts);
+      }),
+    },
+  };
+});
+
+const mockMkdir = jest.fn().mockResolvedValue(undefined);
+const mockWriteFile = jest.fn().mockResolvedValue(undefined);
+const mockCp = jest.fn().mockResolvedValue(undefined);
+const mockRm = jest.fn().mockResolvedValue(undefined);
+const mockReadFile = jest.fn();
+const mockReaddir = jest.fn().mockResolvedValue([]);
+const mockRename = jest.fn().mockResolvedValue(undefined);
+jest.mock('node:fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  cp: (...args: unknown[]) => mockCp(...args),
+  rm: (...args: unknown[]) => mockRm(...args),
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+  readdir: (...args: unknown[]) => mockReaddir(...args),
+  rename: (...args: unknown[]) => mockRename(...args),
+}));
+
+const CDK_STACK_CONTENT = `
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export class cdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+  }
+}
+`;
+
 describe('CustomResourceGenerator - Construct import deduplication', () => {
-  let outputDir: string;
-  let origCwd: () => string;
+  const outputDir = '/fake/output';
   const logger = new SpinningLogger('test');
+  const gen1App = { statefulResourceTypes: [...Array.from(DEFAULT_STATEFUL_RESOURCES)] } as unknown as Gen1App;
 
-  beforeEach(async () => {
-    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'construct-import-dedup-'));
-    origCwd = process.cwd;
-  });
-
-  afterEach(async () => {
-    process.cwd = origCwd;
-    await fs.rm(outputDir, { recursive: true, force: true });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadFile.mockResolvedValue(CDK_STACK_CONTENT);
   });
 
   it('does not inject duplicate Construct import when source uses double quotes', async () => {
-    // cdk-stack.ts with double-quote Construct import already present
-    const cdkStackContent = [
-      'import * as cdk from "aws-cdk-lib";',
-      'import { Construct } from "constructs";',
-      '',
-      'export class cdkStack extends cdk.Stack {',
-      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
-      '    super(scope, id, props);',
-      '  }',
-      '}',
-      '',
-    ].join('\n');
-
-    // Set up gen1 project structure
-    const customDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'myRes');
-    await fs.mkdir(customDir, { recursive: true });
-    await fs.writeFile(path.join(customDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
-    await fs.writeFile(path.join(customDir, 'package.json'), JSON.stringify({ dependencies: {}, devDependencies: {} }), 'utf-8');
-
-    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
-    const configDir = path.join(outputDir, 'amplify', '.config');
-    await fs.mkdir(configDir, { recursive: true });
-    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
-
-    process.cwd = () => outputDir;
-
-    const backendGen = new BackendGenerator(outputDir, logger);
-    const pkgGen = new RootPackageJsonGenerator(outputDir);
-    const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as unknown as { statefulResourceTypes: string[] };
-
-    const generator = new CustomResourceGenerator(gen1App as any, backendGen, pkgGen, outputDir, 'myRes', logger);
+    const backendGenerator = new BackendGenerator(outputDir, logger);
+    const packageJsonGenerator = new RootPackageJsonGenerator(outputDir);
+    const generator = new CustomResourceGenerator(gen1App, backendGenerator, packageJsonGenerator, outputDir, 'myRes', logger);
     const ops = await generator.plan();
     await ops[0].execute();
 
-    const constructContent = await fs.readFile(path.join(outputDir, 'amplify', 'custom', 'myRes', 'construct.ts'), 'utf-8');
+    // The generator writes transformed content to cdk-stack.ts before renaming it
+    const writeCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('cdk-stack.ts'));
+    expect(writeCall).toBeDefined();
+    const writtenContent = writeCall![1] as string;
 
-    // There must be exactly ONE import from 'constructs' or "constructs"
-    const constructsImports = (constructContent.match(/from ['"]constructs['"]/g) || []).length;
+    const constructsImports = (writtenContent.match(/from ['"]constructs['"]/g) || []).length;
     expect(constructsImports).toBe(1);
   });
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.construct-import-dedup.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.construct-import-dedup.test.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import { CustomResourceGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/custom-resources/custom.generator';
+import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
+import { RootPackageJsonGenerator } from '../../../../../../commands/gen2-migration/generate/package.json.generator';
+import { SpinningLogger } from '../../../../../../commands/gen2-migration/_common/spinning-logger';
+import { DEFAULT_STATEFUL_RESOURCES } from '../../../../../../commands/gen2-migration/_common/resource-types';
+
+describe('CustomResourceGenerator - Construct import deduplication', () => {
+  let outputDir: string;
+  let origCwd: () => string;
+  const logger = new SpinningLogger('test');
+
+  beforeEach(async () => {
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'construct-import-dedup-'));
+    origCwd = process.cwd;
+  });
+
+  afterEach(async () => {
+    process.cwd = origCwd;
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('does not inject duplicate Construct import when source uses double quotes', async () => {
+    // cdk-stack.ts with double-quote Construct import already present
+    const cdkStackContent = [
+      'import * as cdk from "aws-cdk-lib";',
+      'import { Construct } from "constructs";',
+      '',
+      'export class cdkStack extends cdk.Stack {',
+      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
+      '    super(scope, id, props);',
+      '  }',
+      '}',
+      '',
+    ].join('\n');
+
+    // Set up gen1 project structure
+    const customDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'myRes');
+    await fs.mkdir(customDir, { recursive: true });
+    await fs.writeFile(path.join(customDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
+    await fs.writeFile(path.join(customDir, 'package.json'), JSON.stringify({ dependencies: {}, devDependencies: {} }), 'utf-8');
+
+    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
+    const configDir = path.join(outputDir, 'amplify', '.config');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
+
+    process.cwd = () => outputDir;
+
+    const backendGen = new BackendGenerator(outputDir, logger);
+    const pkgGen = new RootPackageJsonGenerator(outputDir);
+    const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as unknown as { statefulResourceTypes: string[] };
+
+    const generator = new CustomResourceGenerator(gen1App as any, backendGen, pkgGen, outputDir, 'myRes', logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const constructContent = await fs.readFile(path.join(outputDir, 'amplify', 'custom', 'myRes', 'construct.ts'), 'utf-8');
+
+    // There must be exactly ONE import from 'constructs' or "constructs"
+    const constructsImports = (constructContent.match(/from ['"]constructs['"]/g) || []).length;
+    expect(constructsImports).toBe(1);
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.ts
@@ -219,7 +219,7 @@ async function transformResource(
   let content = await fs.readFile(cdkStackFilePath, { encoding: 'utf-8' });
 
   // Add Construct import if not present
-  if (!content.includes("from 'constructs'")) {
+  if (!/import\s*\{[^}]*\bConstruct\b[^}]*\}\s*from\s*['"]constructs['"]/.test(content)) {
     const importRegex = /(import.*from.*['"]; ?\s*\n)/g;
     let lastImportMatch: RegExpExecArray | null = null;
     let regexMatch: RegExpExecArray | null;


### PR DESCRIPTION
## Problem
`transformResource()` injected `import { Construct } from 'constructs';` guarded by a single-quote-only substring check (`content.includes(\"from 'constructs'\")`). A custom resource whose `cdk-stack.ts` already imported `Construct` with double quotes slipped past the guard, yielding two `Construct` imports — TS2300.

## Fix
Replace the guard with a quote-agnostic, binding-specific regex that detects an existing `Construct` named import in either quote style, while still injecting when only a different binding (e.g. `IConstruct`) is imported from `constructs`.

## Test
`custom.generator.construct-import-dedup.test.ts` drives `CustomResourceGenerator` with a double-quote `Construct` fixture and asserts exactly one `constructs` import.

## Risk
Low. One-line guard change; existing custom-resources tests unchanged.