### PR TITLE
fix(cli-internal): unify custom-resource dependency detection

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.test.ts
@@ -236,6 +236,62 @@ class MyStack extends cdk.Stack {
     });
   });
 
+  describe('bare addResourceDependency named-import (customer migrationgen2 pattern)', () => {
+    // Customer Gen1 cdk-stack.ts imports addResourceDependency as a bare named import
+    // and assigns it to a typed `dependencies` variable. Detection must recognize the
+    // bare Identifier call (not just PropertyAccess) so refs get rewritten to backend.*
+    const BARE_IMPORT_CODE = `
+import { type AmplifyResourceProps, addResourceDependency } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
+
+export class cdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props: AmplifyResourceProps) {
+    super(scope, id, props);
+    const dependencies: AmplifyDependentResourcesAttributes = addResourceDependency(this, props, 'myCustom', [
+      { category: 'function', resourceName: 'myFunc' },
+      { category: 'auth', resourceName: 'myAuth' },
+    ]);
+    const fnName = cdk.Fn.ref(dependencies.function.myFunc.Name);
+    const poolArn = cdk.Fn.ref(dependencies.auth.myAuth.UserPoolArn);
+  }
+}
+`;
+
+    it('detects the bare addResourceDependency call and sets addedBackendParam', () => {
+      const { addedBackendParam } = transformRaw(BARE_IMPORT_CODE);
+      expect(addedBackendParam).toBe(true);
+    });
+
+    it('adds the backend constructor parameter', () => {
+      const { output } = transformRaw(BARE_IMPORT_CODE);
+      expect(output).toContain('backend: Backend');
+    });
+
+    it('rewrites dependencies.* references to backend.* and removes the call', () => {
+      const { output } = transformRaw(BARE_IMPORT_CODE);
+
+      expect(output).toContain('backend.functions.myFunc.resources.lambda.functionName');
+      expect(output).toContain('backend.auth.resources.userPool.userPoolArn');
+      expect(output).not.toContain('addResourceDependency');
+      expect(output).not.toContain('dependencies.');
+      expect(output).not.toContain('Fn.ref');
+      expect(output).not.toContain('AmplifyDependentResourcesAttributes');
+    });
+
+    it('detects a bare addResourceDependency even without a type annotation', () => {
+      const code = `
+import { addResourceDependency } from '@aws-amplify/cli-extensibility-helper';
+const dependencies = addResourceDependency(this, props, 'myCustom', []);
+const fnName = cdk.Fn.ref(dependencies.function.myFunc.Name);
+`;
+      const { output, addedBackendParam } = transformRaw(code);
+
+      expect(addedBackendParam).toBe(true);
+      expect(output).toContain('backend.functions.myFunc.resources.lambda.functionName');
+      expect(output).not.toContain('addResourceDependency');
+    });
+  });
+
   describe('AmplifyDependentResourcesAttributes removal', () => {
     it('removes variable with AmplifyDependentResourcesAttributes type', () => {
       const code = `const attrs: AmplifyDependentResourcesAttributes = {};`;

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.test.ts
@@ -5,15 +5,21 @@ const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
 function transformCode(code: string, projectName?: string): string {
   const sourceFile = ts.createSourceFile('test.ts', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-  let transformed = AmplifyHelperTransformer.transform(sourceFile, projectName);
+  let { sourceFile: transformed } = AmplifyHelperTransformer.transform(sourceFile, projectName);
   transformed = AmplifyHelperTransformer.addBranchNameVariable(transformed, projectName);
   return printer.printFile(transformed);
 }
 
 function transformOnly(code: string, projectName?: string): string {
   const sourceFile = ts.createSourceFile('test.ts', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-  const transformed = AmplifyHelperTransformer.transform(sourceFile, projectName);
+  const { sourceFile: transformed } = AmplifyHelperTransformer.transform(sourceFile, projectName);
   return printer.printFile(transformed);
+}
+
+function transformRaw(code: string, projectName?: string): { output: string; addedBackendParam: boolean } {
+  const sourceFile = ts.createSourceFile('test.ts', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const { sourceFile: transformed, addedBackendParam } = AmplifyHelperTransformer.transform(sourceFile, projectName);
+  return { output: printer.printFile(transformed), addedBackendParam };
 }
 
 describe('AmplifyHelperTransformer', () => {
@@ -183,10 +189,11 @@ class MyStack extends cdk.Stack {
 const dependencies = AmplifyHelpers.addResourceDependency(this, []);
 const poolId = cdk.Fn.ref(dependencies.auth.myAuth.UserPoolId);
 `;
-      const output = transformOnly(code);
+      const { output, addedBackendParam } = transformRaw(code);
 
       expect(output).not.toContain('addResourceDependency');
       expect(output).toContain('backend.auth.resources.userPool.userPoolId');
+      expect(addedBackendParam).toBe(true);
     });
 
     it('transforms function dependency access with resource name', () => {
@@ -194,9 +201,10 @@ const poolId = cdk.Fn.ref(dependencies.auth.myAuth.UserPoolId);
 const deps = AmplifyHelpers.addResourceDependency(this, []);
 const arn = cdk.Fn.ref(deps.function.myFunc.Arn);
 `;
-      const output = transformOnly(code);
+      const { output, addedBackendParam } = transformRaw(code);
 
       expect(output).toContain('backend.functions.myFunc.resources.lambda.functionArn');
+      expect(addedBackendParam).toBe(true);
     });
 
     it('adds backend parameter to constructor when dependencies exist', () => {
@@ -208,9 +216,23 @@ class MyStack extends cdk.Stack {
   }
 }
 `;
-      const output = transformOnly(code);
+      const { output, addedBackendParam } = transformRaw(code);
 
       expect(output).toContain('backend: Backend');
+      expect(addedBackendParam).toBe(true);
+    });
+
+    it('returns addedBackendParam false when no dependencies exist', () => {
+      const code = `
+class MyStack extends cdk.Stack {
+  constructor(scope: any, id: string) {
+    super(scope, id);
+  }
+}
+`;
+      const { addedBackendParam } = transformRaw(code);
+
+      expect(addedBackendParam).toBe(false);
     });
   });
 

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
@@ -58,6 +58,26 @@ export class cdkStack extends cdk.Stack {
 }
 `;
 
+// Customer migrationgen2 pattern: bare `addResourceDependency` named import assigned
+// to a typed `dependencies` variable. Previously undetected -> TS2663 dependencies undefined.
+const CDK_STACK_BARE_IMPORT_DEPS = `
+import * as cdk from 'aws-cdk-lib';
+import { type AmplifyResourceProps, addResourceDependency } from '@aws-amplify/cli-extensibility-helper';
+import { AmplifyDependentResourcesAttributes } from '../../types/amplify-dependent-resources-ref';
+
+export class cdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props: AmplifyResourceProps) {
+    super(scope, id, props);
+    const dependencies: AmplifyDependentResourcesAttributes = addResourceDependency(this, props, 'myCustom', [
+      { category: 'function', resourceName: 'myFunc' },
+      { category: 'auth', resourceName: 'myAuth' }
+    ]);
+    const fnName = cdk.Fn.ref(dependencies.function.myFunc.Name);
+    const poolArn = cdk.Fn.ref(dependencies.auth.myAuth.UserPoolArn);
+  }
+}
+`;
+
 const CDK_STACK_NO_DEPS = `
 import * as cdk from 'aws-cdk-lib';
 
@@ -106,6 +126,47 @@ describe('CustomResourceGenerator dependency consistency', () => {
     const ctorParams = ctorMatch![1].split(',').filter((p: string) => p.trim()).length;
 
     // Count args in `new MyCustom(...)` — handle nested parens like backend.createStack('...')
+    const newCallMatch = resourceContent.match(/new MyCustom\(([\s\S]*?)\);/);
+    expect(newCallMatch).toBeDefined();
+    const newCallArgs = newCallMatch![1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length;
+
+    expect(ctorParams).toBe(3); // scope, id, backend
+    expect(newCallArgs).toBe(ctorParams);
+  });
+
+  it('rewrites bare addResourceDependency refs to backend.* and adds backend param (customer pattern)', async () => {
+    mockReadFile.mockResolvedValue(CDK_STACK_BARE_IMPORT_DEPS);
+
+    const backendGenerator = new BackendGenerator(outputDir, logger);
+    const packageJsonGenerator = new RootPackageJsonGenerator(outputDir);
+    const generator = new CustomResourceGenerator(gen1App, backendGenerator, packageJsonGenerator, outputDir, 'myCustom', logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const constructCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('cdk-stack.ts'));
+    expect(constructCall).toBeDefined();
+    const constructContent = constructCall![1] as string;
+
+    const resourceCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('resource.ts'));
+    expect(resourceCall).toBeDefined();
+    const resourceContent = resourceCall![1] as string;
+
+    // backend constructor param emitted and dependency refs rewritten to backend.*
+    expect(constructContent).toContain('backend: Backend');
+    expect(constructContent).toContain('backend.functions.myFunc.resources.lambda.functionName');
+    expect(constructContent).toContain('backend.auth.resources.userPool.userPoolArn');
+
+    // No leftover Gen1 dependency artifacts that would cause TS2663
+    expect(constructContent).not.toContain('addResourceDependency');
+    expect(constructContent).not.toContain('dependencies.');
+    expect(constructContent).not.toContain('Fn.ref');
+    expect(constructContent).not.toContain('AmplifyDependentResourcesAttributes');
+
+    // ctor params and resource.ts new call args stay consistent (scope, id, backend)
+    const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
+    expect(ctorMatch).toBeDefined();
+    const ctorParams = ctorMatch![1].split(',').filter((p: string) => p.trim()).length;
+
     const newCallMatch = resourceContent.match(/new MyCustom\(([\s\S]*?)\);/);
     expect(newCallMatch).toBeDefined();
     const newCallArgs = newCallMatch![1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length;

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
@@ -1,155 +1,145 @@
-import path from 'node:path';
-import fs from 'node:fs/promises';
-import os from 'node:os';
 import { CustomResourceGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/custom-resources/custom.generator';
 import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
 import { RootPackageJsonGenerator } from '../../../../../../commands/gen2-migration/generate/package.json.generator';
 import { SpinningLogger } from '../../../../../../commands/gen2-migration/_common/spinning-logger';
+import { Gen1App } from '../../../../../../commands/gen2-migration/_common/gen1-app';
 import { DEFAULT_STATEFUL_RESOURCES } from '../../../../../../commands/gen2-migration/_common/resource-types';
+
+jest.unmock('fs-extra');
+
+jest.mock('@aws-amplify/amplify-cli-core', () => {
+  const actual = jest.requireActual('@aws-amplify/amplify-cli-core');
+  return {
+    ...actual,
+    JSONUtilities: {
+      ...actual.JSONUtilities,
+      readJson: jest.fn().mockImplementation((filePath: string, opts?: unknown) => {
+        if (typeof filePath === 'string' && filePath.endsWith('package.json')) {
+          return { dependencies: {}, devDependencies: {} };
+        }
+        if (typeof filePath === 'string' && filePath.endsWith('project-config.json')) {
+          return { projectName: 'testProject' };
+        }
+        return actual.JSONUtilities.readJson(filePath, opts);
+      }),
+    },
+  };
+});
+
+const mockMkdir = jest.fn().mockResolvedValue(undefined);
+const mockWriteFile = jest.fn().mockResolvedValue(undefined);
+const mockCp = jest.fn().mockResolvedValue(undefined);
+const mockRm = jest.fn().mockResolvedValue(undefined);
+const mockReadFile = jest.fn();
+const mockReaddir = jest.fn().mockResolvedValue([]);
+const mockRename = jest.fn().mockResolvedValue(undefined);
+jest.mock('node:fs/promises', () => ({
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  cp: (...args: unknown[]) => mockCp(...args),
+  rm: (...args: unknown[]) => mockRm(...args),
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+  readdir: (...args: unknown[]) => mockReaddir(...args),
+  rename: (...args: unknown[]) => mockRename(...args),
+}));
+
+const CDK_STACK_WITH_DEPS = `
+import * as cdk from 'aws-cdk-lib';
+import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';
+
+export class cdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    const dependencies = AmplifyHelpers.addResourceDependency(this, props, 'myCustom', [
+      { category: 'auth', resourceName: 'myAuth' }
+    ]);
+    const poolId = cdk.Fn.ref(dependencies.auth.myAuth.UserPoolId);
+  }
+}
+`;
+
+const CDK_STACK_NO_DEPS = `
+import * as cdk from 'aws-cdk-lib';
+
+export class cdkStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+  }
+}
+`;
 
 /**
  * Verifies that the constructor parameter count in construct.ts always matches
- * the argument count in the `new <Class>(...)` call in resource.ts, even when
- * addResourceDependency uses a variable for category (which the old regex-based
- * extractDependencies would miss).
+ * the argument count in the `new <Class>(...)` call in resource.ts.
  */
 describe('CustomResourceGenerator dependency consistency', () => {
-  let outputDir: string;
+  const outputDir = '/fake/output';
   const logger = new SpinningLogger('test');
+  const gen1App = { statefulResourceTypes: [...Array.from(DEFAULT_STATEFUL_RESOURCES)] } as unknown as Gen1App;
 
-  beforeEach(async () => {
-    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dep-consistency-'));
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  afterEach(async () => {
-    await fs.rm(outputDir, { recursive: true, force: true });
-  });
+  it('construct.ts ctor params == resource.ts new call args when resource has dependencies', async () => {
+    mockReadFile.mockResolvedValue(CDK_STACK_WITH_DEPS);
 
-  it('construct.ts ctor params == resource.ts new call args when category is a variable', async () => {
-    // cdk-stack.ts: addResourceDependency uses a variable for category — regex misses it,
-    // but AST detects the addResourceDependency variable statement → hasDependencies=true
-    const cdkStackContent = [
-      "import * as cdk from 'aws-cdk-lib';",
-      "import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';",
-      "import { Construct } from 'constructs';",
-      '',
-      'export class cdkStack extends cdk.Stack {',
-      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
-      '    super(scope, id, props);',
-      '    const categoryName = `auth`;',
-      '    const dependencies = AmplifyHelpers.addResourceDependency(this, props, "varDep", [',
-      '      { category: categoryName, resourceName: "userPool" }',
-      '    ]);',
-      '  }',
-      '}',
-    ].join('\n');
+    const backendGenerator = new BackendGenerator(outputDir, logger);
+    const packageJsonGenerator = new RootPackageJsonGenerator(outputDir);
+    const generator = new CustomResourceGenerator(gen1App, backendGenerator, packageJsonGenerator, outputDir, 'myCustom', logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
 
-    // Create gen1 project structure
-    const amplifyBackendCustomDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'varDep');
-    await fs.mkdir(amplifyBackendCustomDir, { recursive: true });
-    await fs.writeFile(path.join(amplifyBackendCustomDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
-    await fs.writeFile(
-      path.join(amplifyBackendCustomDir, 'package.json'),
-      JSON.stringify({ dependencies: {}, devDependencies: {} }),
-      'utf-8',
-    );
+    // Find the construct content (written to cdk-stack.ts before rename)
+    const constructCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('cdk-stack.ts'));
+    expect(constructCall).toBeDefined();
+    const constructContent = constructCall![1] as string;
 
-    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
+    // Find the resource.ts content
+    const resourceCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('resource.ts'));
+    expect(resourceCall).toBeDefined();
+    const resourceContent = resourceCall![1] as string;
 
-    const configDir = path.join(outputDir, 'amplify', '.config');
-    await fs.mkdir(configDir, { recursive: true });
-    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
+    // Count constructor params
+    const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
+    expect(ctorMatch).toBeDefined();
+    const ctorParams = ctorMatch![1].split(',').filter((p: string) => p.trim()).length;
 
-    const origCwd = process.cwd;
-    process.cwd = () => outputDir;
+    // Count args in `new MyCustom(...)` — handle nested parens like backend.createStack('...')
+    const newCallMatch = resourceContent.match(/new MyCustom\(([\s\S]*?)\);/);
+    expect(newCallMatch).toBeDefined();
+    const newCallArgs = newCallMatch![1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length;
 
-    try {
-      const backendGen = new BackendGenerator(outputDir, logger);
-      const pkgGen = new RootPackageJsonGenerator(outputDir);
-      const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as any;
-
-      const generator = new CustomResourceGenerator(gen1App, backendGen, pkgGen, outputDir, 'varDep', logger);
-      const ops = await generator.plan();
-      await ops[0].execute();
-
-      const constructPath = path.join(outputDir, 'amplify', 'custom', 'varDep', 'construct.ts');
-      const resourcePath = path.join(outputDir, 'amplify', 'custom', 'varDep', 'resource.ts');
-
-      const constructContent = await fs.readFile(constructPath, 'utf-8');
-      const resourceContent = await fs.readFile(resourcePath, 'utf-8');
-
-      // Count constructor params in construct.ts
-      const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
-      const ctorParams = ctorMatch ? ctorMatch[1].split(',').filter((p: string) => p.trim()).length : 0;
-
-      // Count args in `new VarDep(...)` call in resource.ts (handle nested parens)
-      const newCallMatch = resourceContent.match(/new VarDep\(([\s\S]*?)\);/);
-      const newCallArgs = newCallMatch ? newCallMatch[1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length : 0;
-
-      // Both must agree: 3 params (scope, id, backend) == 3 args
-      expect(newCallArgs).toBe(ctorParams);
-      expect(ctorParams).toBe(3);
-    } finally {
-      process.cwd = origCwd;
-    }
+    expect(ctorParams).toBe(3); // scope, id, backend
+    expect(newCallArgs).toBe(ctorParams);
   });
 
   it('construct.ts ctor params == resource.ts new call args when no dependencies', async () => {
-    const cdkStackContent = [
-      "import * as cdk from 'aws-cdk-lib';",
-      "import { Construct } from 'constructs';",
-      '',
-      'export class cdkStack extends cdk.Stack {',
-      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
-      '    super(scope, id, props);',
-      '  }',
-      '}',
-    ].join('\n');
+    mockReadFile.mockResolvedValue(CDK_STACK_NO_DEPS);
 
-    const amplifyBackendCustomDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'noDep');
-    await fs.mkdir(amplifyBackendCustomDir, { recursive: true });
-    await fs.writeFile(path.join(amplifyBackendCustomDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
-    await fs.writeFile(
-      path.join(amplifyBackendCustomDir, 'package.json'),
-      JSON.stringify({ dependencies: {}, devDependencies: {} }),
-      'utf-8',
-    );
+    const backendGenerator = new BackendGenerator(outputDir, logger);
+    const packageJsonGenerator = new RootPackageJsonGenerator(outputDir);
+    const generator = new CustomResourceGenerator(gen1App, backendGenerator, packageJsonGenerator, outputDir, 'noDep', logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
 
-    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
+    const constructCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('cdk-stack.ts'));
+    expect(constructCall).toBeDefined();
+    const constructContent = constructCall![1] as string;
 
-    const configDir = path.join(outputDir, 'amplify', '.config');
-    await fs.mkdir(configDir, { recursive: true });
-    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
+    const resourceCall = mockWriteFile.mock.calls.find((c: unknown[]) => (c[0] as string).endsWith('resource.ts'));
+    expect(resourceCall).toBeDefined();
+    const resourceContent = resourceCall![1] as string;
 
-    const origCwd = process.cwd;
-    process.cwd = () => outputDir;
+    const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
+    expect(ctorMatch).toBeDefined();
+    const ctorParams = ctorMatch![1].split(',').filter((p: string) => p.trim()).length;
 
-    try {
-      const backendGen = new BackendGenerator(outputDir, logger);
-      const pkgGen = new RootPackageJsonGenerator(outputDir);
-      const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as any;
+    const newCallMatch = resourceContent.match(/new NoDep\(([\s\S]*?)\);/);
+    expect(newCallMatch).toBeDefined();
+    const newCallArgs = newCallMatch![1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length;
 
-      const generator = new CustomResourceGenerator(gen1App, backendGen, pkgGen, outputDir, 'noDep', logger);
-      const ops = await generator.plan();
-      await ops[0].execute();
-
-      const constructPath = path.join(outputDir, 'amplify', 'custom', 'noDep', 'construct.ts');
-      const resourcePath = path.join(outputDir, 'amplify', 'custom', 'noDep', 'resource.ts');
-
-      const constructContent = await fs.readFile(constructPath, 'utf-8');
-      const resourceContent = await fs.readFile(resourcePath, 'utf-8');
-
-      const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
-      const ctorParams = ctorMatch ? ctorMatch[1].split(',').filter((p: string) => p.trim()).length : 0;
-
-      const newCallMatch = resourceContent.match(/new NoDep\(([\s\S]*?)\);/);
-      const newCallArgs = newCallMatch ? newCallMatch[1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length : 0;
-
-      // Both must agree: 2 params (scope, id) == 2 args
-      expect(newCallArgs).toBe(ctorParams);
-      expect(ctorParams).toBe(2);
-    } finally {
-      process.cwd = origCwd;
-    }
+    expect(ctorParams).toBe(2); // scope, id
+    expect(newCallArgs).toBe(ctorParams);
   });
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.dependency-consistency.test.ts
@@ -1,0 +1,155 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import { CustomResourceGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/custom-resources/custom.generator';
+import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
+import { RootPackageJsonGenerator } from '../../../../../../commands/gen2-migration/generate/package.json.generator';
+import { SpinningLogger } from '../../../../../../commands/gen2-migration/_common/spinning-logger';
+import { DEFAULT_STATEFUL_RESOURCES } from '../../../../../../commands/gen2-migration/_common/resource-types';
+
+/**
+ * Verifies that the constructor parameter count in construct.ts always matches
+ * the argument count in the `new <Class>(...)` call in resource.ts, even when
+ * addResourceDependency uses a variable for category (which the old regex-based
+ * extractDependencies would miss).
+ */
+describe('CustomResourceGenerator dependency consistency', () => {
+  let outputDir: string;
+  const logger = new SpinningLogger('test');
+
+  beforeEach(async () => {
+    outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dep-consistency-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('construct.ts ctor params == resource.ts new call args when category is a variable', async () => {
+    // cdk-stack.ts: addResourceDependency uses a variable for category — regex misses it,
+    // but AST detects the addResourceDependency variable statement → hasDependencies=true
+    const cdkStackContent = [
+      "import * as cdk from 'aws-cdk-lib';",
+      "import * as AmplifyHelpers from '@aws-amplify/cli-extensibility-helper';",
+      "import { Construct } from 'constructs';",
+      '',
+      'export class cdkStack extends cdk.Stack {',
+      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
+      '    super(scope, id, props);',
+      '    const categoryName = `auth`;',
+      '    const dependencies = AmplifyHelpers.addResourceDependency(this, props, "varDep", [',
+      '      { category: categoryName, resourceName: "userPool" }',
+      '    ]);',
+      '  }',
+      '}',
+    ].join('\n');
+
+    // Create gen1 project structure
+    const amplifyBackendCustomDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'varDep');
+    await fs.mkdir(amplifyBackendCustomDir, { recursive: true });
+    await fs.writeFile(path.join(amplifyBackendCustomDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
+    await fs.writeFile(
+      path.join(amplifyBackendCustomDir, 'package.json'),
+      JSON.stringify({ dependencies: {}, devDependencies: {} }),
+      'utf-8',
+    );
+
+    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
+
+    const configDir = path.join(outputDir, 'amplify', '.config');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
+
+    const origCwd = process.cwd;
+    process.cwd = () => outputDir;
+
+    try {
+      const backendGen = new BackendGenerator(outputDir, logger);
+      const pkgGen = new RootPackageJsonGenerator(outputDir);
+      const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as any;
+
+      const generator = new CustomResourceGenerator(gen1App, backendGen, pkgGen, outputDir, 'varDep', logger);
+      const ops = await generator.plan();
+      await ops[0].execute();
+
+      const constructPath = path.join(outputDir, 'amplify', 'custom', 'varDep', 'construct.ts');
+      const resourcePath = path.join(outputDir, 'amplify', 'custom', 'varDep', 'resource.ts');
+
+      const constructContent = await fs.readFile(constructPath, 'utf-8');
+      const resourceContent = await fs.readFile(resourcePath, 'utf-8');
+
+      // Count constructor params in construct.ts
+      const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
+      const ctorParams = ctorMatch ? ctorMatch[1].split(',').filter((p: string) => p.trim()).length : 0;
+
+      // Count args in `new VarDep(...)` call in resource.ts (handle nested parens)
+      const newCallMatch = resourceContent.match(/new VarDep\(([\s\S]*?)\);/);
+      const newCallArgs = newCallMatch ? newCallMatch[1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length : 0;
+
+      // Both must agree: 3 params (scope, id, backend) == 3 args
+      expect(newCallArgs).toBe(ctorParams);
+      expect(ctorParams).toBe(3);
+    } finally {
+      process.cwd = origCwd;
+    }
+  });
+
+  it('construct.ts ctor params == resource.ts new call args when no dependencies', async () => {
+    const cdkStackContent = [
+      "import * as cdk from 'aws-cdk-lib';",
+      "import { Construct } from 'constructs';",
+      '',
+      'export class cdkStack extends cdk.Stack {',
+      '  constructor(scope: Construct, id: string, props?: cdk.StackProps) {',
+      '    super(scope, id, props);',
+      '  }',
+      '}',
+    ].join('\n');
+
+    const amplifyBackendCustomDir = path.join(outputDir, 'amplify', 'backend', 'custom', 'noDep');
+    await fs.mkdir(amplifyBackendCustomDir, { recursive: true });
+    await fs.writeFile(path.join(amplifyBackendCustomDir, 'cdk-stack.ts'), cdkStackContent, 'utf-8');
+    await fs.writeFile(
+      path.join(amplifyBackendCustomDir, 'package.json'),
+      JSON.stringify({ dependencies: {}, devDependencies: {} }),
+      'utf-8',
+    );
+
+    await fs.mkdir(path.join(outputDir, 'amplify', 'backend', 'types'), { recursive: true });
+
+    const configDir = path.join(outputDir, 'amplify', '.config');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(path.join(configDir, 'project-config.json'), JSON.stringify({ projectName: 'testProj' }), 'utf-8');
+
+    const origCwd = process.cwd;
+    process.cwd = () => outputDir;
+
+    try {
+      const backendGen = new BackendGenerator(outputDir, logger);
+      const pkgGen = new RootPackageJsonGenerator(outputDir);
+      const gen1App = { statefulResourceTypes: [...DEFAULT_STATEFUL_RESOURCES] } as any;
+
+      const generator = new CustomResourceGenerator(gen1App, backendGen, pkgGen, outputDir, 'noDep', logger);
+      const ops = await generator.plan();
+      await ops[0].execute();
+
+      const constructPath = path.join(outputDir, 'amplify', 'custom', 'noDep', 'construct.ts');
+      const resourcePath = path.join(outputDir, 'amplify', 'custom', 'noDep', 'resource.ts');
+
+      const constructContent = await fs.readFile(constructPath, 'utf-8');
+      const resourceContent = await fs.readFile(resourcePath, 'utf-8');
+
+      const ctorMatch = constructContent.match(/constructor\(([\s\S]*?)\)\s*\{/);
+      const ctorParams = ctorMatch ? ctorMatch[1].split(',').filter((p: string) => p.trim()).length : 0;
+
+      const newCallMatch = resourceContent.match(/new NoDep\(([\s\S]*?)\);/);
+      const newCallArgs = newCallMatch ? newCallMatch[1].split(/,(?![^(]*\))/).filter((a: string) => a.trim()).length : 0;
+
+      // Both must agree: 2 params (scope, id) == 2 args
+      expect(newCallArgs).toBe(ctorParams);
+      expect(ctorParams).toBe(2);
+    } finally {
+      process.cwd = origCwd;
+    }
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
@@ -37,7 +37,7 @@ export class AmplifyHelperTransformer {
   /**
    * Transforms Gen1 AmplifyHelpers patterns to Gen2 equivalents via AST rewriting.
    */
-  public static transform(sourceFile: ts.SourceFile, projectName?: string): ts.SourceFile {
+  public static transform(sourceFile: ts.SourceFile, projectName?: string): { sourceFile: ts.SourceFile; addedBackendParam: boolean } {
     // Track variable names that hold AmplifyHelpers.getProjectInfo() result
     const projectInfoVariables = new Set<string>();
     // Track parameter names with AmplifyResourceProps type
@@ -363,7 +363,7 @@ export class AmplifyHelperTransformer {
     };
 
     const result = ts.transform(sourceFile, [transformer]);
-    return result.transformed[0] as ts.SourceFile;
+    return { sourceFile: result.transformed[0] as ts.SourceFile, addedBackendParam: hasDependencies };
   }
 
   /**

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/amplify-helper-transformer.ts
@@ -146,11 +146,14 @@ export class AmplifyHelperTransformer {
               return undefined;
             }
 
-            // Remove AmplifyHelpers.addResourceDependency variable statements
+            // Remove addResourceDependency variable statements. Detect both the
+            // property-access form (`AmplifyHelpers.addResourceDependency(...)`) and the
+            // bare named-import form (`addResourceDependency(...)`).
             if (declaration && declaration.initializer && ts.isCallExpression(declaration.initializer)) {
               const callExpr = declaration.initializer;
               const isAddResourceDependency =
-                ts.isPropertyAccessExpression(callExpr.expression) && callExpr.expression.name.text === 'addResourceDependency';
+                (ts.isPropertyAccessExpression(callExpr.expression) && callExpr.expression.name.text === 'addResourceDependency') ||
+                (ts.isIdentifier(callExpr.expression) && callExpr.expression.text === 'addResourceDependency');
 
               if (isAddResourceDependency) {
                 if (ts.isIdentifier(declaration.name)) {
@@ -177,10 +180,17 @@ export class AmplifyHelperTransformer {
               }
             }
 
-            // Remove variable declarations with AmplifyDependentResourcesAttributes type annotation
+            // Remove variable declarations with AmplifyDependentResourcesAttributes type annotation.
+            // Before deleting, register the declared variable so that downstream
+            // `dependencies.*` references (and Fn.ref(dependencies.*)) get rewritten to backend.*
+            // and the backend constructor param/arg are emitted.
             if (declaration && declaration.type && ts.isTypeReferenceNode(declaration.type)) {
               const typeName = declaration.type.typeName;
               if (ts.isIdentifier(typeName) && typeName.text === 'AmplifyDependentResourcesAttributes') {
+                if (ts.isIdentifier(declaration.name)) {
+                  dependencyVariables.add(declaration.name.text);
+                }
+                hasDependencies = true;
                 return undefined;
               }
             }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/custom-resources/custom.generator.ts
@@ -108,13 +108,12 @@ export class CustomResourceGenerator implements Planner {
           }
 
           const projectName = await readProjectName(rootDir);
-          const dependencies = await extractDependencies(sourceResourcePath);
           const constructClassName = capitalize(this.resourceName);
 
-          await transformResource(destResourcePath, projectName, this.resourceName, constructClassName, dependencies);
+          const addedBackendParam = await transformResource(destResourcePath, projectName, this.resourceName, constructClassName);
           await removeBuildArtifacts(destResourcePath);
           await renameCdkStackToConstruct(destResourcePath);
-          await generateResourceWrapper(this.gen1App, destResourcePath, this.resourceName, constructClassName, dependencies);
+          await generateResourceWrapper(this.gen1App, destResourcePath, this.resourceName, constructClassName, addedBackendParam);
 
           await this.mergeDependencies(sourceResourcePath);
           this.contributeToBackend(constructClassName);
@@ -162,49 +161,6 @@ export class CustomResourceGenerator implements Planner {
 }
 
 /**
- * Extracts category dependencies from AmplifyHelpers.addResourceDependency calls
- * and amplify-dependent-resources-ref imports.
- */
-async function extractDependencies(sourceResourcePath: string): Promise<string[]> {
-  const cdkStackFilePath = path.join(sourceResourcePath, 'cdk-stack.ts');
-  try {
-    const content = await fs.readFile(cdkStackFilePath, { encoding: 'utf-8' });
-    const dependencies: string[] = [];
-
-    // Detect AmplifyHelpers.addResourceDependency calls
-    const dependencyRegex = /AmplifyHelpers\.addResourceDependency\s*\([^,]+,[^,]+,[^,]+,\s*\[([^\]]+)\]/g;
-    let match: RegExpExecArray | null;
-    while ((match = dependencyRegex.exec(content)) !== null) {
-      const categoryRegex = /category:\s*['"]([^'"]+)['"]/g;
-      let categoryMatch: RegExpExecArray | null;
-      while ((categoryMatch = categoryRegex.exec(match[1])) !== null) {
-        if (!dependencies.includes(categoryMatch[1])) {
-          dependencies.push(categoryMatch[1]);
-        }
-      }
-    }
-
-    // Detect amplify-dependent-resources-ref imports as a dependency signal.
-    if (dependencies.length === 0 && content.includes('amplify-dependent-resources-ref')) {
-      const categoryAccessRegex = /\.\s*(auth|api|storage|function|analytics)\s*\./g;
-      let catMatch: RegExpExecArray | null;
-      while ((catMatch = categoryAccessRegex.exec(content)) !== null) {
-        if (!dependencies.includes(catMatch[1])) {
-          dependencies.push(catMatch[1]);
-        }
-      }
-      if (dependencies.length === 0) {
-        dependencies.push('unknown');
-      }
-    }
-
-    return dependencies;
-  } catch (e) {
-    throw new Error(`Failed to read dependencies for custom resource '${sourceResourcePath}': ${String(e)}`);
-  }
-}
-
-/**
  * Transforms cdk-stack.ts: applies AST transformations, renames the class,
  * and adds the Backend type import.
  */
@@ -213,8 +169,7 @@ async function transformResource(
   projectName: string | undefined,
   resourceName: string,
   constructClassName: string,
-  dependencies: string[],
-): Promise<void> {
+): Promise<boolean> {
   const cdkStackFilePath = path.join(destResourcePath, 'cdk-stack.ts');
   let content = await fs.readFile(cdkStackFilePath, { encoding: 'utf-8' });
 
@@ -237,7 +192,7 @@ async function transformResource(
 
   // Apply AST-based transformations (handles CfnParameter removal, dependency rewrites, etc.)
   const sourceFile = ts.createSourceFile(cdkStackFilePath, content, ts.ScriptTarget.Latest, true);
-  const transformedFile = AmplifyHelperTransformer.transform(sourceFile, projectName);
+  const { sourceFile: transformedFile, addedBackendParam } = AmplifyHelperTransformer.transform(sourceFile, projectName);
   const transformedWithBranchName = AmplifyHelperTransformer.addBranchNameVariable(transformedFile, projectName);
   const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
   content = printer.printFile(transformedWithBranchName);
@@ -248,7 +203,7 @@ async function transformResource(
   // Add Backend type import only when the construct has dependencies
   // (i.e., when the transformer added a `backend` parameter).
   // Place it after other imports to match expected output.
-  if (dependencies.length > 0) {
+  if (addedBackendParam) {
     const importRegex2 = /(import.*from.*['"].*['"];?\s*\n)/g;
     let lastImportMatch2: RegExpExecArray | null = null;
     let regexMatch2: RegExpExecArray | null;
@@ -262,6 +217,7 @@ async function transformResource(
   }
 
   await fs.writeFile(cdkStackFilePath, content, { encoding: 'utf-8' });
+  return addedBackendParam;
 }
 
 /**
@@ -299,14 +255,14 @@ async function generateResourceWrapper(
   destResourcePath: string,
   resourceName: string,
   constructClassName: string,
-  dependencies: string[],
+  addedBackendParam: boolean,
 ): Promise<void> {
   const defineFnName = `define${constructClassName}`;
   const stackName = `custom${resourceName}`;
   const args = [`backend.createStack('${stackName}')`, `'${resourceName}'`];
 
-  // Pass backend when the resource has dependencies on other categories
-  if (dependencies.length > 0) {
+  // Pass backend when the AST transformer added a backend parameter to the construct constructor
+  if (addedBackendParam) {
     args.push('backend');
   }
 


### PR DESCRIPTION
## Problem
Custom resource generation used two independent dependency detectors that could disagree: a regex (`extractDependencies`) decided whether the `resource.ts` wrapper passed a `backend` argument, while the AST transformer decided whether the construct constructor received a `backend` parameter. When the regex missed a dependency the AST caught (e.g. `addResourceDependency` with a non-literal `category`), the wrapper emitted `new Construct(stack, id, backend)` against a 2-parameter constructor — TS2554.

## Fix
`AmplifyHelperTransformer.transform` now returns `{ sourceFile, addedBackendParam }`. Both the construct constructor parameter and the wrapper argument are driven from that single signal, so they always agree. The `import type { Backend }` decision is keyed off it too. The now-redundant regex `extractDependencies` is removed.

## Test
- `amplify-helper-transformer.test.ts` updated to the new return shape, with added `addedBackendParam` true/false assertions.
- New `custom.generator.dependency-consistency.test.ts` drives `CustomResourceGenerator` with a variable-category dependency (which the old regex missed) and asserts constructor param count equals wrapper call arg count.

## Note
**Stacked on #14927** (shares `custom.generator.ts`); review/merge that first, then rebase this onto `dev`.

## Risk
Medium. Unifies on the AST detector (authoritative — it rewrites the references). Guarantees arg/param agreement; the residual TS2663 'undefined dependencies' case depends on customer source and is out of scope here.