### PR TITLE
ci: report AmplifyCLI-PR-Testing batch status to GitHub from cloud-pr

### DIFF
--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -16,6 +16,7 @@ else
 fi
 
 ada cred update --profile=cb-ci-account --account=$E2E_ACCOUNT_PROD --role=CodeBuildE2E --provider=isengard --once
+# --report-build-batch-status-override makes CodeBuild post the required GitHub commit-status back to the PR head SHA on completion
 RESULT=$(aws codebuild start-build-batch \
 --profile=cb-ci-account \
 --region us-east-1 \
@@ -23,6 +24,7 @@ RESULT=$(aws codebuild start-build-batch \
 --build-timeout-in-minutes-override 180 \
 --source-version "pr/$PR_NUMBER" \
 --git-clone-depth-override=1000 \
+--report-build-batch-status-override \
 --environment-variables-override name=AMPLIFY_CI_MANUAL_PR_BUILD,value=true,type=PLAINTEXT \
 --query 'buildBatch.id' --output text)
 


### PR DESCRIPTION
#### Description of changes

`scripts/cloud-pr.sh` starts the `AmplifyCLI-PR-Testing` CodeBuild batch manually via `aws codebuild start-build-batch`, but did not pass `--report-build-batch-status-override`. Because this project has no GitHub webhook, CodeBuild never posted the required commit-status `AWS CodeBuild BuildBatch us-east-1 (AmplifyCLI-PR-Testing)` back to the PR head SHA. The required check therefore stayed stuck on "Expected", blocking merges even when the manual batch actually succeeded.

This adds `--report-build-batch-status-override` to the `start-build-batch` invocation so CodeBuild posts the commit status back to the PR head commit when the batch completes, allowing the required check to resolve. The CodeBuild project source already has `reportBuildStatus` enabled, so only the override flag is required.

#### Issue #, if available

N/A

#### Description of how you validated changes

- `bash -n scripts/cloud-pr.sh` passes (script parses).
- Change is limited to adding a single CLI flag plus an explanatory comment; no batch was triggered.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
