### PR TITLE
fix(cli): preserve phone-based sign-in in gen2 migration

### DIFF
--- a/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/auth/resource.ts
+++ b/amplify-migration-apps/discussions/_snapshot.post.generate/amplify/auth/resource.ts
@@ -4,10 +4,7 @@ import type { Backend } from '../backend';
 
 export const auth = defineAuth({
   loginWith: {
-    email: {
-      verificationEmailSubject: 'Verification',
-      verificationEmailBody: () => 'Here is your verification code {####}',
-    },
+    phone: true,
   },
   userAttributes: {
     email: {

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
@@ -15,6 +15,7 @@ export const auth = defineAuth({
       verificationEmailSubject: 'Your verification code',
       verificationEmailBody: () => 'Your verification code is {####}',
     },
+    phone: true,
     externalProviders: {
       google: {
         clientId: secret('GOOGLE_CLIENT_ID'),

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -298,7 +298,84 @@ describe('AuthGenerator', () => {
     expect(content).toContain('phone: true');
     expect(content).not.toContain('email: true');
     // email is preserved as a required user attribute, not a login mechanism
-    expect(content).toContain('email');
+    expect(content).toMatch(/userAttributes:\s*\{[^}]*email:\s*\{[^}]*required:\s*true/s);
+  });
+
+  // Login mechanisms should be derived from AliasAttributes when that is the
+  // populated sign-in signal (not just UsernameAttributes/AutoVerifiedAttributes).
+  it('generates phone login from AliasAttributes', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      AliasAttributes: ['phone_number'],
+      SchemaAttributes: [],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    const content = writtenFile('auth/resource.ts');
+    expect(content).toContain('phone: true');
+    expect(content).not.toContain('email: true');
+  });
+
+  // A pool that supports both email and phone sign-in must enable both in loginWith.
+  it('generates both email and phone login when the pool supports both', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      UsernameAttributes: ['email', 'phone_number'],
+      SchemaAttributes: [],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    const content = writtenFile('auth/resource.ts');
+    expect(content).toContain('email: true');
+    expect(content).toContain('phone: true');
   });
 
   it('generates email with verification options', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -208,7 +208,7 @@ describe('AuthGenerator', () => {
 
       export const auth = defineAuth({
         loginWith: {
-          email: true,
+          phone: true,
         },
         multifactor: {
           mode: 'OFF',
@@ -256,6 +256,49 @@ describe('AuthGenerator', () => {
       }
       "
     `);
+  });
+
+  // Regression test for https://github.com/aws-amplify/amplify-cli/issues/14810
+  // A Gen1 pool with email-based verification disabled (SMS/TOTP) keeps email
+  // only as a required attribute; verification is via phone_number. The migration
+  // must generate loginWith: { phone: true }, not email login.
+  it('generates phone login when email verification is disabled but email is a required attribute', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      AutoVerifiedAttributes: ['phone_number'],
+      SchemaAttributes: [{ Name: 'email', Required: true, Mutable: true }],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    const content = writtenFile('auth/resource.ts');
+    expect(content).toContain('phone: true');
+    expect(content).not.toContain('email: true');
+    // email is preserved as a required user attribute, not a login mechanism
+    expect(content).toContain('email');
   });
 
   it('generates email with verification options', async () => {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -661,25 +661,30 @@ export class AuthRenderer {
 
   /**
    * Derives which login mechanisms (email, phone) the Gen1 user pool actually
-   * uses, based on its sign-in and verification configuration.
+   * uses, based on its sign-in configuration.
    *
    * Gen2 `defineAuth` maps `loginWith.email`/`loginWith.phone` (truthy) onto the
-   * Cognito user pool's `signInAliases` and `autoVerify` settings. To preserve
-   * parity we enable a mechanism when it appears as a username attribute, an
-   * alias attribute, or an auto-verified attribute on the source pool. A pool
-   * that verifies via `phone_number` therefore migrates to `loginWith.phone`
-   * rather than being forced onto email verification.
+   * Cognito user pool's `signInAliases` and `autoVerify` settings. The
+   * authoritative signals for "can sign in with" are `UsernameAttributes` and
+   * `AliasAttributes`, so those are consulted first. `AutoVerifiedAttributes`
+   * only controls whether Cognito sends a verification code on signup/update and
+   * does not by itself make an attribute usable for sign in (e.g. a pool may
+   * auto-verify an attribute for SMS-based recovery while supporting only plain
+   * username sign-in). It is therefore used only as a fallback when neither
+   * `UsernameAttributes` nor `AliasAttributes` is populated — which is the
+   * shape of the pool in aws-amplify/amplify-cli#14810, where phone-based
+   * verification is the only signal available.
    *
    * `defineAuth` requires at least one of email/phone, so we fall back to email
-   * when the pool exposes neither (e.g. username-only sign-in), matching the
-   * previous default behavior.
+   * when the pool exposes none of the above (e.g. username-only sign-in),
+   * matching the previous default behavior.
    */
   private static deriveLoginMechanisms(userPool: UserPoolType): { readonly email: boolean; readonly phone: boolean } {
-    const signals = new Set<string>([
-      ...(userPool.UsernameAttributes ?? []),
-      ...(userPool.AliasAttributes ?? []),
-      ...(userPool.AutoVerifiedAttributes ?? []),
-    ]);
+    const signInAttributes = [...(userPool.UsernameAttributes ?? []), ...(userPool.AliasAttributes ?? [])];
+    // Fall back to auto-verified attributes only when no sign-in attribute is
+    // configured, since auto-verify alone does not imply the attribute is a
+    // usable login mechanism.
+    const signals = new Set<string>(signInAttributes.length > 0 ? signInAttributes : userPool.AutoVerifiedAttributes ?? []);
     let email = signals.has('email');
     const phone = signals.has('phone_number');
     if (!email && !phone) {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -659,9 +659,40 @@ export class AuthRenderer {
     }
   }
 
+  /**
+   * Derives which login mechanisms (email, phone) the Gen1 user pool actually
+   * uses, based on its sign-in and verification configuration.
+   *
+   * Gen2 `defineAuth` maps `loginWith.email`/`loginWith.phone` (truthy) onto the
+   * Cognito user pool's `signInAliases` and `autoVerify` settings. To preserve
+   * parity we enable a mechanism when it appears as a username attribute, an
+   * alias attribute, or an auto-verified attribute on the source pool. A pool
+   * that verifies via `phone_number` therefore migrates to `loginWith.phone`
+   * rather than being forced onto email verification.
+   *
+   * `defineAuth` requires at least one of email/phone, so we fall back to email
+   * when the pool exposes neither (e.g. username-only sign-in), matching the
+   * previous default behavior.
+   */
+  private static deriveLoginMechanisms(userPool: UserPoolType): { readonly email: boolean; readonly phone: boolean } {
+    const signals = new Set<string>([
+      ...(userPool.UsernameAttributes ?? []),
+      ...(userPool.AliasAttributes ?? []),
+      ...(userPool.AutoVerifiedAttributes ?? []),
+    ]);
+    let email = signals.has('email');
+    const phone = signals.has('phone_number');
+    if (!email && !phone) {
+      email = true;
+    }
+    return { email, phone };
+  }
+
   private createLogInWithPropertyAssignment(options: AuthRenderOptions, loginFlags: Record<string, boolean>): PropertyAssignment {
     const logInWith = factory.createIdentifier('loginWith');
     const assignments: ts.ObjectLiteralElementLike[] = [];
+
+    const { email: emailEnabled, phone: phoneEnabled } = AuthRenderer.deriveLoginMechanisms(options.userPool);
 
     const emailOptions =
       options.userPool.EmailVerificationMessage || options.userPool.EmailVerificationSubject
@@ -671,10 +702,18 @@ export class AuthRenderer {
           }
         : undefined;
 
-    if (emailOptions) {
-      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), this.createEmailDefinitionObject(emailOptions)));
-    } else {
-      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), factory.createTrue()));
+    if (emailEnabled) {
+      if (emailOptions) {
+        assignments.push(
+          factory.createPropertyAssignment(factory.createIdentifier('email'), this.createEmailDefinitionObject(emailOptions)),
+        );
+      } else {
+        assignments.push(factory.createPropertyAssignment(factory.createIdentifier('email'), factory.createTrue()));
+      }
+    }
+
+    if (phoneEnabled) {
+      assignments.push(factory.createPropertyAssignment(factory.createIdentifier('phone'), factory.createTrue()));
     }
 
     const externalProviders = AuthRenderer.deriveExternalProviders(options.identityProviders);


### PR DESCRIPTION
 #### Description of changes

  The Gen2 migration auth renderer (`packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts`) unconditionally emitted `loginWith.email` and never emitted `loginWith.phone`. As a result, Gen1 Cognito user pools that verify via `phone_number` (email verification disabled, using SMS/TOTP) were migrated to email-based login, breaking parity for sign-in, auto-verification, and forgot-password.

  This change derives the login mechanisms from the source pool's `UsernameAttributes`, `AliasAttributes`, and `AutoVerifiedAttributes`, emitting `phone` and/or `email` to match the Gen1 configuration. It falls back to email only when neither is present (since `defineAuth` requires at least one). Email is preserved as a required user attribute when it is not a sign-in mechanism.

  #### Issue #, if available

Addresses part of #14810 (the `loginWith` mechanism). The SMS configuration / SNS caller-role carry-over described in that issue is a separate concern (Gen2 `defineAuth` does not auto-provision an SNS role from `loginWith: { phone: true }`)
  and is tracked as a follow-up.

#### Description of how you validated changes
  
  - Corrected the existing `generates phone login` unit test snapshot, which previously asserted the buggy `loginWith: { email: true }` output for a phone-based pool.
  - Added a regression test for the exact issue scenario (email verification disabled, `AutoVerifiedAttributes: ['phone_number']`, email as a required attribute) asserting `phone: true` and no email login.
  - Updated the `discussions` and `media-vault` migration-app snapshots to reflect correct phone/combined login.
  - `yarn test` for the gen2-migration suite: 432/432 tests pass across 48 suites.

  #### Checklist

  - [x] PR description included
  - [x] `yarn test` passes
  - [x] Tests are changed or added
  - [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
