### PR TITLE
chore(cli): fix windows build cache tar self-inclusion failure

### DIFF
--- a/codebuild_specs/scripts-windows/shared-scripts-windows.sh
+++ b/codebuild_specs/scripts-windows/shared-scripts-windows.sh
@@ -17,10 +17,7 @@ function storeCache {
     s3Path="s3://$CACHE_BUCKET_NAME/$CODEBUILD_SOURCE_VERSION/$alias"
     echo writing cache to $s3Path
     # zip contents and upload to s3
-    # if ! (cd $localPath && tar -czf cache.tar . && ls && aws s3 cp cache.tar $s3Path); then
-    #     echo Something went wrong storing the cache.
-    # fi
-    if ! (cd $localPath && tar -czf cache.tar . && ls && aws s3 cp cache.tar $s3Path); then
+    if ! (cd $localPath && tar cz . | aws s3 cp - $s3Path); then
         echo Something went wrong storing the cache.
     fi
     echo done writing cache


### PR DESCRIPTION
#### Description of changes

The Windows build cache `storeCache` step in
`codebuild_specs/scripts-windows/shared-scripts-windows.sh` archived
the repository root with `tar -czf cache.tar .` and then uploaded the
resulting `cache.tar`. Because the archive was written into the very
directory being archived, GNU tar aborted with "Can't add archive to
itself", causing the `build_windows` cache step to fail on every PR.

This change streams the archive straight to S3 instead of writing a
temp file:

```
tar cz . | aws s3 cp - $s3Path
```

No on-disk `cache.tar` is ever created, so there is nothing for tar to
recurse into. This matches the canonical streaming pattern already
used by the Linux `storeCache` (`shared-scripts.sh`) and the Windows
`loadCache` in the same file. The stale commented-out copy of the old
command was also removed.

#### Issue #, if available

N/A

#### Description of how you validated changes

Ran `bash -n codebuild_specs/scripts-windows/shared-scripts-windows.sh`
to confirm the script parses with no syntax errors. The fix mirrors the
already-working streaming pattern used elsewhere in the same script.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
