### PR TITLE
fix(cli): use execFileSync for git operations in --app init flow

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/init.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/init.test.ts
@@ -8,7 +8,7 @@ import {
   getPackageManagerByType,
   $TSAny,
 } from '@aws-amplify/amplify-cli-core';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { ensureDir, existsSync, readFileSync, readJSON, readdirSync } from 'fs-extra';
 import { sync } from 'which';
 import { getPreInitSetup } from '../../init-steps/preInitSetup';
@@ -140,8 +140,8 @@ describe('amplify init:', () => {
       const recommendGen2 = true;
       const step = getPreInitSetup(!recommendGen2);
       await step(context as unknown as $TSContext);
-      expect(execSync).toBeCalledWith(`git ls-remote ${appUrl}`, { stdio: 'ignore' });
-      expect(execSync).toBeCalledWith(`git clone ${appUrl} .`, { stdio: 'inherit' });
+      expect(execFileSync).toBeCalledWith('git', ['ls-remote', appUrl], { stdio: 'ignore' });
+      expect(execFileSync).toBeCalledWith('git', ['clone', appUrl, '.'], { stdio: 'inherit' });
       expect(execSync).toBeCalledWith('yarn install', { stdio: 'inherit' });
     });
   });

--- a/packages/amplify-cli/src/init-steps/preInitSetup.ts
+++ b/packages/amplify-cli/src/init-steps/preInitSetup.ts
@@ -1,5 +1,5 @@
 import { $TSContext, AmplifyError, getPackageManager, LocalEnvInfo, pathManager } from '@aws-amplify/amplify-cli-core';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs-extra';
 import * as url from 'url';
 import { generateLocalEnvInfoFile } from './s9-onSuccess';
@@ -83,7 +83,7 @@ function validateGithubRepo(repoUrl: string | boolean): asserts repoUrl is strin
     }
     url.parse(repoUrl);
 
-    execSync(`git ls-remote ${repoUrl}`, { stdio: 'ignore' });
+    execFileSync('git', ['ls-remote', repoUrl], { stdio: 'ignore' });
   } catch (e) {
     throw new AmplifyError(
       'ProjectInitError',
@@ -110,7 +110,7 @@ const cloneRepo = async (repoUrl: string): Promise<void> => {
   }
 
   try {
-    execSync(`git clone ${repoUrl} .`, { stdio: 'inherit' });
+    execFileSync('git', ['clone', repoUrl, '.'], { stdio: 'inherit' });
   } catch (e) {
     throw new AmplifyError(
       'ProjectInitError',


### PR DESCRIPTION
Git operations in the --app flow use execFileSync with explicit argument arrays, preventing unintended shell interpretation of URL parameters.