### PR TITLE
feat(cli): refined e2e wave staggering (per-platform wave sizes, all waves gated)

### DIFF
--- a/codebuild_specs/e2e_workflow_generated.yml
+++ b/codebuild_specs/e2e_workflow_generated.yml
@@ -140,440 +140,600 @@ batch:
       buildspec: codebuild_specs/cleanup_resources.yml
       depend-on:
         - aggregate_e2e_reports
+    - identifier: l_wave_barrier_1
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 300
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: l_wave_barrier_2
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 600
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: l_wave_barrier_3
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 900
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: l_wave_barrier_4
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 1200
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: l_wave_barrier_5
+      buildspec: |
+        version: 0.2
+        phases:
+          build:
+            commands:
+              - sleep 1500
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+      depend-on:
+        - upb
+    - identifier: w_wave_barrier_1
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 300
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_2
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 600
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_3
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 900
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_4
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 1200
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_5
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 1500
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_6
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 1800
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
+    - identifier: w_wave_barrier_7
+      buildspec: |
+        version: 0.2
+        env:
+          shell: powershell.exe
+        phases:
+          build:
+            commands:
+              - Start-Sleep -Seconds 2100
+      env:
+        type: WINDOWS_SERVER_2022_CONTAINER
+        image: $WINDOWS_IMAGE_2019
+      depend-on:
+        - build_windows
+        - upb
     - identifier: l_diagnose_mock_api_hooks_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/diagnose.test.ts|src/__tests__/mock-api.test.ts|src/__tests__/hooks-a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_notifications_lifecycle_auth_2f_auth_2d
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-lifecycle.test.ts|src/__tests__/auth_2f.test.ts|src/__tests__/auth_2d.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_2b_auth_2a_analytics_pinpoint_js
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_2b.test.ts|src/__tests__/auth_2a.test.ts|src/__tests__/analytics-pinpoint-js.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_analytics_pinpoint_flutter_analytics_kinesis_notifications_analytics_compatibility_sms_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/analytics-pinpoint-flutter.test.ts|src/__tests__/analytics-kinesis.test.ts|src/__tests__/notifications-analytics-compatibility-sms-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_notifications_analytics_compatibility_in_app_1_studio_modelgen
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-in-app-1.test.ts|src/__tests__/studio-modelgen.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_plugin_notifications_analytics_compatibility_sms_1_hooks_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/plugin.test.ts|src/__tests__/notifications-analytics-compatibility-sms-1.test.ts|src/__tests__/hooks-b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_global_sandbox_c_analytics_2_pull
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/global_sandbox-c.test.ts|src/__tests__/analytics-2.test.ts|src/__tests__/pull.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_notifications_sms_pull_notifications_in_app_messaging_env_1_custom_transformers
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-pull.test.ts|src/__tests__/notifications-in-app-messaging-env-1.test.ts|src/__tests__/graphql-v2/custom-transformers.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_with_babel_config_notifications_in_app_messaging_env_2_notifications_fcm
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/with-babel-config.test.ts|src/__tests__/notifications-in-app-messaging-env-2.test.ts|src/__tests__/notifications-fcm.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_notifications_apns_init_b_container_hosting
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-apns.test.ts|src/__tests__/init_b.test.ts|src/__tests__/container-hosting.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_10_init_f_init_d
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_10.test.ts|src/__tests__/init_f.test.ts|src/__tests__/init_d.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_env_2_amplify_configure_layer_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/env-2.test.ts|src/__tests__/amplify-configure.test.ts|src/__tests__/layer-4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_init_c_git_clone_attach_configure_project
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init_c.test.ts|src/__tests__/git-clone-attach.test.ts|src/__tests__/configure-project.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_5d_tags_schema_model_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_5d.test.ts|src/__tests__/tags.test.ts|src/__tests__/schema-model-a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_function_4_function_3b_function_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_4.test.ts|src/__tests__/function_3b.test.ts|src/__tests__/function_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_storage_2_function_6_custom_policies_function
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/storage-2.test.ts|src/__tests__/function_6.test.ts|src/__tests__/custom_policies_function.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_1a_auth_trigger_schema_versioned
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_1a.test.ts|src/__tests__/auth-trigger.test.ts|src/__tests__/schema-versioned.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_model_e_schema_auth_4b_notifications_sms
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-model-e.test.ts|src/__tests__/schema-auth-4b.test.ts|src/__tests__/notifications-sms.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_iam_permissions_boundary_export_node_function
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts|src/__tests__/export.test.ts|src/__tests__/migration/node.function.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_model_d_schema_model_b_schema_auth_4a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-model-d.test.ts|src/__tests__/schema-model-b.test.ts|src/__tests__/schema-auth-4a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_s3_sse_geo_add_b_auth_8b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/s3-sse.test.ts|src/__tests__/geo-add-b.test.ts|src/__tests__/auth_8b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_5e_auth_1c_schema_predictions
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_5e.test.ts|src/__tests__/auth_1c.test.ts|src/__tests__/schema-predictions.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_model_c_schema_data_access_patterns_schema_auth_6a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-model-c.test.ts|src/__tests__/schema-data-access-patterns.test.ts|src/__tests__/schema-auth-6a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_auth_4d_frontend_config_drift_env_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4d.test.ts|src/__tests__/frontend_config_drift.test.ts|src/__tests__/env-4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_5f_model_migration_schema_auth_5c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_5f.test.ts|src/__tests__/transformer-migrations/model-migration.test.ts|src/__tests__/schema-auth-5c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_auth_4c_init_a_geo_add_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-4c.test.ts|src/__tests__/init_a.test.ts|src/__tests__/geo-add-a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_env_1_auth_5c_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/env-1.test.ts|src/__tests__/auth_5c.test.ts|src/__tests__/auth_5a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_auth_4c_auth_3c_schema_auth_8c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_4c.test.ts|src/__tests__/auth_3c.test.ts|src/__tests__/schema-auth-8c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_schema_auth_6b_schema_auth_5d_global_sandbox_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6b.test.ts|src/__tests__/schema-auth-5d.test.ts|src/__tests__/global_sandbox-b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_geo_import_2_geo_import_1a_function_9c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/geo-import-2.test.ts|src/__tests__/geo-import-1a.test.ts|src/__tests__/function_9c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_1
     - identifier: l_function_10_function_permissions_env_5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_10.test.ts|src/__tests__/function-permissions.test.ts|src/__tests__/env-5.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_custom_resources_auth_9
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/custom_resources.test.ts|src/__tests__/auth_9.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_5b_schema_auth_8a_schema_auth_7c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_5b.test.ts|src/__tests__/schema-auth-8a.test.ts|src/__tests__/schema-auth-7c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_6d_schema_auth_6c_schema_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-6d.test.ts|src/__tests__/schema-auth-6c.test.ts|src/__tests__/schema-auth-2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_11_c_notifications_analytics_compatibility_in_app_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-c.test.ts|src/__tests__/notifications-analytics-compatibility-in-app-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_init_e_global_sandbox_a_geo_import_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init_e.test.ts|src/__tests__/global_sandbox-a.test.ts|src/__tests__/geo-import-1b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_feature_flags_auth_8c_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/feature-flags.test.ts|src/__tests__/auth_8c.test.ts|src/__tests__/auth_7a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_4a_auth_3b_auth_3a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_4a.test.ts|src/__tests__/auth_3b.test.ts|src/__tests__/auth_3a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_migration_storage_3_schema_auth_9_c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts|src/__tests__/schema-auth-9-c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_9_a_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-9-a.test.ts|src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_1a_geo_headless_function_9a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts|src/__tests__/function_9a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_export_pull_a_api_7
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/export-pull-a.test.ts|src/__tests__/api_7.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_api_10_api_key_migration5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_10.test.ts|src/__tests__/migration/api.key.migration5.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_rollback_1_schema_auth_9_b_schema_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-rollback-1.test.ts|src/__tests__/schema-auth-9-b.test.ts|src/__tests__/schema-auth-7b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_7a_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-7a.test.ts|src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_auth_11_b_predictions_layer_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts|src/__tests__/layer-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_hosting_geo_import_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/hosting.test.ts|src/__tests__/geo-import-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_geo_add_d_geo_add_c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/geo-add-d.test.ts|src/__tests__/geo-add-c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_delete_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/delete.test.ts|src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_predictions_migration_api_key_migration3_api_connection_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts|src/__tests__/migration/api.connection.migration.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_init_special_case_function_3a_python_function_3a_nodejs
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-special-case.test.ts|src/__tests__/function_3a_python.test.ts|src/__tests__/function_3a_nodejs.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_3a_go_function_3a_dotnet_export_pull_b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_3a_go.test.ts|src/__tests__/function_3a_dotnet.test.ts|src/__tests__/export-pull-b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_7b_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_7b.test.ts|src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_function_2_schema_auth_3_schema_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts|src/__tests__/schema-auth-12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_schema_iterative_update_3_schema_iterative_rollback_2_schema_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-3.test.ts|src/__tests__/schema-iterative-rollback-2.test.ts|src/__tests__/schema-auth-5a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_export_pull_d_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/export-pull-d.test.ts|src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_auth_migration_push_pull_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts|src/__tests__/pull-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_pr_previews_multi_env_1_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pr-previews-multi-env-1.test.ts|src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_notifications_sms_update_notifications_multi_env_minify_cloudformation
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts|src/__tests__/minify-cloudformation.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_init_force_push_hooks_c_help
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/init-force-push.test.ts|src/__tests__/hooks-c.test.ts|src/__tests__/help.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_2
     - identifier: l_function_2d_function_15_function_14
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_2d.test.ts|src/__tests__/function_15.test.ts|src/__tests__/function_14.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_function_13_function_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_13.test.ts|src/__tests__/function_12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_export_pull_c_custom_resource_with_storage
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -581,189 +741,189 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-c.test.ts|src/__tests__/custom-resource-with-storage.test.ts
           CLI_REGION: us-west-2
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_build_function_build_function_yarn_modern_auth_5g
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts|src/__tests__/auth_5g.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_auth_2h_auth_2g_auth_12
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_2h.test.ts|src/__tests__/auth_2g.test.ts|src/__tests__/auth_12.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_2b_api_2a_amplify_remove
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts|src/__tests__/amplify-remove.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_S3server_smoketest_smoketest_ios
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/storage-simulator/S3server.test.ts|src/__tests__/smoke-tests/smoketest.test.ts|src/__tests__/smoke-tests/smoketest-ios.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_javascript_notifications_pinpoint_config_javascript_analytics_pinpoint_config_ios_notifications_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/javascript-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/javascript-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/ios-notifications-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_ios_analytics_pinpoint_config_flutter_notifications_pinpoint_config_flutter_analytics_pinpoint_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/ios-analytics-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/flutter-analytics-pinpoint-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_android_notifications_pinpoint_config_android_analytics_pinpoint_config_opensearch_simulator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/pinpoint/android-notifications-pinpoint-config.test.ts|src/__tests__/pinpoint/android-analytics-pinpoint-config.test.ts|src/__tests__/opensearch-simulator/opensearch-simulator.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_general_config_headless_init_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/general-config/general-config-headless-init.test.ts|src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_user_groups_s3_access_hosted_ui_admin_api
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts|src/__tests__/auth/admin-api.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_iterative_update_locking_function_8_api_8
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-locking.test.ts|src/__tests__/function_8.test.ts|src/__tests__/api_8.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_auth_13_layer_2_api_lambda_auth_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-auth-13.test.ts|src/__tests__/layer-2.test.ts|src/__tests__/graphql-v2/api_lambda_auth_2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_iterative_update_1_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-1.test.ts|src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_auth_6_storage_1b_storage_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts|src/__tests__/storage-1a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_iterative_update_2_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-2.test.ts|src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_9b_function_7_function_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_7.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_function_11_api_connection_migration2_storage_4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts|src/__tests__/storage-4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_containers_api_secrets_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/containers-api-secrets.test.ts|src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_key_resolvers_geo_multi_env
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts|src/__tests__/geo-multi-env.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_searchable_datastore_schema_searchable
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/searchable-datastore.test.ts|src/__tests__/schema-searchable.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_apigw_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/apigw.test.ts|src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_lambda_auth_1_schema_auth_14_api_key_migration1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts|src/__tests__/migration/api.key.migration1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_6b_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_6b.test.ts|src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
         variables:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_storage_5
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -771,7 +931,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/storage-5.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_3
     - identifier: l_datastore_modelgen
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -780,7 +940,7 @@ batch:
           TEST_SUITE: src/__tests__/datastore-modelgen.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -789,7 +949,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_uibuilder
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -797,7 +957,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/uibuilder.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -805,7 +965,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -813,7 +973,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_remove_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -821,7 +981,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_add_f
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -829,7 +989,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-f.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_add_e
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -837,7 +997,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-add-e.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_dynamodb_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -845,7 +1005,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_env_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -853,7 +1013,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -861,7 +1021,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_remove_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -869,7 +1029,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_auth_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -877,7 +1037,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_auth_1a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -885,7 +1045,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_s3_2c
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -893,7 +1053,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2c.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_s3_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -901,7 +1061,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -909,7 +1069,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -917,7 +1077,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -925,7 +1085,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_1b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -933,7 +1093,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_update_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -941,7 +1101,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_geo_update_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -949,7 +1109,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-update-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_import_dynamodb_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -957,7 +1117,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_smoketest_amplify_app
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -966,7 +1126,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-amplify-app.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_store_locator
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -975,7 +1135,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-store-locator.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_project_boards
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -984,7 +1144,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-project-boards.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_product_catalog
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -993,7 +1153,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-product-catalog.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_mood_board
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1002,7 +1162,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-mood-board.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_media_vault
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1011,7 +1171,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-media-vault.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_fitness_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1020,7 +1180,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-fitness-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_4
     - identifier: l_gen2_migration_finance_tracker
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1029,7 +1189,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-finance-tracker.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_gen2_migration_discussions
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1038,7 +1198,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-discussions.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_gen2_migration_backend_only
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1047,7 +1207,7 @@ batch:
           TEST_SUITE: src/__tests__/gen2-migration/gen2-migration-backend-only.test.ts
           DISABLE_COVERAGE: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1055,7 +1215,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1063,7 +1223,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_import_s3_2b
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1071,7 +1231,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_s3_2b.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1079,7 +1239,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1087,7 +1247,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1095,7 +1255,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_import_auth_3
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1103,7 +1263,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_auth_3.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_import_dynamodb_2a
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1111,7 +1271,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/import_dynamodb_2a.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1119,7 +1279,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1128,7 +1288,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1137,7 +1297,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/searchable-migration.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1145,7 +1305,7 @@ batch:
           compute-type: BUILD_GENERAL1_SMALL
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: l_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_linux.yml
       env:
@@ -1154,7 +1314,7 @@ batch:
           TEST_SUITE: src/__tests__/import_dynamodb_1.test.ts
           USE_PARENT_ACCOUNT: 1
       depend-on:
-        - upb
+        - l_wave_barrier_5
     - identifier: w_notifications_lifecycle_auth_2f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1164,7 +1324,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-lifecycle.test.ts|src/__tests__/auth_2f.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_auth_2d_auth_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1174,7 +1334,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2d.test.ts|src/__tests__/auth_2b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_auth_2a_analytics_pinpoint_js
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1184,7 +1344,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2a.test.ts|src/__tests__/analytics-pinpoint-js.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_analytics_pinpoint_flutter_analytics_kinesis
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1194,7 +1354,7 @@ batch:
           TEST_SUITE: src/__tests__/analytics-pinpoint-flutter.test.ts|src/__tests__/analytics-kinesis.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_notifications_analytics_compatibility_sms_2_notifications_analytics_compatibility_in_app_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1204,7 +1364,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-2.test.ts|src/__tests__/notifications-analytics-compatibility-in-app-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_studio_modelgen_plugin
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1214,7 +1374,7 @@ batch:
           TEST_SUITE: src/__tests__/studio-modelgen.test.ts|src/__tests__/plugin.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_notifications_analytics_compatibility_sms_1_hooks_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1224,7 +1384,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-sms-1.test.ts|src/__tests__/hooks-b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_global_sandbox_c_analytics_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1234,7 +1394,7 @@ batch:
           TEST_SUITE: src/__tests__/global_sandbox-c.test.ts|src/__tests__/analytics-2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_notifications_sms_pull_notifications_in_app_messaging_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1244,7 +1404,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-sms-pull.test.ts|src/__tests__/notifications-in-app-messaging-env-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_custom_transformers_with_babel_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1254,7 +1414,7 @@ batch:
           TEST_SUITE: src/__tests__/graphql-v2/custom-transformers.test.ts|src/__tests__/with-babel-config.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_notifications_in_app_messaging_env_2_notifications_fcm
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1264,7 +1424,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging-env-2.test.ts|src/__tests__/notifications-fcm.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_notifications_apns_init_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1274,7 +1434,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-apns.test.ts|src/__tests__/init_b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_container_hosting_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1284,7 +1444,7 @@ batch:
           TEST_SUITE: src/__tests__/container-hosting.test.ts|src/__tests__/auth_10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_init_f_init_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1294,7 +1454,7 @@ batch:
           TEST_SUITE: src/__tests__/init_f.test.ts|src/__tests__/init_d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_amplify_configure_layer_4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1304,7 +1464,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-configure.test.ts|src/__tests__/layer-4.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_init_c_configure_project
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1314,7 +1474,7 @@ batch:
           TEST_SUITE: src/__tests__/init_c.test.ts|src/__tests__/configure-project.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_auth_5d_tags
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1324,7 +1484,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_5d.test.ts|src/__tests__/tags.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_schema_model_a_function_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1334,7 +1494,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-model-a.test.ts|src/__tests__/function_2c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_storage_2_custom_policies_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1344,7 +1504,7 @@ batch:
           TEST_SUITE: src/__tests__/storage-2.test.ts|src/__tests__/custom_policies_function.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_auth_1a_auth_trigger
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1354,7 +1514,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_1a.test.ts|src/__tests__/auth-trigger.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_1
     - identifier: w_schema_versioned_schema_model_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1364,7 +1524,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-versioned.test.ts|src/__tests__/schema-model-e.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_4b_notifications_sms
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1374,7 +1534,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-4b.test.ts|src/__tests__/notifications-sms.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_iam_permissions_boundary_node_function
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1384,7 +1544,7 @@ batch:
           TEST_SUITE: src/__tests__/iam-permissions-boundary.test.ts|src/__tests__/migration/node.function.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_model_d_schema_model_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1394,7 +1554,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-model-d.test.ts|src/__tests__/schema-model-b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_4a_s3_sse
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1404,7 +1564,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-4a.test.ts|src/__tests__/s3-sse.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_add_b_auth_8b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1414,7 +1574,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-add-b.test.ts|src/__tests__/auth_8b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_5e_auth_1c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1424,7 +1584,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_5e.test.ts|src/__tests__/auth_1c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_predictions_schema_model_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1434,7 +1594,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-predictions.test.ts|src/__tests__/schema-model-c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_data_access_patterns_schema_auth_6a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1444,7 +1604,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-data-access-patterns.test.ts|src/__tests__/schema-auth-6a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_4d_frontend_config_drift
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1454,7 +1614,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-4d.test.ts|src/__tests__/frontend_config_drift.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_env_4_auth_5f
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1464,7 +1624,7 @@ batch:
           TEST_SUITE: src/__tests__/env-4.test.ts|src/__tests__/auth_5f.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_model_migration_schema_auth_5c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1474,7 +1634,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/model-migration.test.ts|src/__tests__/schema-auth-5c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_4c_init_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1484,7 +1644,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-4c.test.ts|src/__tests__/init_a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_add_a_env_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1494,7 +1654,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-add-a.test.ts|src/__tests__/env-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_5c_auth_5a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1504,7 +1664,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_5c.test.ts|src/__tests__/auth_5a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_auth_4c_auth_3c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1514,7 +1674,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_4c.test.ts|src/__tests__/auth_3c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_8c_schema_auth_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1524,7 +1684,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-8c.test.ts|src/__tests__/schema-auth-6b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_schema_auth_5d_global_sandbox_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1534,7 +1694,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-5d.test.ts|src/__tests__/global_sandbox-b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_geo_import_2_geo_import_1a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1544,7 +1704,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-import-2.test.ts|src/__tests__/geo-import-1a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_9c_function_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1554,7 +1714,7 @@ batch:
           TEST_SUITE: src/__tests__/function_9c.test.ts|src/__tests__/function_10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_2
     - identifier: w_function_permissions_env_5
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1564,7 +1724,7 @@ batch:
           TEST_SUITE: src/__tests__/function-permissions.test.ts|src/__tests__/env-5.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_auth_9_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1574,7 +1734,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_9.test.ts|src/__tests__/auth_5b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_8a_schema_auth_7c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1584,7 +1744,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-8a.test.ts|src/__tests__/schema-auth-7c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_6d_schema_auth_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1594,7 +1754,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-6d.test.ts|src/__tests__/schema-auth-6c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_2b_schema_auth_11_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1604,7 +1764,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-2b.test.ts|src/__tests__/schema-auth-11-c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_notifications_analytics_compatibility_in_app_2_init_e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1614,7 +1774,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-analytics-compatibility-in-app-2.test.ts|src/__tests__/init_e.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_global_sandbox_a_geo_import_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1624,7 +1784,7 @@ batch:
           TEST_SUITE: src/__tests__/global_sandbox-a.test.ts|src/__tests__/geo-import-1b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_feature_flags_auth_8c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1634,7 +1794,7 @@ batch:
           TEST_SUITE: src/__tests__/feature-flags.test.ts|src/__tests__/auth_8c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_auth_7a_auth_4a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1644,7 +1804,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_7a.test.ts|src/__tests__/auth_4a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_auth_3b_auth_3a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1654,7 +1814,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_3b.test.ts|src/__tests__/auth_3a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_function_migration_storage_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1664,7 +1824,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/function-migration.test.ts|src/__tests__/storage-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_9_c_schema_auth_9_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1674,7 +1834,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-9-c.test.ts|src/__tests__/schema-auth-9-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_8b_schema_auth_5b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1684,7 +1844,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-8b.test.ts|src/__tests__/schema-auth-5b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_1a_geo_headless
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1694,7 +1854,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-1a.test.ts|src/__tests__/geo-headless.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_function_9a_export_pull_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1704,7 +1864,7 @@ batch:
           TEST_SUITE: src/__tests__/function_9a.test.ts|src/__tests__/export-pull-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_7_api_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1714,7 +1874,7 @@ batch:
           TEST_SUITE: src/__tests__/api_7.test.ts|src/__tests__/api_10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_api_key_migration5_schema_auth_9_b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1724,7 +1884,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.key.migration5.test.ts|src/__tests__/schema-auth-9-b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_7b_schema_auth_7a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1734,7 +1894,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-7b.test.ts|src/__tests__/schema-auth-7a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_2a_schema_auth_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1744,7 +1904,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-2a.test.ts|src/__tests__/schema-auth-1b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_schema_auth_11_b_predictions
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1754,7 +1914,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-11-b.test.ts|src/__tests__/predictions.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_3
     - identifier: w_layer_3_hosting
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1764,7 +1924,7 @@ batch:
           TEST_SUITE: src/__tests__/layer-3.test.ts|src/__tests__/hosting.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_geo_import_3_geo_add_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1774,7 +1934,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-import-3.test.ts|src/__tests__/geo-add-d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_geo_add_c_delete
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1784,7 +1944,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-add-c.test.ts|src/__tests__/delete.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_auth_1b_auth_11
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1794,7 +1954,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_1b.test.ts|src/__tests__/auth_11.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_predictions_migration_api_key_migration3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1804,7 +1964,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/predictions-migration.test.ts|src/__tests__/migration/api.key.migration3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_api_connection_migration_init_special_case
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1814,7 +1974,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.connection.migration.test.ts|src/__tests__/init-special-case.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_export_pull_b_auth_7b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1824,7 +1984,7 @@ batch:
           TEST_SUITE: src/__tests__/export-pull-b.test.ts|src/__tests__/auth_7b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_api_6a_http_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1834,7 +1994,7 @@ batch:
           TEST_SUITE: src/__tests__/api_6a.test.ts|src/__tests__/transformer-migrations/http-migration.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_schema_function_2_schema_auth_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1844,7 +2004,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-function-2.test.ts|src/__tests__/schema-auth-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_schema_auth_12_schema_iterative_update_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1854,7 +2014,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-12.test.ts|src/__tests__/schema-iterative-update-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_schema_auth_5a_export_pull_d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1864,7 +2024,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-5a.test.ts|src/__tests__/export-pull-d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_auth_8a_auth_4b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1874,7 +2034,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_8a.test.ts|src/__tests__/auth_4b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_auth_migration_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1884,7 +2044,7 @@ batch:
           TEST_SUITE: src/__tests__/transformer-migrations/auth-migration.test.ts|src/__tests__/push.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_parameter_store_2_parameter_store_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1894,7 +2054,7 @@ batch:
           TEST_SUITE: src/__tests__/parameter-store-2.test.ts|src/__tests__/parameter-store-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_notifications_sms_update_notifications_multi_env
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1904,7 +2064,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-sms-update.test.ts|src/__tests__/notifications-multi-env.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_minify_cloudformation_init_force_push
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1914,7 +2074,7 @@ batch:
           TEST_SUITE: src/__tests__/minify-cloudformation.test.ts|src/__tests__/init-force-push.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_help_function_2d
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1924,7 +2084,7 @@ batch:
           TEST_SUITE: src/__tests__/help.test.ts|src/__tests__/function_2d.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_function_14_function_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1934,7 +2094,7 @@ batch:
           TEST_SUITE: src/__tests__/function_14.test.ts|src/__tests__/function_13.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_function_12_export_pull_c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1944,7 +2104,7 @@ batch:
           TEST_SUITE: src/__tests__/function_12.test.ts|src/__tests__/export-pull-c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_build_function_build_function_yarn_modern
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1954,7 +2114,7 @@ batch:
           TEST_SUITE: src/__tests__/build-function.test.ts|src/__tests__/build-function-yarn-modern.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_4
     - identifier: w_auth_5g_auth_2h
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1964,7 +2124,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_5g.test.ts|src/__tests__/auth_2h.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_9a_api_6c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1974,7 +2134,7 @@ batch:
           TEST_SUITE: src/__tests__/api_9a.test.ts|src/__tests__/api_6c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_2b_api_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1984,7 +2144,7 @@ batch:
           TEST_SUITE: src/__tests__/api_2b.test.ts|src/__tests__/api_2a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_amplify_remove_smoketest
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -1994,7 +2154,7 @@ batch:
           TEST_SUITE: src/__tests__/amplify-remove.test.ts|src/__tests__/smoke-tests/smoketest.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_smoketest_ios_general_config_headless_init
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2004,7 +2164,7 @@ batch:
           TEST_SUITE: src/__tests__/smoke-tests/smoketest-ios.test.ts|src/__tests__/general-config/general-config-headless-init.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_dynamodb_simulator_user_groups
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2014,7 +2174,7 @@ batch:
           TEST_SUITE: src/__tests__/dynamodb-simulator/dynamodb-simulator.test.ts|src/__tests__/auth/user-groups.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_user_groups_s3_access_hosted_ui
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2024,7 +2184,7 @@ batch:
           TEST_SUITE: src/__tests__/auth/user-groups-s3-access.test.ts|src/__tests__/auth/hosted-ui.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_admin_api_schema_iterative_update_locking
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2034,7 +2194,7 @@ batch:
           TEST_SUITE: src/__tests__/auth/admin-api.test.ts|src/__tests__/schema-iterative-update-locking.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_8_schema_auth_13
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2044,7 +2204,7 @@ batch:
           TEST_SUITE: src/__tests__/api_8.test.ts|src/__tests__/schema-auth-13.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_lambda_auth_2_schema_iterative_update_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2054,7 +2214,7 @@ batch:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_2.test.ts|src/__tests__/schema-iterative-update-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_function_5_schema_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2064,7 +2224,7 @@ batch:
           TEST_SUITE: src/__tests__/function_5.test.ts|src/__tests__/schema-function-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_schema_connection_2_function_2a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2074,7 +2234,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-connection-2.test.ts|src/__tests__/function_2a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_auth_6_storage_1b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2084,7 +2244,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_6.test.ts|src/__tests__/storage-1b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_storage_1a_schema_iterative_update_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2094,7 +2254,7 @@ batch:
           TEST_SUITE: src/__tests__/storage-1a.test.ts|src/__tests__/schema-iterative-update-2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_function_9b_custom_policies_container
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2104,7 +2264,7 @@ batch:
           TEST_SUITE: src/__tests__/function_9b.test.ts|src/__tests__/custom_policies_container.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_9b_function_2b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2114,7 +2274,7 @@ batch:
           TEST_SUITE: src/__tests__/api_9b.test.ts|src/__tests__/function_2b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_function_11_api_connection_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2124,7 +2284,7 @@ batch:
           TEST_SUITE: src/__tests__/function_11.test.ts|src/__tests__/migration/api.connection.migration2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_storage_4_containers_api_secrets
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2134,7 +2294,7 @@ batch:
           TEST_SUITE: src/__tests__/storage-4.test.ts|src/__tests__/containers-api-secrets.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_api_4_schema_auth_10
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2144,7 +2304,7 @@ batch:
           TEST_SUITE: src/__tests__/api_4.test.ts|src/__tests__/schema-auth-10.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_schema_key_resolvers
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2154,7 +2314,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-key.test.ts|src/__tests__/resolvers.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_5
     - identifier: w_geo_multi_env_searchable_datastore
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2164,7 +2324,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-multi-env.test.ts|src/__tests__/graphql-v2/searchable-datastore.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_schema_searchable_apigw
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2174,7 +2334,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-searchable.test.ts|src/__tests__/apigw.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_api_5_api_key_migration2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2184,7 +2344,7 @@ batch:
           TEST_SUITE: src/__tests__/api_5.test.ts|src/__tests__/migration/api.key.migration2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_api_lambda_auth_1_schema_auth_14
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2194,7 +2354,7 @@ batch:
           TEST_SUITE: src/__tests__/graphql-v2/api_lambda_auth_1.test.ts|src/__tests__/schema-auth-14.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_api_key_migration1_api_6b
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2204,7 +2364,7 @@ batch:
           TEST_SUITE: src/__tests__/migration/api.key.migration1.test.ts|src/__tests__/api_6b.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_api_3_layer_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2214,7 +2374,7 @@ batch:
           TEST_SUITE: src/__tests__/api_3.test.ts|src/__tests__/layer-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_api_1_api_key_migration4
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2224,7 +2384,7 @@ batch:
           TEST_SUITE: src/__tests__/api_1.test.ts|src/__tests__/migration/api.key.migration4.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_schema_iterative_update_4_function_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2234,7 +2394,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-iterative-update-4.test.ts|src/__tests__/function_1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_auth_2e
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2244,7 +2404,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2e.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_auth_2c
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2254,7 +2414,7 @@ batch:
           TEST_SUITE: src/__tests__/auth_2c.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_env_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2264,7 +2424,7 @@ batch:
           TEST_SUITE: src/__tests__/env-3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_notifications_in_app_messaging
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2274,7 +2434,7 @@ batch:
           TEST_SUITE: src/__tests__/notifications-in-app-messaging.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_schema_auth_11_a
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2284,7 +2444,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-11-a.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_import_s3_3
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2294,7 +2454,7 @@ batch:
           TEST_SUITE: src/__tests__/import_s3_3.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_js_frontend_config
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2304,7 +2464,7 @@ batch:
           TEST_SUITE: src/__tests__/aws-exports/js-frontend-config.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_hostingPROD
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2314,7 +2474,7 @@ batch:
           TEST_SUITE: src/__tests__/hostingPROD.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_schema_connection_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2324,7 +2484,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-connection-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_schema_auth_15
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2334,7 +2494,7 @@ batch:
           TEST_SUITE: src/__tests__/schema-auth-15.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_containers_api_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2344,7 +2504,7 @@ batch:
           TEST_SUITE: src/__tests__/containers-api-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_containers_api_2
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2354,7 +2514,7 @@ batch:
           TEST_SUITE: src/__tests__/containers-api-2.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_6
     - identifier: w_import_s3_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2365,7 +2525,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_7
     - identifier: w_searchable_migration
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2376,7 +2536,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_7
     - identifier: w_geo_remove_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2386,7 +2546,7 @@ batch:
           TEST_SUITE: src/__tests__/geo-remove-1.test.ts
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_7
     - identifier: w_import_dynamodb_1
       buildspec: codebuild_specs/run_e2e_tests_windows.yml
       env:
@@ -2397,7 +2557,7 @@ batch:
           USE_PARENT_ACCOUNT: 1
       depend-on:
         - build_windows
-        - upb
+        - w_wave_barrier_7
     - identifier: aggregate_e2e_reports
       env:
         compute-type: BUILD_GENERAL1_MEDIUM

--- a/scripts/split-e2e-tests-codebuild.ts
+++ b/scripts/split-e2e-tests-codebuild.ts
@@ -6,6 +6,29 @@ import { REPO_ROOT } from './cci-utils';
 import { FORCE_REGION_MAP, getOldJobNameWithoutSuffixes, loadTestTimings, USE_PARENT_ACCOUNT } from './cci-utils';
 const CODEBUILD_CONFIG_BASE_PATH = join(REPO_ROOT, 'codebuild_specs', 'e2e_workflow_base.yml');
 const CODEBUILD_GENERATE_CONFIG_PATH = join(REPO_ROOT, 'codebuild_specs', 'e2e_workflow_generated');
+
+/**
+ * Time-barrier wave staggering tunables for the e2e CodeBuild batch (v2, refined).
+ *
+ * The orchestrator that fans the batch out cannot schedule the full ~250-shard
+ * burst at once (it fails with a CoFaWorkflows "Internal Service Error"). To
+ * spread dispatch over time WITHOUT serializing wave completion, shards are
+ * grouped into per-OS waves and EVERY wave — including wave 1 — is gated behind
+ * a synthetic "barrier" build whose only job is to sleep. Nothing fans out
+ * immediately: even wave 1 waits one interval. All barriers depend solely on
+ * `upb` (Linux) / `build_windows`+`upb` (Windows), so they all start in parallel
+ * right after the package upload — the stagger comes purely from their differing
+ * sleep durations (`k * interval`), NOT from chaining one wave to the next.
+ *
+ * This is a more aggressive variant of v1: separate (smaller) wave sizes per OS
+ * and no immediate fan-out, to further flatten the per-scheduling-decision burst.
+ */
+// Number of Linux (`l_`) shards per wave. Smaller => more, smaller dispatch bursts.
+const E2E_WAVE_SIZE_LINUX = 30;
+// Number of Windows (`w_`) shards per wave.
+const E2E_WAVE_SIZE_WINDOWS = 20;
+// Seconds added per wave to the barrier sleep. Wave k sleeps k * interval (wave 1 = 1 interval).
+const E2E_WAVE_BARRIER_INTERVAL_SEC = 300;
 const RUN_SOLO = [
   'src/__tests__/auth_2c.test.ts',
   'src/__tests__/auth_2e.test.ts',
@@ -352,6 +375,77 @@ const splitTestsV3 = (
   });
   return result;
 };
+/**
+ * Builds a synthetic barrier build group whose only job is to sleep, gating a
+ * wave of Linux e2e shards. Depends only on `upb` so it starts in parallel with
+ * every other barrier; the stagger comes from the sleep duration alone. Uses the
+ * smallest compute type since it does nothing but wait.
+ */
+function makeLinuxBarrier(identifier: string, wave: number): any {
+  const sleepSeconds = wave * E2E_WAVE_BARRIER_INTERVAL_SEC;
+  return {
+    identifier,
+    buildspec: `version: 0.2\nphases:\n  build:\n    commands:\n      - sleep ${sleepSeconds}\n`,
+    env: { 'compute-type': 'BUILD_GENERAL1_SMALL' },
+    'depend-on': ['upb'],
+  };
+}
+
+/**
+ * Builds a synthetic barrier build group gating a wave of Windows e2e shards.
+ * Mirrors {@link makeLinuxBarrier} but runs on the Windows container the `w_`
+ * shards use and sleeps via PowerShell. Depends only on `build_windows`/`upb`.
+ * Inherits the default Windows compute type (SMALL is invalid for Windows).
+ */
+function makeWindowsBarrier(identifier: string, wave: number): any {
+  const sleepSeconds = wave * E2E_WAVE_BARRIER_INTERVAL_SEC;
+  return {
+    identifier,
+    buildspec: `version: 0.2\nenv:\n  shell: powershell.exe\nphases:\n  build:\n    commands:\n      - Start-Sleep -Seconds ${sleepSeconds}\n`,
+    env: { type: 'WINDOWS_SERVER_2022_CONTAINER', image: '$WINDOWS_IMAGE_2019' },
+    'depend-on': ['build_windows', 'upb'],
+  };
+}
+
+/**
+ * Applies time-barrier wave staggering to the generated e2e shards in place (v2).
+ *
+ * Splits the `l_`/`w_` shards into per-OS waves ({@link E2E_WAVE_SIZE_LINUX} /
+ * {@link E2E_WAVE_SIZE_WINDOWS}). EVERY wave — including wave 1 — is rewired to
+ * depend ONLY on a synthetic barrier build, so no shard fans out immediately and
+ * no shard depends directly on `upb`/`build_windows` anymore. Each barrier sleeps
+ * `k * interval` seconds and depends only on `upb`/`build_windows` — never on
+ * another barrier or a prior wave — so dispatch is spread over time without
+ * serializing completion.
+ *
+ * Mutates the `depend-on` of each shard and returns the new barrier build groups.
+ */
+function applyWaveStaggering(shards: any[]): any[] {
+  const barriers: any[] = [];
+
+  const stagger = (
+    osPrefix: 'l' | 'w',
+    waveSize: number,
+    keptDeps: string[],
+    makeBarrier: (identifier: string, wave: number) => any,
+  ): void => {
+    const osShards = shards.filter((shard) => shard.identifier.startsWith(`${osPrefix}_`));
+    osShards.forEach((shard, index) => {
+      const wave = Math.floor(index / waveSize) + 1;
+      const barrierId = `${osPrefix}_wave_barrier_${wave}`;
+      if (!barriers.some((barrier) => barrier.identifier === barrierId)) {
+        barriers.push(makeBarrier(barrierId, wave));
+      }
+      shard['depend-on'] = [...keptDeps, barrierId];
+    });
+  };
+
+  stagger('l', E2E_WAVE_SIZE_LINUX, [], makeLinuxBarrier);
+  stagger('w', E2E_WAVE_SIZE_WINDOWS, ['build_windows'], makeWindowsBarrier);
+
+  return barriers;
+}
+
 function main(): void {
   const configBase: any = loadConfigBase();
   const baseBuildGraph = configBase.batch['build-graph'];
@@ -377,10 +471,15 @@ function main(): void {
   );
 
   let allBuilds = [...splitE2ETests];
+  // Report wait list is the shard identifiers only — barriers are synthetic and
+  // must NOT be polled by aggregate_e2e_reports, so compute this before staggering.
   const dependeeIdentifiers: string[] = allBuilds.map((buildObject) => buildObject.identifier).sort();
   const dependeeIdentifiersFileContents = `${JSON.stringify(dependeeIdentifiers, null, 2)}\n`;
   const waitForIdsFilePath = './codebuild_specs/wait_for_ids.json';
   fs.writeFileSync(waitForIdsFilePath, dependeeIdentifiersFileContents);
+  // Stagger shard dispatch with time barriers (mutates shard depend-on in place).
+  const waveBarriers = applyWaveStaggering(splitE2ETests);
+  allBuilds = [...waveBarriers, ...allBuilds];
   const reportsAggregator = {
     identifier: 'aggregate_e2e_reports',
     env: {


### PR DESCRIPTION
#### Description of changes

**Parallel experiment** that is a more aggressive refinement of the time-barrier wave
staggering approach (sibling to `feat/e2e-barrier-wave-staggering`), run on its own
branch/cache so the two experiments don't share a prep cache.

#### Refined wave-staggering design

The e2e CodeBuild batch fans out a large number of shards that previously all depended
directly on `upb` (Linux) or `build_windows`/`upb` (Windows). Dispatching that many
builds as a single instantaneous burst is unreliable, so this change spreads dispatch
over time.

This change spreads dispatch over time using **time barriers** rather than completion
chaining, with two refinements over the first variant:

- **Every wave is gated — including wave 1.** No shard fans out immediately; even the
  first wave waits one interval. No shard depends directly on `upb`/`build_windows`
  anymore.
- **Per-platform wave sizes.** Linux shards are grouped into waves of 30 (5 waves);
  Windows shards into waves of 20 (7 waves).

Each wave `k` is gated by a synthetic barrier build (`l_wave_barrier_k` /
`w_wave_barrier_k`) whose only command sleeps `k * 300` seconds (5m, 10m, 15m, ...).
Every shard depends ONLY on its barrier. All barriers depend solely on `upb` (Linux) /
`build_windows`+`upb` (Windows) — never on another barrier or a prior wave — so they
start in parallel and the stagger comes purely from the differing sleep durations, with
no serial completion chaining that would risk the 240m batch timeout.

Linux barriers run on `BUILD_GENERAL1_SMALL`; Windows barriers inherit the default
Windows container (`SMALL` is invalid for Windows). Barriers are excluded from
`wait_for_ids.json` since they are synthetic and must not be polled by
`aggregate_e2e_reports`; the wait list is computed before the barriers are injected.

Wave sizes and the interval are tunable named constants at the top of the generator.

#### Issue #, if available

N/A — infra experiment.

#### Description of how you validated changes

Regenerated `codebuild_specs/e2e_workflow_generated.yml` and verified via a YAML parse:

- 12 barriers total (5 Linux, 7 Windows)
- Per-wave shard counts: Linux 30/30/30/30/16, Windows 20×6 + 4
- Wave-1 shards gated by their barrier; **0** shards depend directly on `upb`/`build_windows`
- **0** shard-to-shard dependencies
- **0** barrier-to-barrier dependencies
- Barrier sleeps follow `k * 300s` (wave 1 = 300s ... Linux wave 5 = 1500s)
- `wait_for_ids.json` contains no barrier identifiers
- YAML parses cleanly

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
