### PR TITLE
fix(amplify-category-function): remove jstreemap dependency

### DIFF
--- a/packages/amplify-category-function/package.json
+++ b/packages/amplify-category-function/package.json
@@ -41,7 +41,6 @@
     "graphql-transformer-core": "^8.2.18",
     "inquirer": "^7.3.3",
     "inquirer-datepicker": "^2.0.0",
-    "jstreemap": "^1.28.2",
     "lodash": "^4.17.21",
     "promise-sequential": "^1.1.1",
     "uuid": "^8.3.2"

--- a/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cronExpression.ts
+++ b/packages/amplify-category-function/src/provider-utils/awscloudformation/utils/cronExpression.ts
@@ -2,7 +2,6 @@
 AWS Cron Expression generator
 */
 
-import { TreeSet } from 'jstreemap';
 const SECOND = 0;
 const MINUTE = 1;
 const HOUR = 2;
@@ -38,13 +37,13 @@ dayMap.set('SAT', 7);
 
 export class CronExpression {
   private cronExpression: string = null;
-  seconds = new TreeSet();
-  minutes = new TreeSet();
-  hours = new TreeSet();
-  daysOfMonth = new TreeSet();
-  months = new TreeSet();
-  daysOfWeek = new TreeSet();
-  years = new TreeSet();
+  seconds = new Set<number>();
+  minutes = new Set<number>();
+  hours = new Set<number>();
+  daysOfMonth = new Set<number>();
+  months = new Set<number>();
+  daysOfWeek = new Set<number>();
+  years = new Set<number>();
   lastDayOfWeek = false;
   numDayOfWeek = 0;
   lastDayOfMonth = false;
@@ -99,25 +98,25 @@ export class CronExpression {
     this.expressionParsed = true;
     try {
       if (this.seconds === null) {
-        this.seconds = new TreeSet();
+        this.seconds = new Set<number>();
       }
       if (this.minutes === null) {
-        this.minutes = new TreeSet();
+        this.minutes = new Set<number>();
       }
       if (this.hours === null) {
-        this.hours = new TreeSet();
+        this.hours = new Set<number>();
       }
       if (this.daysOfMonth === null) {
-        this.daysOfMonth = new TreeSet();
+        this.daysOfMonth = new Set<number>();
       }
       if (this.months === null) {
-        this.months = new TreeSet();
+        this.months = new Set<number>();
       }
       if (this.daysOfWeek === null) {
-        this.daysOfWeek = new TreeSet();
+        this.daysOfWeek = new Set<number>();
       }
       if (this.years === null) {
-        this.years = new TreeSet();
+        this.years = new Set<number>();
       }
 
       let exprOn = SECOND;
@@ -148,9 +147,9 @@ export class CronExpression {
       if (exprOn <= YEAR) {
         this.storeExpressionValues(0, '*', YEAR);
       }
-      const dow: TreeSet<number> = this.getSet(DAY_OF_WEEK);
+      const dow: Set<number> = this.getSet(DAY_OF_WEEK);
 
-      const dom: TreeSet<number> = this.getSet(DAY_OF_MONTH);
+      const dom: Set<number> = this.getSet(DAY_OF_MONTH);
 
       // Copying the logic from the UnsupportedOperationException below
       const dayOfMSpec = !dom.has(NO_SPEC_INT);
@@ -246,7 +245,7 @@ export class CronExpression {
         throw new Error("'?' can only be specified for Day-of-Month or Day-of-Week." + String(i));
       }
       if (type === DAY_OF_WEEK && !this.lastDayOfMonth) {
-        const val: number = this.daysOfMonth.last();
+        const val: number = Math.max(...this.daysOfMonth);
         if (val === NO_SPEC_INT) {
           throw new Error("'?' can only be specified for Day-of-Month -OR- Day-of-Week." + String(i));
         }
@@ -629,13 +628,13 @@ export class CronExpression {
     // reset internal state
     this.expressionParsed = false;
 
-    this.seconds = new TreeSet();
-    this.minutes = new TreeSet();
-    this.hours = new TreeSet();
-    this.daysOfMonth = new TreeSet();
-    this.months = new TreeSet();
-    this.daysOfWeek = new TreeSet();
-    this.years = new TreeSet();
+    this.seconds = new Set<number>();
+    this.minutes = new Set<number>();
+    this.hours = new Set<number>();
+    this.daysOfMonth = new Set<number>();
+    this.months = new Set<number>();
+    this.daysOfWeek = new Set<number>();
+    this.years = new Set<number>();
 
     this.lastDayOfWeek = false;
     this.numDayOfWeek = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,7 +276,6 @@ __metadata:
     inquirer: ^7.3.3
     inquirer-datepicker: ^2.0.0
     jest: ^29.7.0
-    jstreemap: ^1.28.2
     lodash: ^4.17.21
     promise-sequential: ^1.1.1
     uuid: ^8.3.2
@@ -26087,13 +26086,6 @@ __metadata:
     json-schema: 0.4.0
     verror: 1.10.0
   checksum: 5e4bca99e90727c2040eb4c2190d0ef1fe51798ed5714e87b841d304526190d960f9772acc7108fa1416b61e1122bcd60e4460c91793dce0835df5852aab55af
-  languageName: node
-  linkType: hard
-
-"jstreemap@npm:^1.28.2":
-  version: 1.28.2
-  resolution: "jstreemap@npm:1.28.2"
-  checksum: d7f55ff23c3bc1f54a7b92675fd785ab4f069052b25137b2d1d47a10722dd8f8442d1a710d0d3144322412e654e3f3f71f4326f7126d7287497d4cdbd94c9f80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description of changes

Removes the `jstreemap` dependency from `amplify-category-function` entirely.

jstreemap releases 1.29.1–1.29.3 shipped a broken UMD bundle that threw `ReferenceError: self is not defined` on Node, crashing `amplify-category-function` during `amplify init` and causing SEV-2s. PR #14922 mitigated this by pinning jstreemap to `1.28.2`, but the dependency — and therefore the risk vector — remained.

The package only used jstreemap's `TreeSet`, and only for membership checks and a single max-value lookup. These are trivially served by the native `Set`, so the dependency can be dropped outright rather than pinned, permanently eliminating the broken-bundle risk.

##### Replace TreeSet with native Set

In the cron expression generator, all `TreeSet` usage is migrated to `Set<number>`: the field initializers and reset paths now construct `new Set<number>()`, the `TreeSet<number>` type annotations become `Set<number>`, and the one sorted-order lookup (`daysOfMonth.last()`) becomes `Math.max(...this.daysOfMonth)`, which returns the same largest element. Membership checks (`.has()`) and insertions (`.add()`) are identical on both types, so behavior is unchanged.

##### Drop the dependency

The `jstreemap` entry is removed from the package manifest and `yarn.lock` is regenerated to drop all related entries.

#### Issue #, if available

N/A — follow-up to the mitigation in #14922.

#### Description of how you validated changes

- `tsc` type-checks cleanly with no errors.
- The cron expression test suite (`scheduleWalkthrough`) passes 7/7.
- Zero remaining `jstreemap` / `TreeSet` references across the package, and zero `jstreemap` entries in `yarn.lock`.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
