### PR TITLE
fix(cli-internal): externalize Gen1 Lambda layer /opt/* requires in gen2-migration

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/function/function.generator.test.ts
@@ -4,6 +4,9 @@ import { RootPackageJsonGenerator } from '../../../../../../commands/gen2-migrat
 import { Gen1App } from '../../../../../../commands/gen2-migration/_common/gen1-app';
 import { createGen1App } from '../../_helpers/create-gen1-app';
 import { SpinningLogger } from '../../../../../../commands/gen2-migration/_common/spinning-logger';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
 
 jest.unmock('fs-extra');
 
@@ -1263,5 +1266,161 @@ describe('FunctionGenerator', () => {
 
     const generator = createFunctionGenerator({ gen1App, backendGenerator, packageJsonGenerator, outputDir });
     await expect(generator.plan()).rejects.toThrow("unsupported runtime 'python3.9'");
+  });
+
+  describe('Lambda layer (/opt/*) handling', () => {
+    let fixtureCwd: string;
+    let previousCwd: string;
+
+    /**
+     * Creates a real Gen1 function source tree under a temp cwd so the generator
+     * scans actual files (no mocking of the detection path).
+     */
+    function writeFunctionSource(resourceName: string, files: Record<string, string>): void {
+      const srcDir = nodePath.join(fixtureCwd, 'amplify', 'backend', 'function', resourceName, 'src');
+      mkdirSync(srcDir, { recursive: true });
+      for (const [relPath, content] of Object.entries(files)) {
+        const target = nodePath.join(srcDir, relPath);
+        mkdirSync(nodePath.dirname(target), { recursive: true });
+        writeFileSync(target, content, 'utf8');
+      }
+    }
+
+    async function buildLayerGen1App(resourceName: string): Promise<Gen1App> {
+      const gen1App = await createGen1App({
+        providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+        function: {
+          [resourceName]: {
+            service: 'Lambda',
+            output: {
+              Name: `${resourceName}-main-abc`,
+              Arn: `arn:aws:lambda:us-east-1:123:function:${resourceName}-main-abc`,
+            },
+          },
+        },
+      });
+      jest.spyOn(gen1App, 'resourceMetaOutput').mockReturnValue(`${resourceName}-main-abc`);
+      jest.spyOn(gen1App, 'json').mockReturnValue({ Resources: {} });
+      jest.spyOn(gen1App, 'file').mockReturnValue('{}');
+      jest.spyOn(gen1App, 'fileExists').mockReturnValue(false);
+      jest.spyOn(gen1App.aws, 'fetchFunctionConfig').mockResolvedValue({
+        FunctionName: `${resourceName}-main-abc`,
+        Handler: 'index.handler',
+        Timeout: 3,
+        MemorySize: 128,
+        Runtime: 'nodejs18.x',
+        Environment: { Variables: {} },
+      });
+      jest.spyOn(gen1App.aws, 'fetchFunctionSchedule').mockResolvedValue(undefined);
+      return gen1App;
+    }
+
+    beforeEach(() => {
+      previousCwd = process.cwd();
+      fixtureCwd = mkdtempSync(nodePath.join(tmpdir(), 'gen2-layer-fixture-'));
+      process.chdir(fixtureCwd);
+    });
+
+    afterEach(() => {
+      process.chdir(previousCwd);
+      rmSync(fixtureCwd, { recursive: true, force: true });
+    });
+
+    it('externalizes /opt/* layer requires via the defineFunction layers map', async () => {
+      const gen1App = await buildLayerGen1App('layerFunc');
+      writeFunctionSource('layerFunc', {
+        'index.js': ["const { doThing } = require('/opt/GQLUtilities');", 'exports.handler = async () => doThing();'].join('\n'),
+      });
+
+      const generator = createFunctionGenerator({
+        gen1App,
+        backendGenerator,
+        packageJsonGenerator,
+        outputDir,
+        resourceName: 'layerFunc',
+      });
+      const ops = await generator.plan();
+      await ops[0].execute();
+
+      const output = writtenFile('resource.ts');
+      expect(output).toContain('layers: {');
+      expect(output).toContain("'/opt/GQLUtilities': 'REPLACE_WITH_LAYER_VERSION_ARN'");
+      // The layers map must be inside defineFunction (before the escape-hatch fn),
+      // which is what makes esbuild externalize the module.
+      expect(output.indexOf('layers: {')).toBeLessThan(output.indexOf('applyEscapeHatches'));
+    });
+
+    it('normalizes nested and multiple /opt/* imports to unique layer roots', async () => {
+      const gen1App = await buildLayerGen1App('layerFunc2');
+      writeFunctionSource('layerFunc2', {
+        'index.mjs': [
+          "import util from '/opt/GQLUtilities/helpers/format.js';",
+          "import { z } from '/opt/GQLUtilities';",
+          "const shared = require('/opt/SharedLib');",
+          'export const handler = async () => [util, z, shared];',
+        ].join('\n'),
+        'nested/inner.ts': "export const x = require('/opt/SharedLib/nested');",
+      });
+
+      const generator = createFunctionGenerator({
+        gen1App,
+        backendGenerator,
+        packageJsonGenerator,
+        outputDir,
+        resourceName: 'layerFunc2',
+      });
+      const ops = await generator.plan();
+      await ops[0].execute();
+
+      const output = writtenFile('resource.ts');
+      expect(output).toContain("'/opt/GQLUtilities': 'REPLACE_WITH_LAYER_VERSION_ARN'");
+      expect(output).toContain("'/opt/SharedLib': 'REPLACE_WITH_LAYER_VERSION_ARN'");
+      // Nested subpaths collapse to the layer root — no duplicate keys.
+      expect(output).not.toContain('/opt/GQLUtilities/helpers');
+      expect(output.match(/\/opt\/GQLUtilities'/g)).toHaveLength(1);
+    });
+
+    it('emits a migration warning describing the detected layers', async () => {
+      const gen1App = await buildLayerGen1App('layerFunc3');
+      writeFunctionSource('layerFunc3', {
+        'index.js': "const u = require('/opt/GQLUtilities');\nexports.handler = async () => u;",
+      });
+
+      const generator = createFunctionGenerator({
+        gen1App,
+        backendGenerator,
+        packageJsonGenerator,
+        outputDir,
+        resourceName: 'layerFunc3',
+      });
+      const ops = await generator.plan();
+      const descriptions = await ops[0].describe();
+
+      const warning = descriptions.find((d) => d.includes('/opt/GQLUtilities'));
+      expect(warning).toBeDefined();
+      expect(warning).toContain('replace the placeholder ARN');
+    });
+
+    it('does not emit a layers map when the function has no /opt/* imports', async () => {
+      const gen1App = await buildLayerGen1App('plainFunc');
+      writeFunctionSource('plainFunc', {
+        'index.js': "const os = require('os');\nexports.handler = async () => os.platform();",
+      });
+
+      const generator = createFunctionGenerator({
+        gen1App,
+        backendGenerator,
+        packageJsonGenerator,
+        outputDir,
+        resourceName: 'plainFunc',
+      });
+      const ops = await generator.plan();
+      await ops[0].execute();
+
+      const output = writtenFile('resource.ts');
+      expect(output).not.toContain('layers:');
+      const descriptions = await ops[0].describe();
+      expect(descriptions.some((d) => d.includes('/opt/'))).toBe(false);
+    });
   });
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.generator.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { Dirent, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { AmplifyMigrationOperation } from '../../../_common/operation';
 import { AmplifyError, JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { Planner } from '../../../_common/planner';
@@ -87,6 +88,8 @@ export class FunctionGenerator implements Planner {
     const storageTriggerTables = this.detectDynamoTriggerTables();
     const isKinesisTrigger = this.isKinesisTrigger();
 
+    const layerModules = this.detectLayerModules();
+
     const hasAnalytics = kinesisActions.length > 0 || isKinesisTrigger;
 
     const renderOpts: FunctionRenderOptions = {
@@ -104,6 +107,7 @@ export class FunctionGenerator implements Planner {
       dataTriggerModels,
       storageTriggerTables,
       unMappedAuthActions,
+      layerModules,
       kinesisConfig: hasAnalytics
         ? {
             resourceName: this.gen1App.singleResourceName('analytics', 'Kinesis'),
@@ -123,7 +127,11 @@ export class FunctionGenerator implements Planner {
       {
         resource: this.resource,
         validate: () => undefined,
-        describe: async () => [`Generate amplify/function/${resourceName}/resource.ts`],
+        describe: async () => {
+          const lines = [`Generate amplify/function/${resourceName}/resource.ts`];
+          for (const line of this.layerWarningLines(layerModules)) lines.push(line);
+          return lines;
+        },
         execute: async () => {
           const dirPath = path.join(this.outputDir, 'amplify', 'function', resourceName);
 
@@ -134,6 +142,8 @@ export class FunctionGenerator implements Planner {
           await fs.mkdir(dirPath, { recursive: true });
           await fs.writeFile(path.join(dirPath, 'resource.ts'), content, 'utf-8');
           await this.copyFunctionSource(resourceName, dirPath);
+
+          for (const line of this.layerWarningLines(layerModules)) this.logger.warn(line);
 
           const alias = resourceName;
           this.backendGenerator.addNamespaceImport(alias, `./function/${resourceName}/resource`);
@@ -221,6 +231,72 @@ export class FunctionGenerator implements Planner {
         );
       },
     });
+  }
+
+  /**
+   * Scans the Gen1 function source for Lambda layer imports of the form
+   * `require('/opt/<layer>')` / `import ... from '/opt/<layer>'`. These resolve
+   * to a Lambda layer mounted at `/opt` at runtime and cannot be resolved by
+   * esbuild at build time. Returns the unique layer roots (`/opt/<layer>`) so
+   * they can be externalized via the generated `layers` map.
+   */
+  private detectLayerModules(): string[] {
+    const srcDir = path.join('amplify', 'backend', 'function', this.resource.resourceName, 'src');
+    if (!existsSync(srcDir)) return [];
+
+    const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+    // Matches the module specifier of a require()/import()/import-from statement
+    // whose target starts with `/opt/`.
+    const importPattern = /(?:require\s*\(\s*|import\s*\(\s*|from\s+)['"](\/opt\/[^'"]+)['"]/g;
+
+    const layerRoots = new Set<string>();
+    const walk = (dir: string): void => {
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(dir, { withFileTypes: true }) as Dirent[];
+      } catch {
+        // Directory became unreadable — skip it rather than fail the migration.
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.name === 'node_modules') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!SOURCE_EXTENSIONS.has(path.extname(entry.name))) continue;
+        let content: string;
+        try {
+          content = readFileSync(full, 'utf8');
+        } catch {
+          continue;
+        }
+        for (const match of content.matchAll(importPattern)) {
+          const specifier = match[1];
+          // Normalize `/opt/<layer>/nested/path` down to the layer root `/opt/<layer>`.
+          const segments = specifier.split('/').filter(Boolean); // ['opt', '<layer>', ...]
+          if (segments.length >= 2) layerRoots.add(`/${segments[0]}/${segments[1]}`);
+        }
+      }
+    };
+    walk(srcDir);
+
+    return Array.from(layerRoots).sort();
+  }
+
+  /**
+   * Human-readable migration warnings for detected Lambda layers. Surfaced both
+   * in the plan's Operations Summary and via the logger during execution.
+   */
+  private layerWarningLines(layerModules: readonly string[]): string[] {
+    if (layerModules.length === 0) return [];
+    return [
+      `Detected Lambda layer import(s) (${layerModules.join(', ')}) in function '${this.resource.resourceName}'. ` +
+        `These were externalized in the generated defineFunction({ layers }) so the build succeeds, ` +
+        `but you MUST replace the placeholder ARN(s) with your migrated Lambda layer version ARN(s) before deploying. ` +
+        `The Gen1 layer package itself is not migrated automatically.`,
+    ];
   }
 
   private contributeDependencies(): void {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.renderer.ts
@@ -25,7 +25,20 @@ export interface FunctionRenderOptions {
   readonly kinesisConfig?: KinesisConfig;
   readonly unMappedAuthActions: readonly string[];
   readonly storageTriggerTables: readonly string[];
+  /**
+   * Lambda layer module specifiers (e.g. `/opt/GQLUtilities`) required by the
+   * function source. Each becomes a key in the generated `layers` map so that
+   * esbuild externalizes it instead of failing to resolve `/opt/*` at build time.
+   */
+  readonly layerModules?: readonly string[];
 }
+
+/**
+ * Placeholder value emitted for each detected Lambda layer in the generated
+ * `layers` map. The migration cannot know the Gen2 layer ARN, so the developer
+ * must replace this with a real layer version ARN before deploying.
+ */
+export const LAYER_ARN_PLACEHOLDER = 'REPLACE_WITH_LAYER_VERSION_ARN';
 
 export interface KinesisConfig {
   readonly resourceName: string;
@@ -89,6 +102,7 @@ export class FunctionRenderer {
     this.renderEnvironment(properties, namedImports, opts);
     this.renderRuntime(properties, opts.runtime);
     this.renderSchedule(properties, opts.schedule);
+    this.renderLayers(properties, opts.layerModules);
 
     return TS.renderResourceTsFile({
       exportedVariableName: factory.createIdentifier(opts.resourceName),
@@ -353,6 +367,34 @@ export class FunctionRenderer {
     if (converted) {
       target.push(factory.createPropertyAssignment('schedule', factory.createStringLiteral(converted)));
     }
+  }
+
+  /**
+   * Renders the `layers` property from detected `/opt/*` layer requires.
+   *
+   * Each module specifier becomes a key in the `layers` map. In Gen2 the key is
+   * used to externalize the module during esbuild bundling (so `/opt/*` requires
+   * no longer break the build) and the value is the Lambda layer version ARN
+   * attached at runtime. The ARN is unknown at migration time, so a placeholder
+   * is emitted with an explanatory comment for the developer to fill in.
+   */
+  private renderLayers(target: ObjectLiteralElementLike[], layerModules?: readonly string[]): void {
+    if (!layerModules || layerModules.length === 0) return;
+
+    const layerEntries = Array.from(new Set(layerModules)).map((moduleName) =>
+      factory.createPropertyAssignment(factory.createStringLiteral(moduleName), factory.createStringLiteral(LAYER_ARN_PLACEHOLDER)),
+    );
+
+    const layersProperty = factory.createPropertyAssignment('layers', factory.createObjectLiteralExpression(layerEntries, true));
+
+    ts.addSyntheticLeadingComment(
+      layersProperty,
+      ts.SyntaxKind.SingleLineCommentTrivia,
+      ' TODO: replace the placeholder ARN(s) with the ARN of the migrated Lambda layer version. See https://docs.amplify.aws/react/build-a-backend/functions/add-lambda-layers',
+      true,
+    );
+
+    target.push(layersProperty);
   }
 }
 


### PR DESCRIPTION
### Problem

Gen1→Gen2 migration dropped Lambda **layer** handling entirely. When a Gen1 function's code references a Lambda layer via a `/opt/<layer>` runtime path (e.g. `require('/opt/GQLUtilities')`), the migration tool:

1. did **not** migrate the Gen1 Lambda layer package into any Gen2 layer definition, and
2. did **not** externalize the `/opt/*` requires in the generated `defineFunction` config.

As a result the generated Gen2 app fails at CDK asset bundling — esbuild cannot resolve `/opt/*` and the deploy fails with `FailedToBundleAsset`. Observed on customer app **bpedsys** (ticket V2205182405), whose migrated functions contained `require("/opt/GQLUtilities")`.

### Root cause (exact gap)

`packages/amplify-cli/src/commands/gen2-migration/generate/amplify/function/function.generator.ts` — `FunctionGenerator.plan()` built the `FunctionRenderOptions` (env vars, runtime, schedule, triggers, IAM grants…) but never inspected the function source for `/opt/*` layer imports and never emitted a `layers` map. There was **zero** `layer`/`/opt/` handling anywhere under `gen2-migration/`.

`@aws-amplify/backend-function`'s factory computes esbuild externals as `externalModules = Object.keys(props.layers)`, so populating `defineFunction({ layers })` with a `/opt/<layer>` key is exactly what externalizes the module and unblocks bundling.

### Fix (this PR — minimal, build-unblocking)

- **Detect**: `FunctionGenerator.detectLayerModules()` scans the Gen1 function source (`amplify/backend/function/<name>/src`, recursive, skips `node_modules`, `.js/.jsx/.ts/.tsx/.mjs/.cjs`) for `require()/import()/import … from '/opt/<layer>'` and normalizes each to its layer root `/opt/<layer>` (deduped).
- **Externalize**: `FunctionRenderer.renderLayers()` emits a `layers` map inside `defineFunction`, keyed by each `/opt/<layer>` module, with a `REPLACE_WITH_LAYER_VERSION_ARN` placeholder value and a `// TODO` comment (link to the layers docs). The key makes esbuild externalize the module → **the build now succeeds**.
- **Warn**: a migration warning is surfaced both in the plan's Operations Summary (`describe()`) and via `logger.warn` during execution, telling the developer to replace the placeholder ARN(s) and noting that the Gen1 layer package itself is not migrated automatically.

### Scope / follow-up (honest boundaries)

This PR fixes the **build-breaking externalization gap** so migrated apps build with a single, clearly-documented manual step (supply the layer ARN). It does **not** migrate the Gen1 layer *code* (`function/<layer>/opt/*`) into a Gen2 custom CDK `LayerVersion` and auto-wire it — that is a larger, riskier change recommended as a **follow-up PR**.

### Tests

Added unit tests in `function.generator.test.ts` using **real on-disk Gen1 function fixtures** (temp cwd, no mocking of the detection path):
- externalizes `/opt/*` requires via the `layers` map (and asserts it renders inside `defineFunction`, before the escape-hatch fn);
- normalizes nested + multiple `/opt/*` imports to unique layer roots (no duplicate keys);
- emits the migration warning in `describe()`;
- no-op when the function has no `/opt/*` imports (no `layers` map, no warning).

### Local results

- `function.generator.test.ts`: **27 passed** (23 pre-existing + 4 new), no snapshot changes.
- Full `gen2-migration/generate` suite: **233 passed / 21 suites**, zero regressions.
- `tsc --noEmit` on the package: clean.

🤖 Draft PR opened via Roko.
