### PR TITLE
Fix/e2e wave staggering

### DIFF
--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -468,112 +468,112 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/hosting.test.ts|src/__tests__/geo-import-3.test.ts
       depend-on:
-        - upb
+        - l_diagnose_mock_api_hooks_a
     - identifier: l_geo_add_d_geo_add_c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/geo-add-d.test.ts|src/__tests__/geo-add-c.test.ts
       depend-on:
-        - upb
+        - l_notifications_lifecycle_auth_2f_auth_2d
     - identifier: l_delete_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/delete.test.ts|src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
-        - upb
+        - l_auth_2b_auth_2a_analytics_pinpoint_js
     - identifier: l_predictions_migration_api_key_migration3_api_connection_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts|src/__tests__/migration/api.connection.migration.test.ts
       depend-on:
-        - upb
+        - l_analytics_pinpoint_flutter_analytics_kinesis_notifications_analytics_compatibility_sms_2
     - identifier: l_init_special_case_function_3a_python_function_3a_nodejs
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-special-case.test.ts|src/__tests__/function_3a_python.test.ts|src/__tests__/function_3a_nodejs.test.ts
       depend-on:
-        - upb
+        - l_notifications_analytics_compatibility_in_app_1_studio_modelgen
     - identifier: l_function_3a_go_function_3a_dotnet_export_pull_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_3a_go.test.ts|src/__tests__/function_3a_dotnet.test.ts|src/__tests__/export-pull-b.test.ts
       depend-on:
-        - upb
+        - l_plugin_notifications_analytics_compatibility_sms_1_hooks_b
     - identifier: l_auth_7b_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_7b.test.ts|src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - upb
+        - l_global_sandbox_c_analytics_2_pull
     - identifier: l_schema_function_2_schema_auth_3_schema_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts|src/__tests__/schema-auth-12.test.ts
       depend-on:
-        - upb
+        - l_notifications_sms_pull_notifications_in_app_messaging_env_1_custom_transformers
     - identifier: l_schema_iterative_update_3_schema_iterative_rollback_2_schema_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/schema-auth-5a.test.ts
       depend-on:
-        - upb
+        - l_with_babel_config_notifications_in_app_messaging_env_2_notifications_fcm
     - identifier: l_export_pull_d_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/export-pull-d.test.ts|src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - upb
+        - l_notifications_apns_init_b_container_hosting
     - identifier: l_auth_migration_push_pull_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts|src/__tests__/pull-2.test.ts
       depend-on:
-        - upb
+        - l_auth_10_init_f_init_d
     - identifier: l_pr_previews_multi_env_1_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pr-previews-multi-env-1.test.ts|src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - upb
+        - l_env_2_amplify_configure_layer_4
     - identifier: l_notifications_sms_update_notifications_multi_env_minify_cloudformation
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts|src/__tests__/minify-cloudformation.test.ts
       depend-on:
-        - upb
+        - l_init_c_git_clone_attach_configure_project
     - identifier: l_init_force_push_hooks_c_help
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-force-push.test.ts|src/__tests__/hooks-c.test.ts|src/__tests__/help.test.ts
       depend-on:
-        - upb
+        - l_auth_5d_tags_schema_model_a
     - identifier: l_function_2d_function_15_function_14
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_2d.test.ts|src/__tests__/function_15.test.ts|src/__tests__/function_14.test.ts
       depend-on:
-        - upb
+        - l_function_4_function_3b_function_2c
     - identifier: l_function_13_function_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_13.test.ts|src/__tests__/function_12.test.ts
       depend-on:
-        - upb
+        - l_storage_2_function_6_custom_policies_function
     - identifier: l_export_pull_c_custom_resource_with_storage
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -581,189 +581,189 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-c.test.ts|src/__tests__/custom-resource-with-storage.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - upb
+        - l_auth_1a_auth_trigger_schema_versioned
     - identifier: l_build_function_build_function_yarn_modern_auth_5g
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts|src/__tests__/auth_5g.test.ts
       depend-on:
-        - upb
+        - l_schema_model_e_schema_auth_4b_notifications_sms
     - identifier: l_auth_2h_auth_2g_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_2h.test.ts|src/__tests__/auth_2g.test.ts|src/__tests__/auth_12.test.ts
       depend-on:
-        - upb
+        - l_iam_permissions_boundary_export_node_function
     - identifier: l_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - upb
+        - l_schema_model_d_schema_model_b_schema_auth_4a
     - identifier: l_api_2b_api_2a_amplify_remove
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts|src/__tests__/amplify-remove.test.ts
       depend-on:
-        - upb
+        - l_s3_sse_geo_add_b_auth_8b
     - identifier: l_S3server_smoketest_smoketest_ios
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/storage-simulator/S3server.test.ts|src/__tests__/smoke-tests/smoketest.test.ts|src/__tests__/smoke-tests/smoketest-ios.test.ts
       depend-on:
-        - upb
+        - l_auth_5e_auth_1c_schema_predictions
     - identifier: l_javascript_notifications_pinpoint_config_javascript_analytics_pinpoint_config_ios_notifications_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/javascript-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/javascript-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/ios-notifications-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_schema_model_c_schema_data_access_patterns_schema_auth_6a
     - identifier: l_ios_analytics_pinpoint_config_flutter_notifications_pinpoint_config_flutter_analytics_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/ios-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-analytics-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_4d_frontend_config_drift_env_4
     - identifier: l_android_notifications_pinpoint_config_android_analytics_pinpoint_config_opensearch_simulator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/android-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/android-analytics-pinpoint-config.test.ts|src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
       depend-on:
-        - upb
+        - l_auth_5f_model_migration_schema_auth_5c
     - identifier: l_general_config_headless_init_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/general-config/general-config-headless-init.test.ts|src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_4c_init_a_geo_add_a
     - identifier: l_user_groups_s3_access_hosted_ui_admin_api
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts|src/__tests__/auth/admin-api.test.ts
       depend-on:
-        - upb
+        - l_env_1_auth_5c_auth_5a
     - identifier: l_schema_iterative_update_locking_function_8_api_8
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/function_8.test.ts|src/__tests__/api_8.test.ts
       depend-on:
-        - upb
+        - l_auth_4c_auth_3c_schema_auth_8c
     - identifier: l_schema_auth_13_layer_2_api_lambda_auth_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts|src/__tests__/layer-2.test.ts|src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_6b_schema_auth_5d_global_sandbox_b
     - identifier: l_schema_iterative_update_1_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - upb
+        - l_geo_import_2_geo_import_1a_function_9c
     - identifier: l_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - upb
+        - l_function_10_function_permissions_env_5
     - identifier: l_auth_6_storage_1b_storage_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts|src/__tests__/storage-1a.test.ts
       depend-on:
-        - upb
+        - l_custom_resources_auth_9
     - identifier: l_schema_iterative_update_2_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - upb
+        - l_auth_5b_schema_auth_8a_schema_auth_7c
     - identifier: l_api_9b_function_7_function_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_7.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_6d_schema_auth_6c_schema_auth_2b
     - identifier: l_function_11_api_connection_migration2_storage_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/storage-4.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_11_c_notifications_analytics_compatibility_in_app_2
     - identifier: l_containers_api_secrets_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/containers-api-secrets.test.ts|src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - upb
+        - l_init_e_global_sandbox_a_geo_import_1b
     - identifier: l_schema_key_resolvers_geo_multi_env
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/geo-multi-env.test.ts
       depend-on:
-        - upb
+        - l_feature_flags_auth_8c_auth_7a
     - identifier: l_searchable_datastore_schema_searchable
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts|src/__tests__/schema-searchable.test.ts
       depend-on:
-        - upb
+        - l_auth_4a_auth_3b_auth_3a
     - identifier: l_apigw_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts|src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - upb
+        - l_function_migration_storage_3_schema_auth_9_c
     - identifier: l_api_lambda_auth_1_schema_auth_14_api_key_migration1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts|src/__tests__/migration/api.key.migration1.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_9_a_schema_auth_8b_schema_auth_5b
     - identifier: l_api_6b_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_6b.test.ts|src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - upb
+        - l_schema_auth_1a_geo_headless_function_9a
     - identifier: l_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - upb
+        - l_export_pull_a_api_7
     - identifier: l_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - upb
+        - l_api_10_api_key_migration5
     - identifier: l_storage_5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -771,7 +771,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/storage-5.test.ts
       depend-on:
-        - upb
+        - l_schema_iterative_rollback_1_schema_auth_9_b_schema_auth_7b
     - identifier: l_datastore_modelgen
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -780,7 +780,7 @@ batch:
           TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_auth_7a_schema_auth_2a_schema_auth_1b
     - identifier: l_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -789,7 +789,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_auth_11_b_predictions_layer_3
     - identifier: l_uibuilder
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -797,7 +797,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/uibuilder.test.ts
       depend-on:
-        - upb
+        - l_hosting_geo_import_3
     - identifier: l_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -805,7 +805,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - upb
+        - l_geo_add_d_geo_add_c
     - identifier: l_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -813,7 +813,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - upb
+        - l_delete_auth_1b_auth_11
     - identifier: l_geo_remove_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -821,7 +821,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-3.test.ts
       depend-on:
-        - upb
+        - l_predictions_migration_api_key_migration3_api_connection_migration
     - identifier: l_geo_add_f
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -829,7 +829,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-f.test.ts
       depend-on:
-        - upb
+        - l_init_special_case_function_3a_python_function_3a_nodejs
     - identifier: l_geo_add_e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -837,7 +837,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-e.test.ts
       depend-on:
-        - upb
+        - l_function_3a_go_function_3a_dotnet_export_pull_b
     - identifier: l_import_dynamodb_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -845,7 +845,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2c.test.ts
       depend-on:
-        - upb
+        - l_auth_7b_api_6a_http_migration
     - identifier: l_env_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -853,7 +853,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - upb
+        - l_schema_function_2_schema_auth_3_schema_auth_12
     - identifier: l_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -861,7 +861,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - upb
+        - l_schema_iterative_update_3_schema_iterative_rollback_2_schema_auth_5a
     - identifier: l_geo_remove_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -869,7 +869,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-2.test.ts
       depend-on:
-        - upb
+        - l_export_pull_d_auth_8a_auth_4b
     - identifier: l_import_auth_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -877,7 +877,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2a.test.ts
       depend-on:
-        - upb
+        - l_auth_migration_push_pull_2
     - identifier: l_import_auth_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -885,7 +885,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1a.test.ts
       depend-on:
-        - upb
+        - l_pr_previews_multi_env_1_parameter_store_2_parameter_store_1
     - identifier: l_import_s3_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -893,7 +893,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2c.test.ts
       depend-on:
-        - upb
+        - l_notifications_sms_update_notifications_multi_env_minify_cloudformation
     - identifier: l_import_s3_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -901,7 +901,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2a.test.ts
       depend-on:
-        - upb
+        - l_init_force_push_hooks_c_help
     - identifier: l_import_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -909,7 +909,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2b.test.ts
       depend-on:
-        - upb
+        - l_function_2d_function_15_function_14
     - identifier: l_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -917,7 +917,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - upb
+        - l_function_13_function_12
     - identifier: l_import_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -925,7 +925,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1b.test.ts
       depend-on:
-        - upb
+        - l_export_pull_c_custom_resource_with_storage
     - identifier: l_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -933,7 +933,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - upb
+        - l_build_function_build_function_yarn_modern_auth_5g
     - identifier: l_geo_update_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -941,7 +941,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-2.test.ts
       depend-on:
-        - upb
+        - l_auth_2h_auth_2g_auth_12
     - identifier: l_geo_update_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -949,7 +949,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-1.test.ts
       depend-on:
-        - upb
+        - l_api_9a_api_6c
     - identifier: l_import_dynamodb_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -957,7 +957,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2b.test.ts
       depend-on:
-        - upb
+        - l_api_2b_api_2a_amplify_remove
     - identifier: l_smoketest_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -966,7 +966,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_S3server_smoketest_smoketest_ios
     - identifier: l_gen2_migration_store_locator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -975,7 +975,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-store-locator.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_javascript_notifications_pinpoint_config_javascript_analytics_pinpoint_config_ios_notifications_pinpoint_config
     - identifier: l_gen2_migration_project_boards
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -984,7 +984,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-project-boards.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_ios_analytics_pinpoint_config_flutter_notifications_pinpoint_config_flutter_analytics_pinpoint_config
     - identifier: l_gen2_migration_product_catalog
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -993,7 +993,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-product-catalog.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_android_notifications_pinpoint_config_android_analytics_pinpoint_config_opensearch_simulator
     - identifier: l_gen2_migration_mood_board
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1002,7 +1002,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-mood-board.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_general_config_headless_init_dynamodb_simulator_user_groups
     - identifier: l_gen2_migration_media_vault
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1011,7 +1011,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-media-vault.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_user_groups_s3_access_hosted_ui_admin_api
     - identifier: l_gen2_migration_fitness_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1020,7 +1020,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-fitness-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_iterative_update_locking_function_8_api_8
     - identifier: l_gen2_migration_finance_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1029,7 +1029,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-finance-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_auth_13_layer_2_api_lambda_auth_2
     - identifier: l_gen2_migration_discussions
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1038,7 +1038,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-discussions.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_iterative_update_1_function_5_schema_function_1
     - identifier: l_gen2_migration_backend_only
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1047,7 +1047,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-backend-only.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_schema_connection_2_function_2a
     - identifier: l_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1055,7 +1055,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - upb
+        - l_auth_6_storage_1b_storage_1a
     - identifier: l_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1063,7 +1063,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - upb
+        - l_schema_iterative_update_2_function_9b_custom_policies_container
     - identifier: l_import_s3_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1071,7 +1071,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2b.test.ts
       depend-on:
-        - upb
+        - l_api_9b_function_7_function_2b
     - identifier: l_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1079,7 +1079,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - upb
+        - l_function_11_api_connection_migration2_storage_4
     - identifier: l_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1087,7 +1087,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - upb
+        - l_containers_api_secrets_api_4_schema_auth_10
     - identifier: l_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1095,7 +1095,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - upb
+        - l_schema_key_resolvers_geo_multi_env
     - identifier: l_import_auth_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1103,7 +1103,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_3.test.ts
       depend-on:
-        - upb
+        - l_searchable_datastore_schema_searchable
     - identifier: l_import_dynamodb_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1111,7 +1111,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2a.test.ts
       depend-on:
-        - upb
+        - l_apigw_api_5_api_key_migration2
     - identifier: l_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1119,7 +1119,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - upb
+        - l_api_lambda_auth_1_schema_auth_14_api_key_migration1
     - identifier: l_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1128,7 +1128,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_api_6b_api_3_layer_1
     - identifier: l_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1137,7 +1137,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_api_1_api_key_migration4
     - identifier: l_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1145,7 +1145,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - upb
+        - l_schema_iterative_update_4_function_1
     - identifier: l_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1154,7 +1154,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_storage_5
     - identifier: w_notifications_lifecycle_auth_2f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1163,8 +1163,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-lifecycle.test.ts|src/__tests__/auth_2f.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_datastore_modelgen
     - identifier: w_auth_2d_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1173,8 +1172,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2d.test.ts|src/__tests__/auth_2b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_amplify_app
     - identifier: w_auth_2a_analytics_pinpoint_js
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1183,8 +1181,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2a.test.ts|src/__tests__/analytics-pinpoint-js.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_uibuilder
     - identifier: w_analytics_pinpoint_flutter_analytics_kinesis
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1193,8 +1190,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/analytics-pinpoint-flutter.test.ts|src/__tests__/analytics-kinesis.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_auth_2e
     - identifier: w_notifications_analytics_compatibility_sms_2_notifications_analytics_compatibility_in_app_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1203,8 +1199,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-2.test.ts|src/__tests__/notifications-analytics-compatibility-in-app-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_auth_2c
     - identifier: w_studio_modelgen_plugin
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1213,8 +1208,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/studio-modelgen.test.ts|src/__tests__/plugin.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_remove_3
     - identifier: w_notifications_analytics_compatibility_sms_1_hooks_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1223,8 +1217,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-1.test.ts|src/__tests__/hooks-b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_add_f
     - identifier: w_global_sandbox_c_analytics_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1233,8 +1226,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/global_sandbox-c.test.ts|src/__tests__/analytics-2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_add_e
     - identifier: w_notifications_sms_pull_notifications_in_app_messaging_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1243,8 +1235,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-pull.test.ts|src/__tests__/notifications-in-app-messaging-env-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_dynamodb_2c
     - identifier: w_custom_transformers_with_babel_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1253,8 +1244,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/custom-transformers.test.ts|src/__tests__/with-babel-config.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_env_3
     - identifier: w_notifications_in_app_messaging_env_2_notifications_fcm
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1263,8 +1253,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging-env-2.test.ts|src/__tests__/notifications-fcm.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_notifications_in_app_messaging
     - identifier: w_notifications_apns_init_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1273,8 +1262,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-apns.test.ts|src/__tests__/init_b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_remove_2
     - identifier: w_container_hosting_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1283,8 +1271,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/container-hosting.test.ts|src/__tests__/auth_10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_auth_2a
     - identifier: w_init_f_init_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1293,8 +1280,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init_f.test.ts|src/__tests__/init_d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_auth_1a
     - identifier: w_amplify_configure_layer_4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1303,8 +1289,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-configure.test.ts|src/__tests__/layer-4.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_s3_2c
     - identifier: w_init_c_configure_project
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1313,8 +1298,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init_c.test.ts|src/__tests__/configure-project.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_s3_2a
     - identifier: w_auth_5d_tags
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1323,8 +1307,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5d.test.ts|src/__tests__/tags.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_auth_2b
     - identifier: w_schema_model_a_function_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1333,8 +1316,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-model-a.test.ts|src/__tests__/function_2c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_schema_auth_11_a
     - identifier: w_storage_2_custom_policies_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1343,8 +1325,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-2.test.ts|src/__tests__/custom_policies_function.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_auth_1b
     - identifier: w_auth_1a_auth_trigger
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1353,8 +1334,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_1a.test.ts|src/__tests__/auth-trigger.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_s3_3
     - identifier: w_schema_versioned_schema_model_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1363,8 +1343,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-versioned.test.ts|src/__tests__/schema-model-e.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_update_2
     - identifier: w_schema_auth_4b_notifications_sms
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1373,8 +1352,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4b.test.ts|src/__tests__/notifications-sms.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_update_1
     - identifier: w_iam_permissions_boundary_node_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1383,8 +1361,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts|src/__tests__/migration/node.function.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_dynamodb_2b
     - identifier: w_schema_model_d_schema_model_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1393,8 +1370,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-model-d.test.ts|src/__tests__/schema-model-b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_smoketest_amplify_app
     - identifier: w_schema_auth_4a_s3_sse
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1403,8 +1379,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4a.test.ts|src/__tests__/s3-sse.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_store_locator
     - identifier: w_geo_add_b_auth_8b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1413,8 +1388,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-b.test.ts|src/__tests__/auth_8b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_project_boards
     - identifier: w_auth_5e_auth_1c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1423,8 +1397,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5e.test.ts|src/__tests__/auth_1c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_product_catalog
     - identifier: w_schema_predictions_schema_model_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1433,8 +1406,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-predictions.test.ts|src/__tests__/schema-model-c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_mood_board
     - identifier: w_schema_data_access_patterns_schema_auth_6a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1443,8 +1415,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts|src/__tests__/schema-auth-6a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_media_vault
     - identifier: w_schema_auth_4d_frontend_config_drift
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1453,8 +1424,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4d.test.ts|src/__tests__/frontend_config_drift.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_fitness_tracker
     - identifier: w_env_4_auth_5f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1463,8 +1433,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/env-4.test.ts|src/__tests__/auth_5f.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_finance_tracker
     - identifier: w_model_migration_schema_auth_5c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1473,8 +1442,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/model-migration.test.ts|src/__tests__/schema-auth-5c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_discussions
     - identifier: w_schema_auth_4c_init_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1483,8 +1451,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4c.test.ts|src/__tests__/init_a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_gen2_migration_backend_only
     - identifier: w_geo_add_a_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1493,8 +1460,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-a.test.ts|src/__tests__/env-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_js_frontend_config
     - identifier: w_auth_5c_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1503,8 +1469,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5c.test.ts|src/__tests__/auth_5a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_hostingPROD
     - identifier: w_auth_4c_auth_3c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1513,8 +1478,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_4c.test.ts|src/__tests__/auth_3c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_s3_2b
     - identifier: w_schema_auth_8c_schema_auth_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1523,8 +1487,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8c.test.ts|src/__tests__/schema-auth-6b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_schema_connection_1
     - identifier: w_schema_auth_5d_global_sandbox_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1533,8 +1496,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5d.test.ts|src/__tests__/global_sandbox-b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_schema_auth_15
     - identifier: w_geo_import_2_geo_import_1a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1543,8 +1505,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-import-2.test.ts|src/__tests__/geo-import-1a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_containers_api_1
     - identifier: w_function_9c_function_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1553,8 +1514,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9c.test.ts|src/__tests__/function_10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_auth_3
     - identifier: w_function_permissions_env_5
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1563,8 +1523,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function-permissions.test.ts|src/__tests__/env-5.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_dynamodb_2a
     - identifier: w_auth_9_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1573,8 +1532,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_9.test.ts|src/__tests__/auth_5b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_containers_api_2
     - identifier: w_schema_auth_8a_schema_auth_7c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1583,8 +1541,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8a.test.ts|src/__tests__/schema-auth-7c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_s3_1
     - identifier: w_schema_auth_6d_schema_auth_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1593,8 +1550,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6d.test.ts|src/__tests__/schema-auth-6c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_searchable_migration
     - identifier: w_schema_auth_2b_schema_auth_11_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1603,8 +1559,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2b.test.ts|src/__tests__/schema-auth-11-c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_geo_remove_1
     - identifier: w_notifications_analytics_compatibility_in_app_2_init_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1613,8 +1568,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-in-app-2.test.ts|src/__tests__/init_e.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - l_import_dynamodb_1
     - identifier: w_global_sandbox_a_geo_import_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1623,8 +1577,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/global_sandbox-a.test.ts|src/__tests__/geo-import-1b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_lifecycle_auth_2f
     - identifier: w_feature_flags_auth_8c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1633,8 +1586,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/feature-flags.test.ts|src/__tests__/auth_8c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_2d_auth_2b
     - identifier: w_auth_7a_auth_4a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1643,8 +1595,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_7a.test.ts|src/__tests__/auth_4a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_2a_analytics_pinpoint_js
     - identifier: w_auth_3b_auth_3a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1653,8 +1604,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_3b.test.ts|src/__tests__/auth_3a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_analytics_pinpoint_flutter_analytics_kinesis
     - identifier: w_function_migration_storage_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1663,8 +1613,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_analytics_compatibility_sms_2_notifications_analytics_compatibility_in_app_1
     - identifier: w_schema_auth_9_c_schema_auth_9_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1673,8 +1622,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9-c.test.ts|src/__tests__/schema-auth-9-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_studio_modelgen_plugin
     - identifier: w_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1683,8 +1631,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_analytics_compatibility_sms_1_hooks_b
     - identifier: w_schema_auth_1a_geo_headless
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1693,8 +1640,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_global_sandbox_c_analytics_2
     - identifier: w_function_9a_export_pull_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1703,8 +1649,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9a.test.ts|src/__tests__/export-pull-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_sms_pull_notifications_in_app_messaging_env_1
     - identifier: w_api_7_api_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1713,8 +1658,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_7.test.ts|src/__tests__/api_10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_custom_transformers_with_babel_config
     - identifier: w_api_key_migration5_schema_auth_9_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1723,8 +1667,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts|src/__tests__/schema-auth-9-b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_in_app_messaging_env_2_notifications_fcm
     - identifier: w_schema_auth_7b_schema_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1733,8 +1676,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7b.test.ts|src/__tests__/schema-auth-7a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_apns_init_b
     - identifier: w_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1743,8 +1685,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_container_hosting_auth_10
     - identifier: w_schema_auth_11_b_predictions
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1753,8 +1694,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_init_f_init_d
     - identifier: w_layer_3_hosting
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1763,8 +1703,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/layer-3.test.ts|src/__tests__/hosting.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_amplify_configure_layer_4
     - identifier: w_geo_import_3_geo_add_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1773,8 +1712,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-import-3.test.ts|src/__tests__/geo-add-d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_init_c_configure_project
     - identifier: w_geo_add_c_delete
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1783,8 +1721,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-c.test.ts|src/__tests__/delete.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_5d_tags
     - identifier: w_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1793,8 +1730,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_model_a_function_2c
     - identifier: w_predictions_migration_api_key_migration3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1803,8 +1739,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_storage_2_custom_policies_function
     - identifier: w_api_connection_migration_init_special_case
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1813,8 +1748,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/init-special-case.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_1a_auth_trigger
     - identifier: w_export_pull_b_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1823,8 +1757,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/export-pull-b.test.ts|src/__tests__/auth_7b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_versioned_schema_model_e
     - identifier: w_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1833,8 +1766,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_4b_notifications_sms
     - identifier: w_schema_function_2_schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1843,8 +1775,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_iam_permissions_boundary_node_function
     - identifier: w_schema_auth_12_schema_iterative_update_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1853,8 +1784,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts|src/__tests__/schema-iterative-update-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_model_d_schema_model_b
     - identifier: w_schema_auth_5a_export_pull_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1863,8 +1793,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5a.test.ts|src/__tests__/export-pull-d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_4a_s3_sse
     - identifier: w_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1873,8 +1802,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_geo_add_b_auth_8b
     - identifier: w_auth_migration_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1883,8 +1811,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_5e_auth_1c
     - identifier: w_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1893,8 +1820,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_predictions_schema_model_c
     - identifier: w_notifications_sms_update_notifications_multi_env
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1903,8 +1829,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_data_access_patterns_schema_auth_6a
     - identifier: w_minify_cloudformation_init_force_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1913,8 +1838,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/minify-cloudformation.test.ts|src/__tests__/init-force-push.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_4d_frontend_config_drift
     - identifier: w_help_function_2d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1923,8 +1847,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/help.test.ts|src/__tests__/function_2d.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_env_4_auth_5f
     - identifier: w_function_14_function_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1933,8 +1856,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_14.test.ts|src/__tests__/function_13.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_model_migration_schema_auth_5c
     - identifier: w_function_12_export_pull_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1943,8 +1865,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_12.test.ts|src/__tests__/export-pull-c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_4c_init_a
     - identifier: w_build_function_build_function_yarn_modern
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1953,8 +1874,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_geo_add_a_env_1
     - identifier: w_auth_5g_auth_2h
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1963,8 +1883,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5g.test.ts|src/__tests__/auth_2h.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_5c_auth_5a
     - identifier: w_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1973,8 +1892,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_4c_auth_3c
     - identifier: w_api_2b_api_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1983,8 +1901,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_8c_schema_auth_6b
     - identifier: w_amplify_remove_smoketest
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1993,8 +1910,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-remove.test.ts|src/__tests__/smoke-tests/smoketest.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_5d_global_sandbox_b
     - identifier: w_smoketest_ios_general_config_headless_init
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2003,8 +1919,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-ios.test.ts|src/__tests__/general-config/general-config-headless-init.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_geo_import_2_geo_import_1a
     - identifier: w_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2013,8 +1928,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_function_9c_function_10
     - identifier: w_user_groups_s3_access_hosted_ui
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2023,8 +1937,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_function_permissions_env_5
     - identifier: w_admin_api_schema_iterative_update_locking
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2033,8 +1946,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/admin-api.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_9_auth_5b
     - identifier: w_api_8_schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2043,8 +1955,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_8.test.ts|src/__tests__/schema-auth-13.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_8a_schema_auth_7c
     - identifier: w_api_lambda_auth_2_schema_iterative_update_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2053,8 +1964,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_2.test.ts|src/__tests__/schema-iterative-update-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_6d_schema_auth_6c
     - identifier: w_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2063,8 +1973,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_2b_schema_auth_11_c
     - identifier: w_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2073,8 +1982,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_analytics_compatibility_in_app_2_init_e
     - identifier: w_auth_6_storage_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2083,8 +1991,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_global_sandbox_a_geo_import_1b
     - identifier: w_storage_1a_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2093,8 +2000,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-1a.test.ts|src/__tests__/schema-iterative-update-2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_feature_flags_auth_8c
     - identifier: w_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2103,8 +2009,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_7a_auth_4a
     - identifier: w_api_9b_function_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2113,8 +2018,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_3b_auth_3a
     - identifier: w_function_11_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2123,8 +2027,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_function_migration_storage_3
     - identifier: w_storage_4_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2133,8 +2036,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-4.test.ts|src/__tests__/containers-api-secrets.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_9_c_schema_auth_9_a
     - identifier: w_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2143,8 +2045,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_8b_schema_auth_5b
     - identifier: w_schema_key_resolvers
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2153,8 +2054,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_1a_geo_headless
     - identifier: w_geo_multi_env_searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2163,8 +2063,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-multi-env.test.ts|src/__tests__/graphql-v2/searchable-datastore.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_function_9a_export_pull_a
     - identifier: w_schema_searchable_apigw
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2173,8 +2072,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts|src/__tests__/apigw.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_api_7_api_10
     - identifier: w_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2183,8 +2081,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_api_key_migration5_schema_auth_9_b
     - identifier: w_api_lambda_auth_1_schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2193,8 +2090,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_7b_schema_auth_7a
     - identifier: w_api_key_migration1_api_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2203,8 +2099,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts|src/__tests__/api_6b.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_2a_schema_auth_1b
     - identifier: w_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2213,8 +2108,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_11_b_predictions
     - identifier: w_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2223,8 +2117,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_layer_3_hosting
     - identifier: w_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2233,8 +2126,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_geo_import_3_geo_add_d
     - identifier: w_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2243,8 +2135,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_geo_add_c_delete
     - identifier: w_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2253,8 +2144,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_1b_auth_11
     - identifier: w_env_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2263,8 +2153,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_predictions_migration_api_key_migration3
     - identifier: w_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2273,8 +2162,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_api_connection_migration_init_special_case
     - identifier: w_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2283,8 +2171,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_export_pull_b_auth_7b
     - identifier: w_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2293,8 +2180,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_api_6a_http_migration
     - identifier: w_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2303,8 +2189,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_function_2_schema_auth_3
     - identifier: w_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2313,8 +2198,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_12_schema_iterative_update_3
     - identifier: w_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2323,8 +2207,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_schema_auth_5a_export_pull_d
     - identifier: w_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2333,8 +2216,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_8a_auth_4b
     - identifier: w_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2343,8 +2225,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_auth_migration_push
     - identifier: w_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2353,8 +2234,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_parameter_store_2_parameter_store_1
     - identifier: w_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2364,8 +2244,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_notifications_sms_update_notifications_multi_env
     - identifier: w_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2375,8 +2254,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_minify_cloudformation_init_force_push
     - identifier: w_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2385,8 +2263,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - build_windows
-        - upb
+        - w_help_function_2d
     - identifier: w_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2396,8 +2273,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - build_windows
-        - upb
+        - w_function_14_function_13
     - identifier: aggregate_e2e_reports
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
@@ -2405,4 +2281,49 @@ batch:
           WAIT_FOR_IDS_FILE_PATH: ./codebuild_specs/wait_for_ids.json
       buildspec: codebuild_specs/aggregate_e2e_reports.yml
       depend-on:
-        - upb
+        - w_function_12_export_pull_c
+        - w_build_function_build_function_yarn_modern
+        - w_auth_5g_auth_2h
+        - w_api_9a_api_6c
+        - w_api_2b_api_2a
+        - w_amplify_remove_smoketest
+        - w_smoketest_ios_general_config_headless_init
+        - w_dynamodb_simulator_user_groups
+        - w_user_groups_s3_access_hosted_ui
+        - w_admin_api_schema_iterative_update_locking
+        - w_api_8_schema_auth_13
+        - w_api_lambda_auth_2_schema_iterative_update_1
+        - w_function_5_schema_function_1
+        - w_schema_connection_2_function_2a
+        - w_auth_6_storage_1b
+        - w_storage_1a_schema_iterative_update_2
+        - w_function_9b_custom_policies_container
+        - w_api_9b_function_2b
+        - w_function_11_api_connection_migration2
+        - w_storage_4_containers_api_secrets
+        - w_api_4_schema_auth_10
+        - w_schema_key_resolvers
+        - w_geo_multi_env_searchable_datastore
+        - w_schema_searchable_apigw
+        - w_api_5_api_key_migration2
+        - w_api_lambda_auth_1_schema_auth_14
+        - w_api_key_migration1_api_6b
+        - w_api_3_layer_1
+        - w_api_1_api_key_migration4
+        - w_schema_iterative_update_4_function_1
+        - w_auth_2e
+        - w_auth_2c
+        - w_env_3
+        - w_notifications_in_app_messaging
+        - w_schema_auth_11_a
+        - w_import_s3_3
+        - w_js_frontend_config
+        - w_hostingPROD
+        - w_schema_connection_1
+        - w_schema_auth_15
+        - w_containers_api_1
+        - w_containers_api_2
+        - w_import_s3_1
+        - w_searchable_migration
+        - w_geo_remove_1
+        - w_import_dynamodb_1

--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -1163,6 +1163,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-lifecycle.test.ts|src/__tests__/auth_2f.test.ts
       depend-on:
+        - build_windows
         - l_datastore_modelgen
     - identifier: w_auth_2d_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1172,6 +1173,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2d.test.ts|src/__tests__/auth_2b.test.ts
       depend-on:
+        - build_windows
         - l_amplify_app
     - identifier: w_auth_2a_analytics_pinpoint_js
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1181,6 +1183,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2a.test.ts|src/__tests__/analytics-pinpoint-js.test.ts
       depend-on:
+        - build_windows
         - l_uibuilder
     - identifier: w_analytics_pinpoint_flutter_analytics_kinesis
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1190,6 +1193,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/analytics-pinpoint-flutter.test.ts|src/__tests__/analytics-kinesis.test.ts
       depend-on:
+        - build_windows
         - l_auth_2e
     - identifier: w_notifications_analytics_compatibility_sms_2_notifications_analytics_compatibility_in_app_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1199,6 +1203,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-2.test.ts|src/__tests__/notifications-analytics-compatibility-in-app-1.test.ts
       depend-on:
+        - build_windows
         - l_auth_2c
     - identifier: w_studio_modelgen_plugin
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1208,6 +1213,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/studio-modelgen.test.ts|src/__tests__/plugin.test.ts
       depend-on:
+        - build_windows
         - l_geo_remove_3
     - identifier: w_notifications_analytics_compatibility_sms_1_hooks_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1217,6 +1223,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-1.test.ts|src/__tests__/hooks-b.test.ts
       depend-on:
+        - build_windows
         - l_geo_add_f
     - identifier: w_global_sandbox_c_analytics_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1226,6 +1233,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/global_sandbox-c.test.ts|src/__tests__/analytics-2.test.ts
       depend-on:
+        - build_windows
         - l_geo_add_e
     - identifier: w_notifications_sms_pull_notifications_in_app_messaging_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1235,6 +1243,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-pull.test.ts|src/__tests__/notifications-in-app-messaging-env-1.test.ts
       depend-on:
+        - build_windows
         - l_import_dynamodb_2c
     - identifier: w_custom_transformers_with_babel_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1244,6 +1253,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/custom-transformers.test.ts|src/__tests__/with-babel-config.test.ts
       depend-on:
+        - build_windows
         - l_env_3
     - identifier: w_notifications_in_app_messaging_env_2_notifications_fcm
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1253,6 +1263,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging-env-2.test.ts|src/__tests__/notifications-fcm.test.ts
       depend-on:
+        - build_windows
         - l_notifications_in_app_messaging
     - identifier: w_notifications_apns_init_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1262,6 +1273,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-apns.test.ts|src/__tests__/init_b.test.ts
       depend-on:
+        - build_windows
         - l_geo_remove_2
     - identifier: w_container_hosting_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1271,6 +1283,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/container-hosting.test.ts|src/__tests__/auth_10.test.ts
       depend-on:
+        - build_windows
         - l_import_auth_2a
     - identifier: w_init_f_init_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1280,6 +1293,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init_f.test.ts|src/__tests__/init_d.test.ts
       depend-on:
+        - build_windows
         - l_import_auth_1a
     - identifier: w_amplify_configure_layer_4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1289,6 +1303,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-configure.test.ts|src/__tests__/layer-4.test.ts
       depend-on:
+        - build_windows
         - l_import_s3_2c
     - identifier: w_init_c_configure_project
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1298,6 +1313,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init_c.test.ts|src/__tests__/configure-project.test.ts
       depend-on:
+        - build_windows
         - l_import_s3_2a
     - identifier: w_auth_5d_tags
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1307,6 +1323,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5d.test.ts|src/__tests__/tags.test.ts
       depend-on:
+        - build_windows
         - l_import_auth_2b
     - identifier: w_schema_model_a_function_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1316,6 +1333,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-model-a.test.ts|src/__tests__/function_2c.test.ts
       depend-on:
+        - build_windows
         - l_schema_auth_11_a
     - identifier: w_storage_2_custom_policies_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1325,6 +1343,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-2.test.ts|src/__tests__/custom_policies_function.test.ts
       depend-on:
+        - build_windows
         - l_import_auth_1b
     - identifier: w_auth_1a_auth_trigger
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1334,6 +1353,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_1a.test.ts|src/__tests__/auth-trigger.test.ts
       depend-on:
+        - build_windows
         - l_import_s3_3
     - identifier: w_schema_versioned_schema_model_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1343,6 +1363,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-versioned.test.ts|src/__tests__/schema-model-e.test.ts
       depend-on:
+        - build_windows
         - l_geo_update_2
     - identifier: w_schema_auth_4b_notifications_sms
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1352,6 +1373,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4b.test.ts|src/__tests__/notifications-sms.test.ts
       depend-on:
+        - build_windows
         - l_geo_update_1
     - identifier: w_iam_permissions_boundary_node_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1361,6 +1383,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts|src/__tests__/migration/node.function.test.ts
       depend-on:
+        - build_windows
         - l_import_dynamodb_2b
     - identifier: w_schema_model_d_schema_model_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1370,6 +1393,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-model-d.test.ts|src/__tests__/schema-model-b.test.ts
       depend-on:
+        - build_windows
         - l_smoketest_amplify_app
     - identifier: w_schema_auth_4a_s3_sse
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1379,6 +1403,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4a.test.ts|src/__tests__/s3-sse.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_store_locator
     - identifier: w_geo_add_b_auth_8b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1388,6 +1413,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-b.test.ts|src/__tests__/auth_8b.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_project_boards
     - identifier: w_auth_5e_auth_1c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1397,6 +1423,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5e.test.ts|src/__tests__/auth_1c.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_product_catalog
     - identifier: w_schema_predictions_schema_model_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1406,6 +1433,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-predictions.test.ts|src/__tests__/schema-model-c.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_mood_board
     - identifier: w_schema_data_access_patterns_schema_auth_6a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1415,6 +1443,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts|src/__tests__/schema-auth-6a.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_media_vault
     - identifier: w_schema_auth_4d_frontend_config_drift
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1424,6 +1453,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4d.test.ts|src/__tests__/frontend_config_drift.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_fitness_tracker
     - identifier: w_env_4_auth_5f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1433,6 +1463,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/env-4.test.ts|src/__tests__/auth_5f.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_finance_tracker
     - identifier: w_model_migration_schema_auth_5c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1442,6 +1473,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/model-migration.test.ts|src/__tests__/schema-auth-5c.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_discussions
     - identifier: w_schema_auth_4c_init_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1451,6 +1483,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4c.test.ts|src/__tests__/init_a.test.ts
       depend-on:
+        - build_windows
         - l_gen2_migration_backend_only
     - identifier: w_geo_add_a_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1460,6 +1493,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-a.test.ts|src/__tests__/env-1.test.ts
       depend-on:
+        - build_windows
         - l_js_frontend_config
     - identifier: w_auth_5c_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1469,6 +1503,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5c.test.ts|src/__tests__/auth_5a.test.ts
       depend-on:
+        - build_windows
         - l_hostingPROD
     - identifier: w_auth_4c_auth_3c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1478,6 +1513,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_4c.test.ts|src/__tests__/auth_3c.test.ts
       depend-on:
+        - build_windows
         - l_import_s3_2b
     - identifier: w_schema_auth_8c_schema_auth_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1487,6 +1523,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8c.test.ts|src/__tests__/schema-auth-6b.test.ts
       depend-on:
+        - build_windows
         - l_schema_connection_1
     - identifier: w_schema_auth_5d_global_sandbox_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1496,6 +1533,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5d.test.ts|src/__tests__/global_sandbox-b.test.ts
       depend-on:
+        - build_windows
         - l_schema_auth_15
     - identifier: w_geo_import_2_geo_import_1a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1505,6 +1543,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-import-2.test.ts|src/__tests__/geo-import-1a.test.ts
       depend-on:
+        - build_windows
         - l_containers_api_1
     - identifier: w_function_9c_function_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1514,6 +1553,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9c.test.ts|src/__tests__/function_10.test.ts
       depend-on:
+        - build_windows
         - l_import_auth_3
     - identifier: w_function_permissions_env_5
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1523,6 +1563,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function-permissions.test.ts|src/__tests__/env-5.test.ts
       depend-on:
+        - build_windows
         - l_import_dynamodb_2a
     - identifier: w_auth_9_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1532,6 +1573,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_9.test.ts|src/__tests__/auth_5b.test.ts
       depend-on:
+        - build_windows
         - l_containers_api_2
     - identifier: w_schema_auth_8a_schema_auth_7c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1541,6 +1583,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8a.test.ts|src/__tests__/schema-auth-7c.test.ts
       depend-on:
+        - build_windows
         - l_import_s3_1
     - identifier: w_schema_auth_6d_schema_auth_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1550,6 +1593,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6d.test.ts|src/__tests__/schema-auth-6c.test.ts
       depend-on:
+        - build_windows
         - l_searchable_migration
     - identifier: w_schema_auth_2b_schema_auth_11_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1559,6 +1603,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2b.test.ts|src/__tests__/schema-auth-11-c.test.ts
       depend-on:
+        - build_windows
         - l_geo_remove_1
     - identifier: w_notifications_analytics_compatibility_in_app_2_init_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1568,6 +1613,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-in-app-2.test.ts|src/__tests__/init_e.test.ts
       depend-on:
+        - build_windows
         - l_import_dynamodb_1
     - identifier: w_global_sandbox_a_geo_import_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1577,6 +1623,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/global_sandbox-a.test.ts|src/__tests__/geo-import-1b.test.ts
       depend-on:
+        - build_windows
         - w_notifications_lifecycle_auth_2f
     - identifier: w_feature_flags_auth_8c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1586,6 +1633,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/feature-flags.test.ts|src/__tests__/auth_8c.test.ts
       depend-on:
+        - build_windows
         - w_auth_2d_auth_2b
     - identifier: w_auth_7a_auth_4a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1595,6 +1643,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_7a.test.ts|src/__tests__/auth_4a.test.ts
       depend-on:
+        - build_windows
         - w_auth_2a_analytics_pinpoint_js
     - identifier: w_auth_3b_auth_3a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1604,6 +1653,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_3b.test.ts|src/__tests__/auth_3a.test.ts
       depend-on:
+        - build_windows
         - w_analytics_pinpoint_flutter_analytics_kinesis
     - identifier: w_function_migration_storage_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1613,6 +1663,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts
       depend-on:
+        - build_windows
         - w_notifications_analytics_compatibility_sms_2_notifications_analytics_compatibility_in_app_1
     - identifier: w_schema_auth_9_c_schema_auth_9_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1622,6 +1673,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9-c.test.ts|src/__tests__/schema-auth-9-a.test.ts
       depend-on:
+        - build_windows
         - w_studio_modelgen_plugin
     - identifier: w_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1631,6 +1683,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
+        - build_windows
         - w_notifications_analytics_compatibility_sms_1_hooks_b
     - identifier: w_schema_auth_1a_geo_headless
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1640,6 +1693,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts
       depend-on:
+        - build_windows
         - w_global_sandbox_c_analytics_2
     - identifier: w_function_9a_export_pull_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1649,6 +1703,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9a.test.ts|src/__tests__/export-pull-a.test.ts
       depend-on:
+        - build_windows
         - w_notifications_sms_pull_notifications_in_app_messaging_env_1
     - identifier: w_api_7_api_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1658,6 +1713,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_7.test.ts|src/__tests__/api_10.test.ts
       depend-on:
+        - build_windows
         - w_custom_transformers_with_babel_config
     - identifier: w_api_key_migration5_schema_auth_9_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1667,6 +1723,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts|src/__tests__/schema-auth-9-b.test.ts
       depend-on:
+        - build_windows
         - w_notifications_in_app_messaging_env_2_notifications_fcm
     - identifier: w_schema_auth_7b_schema_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1676,6 +1733,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7b.test.ts|src/__tests__/schema-auth-7a.test.ts
       depend-on:
+        - build_windows
         - w_notifications_apns_init_b
     - identifier: w_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1685,6 +1743,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
+        - build_windows
         - w_container_hosting_auth_10
     - identifier: w_schema_auth_11_b_predictions
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1694,6 +1753,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts
       depend-on:
+        - build_windows
         - w_init_f_init_d
     - identifier: w_layer_3_hosting
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1703,6 +1763,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/layer-3.test.ts|src/__tests__/hosting.test.ts
       depend-on:
+        - build_windows
         - w_amplify_configure_layer_4
     - identifier: w_geo_import_3_geo_add_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1712,6 +1773,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-import-3.test.ts|src/__tests__/geo-add-d.test.ts
       depend-on:
+        - build_windows
         - w_init_c_configure_project
     - identifier: w_geo_add_c_delete
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1721,6 +1783,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-add-c.test.ts|src/__tests__/delete.test.ts
       depend-on:
+        - build_windows
         - w_auth_5d_tags
     - identifier: w_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1730,6 +1793,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
+        - build_windows
         - w_schema_model_a_function_2c
     - identifier: w_predictions_migration_api_key_migration3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1739,6 +1803,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts
       depend-on:
+        - build_windows
         - w_storage_2_custom_policies_function
     - identifier: w_api_connection_migration_init_special_case
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1748,6 +1813,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/init-special-case.test.ts
       depend-on:
+        - build_windows
         - w_auth_1a_auth_trigger
     - identifier: w_export_pull_b_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1757,6 +1823,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/export-pull-b.test.ts|src/__tests__/auth_7b.test.ts
       depend-on:
+        - build_windows
         - w_schema_versioned_schema_model_e
     - identifier: w_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1766,6 +1833,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_4b_notifications_sms
     - identifier: w_schema_function_2_schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1775,6 +1843,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts
       depend-on:
+        - build_windows
         - w_iam_permissions_boundary_node_function
     - identifier: w_schema_auth_12_schema_iterative_update_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1784,6 +1853,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts|src/__tests__/schema-iterative-update-3.test.ts
       depend-on:
+        - build_windows
         - w_schema_model_d_schema_model_b
     - identifier: w_schema_auth_5a_export_pull_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1793,6 +1863,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-5a.test.ts|src/__tests__/export-pull-d.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_4a_s3_sse
     - identifier: w_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1802,6 +1873,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
+        - build_windows
         - w_geo_add_b_auth_8b
     - identifier: w_auth_migration_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1811,6 +1883,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts
       depend-on:
+        - build_windows
         - w_auth_5e_auth_1c
     - identifier: w_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1820,6 +1893,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
+        - build_windows
         - w_schema_predictions_schema_model_c
     - identifier: w_notifications_sms_update_notifications_multi_env
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1829,6 +1903,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts
       depend-on:
+        - build_windows
         - w_schema_data_access_patterns_schema_auth_6a
     - identifier: w_minify_cloudformation_init_force_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1838,6 +1913,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/minify-cloudformation.test.ts|src/__tests__/init-force-push.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_4d_frontend_config_drift
     - identifier: w_help_function_2d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1847,6 +1923,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/help.test.ts|src/__tests__/function_2d.test.ts
       depend-on:
+        - build_windows
         - w_env_4_auth_5f
     - identifier: w_function_14_function_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1856,6 +1933,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_14.test.ts|src/__tests__/function_13.test.ts
       depend-on:
+        - build_windows
         - w_model_migration_schema_auth_5c
     - identifier: w_function_12_export_pull_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1865,6 +1943,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_12.test.ts|src/__tests__/export-pull-c.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_4c_init_a
     - identifier: w_build_function_build_function_yarn_modern
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1874,6 +1953,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts
       depend-on:
+        - build_windows
         - w_geo_add_a_env_1
     - identifier: w_auth_5g_auth_2h
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1883,6 +1963,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_5g.test.ts|src/__tests__/auth_2h.test.ts
       depend-on:
+        - build_windows
         - w_auth_5c_auth_5a
     - identifier: w_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1892,6 +1973,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
+        - build_windows
         - w_auth_4c_auth_3c
     - identifier: w_api_2b_api_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1901,6 +1983,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_8c_schema_auth_6b
     - identifier: w_amplify_remove_smoketest
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1910,6 +1993,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/amplify-remove.test.ts|src/__tests__/smoke-tests/smoketest.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_5d_global_sandbox_b
     - identifier: w_smoketest_ios_general_config_headless_init
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1919,6 +2003,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-ios.test.ts|src/__tests__/general-config/general-config-headless-init.test.ts
       depend-on:
+        - build_windows
         - w_geo_import_2_geo_import_1a
     - identifier: w_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1928,6 +2013,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
+        - build_windows
         - w_function_9c_function_10
     - identifier: w_user_groups_s3_access_hosted_ui
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1937,6 +2023,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts
       depend-on:
+        - build_windows
         - w_function_permissions_env_5
     - identifier: w_admin_api_schema_iterative_update_locking
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1946,6 +2033,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth/admin-api.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
       depend-on:
+        - build_windows
         - w_auth_9_auth_5b
     - identifier: w_api_8_schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1955,6 +2043,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_8.test.ts|src/__tests__/schema-auth-13.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_8a_schema_auth_7c
     - identifier: w_api_lambda_auth_2_schema_iterative_update_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1964,6 +2053,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_2.test.ts|src/__tests__/schema-iterative-update-1.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_6d_schema_auth_6c
     - identifier: w_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1973,6 +2063,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_2b_schema_auth_11_c
     - identifier: w_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1982,6 +2073,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
+        - build_windows
         - w_notifications_analytics_compatibility_in_app_2_init_e
     - identifier: w_auth_6_storage_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -1991,6 +2083,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts
       depend-on:
+        - build_windows
         - w_global_sandbox_a_geo_import_1b
     - identifier: w_storage_1a_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2000,6 +2093,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-1a.test.ts|src/__tests__/schema-iterative-update-2.test.ts
       depend-on:
+        - build_windows
         - w_feature_flags_auth_8c
     - identifier: w_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2009,6 +2103,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
+        - build_windows
         - w_auth_7a_auth_4a
     - identifier: w_api_9b_function_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2018,6 +2113,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
+        - build_windows
         - w_auth_3b_auth_3a
     - identifier: w_function_11_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2027,6 +2123,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
       depend-on:
+        - build_windows
         - w_function_migration_storage_3
     - identifier: w_storage_4_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2036,6 +2133,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/storage-4.test.ts|src/__tests__/containers-api-secrets.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_9_c_schema_auth_9_a
     - identifier: w_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2045,6 +2143,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_8b_schema_auth_5b
     - identifier: w_schema_key_resolvers
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2054,6 +2153,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_1a_geo_headless
     - identifier: w_geo_multi_env_searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2063,6 +2163,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-multi-env.test.ts|src/__tests__/graphql-v2/searchable-datastore.test.ts
       depend-on:
+        - build_windows
         - w_function_9a_export_pull_a
     - identifier: w_schema_searchable_apigw
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2072,6 +2173,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts|src/__tests__/apigw.test.ts
       depend-on:
+        - build_windows
         - w_api_7_api_10
     - identifier: w_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2081,6 +2183,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
+        - build_windows
         - w_api_key_migration5_schema_auth_9_b
     - identifier: w_api_lambda_auth_1_schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2090,6 +2193,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_7b_schema_auth_7a
     - identifier: w_api_key_migration1_api_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2099,6 +2203,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts|src/__tests__/api_6b.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_2a_schema_auth_1b
     - identifier: w_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2108,6 +2213,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_11_b_predictions
     - identifier: w_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2117,6 +2223,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
+        - build_windows
         - w_layer_3_hosting
     - identifier: w_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2126,6 +2233,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
+        - build_windows
         - w_geo_import_3_geo_add_d
     - identifier: w_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2135,6 +2243,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
+        - build_windows
         - w_geo_add_c_delete
     - identifier: w_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2144,6 +2253,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
+        - build_windows
         - w_auth_1b_auth_11
     - identifier: w_env_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2153,6 +2263,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
+        - build_windows
         - w_predictions_migration_api_key_migration3
     - identifier: w_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2162,6 +2273,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
+        - build_windows
         - w_api_connection_migration_init_special_case
     - identifier: w_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2171,6 +2283,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
+        - build_windows
         - w_export_pull_b_auth_7b
     - identifier: w_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2180,6 +2293,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
+        - build_windows
         - w_api_6a_http_migration
     - identifier: w_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2189,6 +2303,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
+        - build_windows
         - w_schema_function_2_schema_auth_3
     - identifier: w_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2198,6 +2313,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_12_schema_iterative_update_3
     - identifier: w_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2207,6 +2323,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
+        - build_windows
         - w_schema_auth_5a_export_pull_d
     - identifier: w_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2216,6 +2333,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
+        - build_windows
         - w_auth_8a_auth_4b
     - identifier: w_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2225,6 +2343,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
+        - build_windows
         - w_auth_migration_push
     - identifier: w_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2234,6 +2353,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
+        - build_windows
         - w_parameter_store_2_parameter_store_1
     - identifier: w_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2244,6 +2364,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
+        - build_windows
         - w_notifications_sms_update_notifications_multi_env
     - identifier: w_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2254,6 +2375,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
+        - build_windows
         - w_minify_cloudformation_init_force_push
     - identifier: w_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2263,6 +2385,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
+        - build_windows
         - w_help_function_2d
     - identifier: w_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
@@ -2273,6 +2396,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
+        - build_windows
         - w_function_14_function_13
     - identifier: aggregate_e2e_reports
       env:

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -180,9 +180,7 @@ const WAVE_SIZE = 46;
 const applyFanOutWaves = (builds: any[]): string[] => {
   builds.forEach((build, index) => {
     const predecessor = index < WAVE_SIZE ? 'upb' : builds[index - WAVE_SIZE].identifier;
-    const extraDeps = (build['depend-on'] || []).filter(
-      (d: string) => d !== 'upb' && !d.startsWith('l_') && !d.startsWith('w_')
-    );
+    const extraDeps = (build['depend-on'] || []).filter((d: string) => d !== 'upb' && !d.startsWith('l_') && !d.startsWith('w_'));
     build['depend-on'] = extraDeps.length ? [...extraDeps, predecessor] : [predecessor];
   });
 

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -150,6 +150,45 @@ const TEST_EXCLUSIONS: { l: string[]; w: string[] } = {
     'src/__tests__/gen2-migration/gen2-migration-store-locator.test.ts',
   ],
 };
+
+/**
+ * Maximum number of E2E jobs released into the batch at once.
+ *
+ * The project's concurrentBuildLimit is 60. Releasing all ~265 jobs at once
+ * (each depending only on `upb`) causes every batch to fail with
+ * "Concurrent build limit exceeded". Staggering the fan-out into waves of
+ * WAVE_SIZE jobs each keeps the maximum simultaneous release width at 46,
+ * well under the 60 cap.
+ *
+ * Wave assignment:
+ *   - jobs at index < WAVE_SIZE depend on `upb` (wave 0)
+ *   - job at index i (i >= WAVE_SIZE) depends on job at index (i - WAVE_SIZE)
+ *
+ * Because each dependency index is strictly less than i, the graph is acyclic.
+ * The most jobs released by any single completion event is WAVE_SIZE.
+ */
+const WAVE_SIZE = 46;
+
+/**
+ * Rewires the `depend-on` edges of the E2E build jobs so that at most
+ * WAVE_SIZE jobs are released at once (see constant above).
+ *
+ * Returns the identifiers of the "leaf" jobs — those in the final wave
+ * (nothing else chains off them) — so that downstream jobs such as
+ * `aggregate_e2e_reports` can wait for the entire fan-out to finish.
+ */
+const applyFanOutWaves = (builds: any[]): string[] => {
+  builds.forEach((build, index) => {
+    build['depend-on'] = index < WAVE_SIZE ? ['upb'] : [builds[index - WAVE_SIZE].identifier];
+  });
+
+  // A job at index i is a leaf when no later job chains off it, i.e. when
+  // (i + WAVE_SIZE) >= builds.length. That is exactly the final WAVE_SIZE jobs.
+  // Every earlier job is an ancestor of one of these leaves, so waiting on the
+  // leaves transitively waits for the whole fan-out.
+  return builds.slice(Math.max(0, builds.length - WAVE_SIZE)).map((build) => build.identifier);
+};
+
 export function loadConfigBase() {
   return yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8'));
 }
@@ -376,6 +415,11 @@ function main(): void {
     undefined,
   );
 
+  // Stagger the e2e fan-out into waves so the batch orchestrator is never asked
+  // to release the entire fan-out at once. Returns the leaf job identifiers so
+  // aggregate_e2e_reports can wait for every test job to finish.
+  const leafJobIdentifiers = applyFanOutWaves(splitE2ETests);
+
   let allBuilds = [...splitE2ETests];
   const dependeeIdentifiers: string[] = allBuilds.map((buildObject) => buildObject.identifier).sort();
   const dependeeIdentifiersFileContents = `${JSON.stringify(dependeeIdentifiers, null, 2)}\n`;
@@ -388,7 +432,7 @@ function main(): void {
       variables: { WAIT_FOR_IDS_FILE_PATH: waitForIdsFilePath },
     },
     buildspec: 'codebuild_specs/aggregate_e2e_reports.yml',
-    'depend-on': ['upb'],
+    'depend-on': leafJobIdentifiers,
   };
   allBuilds.push(reportsAggregator);
   let currentBatch = [...baseBuildGraph, ...allBuilds];

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -179,7 +179,11 @@ const WAVE_SIZE = 46;
  */
 const applyFanOutWaves = (builds: any[]): string[] => {
   builds.forEach((build, index) => {
-    build['depend-on'] = index < WAVE_SIZE ? ['upb'] : [builds[index - WAVE_SIZE].identifier];
+    const predecessor = index < WAVE_SIZE ? 'upb' : builds[index - WAVE_SIZE].identifier;
+    const extraDeps = (build['depend-on'] || []).filter(
+      (d: string) => d !== 'upb' && !d.startsWith('l_') && !d.startsWith('w_')
+    );
+    build['depend-on'] = extraDeps.length ? [...extraDeps, predecessor] : [predecessor];
   });
 
   // A job at index i is a leaf when no later job chains off it, i.e. when


### PR DESCRIPTION

#### Description of changes

E2E tests were failing because CodeBuild had a change in approval and blocks running all of the tasks in one burst. 

This change groups the tests and prevents a burst of too many multiple tests running in parallel.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
