### PR TITLE
fix(amplify-category-storage): make IAM policy names environment-specific

### DIFF
--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -25,6 +25,7 @@ const mockContext = {
       },
     }),
     getUserPoolGroupList: () => [],
+    getEnvInfo: () => ({ envName: 'mockenv' }),
     // eslint-disable-next-line
     getResourceStatus: () => {
       return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
@@ -91,13 +92,13 @@ describe('Test S3 transform generates correct CFN template', () => {
       unauthRoleName: { Ref: 'UnauthRoleName' },
       authRoleName: { Ref: 'AuthRoleName' },
       triggerFunction: mockTriggerFunction,
-      s3PrivatePolicy: `Private_policy_${shortId}`,
-      s3ProtectedPolicy: `Protected_policy_${shortId}`,
-      s3PublicPolicy: `Public_policy_${shortId}`,
-      s3ReadPolicy: `read_policy_${shortId}`,
-      s3UploadsPolicy: `Uploads_policy_${shortId}`,
-      authPolicyName: `s3_amplify_${shortId}`,
-      unauthPolicyName: `s3_amplify_${shortId}`,
+      s3PrivatePolicy: `Private_policy_${shortId}_mockenv`,
+      s3ProtectedPolicy: `Protected_policy_${shortId}_mockenv`,
+      s3PublicPolicy: `Public_policy_${shortId}_mockenv`,
+      s3ReadPolicy: `read_policy_${shortId}_mockenv`,
+      s3UploadsPolicy: `Uploads_policy_${shortId}_mockenv`,
+      authPolicyName: `s3_amplify_${shortId}_mockenv`,
+      unauthPolicyName: `s3_amplify_${shortId}_mockenv`,
       AuthenticatedAllowList: 'ALLOW',
       GuestAllowList: 'ALLOW',
       s3PermissionsAuthenticatedPrivate: 's3:PutObject,s3:GetObject,s3:DeleteObject',

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-builder.test.ts
@@ -25,7 +25,6 @@ const mockContext = {
       },
     }),
     getUserPoolGroupList: () => [],
-    getEnvInfo: () => ({ envName: 'mockenv' }),
     // eslint-disable-next-line
     getResourceStatus: () => {
       return { allResources: S3MockDataBuilder.getMockGetAllResourcesNoExistingLambdas() };
@@ -92,13 +91,13 @@ describe('Test S3 transform generates correct CFN template', () => {
       unauthRoleName: { Ref: 'UnauthRoleName' },
       authRoleName: { Ref: 'AuthRoleName' },
       triggerFunction: mockTriggerFunction,
-      s3PrivatePolicy: `Private_policy_${shortId}_mockenv`,
-      s3ProtectedPolicy: `Protected_policy_${shortId}_mockenv`,
-      s3PublicPolicy: `Public_policy_${shortId}_mockenv`,
-      s3ReadPolicy: `read_policy_${shortId}_mockenv`,
-      s3UploadsPolicy: `Uploads_policy_${shortId}_mockenv`,
-      authPolicyName: `s3_amplify_${shortId}_mockenv`,
-      unauthPolicyName: `s3_amplify_${shortId}_mockenv`,
+      s3PrivatePolicy: `Private_policy_${shortId}`,
+      s3ProtectedPolicy: `Protected_policy_${shortId}`,
+      s3PublicPolicy: `Public_policy_${shortId}`,
+      s3ReadPolicy: `read_policy_${shortId}`,
+      s3UploadsPolicy: `Uploads_policy_${shortId}`,
+      authPolicyName: `s3_amplify_${shortId}`,
+      unauthPolicyName: `s3_amplify_${shortId}`,
       AuthenticatedAllowList: 'ALLOW',
       GuestAllowList: 'ALLOW',
       s3PermissionsAuthenticatedPrivate: 's3:PutObject,s3:GetObject,s3:DeleteObject',

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
@@ -1,0 +1,51 @@
+import { $TSContext } from '@aws-amplify/amplify-cli-core';
+import { AmplifyS3ResourceStackTransform } from '../../../../provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform';
+import { S3UserInputs } from '../../../../provider-utils/awscloudformation/service-walkthrough-types/s3-user-input-types';
+import { S3InputState } from '../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state';
+
+jest.mock('@aws-amplify/amplify-cli-core', () => ({
+  pathManager: {
+    getBackendDirPath: jest.fn().mockReturnValue('mockbackendpath'),
+  },
+}));
+
+jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state');
+
+describe('AmplifyS3ResourceStackTransform', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes the environment name in IAM policy names', () => {
+    const userInput: S3UserInputs = {
+      resourceName: 'storage',
+      bucketName: 'bucket',
+      policyUUID: 'abc123',
+      storageAccess: undefined,
+      guestAccess: [],
+      authAccess: [],
+    };
+    const context = {
+      amplify: {
+        getEnvInfo: jest.fn().mockReturnValue({ envName: 'prod' }),
+      },
+    } as unknown as $TSContext;
+
+    jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockReturnValue(userInput);
+    jest.spyOn(S3InputState.prototype, 'getUserInput').mockReturnValue(userInput);
+    jest.spyOn(S3InputState, 'getCfnPermissionsFromInputPermissions').mockReturnValue([]);
+
+    const transform = new AmplifyS3ResourceStackTransform('storage', context);
+    transform.generateCfnInputParameters();
+
+    expect(transform.getCFNInputParams()).toMatchObject({
+      s3PrivatePolicy: 'Private_policy_abc123_prod',
+      s3ProtectedPolicy: 'Protected_policy_abc123_prod',
+      s3PublicPolicy: 'Public_policy_abc123_prod',
+      s3ReadPolicy: 'read_policy_abc123_prod',
+      s3UploadsPolicy: 'Uploads_policy_abc123_prod',
+      authPolicyName: 's3_amplify_abc123_prod',
+      unauthPolicyName: 's3_amplify_abc123_prod',
+    });
+  });
+});

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
@@ -17,31 +17,40 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
 
 jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state');
 
+const userInput: S3UserInputs = {
+  resourceName: 'storage',
+  bucketName: 'bucket',
+  policyUUID: 'abc123',
+  storageAccess: undefined,
+  guestAccess: [],
+  authAccess: [],
+};
+
+const importedAuthMeta = { auth: { cognitoauth: { service: 'Cognito', serviceType: 'imported' } } };
+const managedAuthMeta = { auth: { cognitoauth: { service: 'Cognito', serviceType: 'managed' } } };
+
+const buildContext = (meta: unknown, envName: string): $TSContext =>
+  ({
+    amplify: {
+      getProjectMeta: jest.fn().mockReturnValue(meta),
+      getEnvInfo: jest.fn().mockReturnValue({ envName }),
+    },
+  } as unknown as $TSContext);
+
+const stubInputState = (): void => {
+  jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockReturnValue(userInput);
+  jest.spyOn(S3InputState.prototype, 'getUserInput').mockReturnValue(userInput);
+  jest.spyOn(S3InputState, 'getCfnPermissionsFromInputPermissions').mockReturnValue([]);
+};
+
 describe('AmplifyS3ResourceStackTransform', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('includes the environment name in IAM policy names', () => {
-    const userInput: S3UserInputs = {
-      resourceName: 'storage',
-      bucketName: 'bucket',
-      policyUUID: 'abc123',
-      storageAccess: undefined,
-      guestAccess: [],
-      authAccess: [],
-    };
-    const context = {
-      amplify: {
-        getEnvInfo: jest.fn().mockReturnValue({ envName: 'prod' }),
-      },
-    } as unknown as $TSContext;
-
-    jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockReturnValue(userInput);
-    jest.spyOn(S3InputState.prototype, 'getUserInput').mockReturnValue(userInput);
-    jest.spyOn(S3InputState, 'getCfnPermissionsFromInputPermissions').mockReturnValue([]);
-
-    const transform = new AmplifyS3ResourceStackTransform('storage', context);
+  it('appends the environment name to IAM policy names when auth is imported', () => {
+    stubInputState();
+    const transform = new AmplifyS3ResourceStackTransform('storage', buildContext(importedAuthMeta, 'prod'));
     transform.generateCfnInputParameters();
 
     expect(transform.getCFNInputParams()).toMatchObject({
@@ -55,27 +64,29 @@ describe('AmplifyS3ResourceStackTransform', () => {
     });
   });
 
-  it('throws when the current environment name cannot be determined', () => {
-    const userInput: S3UserInputs = {
-      resourceName: 'storage',
-      bucketName: 'bucket',
-      policyUUID: 'abc123',
-      storageAccess: undefined,
-      guestAccess: [],
-      authAccess: [],
-    };
-    // Env info carries no envName (uninitialized env / headless path).
-    const context = {
-      amplify: {
-        getEnvInfo: jest.fn().mockReturnValue({}),
-      },
-    } as unknown as $TSContext;
+  it('keeps the legacy (env-agnostic) IAM policy names when auth is not imported', () => {
+    // Managed auth gives each environment its own roles, so names never collide. Keeping the
+    // legacy name avoids forcing a policy replacement on every existing storage app on upgrade.
+    stubInputState();
+    const transform = new AmplifyS3ResourceStackTransform('storage', buildContext(managedAuthMeta, 'prod'));
+    transform.generateCfnInputParameters();
 
-    jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockReturnValue(userInput);
-    jest.spyOn(S3InputState.prototype, 'getUserInput').mockReturnValue(userInput);
-    jest.spyOn(S3InputState, 'getCfnPermissionsFromInputPermissions').mockReturnValue([]);
+    expect(transform.getCFNInputParams()).toMatchObject({
+      s3PrivatePolicy: 'Private_policy_abc123',
+      s3ProtectedPolicy: 'Protected_policy_abc123',
+      s3PublicPolicy: 'Public_policy_abc123',
+      s3ReadPolicy: 'read_policy_abc123',
+      s3UploadsPolicy: 'Uploads_policy_abc123',
+      authPolicyName: 's3_amplify_abc123',
+      unauthPolicyName: 's3_amplify_abc123',
+    });
+  });
 
-    const transform = new AmplifyS3ResourceStackTransform('storage', context);
+  it('throws when auth is imported but the current environment name cannot be determined', () => {
+    // Imported auth needs the env suffix; a blank envName would otherwise degrade to a
+    // shared "_undefined" name and re-collide, so we fail fast instead.
+    stubInputState();
+    const transform = new AmplifyS3ResourceStackTransform('storage', buildContext(importedAuthMeta, ''));
 
     expect(() => transform.generateCfnInputParameters()).toThrow(/environment name/);
   });

--- a/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
+++ b/packages/amplify-category-storage/src/__tests__/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.test.ts
@@ -7,6 +7,12 @@ jest.mock('@aws-amplify/amplify-cli-core', () => ({
   pathManager: {
     getBackendDirPath: jest.fn().mockReturnValue('mockbackendpath'),
   },
+  AmplifyError: class AmplifyError extends Error {
+    constructor(code: string, options: { message: string }) {
+      super(options.message);
+      this.name = code;
+    }
+  },
 }));
 
 jest.mock('../../../../provider-utils/awscloudformation/service-walkthroughs/s3-user-input-state');
@@ -47,5 +53,30 @@ describe('AmplifyS3ResourceStackTransform', () => {
       authPolicyName: 's3_amplify_abc123_prod',
       unauthPolicyName: 's3_amplify_abc123_prod',
     });
+  });
+
+  it('throws when the current environment name cannot be determined', () => {
+    const userInput: S3UserInputs = {
+      resourceName: 'storage',
+      bucketName: 'bucket',
+      policyUUID: 'abc123',
+      storageAccess: undefined,
+      guestAccess: [],
+      authAccess: [],
+    };
+    // Env info carries no envName (uninitialized env / headless path).
+    const context = {
+      amplify: {
+        getEnvInfo: jest.fn().mockReturnValue({}),
+      },
+    } as unknown as $TSContext;
+
+    jest.spyOn(S3InputState.prototype, 'getCliInputPayload').mockReturnValue(userInput);
+    jest.spyOn(S3InputState.prototype, 'getUserInput').mockReturnValue(userInput);
+    jest.spyOn(S3InputState, 'getCfnPermissionsFromInputPermissions').mockReturnValue([]);
+
+    const transform = new AmplifyS3ResourceStackTransform('storage', context);
+
+    expect(() => transform.generateCfnInputParameters()).toThrow(/environment name/);
   });
 });

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -112,13 +112,14 @@ export class AmplifyS3ResourceStackTransform {
     if (userInput.adminTriggerFunction?.triggerFunction && userInput.adminTriggerFunction.triggerFunction !== 'NONE') {
       this.cfnInputParams.adminTriggerFunction = userInput.adminTriggerFunction.triggerFunction;
     }
-    this.cfnInputParams.s3PrivatePolicy = `Private_policy_${userInput.policyUUID}`;
-    this.cfnInputParams.s3ProtectedPolicy = `Protected_policy_${userInput.policyUUID}`;
-    this.cfnInputParams.s3PublicPolicy = `Public_policy_${userInput.policyUUID}`;
-    this.cfnInputParams.s3ReadPolicy = `read_policy_${userInput.policyUUID}`;
-    this.cfnInputParams.s3UploadsPolicy = `Uploads_policy_${userInput.policyUUID}`;
-    this.cfnInputParams.authPolicyName = `s3_amplify_${userInput.policyUUID}`;
-    this.cfnInputParams.unauthPolicyName = `s3_amplify_${userInput.policyUUID}`;
+    const policyNameSuffix = `${userInput.policyUUID}_${this.context.amplify.getEnvInfo().envName}`;
+    this.cfnInputParams.s3PrivatePolicy = `Private_policy_${policyNameSuffix}`;
+    this.cfnInputParams.s3ProtectedPolicy = `Protected_policy_${policyNameSuffix}`;
+    this.cfnInputParams.s3PublicPolicy = `Public_policy_${policyNameSuffix}`;
+    this.cfnInputParams.s3ReadPolicy = `read_policy_${policyNameSuffix}`;
+    this.cfnInputParams.s3UploadsPolicy = `Uploads_policy_${policyNameSuffix}`;
+    this.cfnInputParams.authPolicyName = `s3_amplify_${policyNameSuffix}`;
+    this.cfnInputParams.unauthPolicyName = `s3_amplify_${policyNameSuffix}`;
     this.cfnInputParams.AuthenticatedAllowList = this._getAuthGuestListPermission(S3PermissionType.READ, userInput.authAccess);
     this.cfnInputParams.GuestAllowList = this._getAuthGuestListPermission(S3PermissionType.READ, userInput.guestAccess);
     this.cfnInputParams.s3PermissionsAuthenticatedPrivate = this._getPublicPrivatePermissions(

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -112,20 +112,39 @@ export class AmplifyS3ResourceStackTransform {
     if (userInput.adminTriggerFunction?.triggerFunction && userInput.adminTriggerFunction.triggerFunction !== 'NONE') {
       this.cfnInputParams.adminTriggerFunction = userInput.adminTriggerFunction.triggerFunction;
     }
-    // Policy names must be unique per environment. When multiple environments share the
-    // same IAM role (e.g. an imported Identity Pool with shared auth/unauth roles), reusing
-    // the same policyUUID across environments produces identically named inline policies on
-    // the same role, which CloudFormation's single-stack ownership enforcement rejects with
-    // "Policy resource was already managed by another stack". The environment name is read
-    // once and validated so the suffix never silently degrades to a shared "_undefined".
-    const envName = this.context.amplify.getEnvInfo()?.envName;
-    if (typeof envName !== 'string' || envName.length === 0) {
-      throw new AmplifyError('EnvironmentNotInitializedError', {
-        message: 'Cannot determine the current Amplify environment name while generating S3 IAM policy names.',
-        resolution: `Run 'amplify init' or 'amplify env checkout <env>' in the root of your app directory to select an environment, then try again.`,
-      });
+    // Policy names carry the app-wide policyUUID. That alone is only insufficient when the
+    // authenticated/unauthenticated IAM roles are SHARED across environments, which happens
+    // when auth is an imported Cognito Identity Pool: two environments' storage stacks then
+    // try to manage identically named inline policies on the same role, and CloudFormation's
+    // single-stack ownership enforcement rejects the deploy ("Policy resource was already
+    // managed by another stack"). Appending the environment name keeps them distinct.
+    //
+    // For the default (managed) auth case each environment owns its own auth roles, so the
+    // identical policy names land on different roles and never collide. We deliberately keep
+    // the legacy `${policyUUID}` name there: a PolicyName change is replace-on-update for
+    // AWS::IAM::Policy, so suffixing unconditionally would force a policy replacement on
+    // EVERY existing storage app's next push -- churn (and risk) far beyond the shared-role
+    // bug this fixes. Gating on imported auth limits the rename to the environments that
+    // actually need it (and whose deploys are already failing).
+    const authResources = this.context.amplify.getProjectMeta?.()?.auth ?? {};
+    const hasImportedAuth = Object.values(authResources).some(
+      (authResource: $TSAny) => authResource?.service === 'Cognito' && authResource?.serviceType === 'imported',
+    );
+    let policyNameSuffix = userInput.policyUUID;
+    if (hasImportedAuth) {
+      // Imported auth shares roles across environments, so the env name is required to keep
+      // policy names distinct. generateCfnInputParameters only runs for a checked-out
+      // environment (push / add / update / override / export), so envName is expected here;
+      // fail fast with a clear error rather than silently producing a shared "_undefined".
+      const envName = this.context.amplify.getEnvInfo()?.envName;
+      if (typeof envName !== 'string' || envName.length === 0) {
+        throw new AmplifyError('EnvironmentNotInitializedError', {
+          message: 'Cannot determine the current Amplify environment name while generating S3 IAM policy names for imported auth.',
+          resolution: `Run 'amplify init' or 'amplify env checkout <env>' in the root of your app directory to select an environment, then try again.`,
+        });
+      }
+      policyNameSuffix = `${userInput.policyUUID}_${envName}`;
     }
-    const policyNameSuffix = `${userInput.policyUUID}_${envName}`;
     this.cfnInputParams.s3PrivatePolicy = `Private_policy_${policyNameSuffix}`;
     this.cfnInputParams.s3ProtectedPolicy = `Protected_policy_${policyNameSuffix}`;
     this.cfnInputParams.s3PublicPolicy = `Public_policy_${policyNameSuffix}`;

--- a/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
+++ b/packages/amplify-category-storage/src/provider-utils/awscloudformation/cdk-stack-builder/s3-stack-transform.ts
@@ -112,7 +112,20 @@ export class AmplifyS3ResourceStackTransform {
     if (userInput.adminTriggerFunction?.triggerFunction && userInput.adminTriggerFunction.triggerFunction !== 'NONE') {
       this.cfnInputParams.adminTriggerFunction = userInput.adminTriggerFunction.triggerFunction;
     }
-    const policyNameSuffix = `${userInput.policyUUID}_${this.context.amplify.getEnvInfo().envName}`;
+    // Policy names must be unique per environment. When multiple environments share the
+    // same IAM role (e.g. an imported Identity Pool with shared auth/unauth roles), reusing
+    // the same policyUUID across environments produces identically named inline policies on
+    // the same role, which CloudFormation's single-stack ownership enforcement rejects with
+    // "Policy resource was already managed by another stack". The environment name is read
+    // once and validated so the suffix never silently degrades to a shared "_undefined".
+    const envName = this.context.amplify.getEnvInfo()?.envName;
+    if (typeof envName !== 'string' || envName.length === 0) {
+      throw new AmplifyError('EnvironmentNotInitializedError', {
+        message: 'Cannot determine the current Amplify environment name while generating S3 IAM policy names.',
+        resolution: `Run 'amplify init' or 'amplify env checkout <env>' in the root of your app directory to select an environment, then try again.`,
+      });
+    }
+    const policyNameSuffix = `${userInput.policyUUID}_${envName}`;
     this.cfnInputParams.s3PrivatePolicy = `Private_policy_${policyNameSuffix}`;
     this.cfnInputParams.s3ProtectedPolicy = `Protected_policy_${policyNameSuffix}`;
     this.cfnInputParams.s3PublicPolicy = `Public_policy_${policyNameSuffix}`;


### PR DESCRIPTION
#### Description of changes

I made generated S3 IAM policy names environment-specific by appending the current Amplify environment name to the existing policy UUID. This prevents two environments that share imported auth roles from trying to manage identically named inline policies.

I also added a focused regression test for the generated policy names and updated the existing stack-transform expectations.

#### Issue #, if available

Fixes #14961

#### Description of how you validated changes

- `yarn lerna run build --scope @aws-amplify/amplify-category-storage --include-dependencies --concurrency 4`
- `node ../../node_modules/jest/bin/jest.js --runInBand --coverage=false` from `packages/amplify-category-storage` (15 suites, 48 tests)
- Prettier and ESLint checks for all changed TypeScript files

I did not run cloud E2E tests or the macOS CI job locally.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes for the changed package
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
