### PR TITLE
fix(amplify-velocity-template): block prototype-chain property access in vtl reference resolver

### DIFF
--- a/packages/amplify-velocity-template/src/compile/references.js
+++ b/packages/amplify-velocity-template/src/compile/references.js
@@ -1,6 +1,28 @@
 module.exports = function (Velocity, utils) {
   'use strict';
 
+  var BLOCKED_PROPERTIES = [
+    'constructor',
+    '__proto__',
+    'prototype',
+    '__defineGetter__',
+    '__defineSetter__',
+    '__lookupGetter__',
+    '__lookupSetter__',
+  ];
+
+  /**
+   * Determine whether a property name traverses the JavaScript prototype
+   * chain (e.g. constructor/__proto__/prototype) and must be blocked so it
+   * cannot be used to reach the Function constructor and escape the template
+   * sandbox.
+   * @param {string} name property name being resolved
+   * @returns {boolean} true when the name is disallowed
+   */
+  function isBlockedProperty(name) {
+    return typeof name === 'string' && BLOCKED_PROPERTIES.indexOf(name) !== -1;
+  }
+
   function getSize(obj) {
     if (utils.isArray(obj)) {
       return obj.length;
@@ -194,7 +216,7 @@ module.exports = function (Velocity, utils) {
       if (type === 'method') {
         ret = this.getPropMethod(property, baseRef, ast);
       } else if (type === 'property') {
-        ret = baseRef[id];
+        ret = isBlockedProperty(id) ? undefined : baseRef[id];
       } else {
         ret = this.getPropIndex(property, baseRef);
       }
@@ -216,7 +238,7 @@ module.exports = function (Velocity, utils) {
         key = ast.value;
       }
 
-      return baseRef[key];
+      return isBlockedProperty(key) ? undefined : baseRef[key];
     },
 
     /**
@@ -225,6 +247,10 @@ module.exports = function (Velocity, utils) {
     getPropMethod: function (property, baseRef, ast) {
       var id = property.id;
       var ret = '';
+
+      if (isBlockedProperty(id)) {
+        return undefined;
+      }
 
       // get(xxx)
       if (id === 'get' && !(id in baseRef)) {

--- a/packages/amplify-velocity-template/tests/references.test.js
+++ b/packages/amplify-velocity-template/tests/references.test.js
@@ -1,0 +1,39 @@
+var Velocity = require('../src/velocity');
+require('should');
+
+describe('Reference resolver property access', function () {
+  var render = Velocity.render;
+
+  it('does not resolve constructor via dot or bracket access', function () {
+    render('$!ctx.constructor', { ctx: { name: 'foo' } }).should.eql('');
+    render("$!ctx['constructor']", { ctx: { name: 'foo' } }).should.eql('');
+  });
+
+  it('does not resolve chained constructor access', function () {
+    render('$!ctx.constructor.constructor("return 1")', { ctx: { name: 'foo' } }).should.eql('');
+  });
+
+  it('does not execute a chained constructor invocation', function () {
+    delete global.__vtlMarker;
+    var vm = '$!ctx.constructor.constructor("globalThis.__vtlMarker = true").call()';
+    render(vm, { ctx: { name: 'foo' } }).should.eql('');
+    (global.__vtlMarker === undefined).should.eql(true);
+  });
+
+  it('does not expose the prototype chain', function () {
+    render('$!ctx.__proto__', { ctx: { name: 'foo' } }).should.eql('');
+    render('$!ctx.prototype', { ctx: { name: 'foo' } }).should.eql('');
+    render("$!ctx['__proto__']", { ctx: { name: 'foo' } }).should.eql('');
+  });
+
+  it('still resolves normal data access', function () {
+    render('$ctx.name', { ctx: { name: 'foo' } }).should.eql('foo');
+    render("$ctx['name']", { ctx: { name: 'foo' } }).should.eql('foo');
+  });
+
+  it('still resolves normal method calls', function () {
+    render('$str.toUpperCase()', { str: 'foo' }).should.eql('FOO');
+    render('$list.size()', { list: [1, 2, 3] }).should.eql('3');
+    render('$map.keySet()', { map: { a: 1, b: 2 } }).should.eql('[a, b]');
+  });
+});


### PR DESCRIPTION
#### Description of changes

The VTL reference resolver mapped property, index, and method access in a
template directly onto JavaScript property lookups with no restriction on
which names could be resolved. Because JavaScript objects expose their
internal machinery through the prototype chain, a template could walk from
any context value up to the `Function` constructor — for example
`$ctx.constructor.constructor("...")` — and from there build and invoke
arbitrary code, escaping the intended template sandbox.

This change hardens the resolver so that JavaScript-internal, prototype-chain
property names can never be resolved or invoked from a template.

##### Blocked-property guard in the reference resolver

Adds a single `isBlockedProperty` guard backed by a small list of
prototype-chain names: `constructor`, `__proto__`, `prototype`,
`__defineGetter__`, `__defineSetter__`, `__lookupGetter__`, and
`__lookupSetter__`. The guard is applied consistently to all three access
paths the resolver supports:

- dot / property access (`$ctx.constructor`)
- bracket / index access (`$ctx['constructor']`)
- method-call access (`$ctx.constructor(...)`)

When a template references one of these names it now resolves to an undefined
reference, so it renders as empty (or the literal text under non-silent
reference notation) and can never be called. This closes the path from a
context value to the `Function` constructor.

##### Backward compatibility

Only these JavaScript-internal names change behavior. Normal data access and
method calls are unaffected — `$ctx.name`, `$ctx['name']`,
`$str.toUpperCase()`, `$list.size()`, and `$map.keySet()` all continue to
work exactly as before. Real template data has no legitimate need to resolve
prototype-chain properties, so this narrows the resolver's surface without
affecting valid templates.

#### Issue #, if available

N/A

#### Description of how you validated changes

Added regression tests in `packages/amplify-velocity-template/tests/references.test.js`:

- Negative assertions that dot, bracket, and chained `constructor` /
  `__proto__` / `prototype` access all render empty.
- An execution-safety assertion that a chained constructor invocation
  (`$!ctx.constructor.constructor("globalThis.__vtlMarker = true").call()`)
  renders empty and leaves the global marker unset, proving no code was
  executed.
- Positive regressions confirming normal property access and normal method
  calls (`toUpperCase()`, `size()`, `keySet()`) still resolve correctly.

Ran the full package suite with mocha:

```
153 passing (59ms)
```

0 failing.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] [Pull request labels](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#labels) are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
