### PR TITLE
fix(amplify-provider-awscloudformation): preserve GraphQLSchema logical id on v1 to v2 migration

### DIFF
--- a/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/graphql-schema-logical-id-preserver.test.ts
+++ b/packages/amplify-provider-awscloudformation/src/__tests__/pre-push-cfn-processor/graphql-schema-logical-id-preserver.test.ts
@@ -1,0 +1,147 @@
+import { pathManager, readCFNTemplate } from '@aws-amplify/amplify-cli-core';
+import { Template } from 'cloudform-types';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { preserveGraphQLSchemaLogicalId } from '../../pre-push-cfn-processor/graphql-schema-logical-id-preserver';
+
+jest.mock('@aws-amplify/amplify-cli-core');
+jest.mock('fs-extra');
+
+const readCFNTemplate_mock = readCFNTemplate as jest.MockedFunction<typeof readCFNTemplate>;
+const pathManager_mock = pathManager as jest.Mocked<typeof pathManager>;
+const existsSync_mock = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+
+const CURRENT_CLOUD_BACKEND = '/project/amplify/#current-cloud-backend';
+const API_NAME = 'myapi';
+const PUSH_TEMPLATE_PATH = path.join('/project/amplify/backend/api', API_NAME, 'build', 'cloudformation-template.json');
+const HASHED_SCHEMA_ID = 'GraphQLAPITransformerSchema1A2B3C4D';
+
+const v2SynthesizedTemplate = (): Template =>
+  ({
+    Resources: {
+      GraphQLAPI: {
+        Type: 'AWS::AppSync::GraphQLApi',
+        Properties: { Name: 'myapi' },
+      },
+      [HASHED_SCHEMA_ID]: {
+        Type: 'AWS::AppSync::GraphQLSchema',
+        Properties: {
+          ApiId: { 'Fn::GetAtt': ['GraphQLAPI', 'ApiId'] },
+          DefinitionS3Location: 's3://bucket/schema.graphql',
+        },
+      },
+      GraphQLAPIDefaultApiKey: {
+        Type: 'AWS::AppSync::ApiKey',
+        DependsOn: [HASHED_SCHEMA_ID],
+        Properties: { ApiId: { 'Fn::GetAtt': ['GraphQLAPI', 'ApiId'] } },
+      },
+      TodoResolver: {
+        Type: 'AWS::AppSync::Resolver',
+        DependsOn: ['GraphQLAPI', HASHED_SCHEMA_ID],
+        Properties: {
+          ApiId: { Ref: 'GraphQLAPI' },
+          RequestMappingTemplate: {
+            'Fn::Sub': ['## resolver for ${SchemaRef}', { SchemaRef: { Ref: HASHED_SCHEMA_ID } }],
+          },
+          SchemaArn: { 'Fn::GetAtt': [HASHED_SCHEMA_ID, 'Arn'] },
+          SchemaArnString: { 'Fn::GetAtt': `${HASHED_SCHEMA_ID}.Arn` },
+          Description: { 'Fn::Sub': 'depends on ${' + HASHED_SCHEMA_ID + '}' },
+        },
+      },
+    },
+    Outputs: {
+      SchemaRef: { Value: { Ref: HASHED_SCHEMA_ID } },
+      SchemaArn: { Value: { 'Fn::GetAtt': [HASHED_SCHEMA_ID, 'Arn'] } },
+    },
+  } as unknown as Template);
+
+const v1DeployedTemplate = (): Template =>
+  ({
+    Resources: {
+      GraphQLAPI: { Type: 'AWS::AppSync::GraphQLApi', Properties: {} },
+      GraphQLSchema: {
+        Type: 'AWS::AppSync::GraphQLSchema',
+        Properties: { ApiId: { 'Fn::GetAtt': ['GraphQLAPI', 'ApiId'] } },
+      },
+    },
+  } as unknown as Template);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  pathManager_mock.getCurrentCloudBackendDirPath.mockReturnValue(CURRENT_CLOUD_BACKEND);
+});
+
+describe('preserveGraphQLSchemaLogicalId', () => {
+  it('renames the hashed schema logical id to GraphQLSchema and rewrites every reference on a v1 to v2 migration', () => {
+    existsSync_mock.mockReturnValue(true);
+    readCFNTemplate_mock.mockReturnValue({ templateFormat: 'json' as any, cfnTemplate: v1DeployedTemplate() });
+
+    const template = v2SynthesizedTemplate();
+    preserveGraphQLSchemaLogicalId(template, PUSH_TEMPLATE_PATH);
+
+    expect(template.Resources[HASHED_SCHEMA_ID]).toBeUndefined();
+    expect(template.Resources.GraphQLSchema?.Type).toEqual('AWS::AppSync::GraphQLSchema');
+
+    expect(template.Resources.GraphQLAPIDefaultApiKey.DependsOn).toEqual(['GraphQLSchema']);
+    expect(template.Resources.TodoResolver.DependsOn).toEqual(['GraphQLAPI', 'GraphQLSchema']);
+
+    const resolverProps = template.Resources.TodoResolver.Properties;
+    expect(resolverProps.RequestMappingTemplate['Fn::Sub'][1]).toEqual({ SchemaRef: { Ref: 'GraphQLSchema' } });
+    expect(resolverProps.SchemaArn['Fn::GetAtt']).toEqual(['GraphQLSchema', 'Arn']);
+    expect(resolverProps.SchemaArnString['Fn::GetAtt']).toEqual('GraphQLSchema.Arn');
+    expect(resolverProps.Description['Fn::Sub']).toEqual('depends on ${GraphQLSchema}');
+
+    expect(template.Outputs.SchemaRef.Value).toEqual({ Ref: 'GraphQLSchema' });
+    expect(template.Outputs.SchemaArn.Value).toEqual({ 'Fn::GetAtt': ['GraphQLSchema', 'Arn'] });
+
+    // untouched reference should stay intact
+    expect(template.Resources.TodoResolver.Properties.ApiId).toEqual({ Ref: 'GraphQLAPI' });
+  });
+
+  it('leaves a born-v2 template unchanged when the deployed template already uses the hashed id', () => {
+    existsSync_mock.mockReturnValue(true);
+    const deployedV2 = v2SynthesizedTemplate();
+    readCFNTemplate_mock.mockReturnValue({ templateFormat: 'json' as any, cfnTemplate: deployedV2 });
+
+    const template = v2SynthesizedTemplate();
+    const before = JSON.stringify(template);
+    preserveGraphQLSchemaLogicalId(template, PUSH_TEMPLATE_PATH);
+
+    expect(JSON.stringify(template)).toEqual(before);
+  });
+
+  it('leaves a brand-new API template unchanged when there is no prior deployed template', () => {
+    existsSync_mock.mockReturnValue(false);
+
+    const template = v2SynthesizedTemplate();
+    const before = JSON.stringify(template);
+    preserveGraphQLSchemaLogicalId(template, PUSH_TEMPLATE_PATH);
+
+    expect(JSON.stringify(template)).toEqual(before);
+    expect(readCFNTemplate_mock).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the template already uses the GraphQLSchema logical id', () => {
+    existsSync_mock.mockReturnValue(true);
+    readCFNTemplate_mock.mockReturnValue({ templateFormat: 'json' as any, cfnTemplate: v1DeployedTemplate() });
+
+    const template = v1DeployedTemplate();
+    const before = JSON.stringify(template);
+    preserveGraphQLSchemaLogicalId(template, PUSH_TEMPLATE_PATH);
+
+    expect(JSON.stringify(template)).toEqual(before);
+  });
+
+  it('does nothing for non-API-root templates such as nested stacks', () => {
+    existsSync_mock.mockReturnValue(true);
+    readCFNTemplate_mock.mockReturnValue({ templateFormat: 'json' as any, cfnTemplate: v1DeployedTemplate() });
+
+    const nestedPath = path.join('/project/amplify/backend/api', API_NAME, 'build', 'stacks', 'Todo.json');
+    const template = v2SynthesizedTemplate();
+    const before = JSON.stringify(template);
+    preserveGraphQLSchemaLogicalId(template, nestedPath);
+
+    expect(JSON.stringify(template)).toEqual(before);
+    expect(readCFNTemplate_mock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
+++ b/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/cfn-pre-processor.ts
@@ -2,6 +2,7 @@ import { pathManager, readCFNTemplate, writeCFNTemplate, generateCustomPoliciesI
 import * as path from 'path';
 import { ProviderName as providerName } from '../constants';
 import { prePushCfnTemplateModifier } from './pre-push-cfn-modifier';
+import { preserveGraphQLSchemaLogicalId } from './graphql-schema-logical-id-preserver';
 
 const buildDir = 'build';
 
@@ -16,6 +17,7 @@ export const preProcessCFNTemplate = async (filePath: string, options?: { minify
   const { templateFormat, cfnTemplate } = readCFNTemplate(filePath);
 
   await prePushCfnTemplateModifier(cfnTemplate);
+  preserveGraphQLSchemaLogicalId(cfnTemplate, filePath);
   const backendDir = pathManager.getBackendDirPath();
   const pathSuffix = filePath.startsWith(backendDir) ? filePath.slice(backendDir.length) : path.parse(filePath).base;
   const newPath = path.join(backendDir, providerName, buildDir, pathSuffix);

--- a/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/graphql-schema-logical-id-preserver.ts
+++ b/packages/amplify-provider-awscloudformation/src/pre-push-cfn-processor/graphql-schema-logical-id-preserver.ts
@@ -1,0 +1,154 @@
+import { pathManager, readCFNTemplate } from '@aws-amplify/amplify-cli-core';
+import { Template } from 'cloudform-types';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+const APPSYNC_SCHEMA_TYPE = 'AWS::AppSync::GraphQLSchema';
+const API_ROOT_TEMPLATE_FILE_NAME = 'cloudformation-template.json';
+
+/**
+ * The hard-coded logical ID used by the v1 GraphQL transformer for the AppSync schema resource.
+ * The v2 (CDK) transformer instead emits a hashed logical ID (e.g. `GraphQLAPITransformerSchema<hash>`).
+ */
+export const V1_GRAPHQL_SCHEMA_LOGICAL_ID = 'GraphQLSchema';
+
+/**
+ * Preserves the v1 AppSync `GraphQLSchema` logical ID across a v1 to v2 GraphQL transformer migration.
+ *
+ * On a v1 to v2 migration the schema resource's logical ID changes from the hard-coded `GraphQLSchema`
+ * to a CDK-hashed `GraphQLAPITransformerSchema<hash>`. Since the schema's physical ID (`<apiId>GraphQLSchema`)
+ * is unique per API, CloudFormation attempts a create-before-delete on the rename and fails with
+ * `<apiId>GraphQLSchema already exists in stack`, rolling back the deployment.
+ *
+ * When the previously-deployed API template still uses the v1 `GraphQLSchema` logical ID, this rewrites the
+ * template being pushed so the schema resource keeps that logical ID (and updates every reference to it),
+ * letting CloudFormation perform an in-place update instead. Mutates `template` in place.
+ *
+ * The rewrite is gated on an actual v1 to v2 migration and is a no-op for born-v2 APIs, brand-new APIs,
+ * non-API templates, nested stack templates, and templates that already use the v1 logical ID.
+ *
+ * @param template the API root CloudFormation template about to be pushed
+ * @param filePath the on-disk path of the template being processed, used to locate the API resource
+ */
+export const preserveGraphQLSchemaLogicalId = (template: Template, filePath: string): void => {
+  if (path.basename(filePath) !== API_ROOT_TEMPLATE_FILE_NAME || !template?.Resources) {
+    return;
+  }
+
+  const apiName = getApiResourceNameFromTemplatePath(filePath);
+  if (!apiName) {
+    return;
+  }
+
+  const schemaLogicalIds = Object.entries(template.Resources)
+    .filter(([, resource]) => resource?.Type === APPSYNC_SCHEMA_TYPE)
+    .map(([logicalId]) => logicalId);
+
+  if (schemaLogicalIds.length !== 1) {
+    return;
+  }
+
+  const currentSchemaLogicalId = schemaLogicalIds[0];
+
+  if (currentSchemaLogicalId === V1_GRAPHQL_SCHEMA_LOGICAL_ID || template.Resources[V1_GRAPHQL_SCHEMA_LOGICAL_ID]) {
+    return;
+  }
+
+  if (!deployedTemplateHasV1SchemaLogicalId(apiName)) {
+    return;
+  }
+
+  renameLogicalId(template, currentSchemaLogicalId, V1_GRAPHQL_SCHEMA_LOGICAL_ID);
+};
+
+const getApiResourceNameFromTemplatePath = (filePath: string): string | undefined => {
+  const segments = path.normalize(filePath).split(path.sep);
+  const apiIndex = segments.indexOf('api');
+  if (apiIndex === -1 || apiIndex + 1 >= segments.length) {
+    return undefined;
+  }
+  return segments[apiIndex + 1];
+};
+
+const deployedTemplateHasV1SchemaLogicalId = (apiName: string): boolean => {
+  const deployedTemplatePath = path.join(pathManager.getCurrentCloudBackendDirPath(), 'api', apiName, 'build', API_ROOT_TEMPLATE_FILE_NAME);
+
+  if (!fs.existsSync(deployedTemplatePath)) {
+    return false;
+  }
+
+  const { cfnTemplate } = readCFNTemplate(deployedTemplatePath);
+  return cfnTemplate?.Resources?.[V1_GRAPHQL_SCHEMA_LOGICAL_ID]?.Type === APPSYNC_SCHEMA_TYPE;
+};
+
+const renameLogicalId = (template: Template, oldLogicalId: string, newLogicalId: string): void => {
+  const resources = template.Resources as Record<string, unknown>;
+  resources[newLogicalId] = resources[oldLogicalId];
+  delete resources[oldLogicalId];
+  rewriteReferences(template, oldLogicalId, newLogicalId);
+};
+
+const rewriteReferences = (node: unknown, oldLogicalId: string, newLogicalId: string): void => {
+  if (Array.isArray(node)) {
+    node.forEach((element) => rewriteReferences(element, oldLogicalId, newLogicalId));
+    return;
+  }
+
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  const record = node as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    const value = record[key];
+
+    switch (key) {
+      case 'Ref':
+        if (value === oldLogicalId) {
+          record[key] = newLogicalId;
+        }
+        break;
+      case 'DependsOn':
+        if (value === oldLogicalId) {
+          record[key] = newLogicalId;
+        } else if (Array.isArray(value)) {
+          record[key] = value.map((entry) => (entry === oldLogicalId ? newLogicalId : entry));
+        }
+        break;
+      case 'Fn::GetAtt':
+        if (Array.isArray(value) && value[0] === oldLogicalId) {
+          value[0] = newLogicalId;
+        } else if (typeof value === 'string') {
+          record[key] = replaceGetAttString(value, oldLogicalId, newLogicalId);
+        }
+        break;
+      case 'Fn::Sub':
+        if (typeof value === 'string') {
+          record[key] = replaceSubString(value, oldLogicalId, newLogicalId);
+        } else if (Array.isArray(value)) {
+          if (typeof value[0] === 'string') {
+            value[0] = replaceSubString(value[0], oldLogicalId, newLogicalId);
+          }
+          rewriteReferences(value[1], oldLogicalId, newLogicalId);
+        }
+        break;
+      default:
+        rewriteReferences(value, oldLogicalId, newLogicalId);
+    }
+  }
+};
+
+const replaceGetAttString = (value: string, oldLogicalId: string, newLogicalId: string): string => {
+  const dotIndex = value.indexOf('.');
+  if (dotIndex === -1) {
+    return value === oldLogicalId ? newLogicalId : value;
+  }
+  return value.slice(0, dotIndex) === oldLogicalId ? `${newLogicalId}${value.slice(dotIndex)}` : value;
+};
+
+const replaceSubString = (value: string, oldLogicalId: string, newLogicalId: string): string => {
+  const pattern = new RegExp(`\\$\\{${escapeRegExp(oldLogicalId)}(\\.[^}]*)?\\}`, 'g');
+  return value.replace(pattern, (_match, attribute = '') => `\${${newLogicalId}${attribute}}`);
+};
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
#### Description of changes

Deploy-time, migration-gated fix in the Gen1 CLI for the v1 to v2
`AWS::AppSync::GraphQLSchema` logical-ID collision.

On a v1 to v2 GraphQL transformer migration the schema resource's
logical ID changes from v1's hard-coded `GraphQLSchema` to v2's
CDK-hashed `GraphQLAPITransformerSchema<hash>`. Because the schema's
physical ID is `<apiId>GraphQLSchema` (one per API), CloudFormation
attempts a create-before-delete on the rename and fails with
`CREATE_FAILED: <apiId>GraphQLSchema already exists`, rolling back the
migration deployment.

The fix adds a whole-template pass in `preProcessCFNTemplate` that runs
**only** when the previously-deployed API template still has the schema
at logical ID `GraphQLSchema`. In that case it rewrites the hashed
logical ID back to `GraphQLSchema` and fixes every reference (`Ref`,
`DependsOn`, `Fn::GetAtt`, `Fn::Sub`) — so CloudFormation performs an
in-place update instead of a colliding replacement.

The rewrite is migration-gated. Born-v2 Gen1 apps, brand-new APIs,
non-API/nested-stack templates, and Gen2/CDK consumers are unaffected
and produce byte-identical output. The change is confined to
`amplify-provider-awscloudformation`; transformer packages are
untouched.

#### Issue #, if available

N/A

#### Description of how you validated changes

- 5 new unit tests for `preserveGraphQLSchemaLogicalId`, including a
  born-v2 byte-identical (no-op) case; all pass.
- Existing `amplify-provider-awscloudformation` suite green.
- Live v1 to v2 migration e2e on a real account reached
  `UPDATE_COMPLETE`, the schema resource stayed at
  `LogicalResourceId=GraphQLSchema`, and no logical-ID collision
  occurred.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
