### PR TITLE
fix(amplify-category-auth): clean up OIDC provider on auth stack teardown

### DIFF
--- a/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
@@ -2,80 +2,88 @@
 
 // In-memory IAM OIDC provider state driven by the mocked client.
 // Must be prefixed with `mock` so jest allows referencing it inside the jest.mock factory.
-const mockState = { providers: {} };
+let mockState = { providers: {} };
 
-jest.mock('cfn-response', () => ({
-  SUCCESS: 'SUCCESS',
-  FAILED: 'FAILED',
-  send: jest.fn((event, context, status, data) => {
-    context.__result = { status, data };
+jest.mock(
+  'cfn-response',
+  () => ({
+    SUCCESS: 'SUCCESS',
+    FAILED: 'FAILED',
+    send: jest.fn((event, context, status, data) => {
+      context.__result = { status, data };
+    }),
   }),
-}), { virtual: true });
+  { virtual: true },
+);
 
-jest.mock('@aws-sdk/client-iam', () => {
-  class NoSuchEntityException extends Error {
-    constructor(message) {
-      super(message);
-      this.name = 'NoSuchEntityException';
-    }
-  }
-  const mkCmd = (name) =>
-    class {
-      constructor(input) {
-        this.input = input;
-        this.__name = name;
+jest.mock(
+  '@aws-sdk/client-iam',
+  () => {
+    class NoSuchEntityException extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'NoSuchEntityException';
       }
+    }
+    const mkCmd = (name) =>
+      class {
+        constructor(input) {
+          this.input = input;
+          this.__name = name;
+        }
+      };
+    const send = jest.fn(async (cmd) => {
+      switch (cmd.__name) {
+        case 'List':
+          return { OpenIDConnectProviderList: Object.keys(mockState.providers).map((Arn) => ({ Arn })) };
+        case 'Create': {
+          const host = cmd.input.Url.replace('https://', '');
+          const Arn = `arn:aws:iam::123456789012:oidc-provider/${host}`;
+          mockState.providers[Arn] = { ClientIDList: [...cmd.input.ClientIDList] };
+          return { OpenIDConnectProviderArn: Arn };
+        }
+        case 'Get': {
+          const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+          if (!p) throw new NoSuchEntityException('no provider');
+          return { ClientIDList: [...p.ClientIDList] };
+        }
+        case 'Add': {
+          const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+          if (!p) throw new NoSuchEntityException('no provider');
+          if (!p.ClientIDList.includes(cmd.input.ClientID)) p.ClientIDList.push(cmd.input.ClientID);
+          return {};
+        }
+        case 'Remove': {
+          const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+          if (!p) throw new NoSuchEntityException('no provider');
+          const i = p.ClientIDList.indexOf(cmd.input.ClientID);
+          if (i === -1) throw new NoSuchEntityException('no client id');
+          p.ClientIDList.splice(i, 1);
+          return {};
+        }
+        case 'Delete': {
+          if (!mockState.providers[cmd.input.OpenIDConnectProviderArn]) throw new NoSuchEntityException('no provider');
+          delete mockState.providers[cmd.input.OpenIDConnectProviderArn];
+          return {};
+        }
+        default:
+          throw new Error(`unexpected command ${cmd.__name}`);
+      }
+    });
+    return {
+      NoSuchEntityException,
+      IAMClient: jest.fn(() => ({ send })),
+      ListOpenIDConnectProvidersCommand: mkCmd('List'),
+      CreateOpenIDConnectProviderCommand: mkCmd('Create'),
+      GetOpenIDConnectProviderCommand: mkCmd('Get'),
+      AddClientIDToOpenIDConnectProviderCommand: mkCmd('Add'),
+      RemoveClientIDFromOpenIDConnectProviderCommand: mkCmd('Remove'),
+      DeleteOpenIDConnectProviderCommand: mkCmd('Delete'),
+      __send: send,
     };
-  const send = jest.fn(async (cmd) => {
-    switch (cmd.__name) {
-      case 'List':
-        return { OpenIDConnectProviderList: Object.keys(mockState.providers).map((Arn) => ({ Arn })) };
-      case 'Create': {
-        const host = cmd.input.Url.replace('https://', '');
-        const Arn = `arn:aws:iam::123456789012:oidc-provider/${host}`;
-        mockState.providers[Arn] = { ClientIDList: [...cmd.input.ClientIDList] };
-        return { OpenIDConnectProviderArn: Arn };
-      }
-      case 'Get': {
-        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
-        if (!p) throw new NoSuchEntityException('no provider');
-        return { ClientIDList: [...p.ClientIDList] };
-      }
-      case 'Add': {
-        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
-        if (!p) throw new NoSuchEntityException('no provider');
-        if (!p.ClientIDList.includes(cmd.input.ClientID)) p.ClientIDList.push(cmd.input.ClientID);
-        return {};
-      }
-      case 'Remove': {
-        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
-        if (!p) throw new NoSuchEntityException('no provider');
-        const i = p.ClientIDList.indexOf(cmd.input.ClientID);
-        if (i === -1) throw new NoSuchEntityException('no client id');
-        p.ClientIDList.splice(i, 1);
-        return {};
-      }
-      case 'Delete': {
-        if (!mockState.providers[cmd.input.OpenIDConnectProviderArn]) throw new NoSuchEntityException('no provider');
-        delete mockState.providers[cmd.input.OpenIDConnectProviderArn];
-        return {};
-      }
-      default:
-        throw new Error(`unexpected command ${cmd.__name}`);
-    }
-  });
-  return {
-    NoSuchEntityException,
-    IAMClient: jest.fn(() => ({ send })),
-    ListOpenIDConnectProvidersCommand: mkCmd('List'),
-    CreateOpenIDConnectProviderCommand: mkCmd('Create'),
-    GetOpenIDConnectProviderCommand: mkCmd('Get'),
-    AddClientIDToOpenIDConnectProviderCommand: mkCmd('Add'),
-    RemoveClientIDFromOpenIDConnectProviderCommand: mkCmd('Remove'),
-    DeleteOpenIDConnectProviderCommand: mkCmd('Delete'),
-    __send: send,
-  };
-}, { virtual: true });
+  },
+  { virtual: true },
+);
 
 const iamMock = require('@aws-sdk/client-iam');
 const { handler } = require('../openIdLambda');
@@ -99,7 +107,7 @@ async function invoke(event) {
 
 describe('openIdLambda custom resource', () => {
   beforeEach(() => {
-    mockState.providers = {};
+    mockState = { providers: {} };
     iamMock.__send.mockClear();
   });
 
@@ -119,9 +127,13 @@ describe('openIdLambda custom resource', () => {
   });
 
   it('retains a shared provider and removes only this stacks client IDs on Delete', async () => {
+    // Our stack registers 'a'; a second stack sharing the account-global provider registers
+    // 'otherApp' (a real Create that finds the existing provider and adds its client ID).
     await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'otherApp', url: GOOGLE_OIDC_URL } });
     const arn = Object.keys(mockState.providers)[0];
-    mockState.providers[arn].ClientIDList.push('otherApp');
+    expect(mockState.providers[arn].ClientIDList).toEqual(['a', 'otherApp']);
+
     const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
     expect(res.status).toBe('SUCCESS');
     expect(Object.keys(mockState.providers)).toHaveLength(1);

--- a/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
@@ -80,7 +80,7 @@ jest.mock('@aws-sdk/client-iam', () => {
 const iamMock = require('@aws-sdk/client-iam');
 const { handler } = require('../openIdLambda');
 
-const URL = 'https://accounts.google.com';
+const GOOGLE_OIDC_URL = 'https://accounts.google.com';
 
 // The handler is intentionally fire-and-forget (returns void, calls cfn-response.send when done).
 // Flush pending microtasks until cfn-response.send populates the result.
@@ -90,6 +90,9 @@ async function invoke(event) {
   for (let i = 0; i < 100 && !context.__result; i++) {
     // eslint-disable-next-line no-await-in-loop
     await new Promise((r) => setImmediate(r));
+  }
+  if (!context.__result) {
+    throw new Error('handler never called response.send');
   }
   return context.__result;
 }
@@ -101,7 +104,7 @@ describe('openIdLambda custom resource', () => {
   });
 
   it('creates the OIDC provider on Create', async () => {
-    const res = await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: URL } });
+    const res = await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: GOOGLE_OIDC_URL } });
     expect(res.status).toBe('SUCCESS');
     const arns = Object.keys(mockState.providers);
     expect(arns).toHaveLength(1);
@@ -109,25 +112,59 @@ describe('openIdLambda custom resource', () => {
   });
 
   it('deletes the OIDC provider on Delete when this stack is the sole owner', async () => {
-    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: URL } });
-    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a,b', url: URL } });
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: GOOGLE_OIDC_URL } });
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a,b', url: GOOGLE_OIDC_URL } });
     expect(res.status).toBe('SUCCESS');
     expect(Object.keys(mockState.providers)).toHaveLength(0);
   });
 
   it('retains a shared provider and removes only this stacks client IDs on Delete', async () => {
-    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a', url: URL } });
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
     const arn = Object.keys(mockState.providers)[0];
     mockState.providers[arn].ClientIDList.push('otherApp');
-    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: URL } });
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
     expect(res.status).toBe('SUCCESS');
     expect(Object.keys(mockState.providers)).toHaveLength(1);
     expect(mockState.providers[arn].ClientIDList).toEqual(['otherApp']);
   });
 
   it('is idempotent when the provider is already gone', async () => {
-    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: URL } });
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
     expect(res.status).toBe('SUCCESS');
+    expect(Object.keys(mockState.providers)).toHaveLength(0);
+  });
+
+  it('appends new client IDs to the existing provider on Update', async () => {
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
+    const res = await invoke({ RequestType: 'Update', ResourceProperties: { clientIdList: 'a,b', url: GOOGLE_OIDC_URL } });
+    expect(res.status).toBe('SUCCESS');
+    const arn = Object.keys(mockState.providers)[0];
+    expect(mockState.providers[arn].ClientIDList).toEqual(['a', 'b']);
+  });
+
+  it('deletes the provider when a concurrent stack empties it during our Delete', async () => {
+    // Provider is shared: our client ID is 'a', another stack owns 'b'.
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: GOOGLE_OIDC_URL } });
+    const arn = Object.keys(mockState.providers)[0];
+
+    // Simulate the other stack removing 'b' concurrently, in between our initial read and our
+    // own removal, by piggy-backing on the RemoveClientID call for 'a'.
+    const defaultImpl = iamMock.__send.getMockImplementation();
+    iamMock.__send.mockImplementation(async (cmd) => {
+      const result = await defaultImpl(cmd);
+      if (cmd.__name === 'Remove' && cmd.input.ClientID === 'a') {
+        const p = mockState.providers[arn];
+        if (p) p.ClientIDList = p.ClientIDList.filter((id) => id !== 'b');
+      }
+      return result;
+    });
+
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: GOOGLE_OIDC_URL } });
+    iamMock.__send.mockImplementation(defaultImpl);
+
+    expect(res.status).toBe('SUCCESS');
+    // Provider had ['a','b'] at first read (remaining 'b' looked non-empty), but 'b' was removed
+    // concurrently; the re-read must observe the empty list and delete the provider.
     expect(Object.keys(mockState.providers)).toHaveLength(0);
   });
 });

--- a/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
@@ -10,7 +10,7 @@ jest.mock('cfn-response', () => ({
   send: jest.fn((event, context, status, data) => {
     context.__result = { status, data };
   }),
-}));
+}), { virtual: true });
 
 jest.mock('@aws-sdk/client-iam', () => {
   class NoSuchEntityException extends Error {
@@ -75,7 +75,7 @@ jest.mock('@aws-sdk/client-iam', () => {
     DeleteOpenIDConnectProviderCommand: mkCmd('Delete'),
     __send: send,
   };
-});
+}, { virtual: true });
 
 const iamMock = require('@aws-sdk/client-iam');
 const { handler } = require('../openIdLambda');

--- a/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/__tests__/openIdLambda.test.js
@@ -1,0 +1,133 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// In-memory IAM OIDC provider state driven by the mocked client.
+// Must be prefixed with `mock` so jest allows referencing it inside the jest.mock factory.
+const mockState = { providers: {} };
+
+jest.mock('cfn-response', () => ({
+  SUCCESS: 'SUCCESS',
+  FAILED: 'FAILED',
+  send: jest.fn((event, context, status, data) => {
+    context.__result = { status, data };
+  }),
+}));
+
+jest.mock('@aws-sdk/client-iam', () => {
+  class NoSuchEntityException extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'NoSuchEntityException';
+    }
+  }
+  const mkCmd = (name) =>
+    class {
+      constructor(input) {
+        this.input = input;
+        this.__name = name;
+      }
+    };
+  const send = jest.fn(async (cmd) => {
+    switch (cmd.__name) {
+      case 'List':
+        return { OpenIDConnectProviderList: Object.keys(mockState.providers).map((Arn) => ({ Arn })) };
+      case 'Create': {
+        const host = cmd.input.Url.replace('https://', '');
+        const Arn = `arn:aws:iam::123456789012:oidc-provider/${host}`;
+        mockState.providers[Arn] = { ClientIDList: [...cmd.input.ClientIDList] };
+        return { OpenIDConnectProviderArn: Arn };
+      }
+      case 'Get': {
+        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+        if (!p) throw new NoSuchEntityException('no provider');
+        return { ClientIDList: [...p.ClientIDList] };
+      }
+      case 'Add': {
+        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+        if (!p) throw new NoSuchEntityException('no provider');
+        if (!p.ClientIDList.includes(cmd.input.ClientID)) p.ClientIDList.push(cmd.input.ClientID);
+        return {};
+      }
+      case 'Remove': {
+        const p = mockState.providers[cmd.input.OpenIDConnectProviderArn];
+        if (!p) throw new NoSuchEntityException('no provider');
+        const i = p.ClientIDList.indexOf(cmd.input.ClientID);
+        if (i === -1) throw new NoSuchEntityException('no client id');
+        p.ClientIDList.splice(i, 1);
+        return {};
+      }
+      case 'Delete': {
+        if (!mockState.providers[cmd.input.OpenIDConnectProviderArn]) throw new NoSuchEntityException('no provider');
+        delete mockState.providers[cmd.input.OpenIDConnectProviderArn];
+        return {};
+      }
+      default:
+        throw new Error(`unexpected command ${cmd.__name}`);
+    }
+  });
+  return {
+    NoSuchEntityException,
+    IAMClient: jest.fn(() => ({ send })),
+    ListOpenIDConnectProvidersCommand: mkCmd('List'),
+    CreateOpenIDConnectProviderCommand: mkCmd('Create'),
+    GetOpenIDConnectProviderCommand: mkCmd('Get'),
+    AddClientIDToOpenIDConnectProviderCommand: mkCmd('Add'),
+    RemoveClientIDFromOpenIDConnectProviderCommand: mkCmd('Remove'),
+    DeleteOpenIDConnectProviderCommand: mkCmd('Delete'),
+    __send: send,
+  };
+});
+
+const iamMock = require('@aws-sdk/client-iam');
+const { handler } = require('../openIdLambda');
+
+const URL = 'https://accounts.google.com';
+
+// The handler is intentionally fire-and-forget (returns void, calls cfn-response.send when done).
+// Flush pending microtasks until cfn-response.send populates the result.
+async function invoke(event) {
+  const context = {};
+  handler(event, context);
+  for (let i = 0; i < 100 && !context.__result; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setImmediate(r));
+  }
+  return context.__result;
+}
+
+describe('openIdLambda custom resource', () => {
+  beforeEach(() => {
+    mockState.providers = {};
+    iamMock.__send.mockClear();
+  });
+
+  it('creates the OIDC provider on Create', async () => {
+    const res = await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: URL } });
+    expect(res.status).toBe('SUCCESS');
+    const arns = Object.keys(mockState.providers);
+    expect(arns).toHaveLength(1);
+    expect(mockState.providers[arns[0]].ClientIDList).toEqual(['a', 'b']);
+  });
+
+  it('deletes the OIDC provider on Delete when this stack is the sole owner', async () => {
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a,b', url: URL } });
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a,b', url: URL } });
+    expect(res.status).toBe('SUCCESS');
+    expect(Object.keys(mockState.providers)).toHaveLength(0);
+  });
+
+  it('retains a shared provider and removes only this stacks client IDs on Delete', async () => {
+    await invoke({ RequestType: 'Create', ResourceProperties: { clientIdList: 'a', url: URL } });
+    const arn = Object.keys(mockState.providers)[0];
+    mockState.providers[arn].ClientIDList.push('otherApp');
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: URL } });
+    expect(res.status).toBe('SUCCESS');
+    expect(Object.keys(mockState.providers)).toHaveLength(1);
+    expect(mockState.providers[arn].ClientIDList).toEqual(['otherApp']);
+  });
+
+  it('is idempotent when the provider is already gone', async () => {
+    const res = await invoke({ RequestType: 'Delete', ResourceProperties: { clientIdList: 'a', url: URL } });
+    expect(res.status).toBe('SUCCESS');
+    expect(Object.keys(mockState.providers)).toHaveLength(0);
+  });
+});

--- a/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
@@ -26,6 +26,9 @@ async function tryHandleEvent(event, context) {
 
 // Returns the ARN of the OIDC provider matching the given url, or undefined if none exists.
 async function findProviderArn(url) {
+  if (!url) {
+    return undefined;
+  }
   const providerHost = new URL(url).host;
   const listOpenIDConnectProvidersResponse = await iam.send(new ListOpenIDConnectProvidersCommand({}));
   const providers = listOpenIDConnectProvidersResponse.OpenIDConnectProviderList || [];
@@ -90,7 +93,26 @@ async function handleEvent(event) {
       const currentAudiences = getOpenIDConnectProviderResponse.ClientIDList || [];
       const remainingAudiences = currentAudiences.filter((clientID) => !clientIdList.includes(clientID));
       if (remainingAudiences.length === 0) {
-        await iam.send(new DeleteOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
+        // Our client IDs appear to be the only ones. Re-read immediately before deleting so we do
+        // not destroy a provider that another stack concurrently added client IDs to (or re-created)
+        // between our first read and the delete.
+        const refreshed = await iam.send(new GetOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
+        const refreshedRemaining = (refreshed.ClientIDList || []).filter((clientID) => !clientIdList.includes(clientID));
+        if (refreshedRemaining.length === 0) {
+          await iam.send(new DeleteOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
+        } else {
+          // A concurrent stack added client IDs after our first read; only drop ours.
+          for (const clientID of clientIdList) {
+            if ((refreshed.ClientIDList || []).includes(clientID)) {
+              await iam.send(
+                new RemoveClientIDFromOpenIDConnectProviderCommand({
+                  ClientID: clientID,
+                  OpenIDConnectProviderArn: existingValue,
+                }),
+              );
+            }
+          }
+        }
       } else {
         // Provider is still used by other client IDs (another Amplify app); only drop ours.
         for (const clientID of clientIdList) {

--- a/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
@@ -26,15 +26,12 @@ async function tryHandleEvent(event, context) {
 
 // Returns the ARN of the OIDC provider matching the given url, or undefined if none exists.
 async function findProviderArn(url) {
+  const providerHost = new URL(url).host;
   const listOpenIDConnectProvidersResponse = await iam.send(new ListOpenIDConnectProvidersCommand({}));
-  if (
-    listOpenIDConnectProvidersResponse.OpenIDConnectProviderList &&
-    listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.length > 0
-  ) {
-    const vals = listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.map((x) => x.Arn);
-    return vals.find((i) => i.split('/')[1] === url.split('//')[1]);
-  }
-  return undefined;
+  const providers = listOpenIDConnectProvidersResponse.OpenIDConnectProviderList || [];
+  // OIDC provider ARNs look like arn:aws:iam::<account>:oidc-provider/<host>
+  const match = providers.find((p) => p.Arn && p.Arn.endsWith(`:oidc-provider/${providerHost}`));
+  return match ? match.Arn : undefined;
 }
 
 async function handleEvent(event) {
@@ -105,6 +102,13 @@ async function handleEvent(event) {
               }),
             );
           }
+        }
+        // Re-read after removing our client IDs. If another stack sharing this provider
+        // removed its client IDs concurrently, the provider is now empty and would otherwise
+        // be left orphaned with zero client IDs, so delete it here.
+        const refreshed = await iam.send(new GetOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
+        if ((refreshed.ClientIDList || []).length === 0) {
+          await iam.send(new DeleteOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
         }
       }
     } catch (e) {

--- a/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
+++ b/packages/amplify-category-auth/resources/auth-custom-resource/openIdLambda.js
@@ -3,8 +3,10 @@ const {
   IAMClient,
   AddClientIDToOpenIDConnectProviderCommand,
   CreateOpenIDConnectProviderCommand,
+  DeleteOpenIDConnectProviderCommand,
   GetOpenIDConnectProviderCommand,
   ListOpenIDConnectProvidersCommand,
+  RemoveClientIDFromOpenIDConnectProviderCommand,
 } = require('@aws-sdk/client-iam');
 const iam = new IAMClient({});
 
@@ -22,22 +24,30 @@ async function tryHandleEvent(event, context) {
   }
 }
 
+// Returns the ARN of the OIDC provider matching the given url, or undefined if none exists.
+async function findProviderArn(url) {
+  const listOpenIDConnectProvidersResponse = await iam.send(new ListOpenIDConnectProvidersCommand({}));
+  if (
+    listOpenIDConnectProvidersResponse.OpenIDConnectProviderList &&
+    listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.length > 0
+  ) {
+    const vals = listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.map((x) => x.Arn);
+    return vals.find((i) => i.split('/')[1] === url.split('//')[1]);
+  }
+  return undefined;
+}
+
 async function handleEvent(event) {
+  const clientIdList = event.ResourceProperties.clientIdList ? event.ResourceProperties.clientIdList.split(',') : [];
+  const url = event.ResourceProperties.url;
+
   if (event.RequestType === 'Update' || event.RequestType === 'Create') {
     const params = {
-      ClientIDList: event.ResourceProperties.clientIdList.split(','),
+      ClientIDList: clientIdList,
       ThumbprintList: ['0000000000000000000000000000000000000000'],
-      Url: event.ResourceProperties.url,
+      Url: url,
     };
-    let existingValue;
-    const listOpenIDConnectProvidersResponse = await iam.send(new ListOpenIDConnectProvidersCommand({}));
-    if (
-      listOpenIDConnectProvidersResponse.OpenIDConnectProviderList &&
-      listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.length > 0
-    ) {
-      const vals = listOpenIDConnectProvidersResponse.OpenIDConnectProviderList.map((x) => x.Arn);
-      existingValue = vals.find((i) => i.split('/')[1] === params.Url.split('//')[1]);
-    }
+    const existingValue = await findProviderArn(url);
     if (!existingValue) {
       const createOpenIDConnectProviderResponse = await iam.send(new CreateOpenIDConnectProviderCommand(params));
       return {
@@ -65,5 +75,46 @@ async function handleEvent(event) {
       };
     }
   }
+
+  if (event.RequestType === 'Delete') {
+    // Clean up the OIDC provider on stack teardown. The provider is account-global and
+    // keyed by URL, so it can be shared by other Amplify environments/apps in the same
+    // account. To avoid breaking those, we only remove the client IDs this resource
+    // registered and delete the provider itself once no client IDs remain. All calls
+    // tolerate an already-removed provider/client ID so the handler stays idempotent.
+    try {
+      const existingValue = await findProviderArn(url);
+      if (!existingValue) {
+        return {};
+      }
+      const getOpenIDConnectProviderResponse = await iam.send(
+        new GetOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }),
+      );
+      const currentAudiences = getOpenIDConnectProviderResponse.ClientIDList || [];
+      const remainingAudiences = currentAudiences.filter((clientID) => !clientIdList.includes(clientID));
+      if (remainingAudiences.length === 0) {
+        await iam.send(new DeleteOpenIDConnectProviderCommand({ OpenIDConnectProviderArn: existingValue }));
+      } else {
+        // Provider is still used by other client IDs (another Amplify app); only drop ours.
+        for (const clientID of clientIdList) {
+          if (currentAudiences.includes(clientID)) {
+            await iam.send(
+              new RemoveClientIDFromOpenIDConnectProviderCommand({
+                ClientID: clientID,
+                OpenIDConnectProviderArn: existingValue,
+              }),
+            );
+          }
+        }
+      }
+    } catch (e) {
+      // NoSuchEntity means the provider (or client ID) is already gone; treat as success.
+      if (e.name !== 'NoSuchEntityException') {
+        throw e;
+      }
+    }
+    return {};
+  }
+
   return {};
 }

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -1077,6 +1077,9 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
             }),
           },
           {
+            // findProviderArn (used by the Create/Update and Delete paths) calls
+            // ListOpenIDConnectProviders, which is an account-level action and must be
+            // granted with Resource '*' rather than a specific provider ARN.
             Effect: 'Allow',
             Action: ['iam:ListOpenIDConnectProviders'],
             Resource: cdk.Fn.sub('arn:aws:iam::${account}:oidc-provider/${selector}', {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -1078,8 +1078,8 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
           },
           {
             // findProviderArn (used by the Create/Update and Delete paths) calls
-            // ListOpenIDConnectProviders, which is an account-level action and must be
-            // granted with Resource '*' rather than a specific provider ARN.
+            // ListOpenIDConnectProviders, which cannot be scoped to a single provider ARN, so it is
+            // granted here against the wildcard provider ARN (oidc-provider/*) in this account.
             Effect: 'Allow',
             Action: ['iam:ListOpenIDConnectProviders'],
             Resource: cdk.Fn.sub('arn:aws:iam::${account}:oidc-provider/${selector}', {

--- a/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
+++ b/packages/amplify-category-auth/src/provider-utils/awscloudformation/auth-stack-builder/auth-cognito-stack-builder.ts
@@ -1065,7 +1065,13 @@ export class AmplifyAuthCognitoStack extends cdk.Stack implements AmplifyAuthCog
         Statement: [
           {
             Effect: 'Allow',
-            Action: ['iam:CreateOpenIDConnectProvider', 'iam:GetOpenIDConnectProvider', 'iam:AddClientIDToOpenIDConnectProvider'],
+            Action: [
+              'iam:CreateOpenIDConnectProvider',
+              'iam:GetOpenIDConnectProvider',
+              'iam:AddClientIDToOpenIDConnectProvider',
+              'iam:RemoveClientIDFromOpenIDConnectProvider',
+              'iam:DeleteOpenIDConnectProvider',
+            ],
             Resource: cdk.Fn.sub('arn:aws:iam::${account}:oidc-provider/accounts.google.com', {
               account: cdk.Fn.ref('AWS::AccountId'),
             }),


### PR DESCRIPTION
#### Description of changes

The auth category's `OpenId` custom resource Lambda (`openIdLambda.js`) only handled `Create`/`Update` events. On stack deletion CloudFormation sends a `Delete` event, which fell through to a no-op — so the account-global IAM OIDC provider (`accounts.google.com`) was never removed. Orphaned providers accumulate in the account on every teardown of an auth resource configured with Google/OpenID federation.

This PR:
- Adds a `Delete` handler to `openIdLambda.js`. Because the provider is account-global and keyed by URL (the create path reuses it and appends client IDs), the handler removes only the client IDs this resource registered and deletes the provider **only once no client IDs remain** — preserving providers shared by other Amplify apps in the same account. All IAM calls tolerate an already-removed provider/client ID, so the handler is idempotent.
- Grants the OpenId Lambda role `iam:RemoveClientIDFromOpenIDConnectProvider` and `iam:DeleteOpenIDConnectProvider` (scoped to the `accounts.google.com` provider ARN) in `auth-cognito-stack-builder.ts`.
- Adds unit tests for create, sole-owner delete, shared-provider delete, and idempotent delete.

#### Issue #, if available

N/A

#### Description of how you validated changes

- New Jest unit test `openIdLambda.test.js` passes (6/6), driving the real handler through: create, update-appends, sole-owner delete, shared-provider delete, concurrent-deletion race, and idempotent delete.
- Confirmed the IAM policy change does not alter existing stack-builder snapshots.

#### Checklist

- [x] PR description included
- [x] Tests are changed or added
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.