### PR TITLE
fix(cli-internal): guard confirmPrompt against node 24 readline crash

### DIFF
--- a/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/confirm-prompt.test.ts
+++ b/packages/amplify-cli/src/__tests__/extensions/amplify-helpers/confirm-prompt.test.ts
@@ -1,21 +1,95 @@
+import * as inquirer from 'inquirer';
 import { confirmPrompt } from '../../../extensions/amplify-helpers/confirm-prompt';
 
-jest.mock('inquirer', () => {
-  return {
-    prompt: (input) => {
-      return new Promise((resolve) => resolve({ yesno: input }));
-    },
-  };
-});
+jest.mock('inquirer', () => ({
+  prompt: jest.fn(),
+}));
+
+const promptMock = inquirer.prompt as unknown as jest.Mock;
+
+// Shape of the value inquirer.prompt() returns: a promise with the prompt UI
+// (which carries the captured answers) monkey-patched onto it.
+type PromptUiShape = { answers: Record<string, unknown> };
+const attachUi = (promise: Promise<unknown>, ui: PromptUiShape): Promise<unknown> => {
+  (promise as Promise<unknown> & { ui: PromptUiShape }).ui = ui;
+  return promise;
+};
+
+// Mirrors the error Node >=24 throws from readline.Interface#pause() once the
+// interface is closed (Node <=22 made the call a no-op).
+const nodeReadlineAfterCloseError = (): Error => {
+  const err = new Error('readline was closed') as NodeJS.ErrnoException;
+  err.code = 'ERR_USE_AFTER_CLOSE';
+  return err;
+};
 
 describe('confirmPrompt', () => {
-  it('returns an object', async () => {
-    const result = await confirmPrompt('test', true);
-    expect(result).toStrictEqual({
-      name: 'yesno',
-      message: 'test',
-      type: 'confirm',
-      default: true,
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('asks inquirer a confirm question and returns the answer', async () => {
+    promptMock.mockReturnValue(attachUi(Promise.resolve({ yesno: false }), { answers: { yesno: false } }));
+
+    await expect(confirmPrompt('Proceed?', true)).resolves.toBe(false);
+    expect(promptMock).toHaveBeenCalledWith({ name: 'yesno', message: 'Proceed?', type: 'confirm', default: true });
+  });
+
+  it('recovers a "yes" answer when inquirer teardown throws ERR_USE_AFTER_CLOSE on Node >=24', async () => {
+    // inquirer captures the answer on ui.answers, then baseUI.close() -> rl.pause()
+    // throws because stdin has already closed, rejecting the prompt promise.
+    const ui: PromptUiShape = { answers: {} };
+    const rejectsAfterCapturing = Promise.resolve().then(() => {
+      ui.answers.yesno = true;
+      throw nodeReadlineAfterCloseError();
     });
+    promptMock.mockReturnValue(attachUi(rejectsAfterCapturing, ui));
+
+    await expect(confirmPrompt('Edit now?', false)).resolves.toBe(true);
+  });
+
+  it('recovers a "no" answer when inquirer teardown throws ERR_USE_AFTER_CLOSE on Node >=24', async () => {
+    const ui: PromptUiShape = { answers: {} };
+    const rejectsAfterCapturing = Promise.resolve().then(() => {
+      ui.answers.yesno = false;
+      throw nodeReadlineAfterCloseError();
+    });
+    promptMock.mockReturnValue(attachUi(rejectsAfterCapturing, ui));
+
+    await expect(confirmPrompt('Edit now?', true)).resolves.toBe(false);
+  });
+
+  it('falls back to the default answer when the crash happens before any answer is captured', async () => {
+    const uiTrueDefault: PromptUiShape = { answers: {} };
+    promptMock.mockReturnValueOnce(
+      attachUi(
+        Promise.resolve().then(() => {
+          throw nodeReadlineAfterCloseError();
+        }),
+        uiTrueDefault,
+      ),
+    );
+    await expect(confirmPrompt('Edit now?', true)).resolves.toBe(true);
+
+    const uiFalseDefault: PromptUiShape = { answers: {} };
+    promptMock.mockReturnValueOnce(
+      attachUi(
+        Promise.resolve().then(() => {
+          throw nodeReadlineAfterCloseError();
+        }),
+        uiFalseDefault,
+      ),
+    );
+    await expect(confirmPrompt('Edit now?', false)).resolves.toBe(false);
+  });
+
+  it('rethrows errors that are not the Node readline-after-close crash', async () => {
+    const ui: PromptUiShape = { answers: {} };
+    const rejectsWithUnrelatedError = Promise.resolve().then(() => {
+      throw new Error('something else went wrong');
+    });
+    promptMock.mockReturnValue(attachUi(rejectsWithUnrelatedError, ui));
+
+    await expect(confirmPrompt('Proceed?')).rejects.toThrow('something else went wrong');
   });
 });

--- a/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.ts
+++ b/packages/amplify-cli/src/extensions/amplify-helpers/confirm-prompt.ts
@@ -1,14 +1,45 @@
 import * as inquirer from 'inquirer';
 
+// Node v24 made readline.Interface#pause() throw with this code when the
+// interface is already closed; Node <=22 treated the call as a no-op.
+const READLINE_USE_AFTER_CLOSE = 'ERR_USE_AFTER_CLOSE';
+
 /**
+ * Prompts the user with a yes/no question and resolves to their boolean answer.
+ *
+ * On Node >=24 inquirer@7's prompt teardown crashes the CLI: `baseUI.close()`
+ * calls `readline.Interface#pause()` unconditionally, and Node >=24 throws
+ * `ERR_USE_AFTER_CLOSE` from that call once stdin has closed (for example EOF on
+ * piped input) as the prompt finishes. The answer is captured on the prompt UI
+ * before teardown runs, so this helper recovers it and returns it, restoring the
+ * pre-Node-24 behavior where the teardown was a silent no-op for every caller.
+ *
+ * @param message - the question to display to the user
+ * @param defaultValue - the answer used when the user accepts the default
+ * @returns the user's boolean response
  * @deprecated Use confirmContinue from amplify-prompts instead
  */
-export async function confirmPrompt(message: string, defaultValue = true) {
-  const ans = await inquirer.prompt({
+export async function confirmPrompt(message: string, defaultValue = true): Promise<boolean> {
+  const promptPromise = inquirer.prompt({
     name: 'yesno',
     message,
     type: 'confirm',
     default: defaultValue,
   });
-  return ans.yesno;
+  try {
+    const ans = await promptPromise;
+    return ans.yesno;
+  } catch (err) {
+    if (!isReadlineUseAfterCloseError(err)) {
+      throw err;
+    }
+    // The crash happens during teardown, after the answer was captured on the
+    // prompt UI. Recover it so the caller sees the user's real choice; fall back
+    // to the default if the prompt closed before an answer was recorded.
+    const capturedAnswer = promptPromise.ui?.answers?.yesno;
+    return typeof capturedAnswer === 'boolean' ? capturedAnswer : defaultValue;
+  }
 }
+
+const isReadlineUseAfterCloseError = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && (err as { code?: unknown }).code === READLINE_USE_AFTER_CLOSE;


### PR DESCRIPTION
#### Description of changes

`amplify add function` crashes on Node 24 with the generic
`🛑 There was an error adding the function resource`. This restores the
pre-Node-24 behavior.

##### Root cause

Node 24 changed `readline.Interface#pause()` to **throw** `ERR_USE_AFTER_CLOSE`
when the interface is already closed; Node 22 and earlier treated the call as a
no-op. `inquirer@7`'s `baseUI.close()` calls `rl.pause()` unconditionally during
prompt teardown. So when stdin closes (EOF / piped input) just as a confirm
prompt finishes, the `pause()` call throws, the prompt promise rejects, and the
error bubbles up and aborts the command.

The user-visible crash path is `amplify-category-function`'s `openEditor()`,
which asks "Do you want to edit the local … file now?" through
`context.amplify.confirmPrompt(...)`. That routes to the legacy
`confirm-prompt.ts` helper, which is built on `inquirer@7` and therefore hits
the throw.

##### Fix

Guard the legacy `confirmPrompt` helper (the implementation behind
`context.amplify.confirmPrompt`) so an `ERR_USE_AFTER_CLOSE` raised during
teardown is caught. inquirer records the user's answer on the prompt UI
**before** teardown runs, so the helper recovers it from the prompt promise's
`ui.answers` and returns it — exactly what the caller would have received on
Node ≤22. If the prompt closed before any answer was recorded, it falls back to
the supplied default. Any other error is re-thrown unchanged.

Because every caller of `context.amplify.confirmPrompt` funnels through this one
helper, this fixes `amplify add function` on Node 24 and the same latent crash
for all ~28 other callers, without changing behavior on older Node versions.

##### Why guard instead of re-implementing on `amplify-prompts`

`confirmPrompt` is `@deprecated` in favor of `amplify-prompts`' enquirer-based
`prompter`, and re-pointing it there was considered. It was rejected as too
risky for a bug fix: the `prompter` throws in non-interactive (non-TTY) shells
and owns `--yes` handling, whereas several existing `confirmPrompt` callers
(e.g. `s0-analyzeProject`) already gate `--yes` themselves and rely on the
current non-interactive semantics. The narrow guard restores the exact
pre-Node-24 contract for every caller and is the lower-risk change. Migrating
callers to `amplify-prompts` remains a good future cleanup, separate from this
fix.

##### Relation to the e2e harness stopgap

A separate `amplify-category-api` change (#3503) patches the **e2e test
harness's** installed `inquirer` as a stopgap so suites stop crashing on Node
24. This PR is the actual product fix; once it ships in a `cli-internal`
release, that harness patch can be retired.

#### Issue #, if available

N/A. Related stopgap: aws-amplify/amplify-category-api#3503 (e2e harness patch,
can be retired once this ships).

#### Description of how you validated changes

- Added unit regression tests in
  `packages/amplify-cli/src/__tests__/extensions/amplify-helpers/confirm-prompt.test.ts`
  that simulate the Node 24 teardown crash: the answer is captured on
  `ui.answers` and the prompt promise then rejects with `ERR_USE_AFTER_CLOSE`.
  The tests assert `confirmPrompt` returns the real answer (yes/no) instead of
  throwing, falls back to the default when no answer was captured, and still
  re-throws unrelated errors.
- Independently verified against the real `inquirer@7` that the answer is
  present on the prompt promise's `ui.answers` after the simulated crash, so the
  recovery reads a real value rather than a test artifact.
- Built with `tsc -b` (clean) and ran the `amplify-helpers` Jest suite:
  **40 suites / 155 tests pass**. Lint clean on both touched files.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes (touched `amplify-helpers` suite: 40 suites / 155 tests)
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
