### PR TITLE
fix(cli): paginate API Gateway resources when resolving REST API root resource

### DIFF
--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_common/aws-fetcher.test.ts
@@ -1,0 +1,61 @@
+import { AwsFetcher } from '../../../../commands/gen2-migration/_common/aws-fetcher';
+import { AwsClients } from '../../../../commands/gen2-migration/_common/aws-clients';
+import { mockClient } from 'aws-sdk-client-mock';
+import { APIGatewayClient, GetResourcesCommand } from '@aws-sdk/client-api-gateway';
+
+describe('AwsFetcher', () => {
+  let apiGatewayMock: ReturnType<typeof mockClient>;
+  let fetcher: AwsFetcher;
+
+  beforeEach(() => {
+    apiGatewayMock = mockClient(APIGatewayClient);
+    const clients = new (AwsClients as any)({ region: 'us-east-1' });
+    (clients as any).apiGateway = new APIGatewayClient({});
+    fetcher = new AwsFetcher(clients);
+  });
+
+  afterEach(() => apiGatewayMock.restore());
+
+  describe('fetchRestApiRootResourceId', () => {
+    it('returns the root resource id when it is on the first page', async () => {
+      apiGatewayMock.on(GetResourcesCommand).resolves({
+        items: [
+          { id: 'abc123', path: '/items' },
+          { id: 'root01', path: '/' },
+        ],
+      });
+
+      await expect(fetcher.fetchRestApiRootResourceId('api-1')).resolves.toBe('root01');
+      expect(apiGatewayMock.commandCalls(GetResourcesCommand)).toHaveLength(1);
+    });
+
+    it('follows pagination when the root resource is on a later page', async () => {
+      const firstPage = Array.from({ length: 25 }, (_, i) => ({ id: `res${i}`, path: `/path${i}` }));
+      apiGatewayMock
+        .on(GetResourcesCommand)
+        .resolvesOnce({ items: firstPage, position: 'page-2' })
+        .resolvesOnce({
+          items: [
+            { id: 'res25', path: '/path25' },
+            { id: 'root01', path: '/' },
+          ],
+        });
+
+      await expect(fetcher.fetchRestApiRootResourceId('api-1')).resolves.toBe('root01');
+
+      const calls = apiGatewayMock.commandCalls(GetResourcesCommand);
+      expect(calls).toHaveLength(2);
+      expect(calls[1].args[0].input).toMatchObject({ restApiId: 'api-1', position: 'page-2' });
+    });
+
+    it('throws RestApiResourceNotFoundError when no page contains the root resource', async () => {
+      apiGatewayMock
+        .on(GetResourcesCommand)
+        .resolvesOnce({ items: [{ id: 'res0', path: '/path0' }], position: 'page-2' })
+        .resolvesOnce({ items: [{ id: 'res1', path: '/path1' }] });
+
+      await expect(fetcher.fetchRestApiRootResourceId('api-1')).rejects.toThrow("Root resource not found for REST API 'api-1'");
+      expect(apiGatewayMock.commandCalls(GetResourcesCommand)).toHaveLength(2);
+    });
+  });
+});

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/aws-fetcher.ts
@@ -23,7 +23,7 @@ import {
 import { GetGraphqlApiCommand, GraphqlApi } from '@aws-sdk/client-appsync';
 import { DescribeTableCommand, TableDescription } from '@aws-sdk/client-dynamodb';
 import { GetAppCommand } from '@aws-sdk/client-amplify';
-import { GetResourcesCommand } from '@aws-sdk/client-api-gateway';
+import { paginateGetResources } from '@aws-sdk/client-api-gateway';
 import { paginateListStackResources, StackResourceSummary } from '@aws-sdk/client-cloudformation';
 import { AmplifyError } from '@aws-amplify/amplify-cli-core';
 import { AwsClients } from './aws-clients';
@@ -190,15 +190,17 @@ export class AwsFetcher {
   // ── API Gateway ────────────────────────────────────────────────
 
   public async fetchRestApiRootResourceId(restApiId: string): Promise<string> {
-    const { items } = await this.clients.apiGateway.send(new GetResourcesCommand({ restApiId }));
-    const root = items?.find((r) => r.path === '/');
-    if (!root?.id) {
-      throw new AmplifyError('RestApiResourceNotFoundError', {
-        message: `Root resource not found for REST API '${restApiId}'`,
-        resolution: 'Verify the API Gateway REST API exists and the CLI has the correct AWS credentials and region configured.',
-      });
+    const paginator = paginateGetResources({ client: this.clients.apiGateway }, { restApiId });
+    for await (const page of paginator) {
+      const root = page.items?.find((r) => r.path === '/');
+      if (root?.id) {
+        return root.id;
+      }
     }
-    return root.id;
+    throw new AmplifyError('RestApiResourceNotFoundError', {
+      message: `Root resource not found for REST API '${restApiId}'`,
+      resolution: 'Verify the API Gateway REST API exists and the CLI has the correct AWS credentials and region configured.',
+    });
   }
 
   // ── CloudFormation ─────────────────────────────────────────────


### PR DESCRIPTION
#### Description of changes

`fetchRestApiRootResourceId` called API Gateway `GetResources` once and never followed the pagination token. API Gateway returns 25 resources per page by default with no ordering guarantee, so on REST APIs with more than 25 resources the root `/` resource can land on a later page and `gen2-migration generate` or `assess` fails with "Root resource not found for REST API" even though the API is healthy.

This change uses `paginateGetResources` to walk pages until the root resource is found, returning early once it is. This matches the paginator pattern already used in `aws-fetcher.ts` for CloudFormation and Cognito calls.

#### Issue #, if available

Fixes #14948

#### Description of how you validated changes

Added unit tests for `fetchRestApiRootResourceId` covering:

- root resource on the first page
- root resource on a later page, verifying the pagination token is passed through
- root resource missing from all pages, verifying `RestApiResourceNotFoundError` is thrown

All existing `gen2-migration` REST API generator and infra tests pass.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/dev/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
