### PR TITLE
fix(cli): scope migrated private/protected S3 access to the caller identity

### DIFF
--- a/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/backend-only/_snapshot.post.generate/amplify/storage/resource.ts
@@ -12,10 +12,11 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/storage/resource.ts
@@ -9,10 +9,11 @@ export const storage = defineStorage({
   access: (allow) => ({
     'public/*': [allow.authenticated.to(['write', 'read', 'delete'])],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/amplify-migration-apps/finance-tracker/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/finance-tracker/_snapshot.post.generate/amplify/storage/resource.ts
@@ -12,10 +12,11 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/amplify-migration-apps/imported-resources/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/imported-resources/_snapshot.post.generate/amplify/storage/resource.ts
@@ -12,10 +12,11 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/storage/resource.ts
@@ -18,13 +18,14 @@ export const storage = defineStorage({
       allow.resource(thumbnailgen).to(['read', 'write', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
       allow.groups(['Admin']).to(['write', 'read', 'delete']),
       allow.groups(['Basic']).to(['read']),
       allow.resource(thumbnailgen).to(['read', 'write', 'delete']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
       allow.groups(['Admin']).to(['write', 'read', 'delete']),
       allow.groups(['Basic']).to(['read']),
       allow.resource(thumbnailgen).to(['read', 'write', 'delete']),

--- a/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/mood-board/_snapshot.post.generate/amplify/storage/resource.ts
@@ -12,10 +12,11 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/product-catalog/_snapshot.post.generate/amplify/storage/resource.ts
@@ -10,10 +10,11 @@ export const storage = defineStorage({
   access: (allow) => ({
     'public/*': [allow.authenticated.to(['write', 'read', 'delete'])],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
   triggers: {

--- a/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/project-boards/_snapshot.post.generate/amplify/storage/resource.ts
@@ -12,10 +12,11 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
     ],
     'protected/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
+      allow.authenticated.to(['read']),
     ],
     'private/{entity_id}/*': [
-      allow.authenticated.to(['write', 'read', 'delete']),
+      allow.entity('identity').to(['write', 'read', 'delete']),
     ],
   }),
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
@@ -189,8 +189,11 @@ describe('S3Generator', () => {
         name: \`myBucket-main-\${branchName}\`,
         access: (allow) => ({
           'public/*': [allow.authenticated.to(['read', 'write'])],
-          'protected/{entity_id}/*': [allow.authenticated.to(['read', 'write'])],
-          'private/{entity_id}/*': [allow.authenticated.to(['read', 'write'])],
+          'protected/{entity_id}/*': [
+            allow.entity('identity').to(['read', 'write']),
+            allow.authenticated.to(['read']),
+          ],
+          'private/{entity_id}/*': [allow.entity('identity').to(['read', 'write'])],
         }),
       });
 
@@ -216,6 +219,43 @@ describe('S3Generator', () => {
       }
       "
     `);
+  });
+
+  // private/ and protected/ are per-user paths: authenticated access must be scoped to the
+  // caller's own identity via allow.entity('identity'), matching the Gen1 configuration.
+  it('scopes authenticated private/protected access to the caller identity', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      storage: { myBucket: { service: 'S3', output: { BucketName: 'myBucket-main-abc123' } } },
+    });
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      authAccess: ['READ', 'CREATE_AND_UPDATE', 'DELETE'],
+      guestAccess: [],
+    });
+    jest.spyOn(gen1App.aws, 'fetchBucketAccelerate').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketVersioning').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketEncryption').mockResolvedValue(undefined);
+
+    const generator = new S3Generator(
+      gen1App,
+      backendGenerator,
+      outputDir,
+      { category: 'storage', resourceName: 'myBucket', service: 'S3', key: 'storage:S3' },
+      logger,
+    );
+    const ops = await generator.plan();
+    await ops[0].execute();
+    const content = writtenFile('resource.ts');
+    const normalized = content.replace(/\s+/g, ' ');
+
+    // Per-user paths use entity('identity') so {entity_id} maps to the caller's identity.
+    expect(normalized).toMatch(
+      /'private\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)\s*,?\s*\]/,
+    );
+    expect(normalized).toMatch(/'protected\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)/);
+
+    // Enforce per-user scoping: private/protected must not grant write/delete via allow.authenticated.
+    expect(content).not.toMatch(/'(private|protected)\/\{entity_id\}\/\*': \[[^\]]*allow\.authenticated\.to\(\[[^\]]*'(write|delete)'/s);
   });
 
   it('renders guest access patterns', async () => {
@@ -324,10 +364,11 @@ describe('S3Generator', () => {
             allow.authenticated.to(['read', 'write', 'delete']),
           ],
           'protected/{entity_id}/*': [
-            allow.authenticated.to(['read', 'write', 'delete']),
+            allow.entity('identity').to(['read', 'write', 'delete']),
+            allow.authenticated.to(['read']),
           ],
           'private/{entity_id}/*': [
-            allow.authenticated.to(['read', 'write', 'delete']),
+            allow.entity('identity').to(['read', 'write', 'delete']),
           ],
         }),
       });
@@ -402,11 +443,12 @@ describe('S3Generator', () => {
             allow.groups(['admin']).to(['read', 'write', 'delete']),
           ],
           'protected/{entity_id}/*': [
+            allow.entity('identity').to(['read']),
             allow.authenticated.to(['read']),
             allow.groups(['admin']).to(['read', 'write', 'delete']),
           ],
           'private/{entity_id}/*': [
-            allow.authenticated.to(['read']),
+            allow.entity('identity').to(['read']),
             allow.groups(['admin']).to(['read', 'write', 'delete']),
           ],
         }),

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
@@ -248,10 +248,51 @@ describe('S3Generator', () => {
     const content = writtenFile('resource.ts');
     const normalized = content.replace(/\s+/g, ' ');
 
-    expect(normalized).toMatch(
-      /'private\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)\s*,?\s*\]/,
-    );
-    expect(normalized).toMatch(/'protected\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)/);
+    // Positive assertion: full generated file locks the per-user mapping (owner scoped to
+    // entity('identity'); protected/ retains authenticated read).
+    expect(content).toMatchInlineSnapshot(`
+      "import { defineStorage } from '@aws-amplify/backend';
+      import { CfnResource } from 'aws-cdk-lib';
+      import type { Backend } from '../backend';
+
+      const branchName = process.env.AWS_BRANCH ?? 'sandbox';
+
+      export const storage = defineStorage({
+        name: \`myBucket-main-\${branchName}\`,
+        access: (allow) => ({
+          'public/*': [allow.authenticated.to(['read', 'write', 'delete'])],
+          'protected/{entity_id}/*': [
+            allow.entity('identity').to(['read', 'write', 'delete']),
+            allow.authenticated.to(['read']),
+          ],
+          'private/{entity_id}/*': [
+            allow.entity('identity').to(['read', 'write', 'delete']),
+          ],
+        }),
+      });
+
+      export function postRefactor(backend: Backend) {
+        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
+        s3Bucket.bucketName = 'myBucket-main-abc123';
+      }
+
+      export function applyEscapeHatches(backend: Backend) {
+        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
+        for (const cfnResource of backend.storage.stack.node
+          .findAll()
+          .filter(
+            (c) =>
+              CfnResource.isCfnResource(c) &&
+              ['AWS::S3::Bucket', 'Custom::S3AutoDeleteObjects'].includes(
+                c.cfnResourceType
+              )
+          )) {
+          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
+          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
+        }
+      }
+      "
+    `);
 
     // private/ and protected/ must not grant write/delete via allow.authenticated (public/*
     // legitimately can, so the check is scoped to those paths). Rules render in the order
@@ -264,6 +305,75 @@ describe('S3Generator', () => {
     for (const segment of [protectedSegment, privateSegment]) {
       expect(segment).not.toMatch(/allow\.authenticated\.to\(\[[^\]]*'(write|delete)'/);
     }
+  });
+
+  it('scopes write-only authenticated protected access and retains authenticated read', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      storage: { myBucket: { service: 'S3', output: { BucketName: 'myBucket-main-abc123' } } },
+    });
+    // Write-only Gen1 auth (no READ in the auth set): the owner rule must still render as
+    // entity('identity').to(['write']) and protected/ must still get the unconditional
+    // authenticated read (Gen1 cross-user read semantics).
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({
+      authAccess: ['CREATE_AND_UPDATE'],
+      guestAccess: [],
+    });
+    jest.spyOn(gen1App.aws, 'fetchBucketAccelerate').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketVersioning').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketEncryption').mockResolvedValue(undefined);
+
+    const generator = new S3Generator(
+      gen1App,
+      backendGenerator,
+      outputDir,
+      { category: 'storage', resourceName: 'myBucket', service: 'S3', key: 'storage:S3' },
+      logger,
+    );
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
+      "import { defineStorage } from '@aws-amplify/backend';
+      import { CfnResource } from 'aws-cdk-lib';
+      import type { Backend } from '../backend';
+
+      const branchName = process.env.AWS_BRANCH ?? 'sandbox';
+
+      export const storage = defineStorage({
+        name: \`myBucket-main-\${branchName}\`,
+        access: (allow) => ({
+          'public/*': [allow.authenticated.to(['write'])],
+          'protected/{entity_id}/*': [
+            allow.entity('identity').to(['write']),
+            allow.authenticated.to(['read']),
+          ],
+          'private/{entity_id}/*': [allow.entity('identity').to(['write'])],
+        }),
+      });
+
+      export function postRefactor(backend: Backend) {
+        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
+        s3Bucket.bucketName = 'myBucket-main-abc123';
+      }
+
+      export function applyEscapeHatches(backend: Backend) {
+        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
+        for (const cfnResource of backend.storage.stack.node
+          .findAll()
+          .filter(
+            (c) =>
+              CfnResource.isCfnResource(c) &&
+              ['AWS::S3::Bucket', 'Custom::S3AutoDeleteObjects'].includes(
+                c.cfnResourceType
+              )
+          )) {
+          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
+          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
+        }
+      }
+      "
+    `);
   });
 
   it('renders guest access patterns', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
@@ -248,14 +248,22 @@ describe('S3Generator', () => {
     const content = writtenFile('resource.ts');
     const normalized = content.replace(/\s+/g, ' ');
 
-    // Per-user paths use entity('identity') so {entity_id} maps to the caller's identity.
     expect(normalized).toMatch(
       /'private\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)\s*,?\s*\]/,
     );
     expect(normalized).toMatch(/'protected\/\{entity_id\}\/\*':\s*\[\s*allow\.entity\('identity'\)\.to\(\['read', 'write', 'delete'\]\)/);
 
-    // Enforce per-user scoping: private/protected must not grant write/delete via allow.authenticated.
-    expect(content).not.toMatch(/'(private|protected)\/\{entity_id\}\/\*': \[[^\]]*allow\.authenticated\.to\(\[[^\]]*'(write|delete)'/s);
+    // private/ and protected/ must not grant write/delete via allow.authenticated (public/*
+    // legitimately can, so the check is scoped to those paths). Rules render in the order
+    // public, protected, private, so slice out each per-user segment and assert on it.
+    const protectedSegment = normalized.slice(
+      normalized.indexOf("'protected/{entity_id}/*'"),
+      normalized.indexOf("'private/{entity_id}/*'"),
+    );
+    const privateSegment = normalized.slice(normalized.indexOf("'private/{entity_id}/*'"));
+    for (const segment of [protectedSegment, privateSegment]) {
+      expect(segment).not.toMatch(/allow\.authenticated\.to\(\[[^\]]*'(write|delete)'/);
+    }
   });
 
   it('renders guest access patterns', async () => {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
@@ -277,22 +277,25 @@ export class S3Renderer {
     const protectedPathAccess: CallExpression[] = [];
 
     if (accessPatterns.guest && accessPatterns.guest.length > 0) {
-      publicPathAccess.push(this.createAllowPattern(allowIdentifier, 'guest', accessPatterns.guest));
+      publicPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'guest', accessPatterns.guest));
     }
     if (accessPatterns.auth && accessPatterns.auth.length > 0) {
       // public/* is a shared path: authenticated users get the Gen1 auth permission set.
-      publicPathAccess.push(this.createAllowPattern(allowIdentifier, 'authenticated', accessPatterns.auth));
+      publicPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'authenticated', accessPatterns.auth));
       // private/ and protected/ are per-user paths. Use allow.entity('identity') so the
       // {entity_id} token resolves to the caller's own Cognito identity, matching the
       // per-user scoping of the Gen1 configuration.
-      privatePathAccess.push(this.createEntityPattern(allowIdentifier, accessPatterns.auth));
-      protectedPathAccess.push(this.createEntityPattern(allowIdentifier, accessPatterns.auth));
-      // Gen1 protected/ also grants read to other authenticated users.
-      protectedPathAccess.push(this.createAllowPattern(allowIdentifier, 'authenticated', ['read']));
+      privatePathAccess.push(S3Renderer.createEntityPattern(allowIdentifier, accessPatterns.auth));
+      protectedPathAccess.push(S3Renderer.createEntityPattern(allowIdentifier, accessPatterns.auth));
+      // Gen1 protected/ also grants read to other authenticated users. When the Gen1 auth
+      // permission set is read-only, this authenticated read subsumes the owner's
+      // entity('identity') read rule above; the overlap is harmless and keeps the per-path
+      // mapping uniform across permission sets.
+      protectedPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'authenticated', ['read']));
     }
     if (accessPatterns.groups) {
       for (const [groupName, permissions] of Object.entries(accessPatterns.groups)) {
-        const pattern = this.createAllowPattern(allowIdentifier, `groups(['${groupName}'])`, permissions);
+        const pattern = S3Renderer.createAllowPattern(allowIdentifier, `groups(['${groupName}'])`, permissions);
         publicPathAccess.push(pattern);
         privatePathAccess.push(pattern);
         protectedPathAccess.push(pattern);
@@ -308,7 +311,7 @@ export class S3Renderer {
         }
       }
       for (const [functionName, permissions] of Object.entries(consolidated)) {
-        const pattern = this.createResourcePattern(allowIdentifier, functionName, Array.from(permissions));
+        const pattern = S3Renderer.createResourcePattern(allowIdentifier, functionName, Array.from(permissions));
         publicPathAccess.push(pattern);
         privatePathAccess.push(pattern);
         protectedPathAccess.push(pattern);
@@ -349,7 +352,7 @@ export class S3Renderer {
     return factory.createPropertyAssignment(factory.createIdentifier('access'), accessFunction);
   }
 
-  private createAllowPattern(allowIdentifier: ts.Identifier, userLevel: string, permissions: readonly Permission[]): CallExpression {
+  private static createAllowPattern(allowIdentifier: ts.Identifier, userLevel: string, permissions: readonly Permission[]): CallExpression {
     return factory.createCallExpression(
       factory.createPropertyAccessExpression(allowIdentifier, factory.createIdentifier(`${userLevel}.to`)),
       undefined,
@@ -361,7 +364,7 @@ export class S3Renderer {
    * Renders `allow.entity('identity').to([...])`, which scopes an {entity_id} path to the
    * caller's own Cognito identity in the generated IAM policy.
    */
-  private createEntityPattern(allowIdentifier: ts.Identifier, permissions: readonly Permission[]): CallExpression {
+  private static createEntityPattern(allowIdentifier: ts.Identifier, permissions: readonly Permission[]): CallExpression {
     return factory.createCallExpression(
       factory.createPropertyAccessExpression(
         factory.createCallExpression(
@@ -376,7 +379,11 @@ export class S3Renderer {
     );
   }
 
-  private createResourcePattern(allowIdentifier: ts.Identifier, functionName: string, permissions: readonly Permission[]): CallExpression {
+  private static createResourcePattern(
+    allowIdentifier: ts.Identifier,
+    functionName: string,
+    permissions: readonly Permission[],
+  ): CallExpression {
     return factory.createCallExpression(
       factory.createPropertyAccessExpression(
         factory.createCallExpression(

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
@@ -280,10 +280,15 @@ export class S3Renderer {
       publicPathAccess.push(this.createAllowPattern(allowIdentifier, 'guest', accessPatterns.guest));
     }
     if (accessPatterns.auth && accessPatterns.auth.length > 0) {
-      const pattern = this.createAllowPattern(allowIdentifier, 'authenticated', accessPatterns.auth);
-      publicPathAccess.push(pattern);
-      protectedPathAccess.push(pattern);
-      privatePathAccess.push(pattern);
+      // public/* is a shared path: authenticated users get the Gen1 auth permission set.
+      publicPathAccess.push(this.createAllowPattern(allowIdentifier, 'authenticated', accessPatterns.auth));
+      // private/ and protected/ are per-user paths. Use allow.entity('identity') so the
+      // {entity_id} token resolves to the caller's own Cognito identity, matching the
+      // per-user scoping of the Gen1 configuration.
+      privatePathAccess.push(this.createEntityPattern(allowIdentifier, accessPatterns.auth));
+      protectedPathAccess.push(this.createEntityPattern(allowIdentifier, accessPatterns.auth));
+      // Gen1 protected/ also grants read to other authenticated users.
+      protectedPathAccess.push(this.createAllowPattern(allowIdentifier, 'authenticated', ['read']));
     }
     if (accessPatterns.groups) {
       for (const [groupName, permissions] of Object.entries(accessPatterns.groups)) {
@@ -347,6 +352,25 @@ export class S3Renderer {
   private createAllowPattern(allowIdentifier: ts.Identifier, userLevel: string, permissions: readonly Permission[]): CallExpression {
     return factory.createCallExpression(
       factory.createPropertyAccessExpression(allowIdentifier, factory.createIdentifier(`${userLevel}.to`)),
+      undefined,
+      [factory.createArrayLiteralExpression(permissions.map((p) => factory.createStringLiteral(p)))],
+    );
+  }
+
+  /**
+   * Renders `allow.entity('identity').to([...])`, which scopes an {entity_id} path to the
+   * caller's own Cognito identity in the generated IAM policy.
+   */
+  private createEntityPattern(allowIdentifier: ts.Identifier, permissions: readonly Permission[]): CallExpression {
+    return factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createCallExpression(
+          factory.createPropertyAccessExpression(allowIdentifier, factory.createIdentifier('entity')),
+          undefined,
+          [factory.createStringLiteral('identity')],
+        ),
+        factory.createIdentifier('to'),
+      ),
       undefined,
       [factory.createArrayLiteralExpression(permissions.map((p) => factory.createStringLiteral(p)))],
     );

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
@@ -280,17 +280,16 @@ export class S3Renderer {
       publicPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'guest', accessPatterns.guest));
     }
     if (accessPatterns.auth && accessPatterns.auth.length > 0) {
-      // public/* is a shared path: authenticated users get the Gen1 auth permission set.
+      // Gen1 authenticated access maps per path:
+      // - public/* is shared: authenticated users get the Gen1 auth permission set.
+      // - private/ and protected/ are per-user: use allow.entity('identity') so {entity_id}
+      //   resolves to the caller's own Cognito identity, matching the Gen1 per-user scoping.
+      // - protected/ additionally grants authenticated read (Gen1 cross-user read). When the
+      //   auth set is read-only this subsumes the owner's entity read; the overlap is harmless
+      //   and keeps the per-path mapping uniform across permission sets.
       publicPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'authenticated', accessPatterns.auth));
-      // private/ and protected/ are per-user paths. Use allow.entity('identity') so the
-      // {entity_id} token resolves to the caller's own Cognito identity, matching the
-      // per-user scoping of the Gen1 configuration.
       privatePathAccess.push(S3Renderer.createEntityPattern(allowIdentifier, accessPatterns.auth));
       protectedPathAccess.push(S3Renderer.createEntityPattern(allowIdentifier, accessPatterns.auth));
-      // Gen1 protected/ also grants read to other authenticated users. When the Gen1 auth
-      // permission set is read-only, this authenticated read subsumes the owner's
-      // entity('identity') read rule above; the overlap is harmless and keeps the per-path
-      // mapping uniform across permission sets.
       protectedPathAccess.push(S3Renderer.createAllowPattern(allowIdentifier, 'authenticated', ['read']));
     }
     if (accessPatterns.groups) {
@@ -360,10 +359,8 @@ export class S3Renderer {
     );
   }
 
-  /**
-   * Renders `allow.entity('identity').to([...])`, which scopes an {entity_id} path to the
-   * caller's own Cognito identity in the generated IAM policy.
-   */
+  // Renders `allow.entity('identity').to([...])`, which scopes an {entity_id} path to the
+  // caller's own Cognito identity in the generated IAM policy.
   private static createEntityPattern(allowIdentifier: ts.Identifier, permissions: readonly Permission[]): CallExpression {
     return factory.createCallExpression(
       factory.createPropertyAccessExpression(


### PR DESCRIPTION
#### Description of changes

The `gen2-migration generate` storage generator rendered Gen1 authenticated
access on the per-user paths `private/{entity_id}/*` and
`protected/{entity_id}/*` using `allow.authenticated`. With that rule the
`{entity_id}` token is not bound to the requesting user, so the generated
`defineStorage` access did not match the per-user scoping of the original
Gen1 configuration.

This change maps Gen1 authenticated access on `private/` and `protected/` to
`allow.entity('identity')`, so `{entity_id}` resolves to the caller's own
Cognito identity — matching the Gen1 behavior. `protected/` additionally
keeps `allow.authenticated` read access (Gen1 protected semantics), and
`public/*` is unchanged. Group and function access mappings are unchanged.

Files:
- `packages/amplify-cli/.../generate/amplify/storage/s3.renderer.ts` — access-rule mapping + a small `entity('identity')` render helper.
- `packages/amplify-cli/.../__tests__/.../storage/s3.generator.test.ts` — new coverage + updated inline snapshots.

#### Issue #, if available

<!-- fill in if you have a public tracking issue; otherwise leave blank -->

#### Description of how you validated changes

- `yarn jest s3.generator` — 12 tests pass, snapshots updated.
- Added a test asserting the per-user paths render `allow.entity('identity')`
  and never grant write/delete via `allow.authenticated`.
- Deployed a sandbox with a representative migrated config and confirmed the
  authenticated-role IAM policy scopes `private`/`protected` object access to
  the caller's Cognito identity.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
