### PR TITLE
feat(cli): add time-barrier wave staggering to e2e batch fan-out

### DIFF
--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -140,6 +140,58 @@ batch:
       buildspec: codebuild_specs/cleanup_resources.yml
       depend-on:
         - aggregate_e2e_reports
+    - identifier: l_wave_barrier_2
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 300
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: l_wave_barrier_3
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 600
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: w_wave_barrier_2
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 300
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_3
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 600
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
     - identifier: l_diagnose_mock_api_hooks_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -496,84 +548,84 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/init-special-case.test.ts|src/__tests__/function_3a_python.test.ts|src/__tests__/function_3a_nodejs.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_3a_go_function_3a_dotnet_export_pull_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_3a_go.test.ts|src/__tests__/function_3a_dotnet.test.ts|src/__tests__/export-pull-b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_7b_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_7b.test.ts|src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_function_2_schema_auth_3_schema_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts|src/__tests__/schema-auth-12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_3_schema_iterative_rollback_2_schema_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/schema-auth-5a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_export_pull_d_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/export-pull-d.test.ts|src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_migration_push_pull_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts|src/__tests__/pull-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_pr_previews_multi_env_1_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pr-previews-multi-env-1.test.ts|src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_notifications_sms_update_notifications_multi_env_minify_cloudformation
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts|src/__tests__/minify-cloudformation.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_init_force_push_hooks_c_help
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-force-push.test.ts|src/__tests__/hooks-c.test.ts|src/__tests__/help.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_2d_function_15_function_14
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_2d.test.ts|src/__tests__/function_15.test.ts|src/__tests__/function_14.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_13_function_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_13.test.ts|src/__tests__/function_12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_export_pull_c_custom_resource_with_storage
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -581,189 +633,189 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-c.test.ts|src/__tests__/custom-resource-with-storage.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_build_function_build_function_yarn_modern_auth_5g
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts|src/__tests__/auth_5g.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_2h_auth_2g_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_2h.test.ts|src/__tests__/auth_2g.test.ts|src/__tests__/auth_12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_2b_api_2a_amplify_remove
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts|src/__tests__/amplify-remove.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_S3server_smoketest_smoketest_ios
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/storage-simulator/S3server.test.ts|src/__tests__/smoke-tests/smoketest.test.ts|src/__tests__/smoke-tests/smoketest-ios.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_javascript_notifications_pinpoint_config_javascript_analytics_pinpoint_config_ios_notifications_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/javascript-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/javascript-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/ios-notifications-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_ios_analytics_pinpoint_config_flutter_notifications_pinpoint_config_flutter_analytics_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/ios-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-analytics-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_android_notifications_pinpoint_config_android_analytics_pinpoint_config_opensearch_simulator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/android-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/android-analytics-pinpoint-config.test.ts|src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_general_config_headless_init_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/general-config/general-config-headless-init.test.ts|src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_user_groups_s3_access_hosted_ui_admin_api
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts|src/__tests__/auth/admin-api.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_locking_function_8_api_8
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/function_8.test.ts|src/__tests__/api_8.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_13_layer_2_api_lambda_auth_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts|src/__tests__/layer-2.test.ts|src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_1_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_6_storage_1b_storage_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts|src/__tests__/storage-1a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_2_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_9b_function_7_function_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_7.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_11_api_connection_migration2_storage_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/storage-4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_containers_api_secrets_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/containers-api-secrets.test.ts|src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_key_resolvers_geo_multi_env
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/geo-multi-env.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_searchable_datastore_schema_searchable
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts|src/__tests__/schema-searchable.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_apigw_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts|src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_lambda_auth_1_schema_auth_14_api_key_migration1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts|src/__tests__/migration/api.key.migration1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_6b_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_6b.test.ts|src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_storage_5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -771,7 +823,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/storage-5.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_datastore_modelgen
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -780,7 +832,7 @@ batch:
           TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -789,7 +841,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_uibuilder
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -797,7 +849,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/uibuilder.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -805,7 +857,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -813,7 +865,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_geo_remove_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -821,7 +873,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_geo_add_f
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -829,7 +881,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-f.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_geo_add_e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -837,7 +889,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-e.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_import_dynamodb_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -845,7 +897,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_env_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -853,7 +905,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -861,7 +913,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_geo_remove_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -869,7 +921,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_auth_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -877,7 +929,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_auth_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -885,7 +937,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_s3_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -893,7 +945,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_s3_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -901,7 +953,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -909,7 +961,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -917,7 +969,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -925,7 +977,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -933,7 +985,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_geo_update_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -941,7 +993,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_geo_update_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -949,7 +1001,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_dynamodb_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -957,7 +1009,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_smoketest_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -966,7 +1018,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_store_locator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -975,7 +1027,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-store-locator.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_project_boards
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -984,7 +1036,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-project-boards.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_product_catalog
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -993,7 +1045,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-product-catalog.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_mood_board
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1002,7 +1054,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-mood-board.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_media_vault
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1011,7 +1063,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-media-vault.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_fitness_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1020,7 +1072,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-fitness-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_finance_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1029,7 +1081,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-finance-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_discussions
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1038,7 +1090,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-discussions.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_gen2_migration_backend_only
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1047,7 +1099,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-backend-only.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1055,7 +1107,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1063,7 +1115,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_s3_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1071,7 +1123,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1079,7 +1131,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1087,7 +1139,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1095,7 +1147,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_auth_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1103,7 +1155,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_dynamodb_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1111,7 +1163,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1119,7 +1171,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1128,7 +1180,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1137,7 +1189,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1145,7 +1197,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1154,7 +1206,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: w_notifications_lifecycle_auth_2f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1664,7 +1716,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_9_c_schema_auth_9_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1674,7 +1726,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-9-c.test.ts|src/__tests__/schema-auth-9-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1684,7 +1736,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_1a_geo_headless
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1694,7 +1746,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_9a_export_pull_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1704,7 +1756,7 @@ batch:
           TEST_SUITE: src/__tests__/function_9a.test.ts|src/__tests__/export-pull-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_7_api_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1714,7 +1766,7 @@ batch:
           TEST_SUITE: src/__tests__/api_7.test.ts|src/__tests__/api_10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_key_migration5_schema_auth_9_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1724,7 +1776,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts|src/__tests__/schema-auth-9-b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_7b_schema_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1734,7 +1786,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-7b.test.ts|src/__tests__/schema-auth-7a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1744,7 +1796,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_11_b_predictions
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1754,7 +1806,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_layer_3_hosting
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1764,7 +1816,7 @@ batch:
           TEST_SUITE: src/__tests__/layer-3.test.ts|src/__tests__/hosting.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_import_3_geo_add_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1774,7 +1826,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-import-3.test.ts|src/__tests__/geo-add-d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_add_c_delete
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1784,7 +1836,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-add-c.test.ts|src/__tests__/delete.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1794,7 +1846,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_predictions_migration_api_key_migration3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1804,7 +1856,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_connection_migration_init_special_case
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1814,7 +1866,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/init-special-case.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_export_pull_b_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1824,7 +1876,7 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-b.test.ts|src/__tests__/auth_7b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1834,7 +1886,7 @@ batch:
           TEST_SUITE: src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_function_2_schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1844,7 +1896,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_12_schema_iterative_update_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1854,7 +1906,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts|src/__tests__/schema-iterative-update-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_5a_export_pull_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1864,7 +1916,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-5a.test.ts|src/__tests__/export-pull-d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1874,7 +1926,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_migration_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1884,7 +1936,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1894,7 +1946,7 @@ batch:
           TEST_SUITE: src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_notifications_sms_update_notifications_multi_env
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1904,7 +1956,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_minify_cloudformation_init_force_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1914,7 +1966,7 @@ batch:
           TEST_SUITE: src/__tests__/minify-cloudformation.test.ts|src/__tests__/init-force-push.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_help_function_2d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1924,7 +1976,7 @@ batch:
           TEST_SUITE: src/__tests__/help.test.ts|src/__tests__/function_2d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_14_function_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1934,7 +1986,7 @@ batch:
           TEST_SUITE: src/__tests__/function_14.test.ts|src/__tests__/function_13.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_12_export_pull_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1944,7 +1996,7 @@ batch:
           TEST_SUITE: src/__tests__/function_12.test.ts|src/__tests__/export-pull-c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_build_function_build_function_yarn_modern
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1954,7 +2006,7 @@ batch:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_5g_auth_2h
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1964,7 +2016,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_5g.test.ts|src/__tests__/auth_2h.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1974,7 +2026,7 @@ batch:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_2b_api_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1984,7 +2036,7 @@ batch:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_amplify_remove_smoketest
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1994,7 +2046,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-remove.test.ts|src/__tests__/smoke-tests/smoketest.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_smoketest_ios_general_config_headless_init
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2004,7 +2056,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-ios.test.ts|src/__tests__/general-config/general-config-headless-init.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2014,7 +2066,7 @@ batch:
           TEST_SUITE: src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_user_groups_s3_access_hosted_ui
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2024,7 +2076,7 @@ batch:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_admin_api_schema_iterative_update_locking
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2034,7 +2086,7 @@ batch:
           TEST_SUITE: src/__tests__/auth/admin-api.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_8_schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2044,7 +2096,7 @@ batch:
           TEST_SUITE: src/__tests__/api_8.test.ts|src/__tests__/schema-auth-13.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_lambda_auth_2_schema_iterative_update_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2054,7 +2106,7 @@ batch:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_2.test.ts|src/__tests__/schema-iterative-update-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2064,7 +2116,7 @@ batch:
           TEST_SUITE: src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2074,7 +2126,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_6_storage_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2084,7 +2136,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_storage_1a_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2094,7 +2146,7 @@ batch:
           TEST_SUITE: src/__tests__/storage-1a.test.ts|src/__tests__/schema-iterative-update-2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2104,7 +2156,7 @@ batch:
           TEST_SUITE: src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_9b_function_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2114,7 +2166,7 @@ batch:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_11_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2124,7 +2176,7 @@ batch:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_storage_4_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2134,7 +2186,7 @@ batch:
           TEST_SUITE: src/__tests__/storage-4.test.ts|src/__tests__/containers-api-secrets.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2144,7 +2196,7 @@ batch:
           TEST_SUITE: src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_key_resolvers
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2154,7 +2206,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_multi_env_searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2164,7 +2216,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-multi-env.test.ts|src/__tests__/graphql-v2/searchable-datastore.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_searchable_apigw
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2174,7 +2226,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts|src/__tests__/apigw.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2184,7 +2236,7 @@ batch:
           TEST_SUITE: src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_lambda_auth_1_schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2194,7 +2246,7 @@ batch:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_key_migration1_api_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2204,7 +2256,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts|src/__tests__/api_6b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2214,7 +2266,7 @@ batch:
           TEST_SUITE: src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2224,7 +2276,7 @@ batch:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2234,7 +2286,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2244,7 +2296,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2254,7 +2306,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_env_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2264,7 +2316,7 @@ batch:
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2274,7 +2326,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2284,7 +2336,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2294,7 +2346,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2304,7 +2356,7 @@ batch:
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2314,7 +2366,7 @@ batch:
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2324,7 +2376,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2334,7 +2386,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2344,7 +2396,7 @@ batch:
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2354,7 +2406,7 @@ batch:
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2365,7 +2417,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2376,7 +2428,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2386,7 +2438,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2397,7 +2449,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: aggregate_e2e_reports
       env:
         compute-type: BUILD_GENERAL1_MEDIUM

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -6,6 +6,23 @@ import { REPO_ROOT } from './cci-utils';
 import { FORCE_REGION_MAP, getOldJobNameWithoutSuffixes, loadTestTimings, USE_PARENT_ACCOUNT } from './cci-utils';
 const CODEBUILD_CONFIG_BASE_PATH = join(REPO_ROOT, 'codebuild_specs', 'e2e_workflow_base.yml');
 const CODEBUILD_GENERATE_CONFIG_PATH = join(REPO_ROOT, 'codebuild_specs', 'e2e_workflow_generated');
+
+/**
+ * Time-barrier wave staggering tunables for the e2e CodeBuild batch.
+ *
+ * The orchestrator that fans the batch out cannot schedule the full ~280-shard
+ * burst at once (it fails with a CoFaWorkflows "Internal Service Error"). To
+ * spread dispatch over time WITHOUT serializing wave completion, shards are
+ * grouped into waves. Wave 1 starts immediately after `upb`/`build_windows`;
+ * each later wave is gated behind a synthetic "barrier" build that only sleeps.
+ * All barriers depend solely on `upb`/`build_windows`, so they all start in
+ * parallel right after the package upload — the stagger comes purely from their
+ * differing sleep durations, NOT from chaining one wave's completion to the next.
+ */
+// Number of shards per wave (per OS). Wave 1 has no barrier.
+const E2E_WAVE_SIZE = 50;
+// Seconds added per wave to the barrier sleep. Wave k sleeps (k-1) * interval.
+const E2E_WAVE_BARRIER_INTERVAL_SEC = 300;
 const RUN_SOLO = [
   'src/__tests__/auth_2c.test.ts',
   'src/__tests__/auth_2e.test.ts',
@@ -352,6 +369,72 @@ const splitTestsV3 = (
   });
   return result;
 };
+/**
+ * Builds a synthetic barrier build group whose only job is to sleep, gating a
+ * wave of Linux e2e shards. Depends only on `upb` so it starts in parallel with
+ * every other barrier; the stagger comes from the sleep duration alone.
+ */
+function makeLinuxBarrier(identifier: string, wave: number): any {
+  const sleepSeconds = (wave - 1) * E2E_WAVE_BARRIER_INTERVAL_SEC;
+  return {
+    identifier,
+    buildspec: `version: 0.2\nphases:\n  build:\n    commands:\n      - sleep ${sleepSeconds}\n`,
+    env: { 'compute-type': 'BUILD_GENERAL1_SMALL' },
+    'depend-on': ['upb'],
+  };
+}
+
+/**
+ * Builds a synthetic barrier build group gating a wave of Windows e2e shards.
+ * Mirrors {@link makeLinuxBarrier} but runs on the Windows container the `w_`
+ * shards use and sleeps via PowerShell. Depends only on `build_windows`/`upb`.
+ */
+function makeWindowsBarrier(identifier: string, wave: number): any {
+  const sleepSeconds = (wave - 1) * E2E_WAVE_BARRIER_INTERVAL_SEC;
+  return {
+    identifier,
+    buildspec: `version: 0.2\nenv:\n  shell: powershell.exe\nphases:\n  build:\n    commands:\n      - Start-Sleep -Seconds ${sleepSeconds}\n`,
+    env: { type: 'WINDOWS_SERVER_2022_CONTAINER', image: '$WINDOWS_IMAGE_2019' },
+    'depend-on': ['build_windows', 'upb'],
+  };
+}
+
+/**
+ * Applies time-barrier wave staggering to the generated e2e shards in place.
+ *
+ * Splits the `l_`/`w_` shards into waves of {@link E2E_WAVE_SIZE}. Wave 1 keeps
+ * its original dependency on `upb` (and `build_windows` for Windows). Each later
+ * wave is rewired to depend on a synthetic barrier build instead, so the wave
+ * cannot dispatch until that barrier's sleep elapses. Barriers depend only on
+ * `upb`/`build_windows` — never on each other or on a prior wave — so dispatch
+ * is spread over time without serializing completion.
+ *
+ * Mutates the `depend-on` of each shard and returns the new barrier build groups.
+ */
+function applyWaveStaggering(shards: any[]): any[] {
+  const barriers: any[] = [];
+
+  const stagger = (osPrefix: 'l' | 'w', keptDeps: string[], makeBarrier: (identifier: string, wave: number) => any): void => {
+    const osShards = shards.filter((shard) => shard.identifier.startsWith(`${osPrefix}_`));
+    osShards.forEach((shard, index) => {
+      const wave = Math.floor(index / E2E_WAVE_SIZE) + 1;
+      if (wave === 1) {
+        return; // wave 1 keeps its original depend-on (upb / build_windows + upb)
+      }
+      const barrierId = `${osPrefix}_wave_barrier_${wave}`;
+      if (!barriers.some((barrier) => barrier.identifier === barrierId)) {
+        barriers.push(makeBarrier(barrierId, wave));
+      }
+      shard['depend-on'] = [...keptDeps, barrierId];
+    });
+  };
+
+  stagger('l', [], makeLinuxBarrier);
+  stagger('w', ['build_windows'], makeWindowsBarrier);
+
+  return barriers;
+}
+
 function main(): void {
   const configBase: any = loadConfigBase();
   const baseBuildGraph = configBase.batch['build-graph'];
@@ -377,10 +460,15 @@ function main(): void {
   );
 
   let allBuilds = [...splitE2ETests];
+  // Report wait list is the shard identifiers only — barriers are synthetic and
+  // must NOT be polled by aggregate_e2e_reports, so compute this before staggering.
   const dependeeIdentifiers: string[] = allBuilds.map((buildObject) => buildObject.identifier).sort();
   const dependeeIdentifiersFileContents = `${JSON.stringify(dependeeIdentifiers, null, 2)}\n`;
   const waitForIdsFilePath = './codebuild_specs/wait_for_ids.json';
   fs.writeFileSync(waitForIdsFilePath, dependeeIdentifiersFileContents);
+  // Stagger shard dispatch with time barriers (mutates shard depend-on in place).
+  const waveBarriers = applyWaveStaggering(splitE2ETests);
+  allBuilds = [...waveBarriers, ...allBuilds];
   const reportsAggregator = {
     identifier: 'aggregate_e2e_reports',
     env: {


### PR DESCRIPTION
#### Description of changes

Experimental change that staggers the e2e CodeBuild batch fan-out over time using **time-based barriers**, to bound how many builds are dispatched simultaneously.

##### Problem

The e2e batch fans out a large number of shards that today all depend only on `upb` (Linux `l_*`) or `build_windows`/`upb` (Windows `w_*`). Dispatching this many builds as a single instantaneous burst is unreliable. This experiment spreads dispatch over time to reduce the size of that burst.

##### Design — time barriers, not completion chaining

Shards are grouped into waves of `E2E_WAVE_SIZE` per OS:

- **Wave 1** keeps its original dependency (`upb`, or `build_windows`/`upb` for Windows) — it dispatches immediately.
- **Each later wave k** depends on a synthetic **barrier** build (`l_wave_barrier_k` / `w_wave_barrier_k`) whose only command is to sleep `(k-1) * E2E_WAVE_BARRIER_INTERVAL_SEC` seconds.
- Critically, **every barrier depends ONLY on `upb`/`build_windows`** — never on the prior barrier or the prior wave. All barriers start in parallel right after the package upload; the stagger comes purely from their differing sleep durations.

This deliberately avoids a serial **completion chain** approach (shard N depends on shard N-1), which would risk timing out at the 240m batch limit. Here dispatch is spread over time **without** waiting for any prior wave to finish.

##### Tunable knobs

Two constants near the top of the generator:

- `E2E_WAVE_SIZE` (default `50`) — shards per wave.
- `E2E_WAVE_BARRIER_INTERVAL_SEC` (default `300`) — seconds of additional sleep per wave (barrier_2 sleeps 300s, barrier_3 sleeps 600s, …).

##### Notes

- Linux barriers run on `BUILD_GENERAL1_SMALL` and sleep via bash `sleep`. Windows barriers run on the same `WINDOWS_SERVER_2022_CONTAINER` / `$WINDOWS_IMAGE_2019` env as `w_*` shards and sleep via PowerShell `Start-Sleep` (bash `sleep` is not guaranteed on the Windows image), using an inline buildspec with `shell: powershell.exe`.
- Barriers are **excluded** from the e2e report wait list (`wait_for_ids.json`) — the list is computed from the test shards before barriers are injected, so `aggregate_e2e_reports` does not poll the synthetic builds.
- The test split / balancing logic and shard contents are **unchanged** — only the dependency wiring and the new barrier build groups were added.

#### Issue #, if available

N/A — infra experiment.

#### Description of how you validated changes

- Regenerated `codebuild_specs/e2e_workflow_generated.yml` and validated it parses with `js-yaml`.
- Verified 4 barriers present (`l_wave_barrier_2/3`, `w_wave_barrier_2/3`), each depending only on `upb` / `build_windows`+`upb`.
- Verified wave-1 shards still depend on `upb` (Linux) / `build_windows`+`upb` (Windows), and wave-k shards reference their barrier.
- Confirmed **no `l_`/`w_` shard depends on another shard** and **no barrier depends on another barrier** (grep proof).
- Confirmed `wait_for_ids.json` is unchanged and contains no barrier identifiers.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes (CI/CD config change only — no unit-test surface)
- [ ] Tests are changed or added (N/A — build-graph generation change)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies (N/A)
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
