### PR TITLE
fix: use execFileSync for git commands in preInitSetup to prevent shell injection

### DIFF
--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -1,5 +1,5 @@
 import { $TSContext, AmplifyError, getPackageManager, LocalEnvInfo, pathManager } from '@aws-amplify/amplify-cli-core';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs-extra';
 import * as url from 'url';
 import { generateLocalEnvInfoFile } from './s9-onSuccess';
@@ -83,7 +83,7 @@ function validateGithubRepo(repoUrl: string | boolean): asserts repoUrl is strin
     }
     url.parse(repoUrl);
 
-    execSync(`git ls-remote ${repoUrl}`, { stdio: 'ignore' });
+    execFileSync('git', ['ls-remote', repoUrl], { stdio: 'ignore' });
   } catch (e) {
     throw new AmplifyError(
       'ProjectInitError',
@@ -110,7 +110,7 @@ const cloneRepo = async (repoUrl: string): Promise<void> => {
   }
 
   try {
-    execSync(`git clone ${repoUrl} .`, { stdio: 'inherit' });
+    execFileSync('git', ['clone', repoUrl, '.'], { stdio: 'inherit' });
   } catch (e) {
     throw new AmplifyError(
       'ProjectInitError',


### PR DESCRIPTION
## Summary

Replace `execSync` with `execFileSync` (array form) for the two git commands in `packages/amplify-cli/src/init-steps/preInitSetup.ts`:

- `git ls-remote <url>` in `validateGithubRepo()`
- `git clone <url> .` in `cloneRepo()`

## Motivation

Using the array-form `execFileSync` avoids spawning a shell and passes arguments directly to the executable. This is the recommended Node.js `child_process` API when constructing commands with variable inputs, as it avoids potential issues with special characters in URLs being interpreted by the shell.

## Changes

- Import `execFileSync` from `child_process`
- Replace `execSync(\`git ls-remote ${repoUrl}\`)` with `execFileSync('git', ['ls-remote', repoUrl])`
- Replace `execSync(\`git clone ${repoUrl} .\`)` with `execFileSync('git', ['clone', repoUrl, '.'])`

## Testing

- Pre-commit hooks (prettier, eslint, commitlint) pass
- No functional change in behavior for valid URLs