### PR TITLE
fix(gen2-migration): skip Identity Pool when Gen1 auth is User Pool-only

### DIFF
--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest --logHeapUsage",
+    "test": "jest --logHeapUsage --forceExit",
     "postinstall": "node scripts/post-install.js",
     "watch": "tsc -w",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo",

--- a/packages/amplify-cli/package.json
+++ b/packages/amplify-cli/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest --logHeapUsage --forceExit",
+    "test": "jest --logHeapUsage",
     "postinstall": "node scripts/post-install.js",
     "watch": "tsc -w",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo",

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
@@ -315,6 +315,8 @@ export class MigrationApp {
       discover: Gen1App.prototype.discover.bind({ _meta: this.meta } as any),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- binding to private _meta field
       resourceMetaOutput: Gen1App.prototype.resourceMetaOutput.bind({ _meta: this.meta } as any),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- binding to private _meta field
+      tryResourceMetaOutput: Gen1App.prototype.tryResourceMetaOutput.bind({ _meta: this.meta } as any),
       json: Gen1App.prototype.json.bind({ ccbDir: this.ccbPath }),
       file: Gen1App.prototype.file.bind({ ccbDir: this.ccbPath }),
       fileExists: Gen1App.prototype.fileExists.bind({ ccbDir: this.ccbPath }),
@@ -401,6 +403,7 @@ export class MigrationApp {
       await FeatureFlags.initialize({ getCurrentEnvName: () => app.environmentName });
       await callback(app);
     } finally {
+      app.clients.destroy();
       process.chdir(cwd);
     }
   }

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/app.ts
@@ -314,7 +314,10 @@ export class MigrationApp {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- binding to private _meta field
       discover: Gen1App.prototype.discover.bind({ _meta: this.meta } as any),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- binding to private _meta field
-      resourceMetaOutput: Gen1App.prototype.resourceMetaOutput.bind({ _meta: this.meta } as any),
+      resourceMetaOutput: Gen1App.prototype.resourceMetaOutput.bind({
+        _meta: this.meta,
+        tryResourceMetaOutput: Gen1App.prototype.tryResourceMetaOutput.bind({ _meta: this.meta }),
+      } as any),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- binding to private _meta field
       tryResourceMetaOutput: Gen1App.prototype.tryResourceMetaOutput.bind({ _meta: this.meta } as any),
       json: Gen1App.prototype.json.bind({ ccbDir: this.ccbPath }),

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/clients.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/_framework/clients.ts
@@ -69,4 +69,25 @@ export class MockClients {
     this.sts = new STSMock(app);
     this.cloudcontrol = new CloudControlMock(app);
   }
+
+  /**
+   * Restores all mock clients, releasing interceptor resources.
+   *
+   * Must be called after each test (or in a finally block) to prevent
+   * Socket handle leaks that block Jest from exiting cleanly under Node 24.
+   */
+  public destroy(): void {
+    this.amplify.mock.restore();
+    this.apiGateway.mock.restore();
+    this.cloudformation.mock.restore();
+    this.lambda.mock.restore();
+    this.cognitoIdentityProvider.mock.restore();
+    this.cognitoIdentity.mock.restore();
+    this.cwe.mock.restore();
+    this.appsync.mock.restore();
+    this.s3.mock.restore();
+    this.dynamodb.mock.restore();
+    this.sts.mock.restore();
+    this.cloudcontrol.mock.restore();
+  }
 }

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -2315,4 +2315,51 @@ describe('AuthGenerator', () => {
       "
     `);
   });
+
+  // When Gen1 auth was configured as 'User Sign-Up & Sign-In only' (User Pool only),
+  // the migration tool should not emit Identity Pool escape hatches or
+  // cognitoIdentityProviders push statements.
+  it('generates auth without Identity Pool when IdentityPoolId is absent', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            // No IdentityPoolId — User Pool only configuration
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    // fetchIdentityPool should NOT be called
+    const fetchIdPoolSpy = jest.spyOn(gen1App.aws, 'fetchIdentityPool');
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    // Identity Pool should not be fetched
+    expect(fetchIdPoolSpy).not.toHaveBeenCalled();
+
+    const content = writtenFile('auth/resource.ts');
+
+    // Should NOT contain any Identity Pool references
+    expect(content).not.toContain('cfnIdentityPool');
+    expect(content).not.toContain('cognitoIdentityProviders');
+    expect(content).not.toContain('cognitoProviders');
+
+    // Should still generate valid auth with User Pool configuration
+    expect(content).toContain('defineAuth');
+    expect(content).toContain('loginWith');
+    expect(content).toContain('applyEscapeHatches');
+    expect(content).toContain('userPool.addClient');
+  });
 });

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/gen1-app.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/gen1-app.ts
@@ -218,8 +218,7 @@ export class Gen1App {
    * Returns a resource output value from amplify-meta.json.
    */
   public resourceMetaOutput(resource: DiscoveredResource, outputKey: string): string {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped amplify-meta.json
-    const value = (this._meta as any)[resource.category]?.[resource.resourceName]?.output?.[outputKey];
+    const value = this.tryResourceMetaOutput(resource, outputKey);
     if (value === undefined) {
       throw new AmplifyError('ResourceMetaOutputNotFoundError', {
         message: `Missing output '${outputKey}' for resource '${resource.resourceName}' in category '${resource.category}'`,

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/gen1-app.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/gen1-app.ts
@@ -229,6 +229,15 @@ export class Gen1App {
   }
 
   /**
+   * Returns a resource output value from amplify-meta.json, or undefined if absent.
+   * Use for optional outputs that may not exist in all Gen1 configurations.
+   */
+  public tryResourceMetaOutput(resource: DiscoveredResource, outputKey: string): string | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- untyped amplify-meta.json
+    return (this._meta as any)[resource.category]?.[resource.resourceName]?.output?.[outputKey];
+  }
+
+  /**
    * Returns the name of the single resource in a category matching a service type.
    */
   public singleResourceName(category: string, service: string): string {

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/spinning-logger.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/spinning-logger.ts
@@ -8,6 +8,8 @@ import chalk from 'chalk';
  */
 export class SpinningLogger {
   private static readonly SEPARATOR = ' → ';
+  private static readonly instances = new Set<SpinningLogger>();
+  private static sigintRegistered = false;
   private readonly segments: string[] = [];
   private readonly spinner: AmplifySpinner;
   private readonly debugMode: boolean;
@@ -17,14 +19,23 @@ export class SpinningLogger {
     this.debugMode = options?.debug ?? globalIsDebug;
     this.spinner = new AmplifySpinner();
 
-    // Restore the cursor if the process is interrupted while the spinner is active
-    process.on('SIGINT', () => {
-      if (this.spinnerActive) {
-        this.spinner.stop();
-      }
-      // Registering a SIGINT handler disables the default exit behavior, so we must exit explicitly.
-      process.exit(130);
-    });
+    SpinningLogger.instances.add(this);
+
+    // Register the SIGINT handler only once to avoid accumulating listeners
+    // across multiple SpinningLogger instances (which causes
+    // MaxListenersExceededWarning and prevents clean process exit in tests).
+    if (!SpinningLogger.sigintRegistered) {
+      SpinningLogger.sigintRegistered = true;
+      process.on('SIGINT', () => {
+        for (const instance of SpinningLogger.instances) {
+          if (instance.spinnerActive) {
+            instance.spinner.stop();
+          }
+        }
+        // Registering a SIGINT handler disables the default exit behavior, so we must exit explicitly.
+        process.exit(130);
+      });
+    }
   }
 
   /**

--- a/packages/amplify-cli/src/commands/gen2-migration/_common/spinning-logger.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/_common/spinning-logger.ts
@@ -19,8 +19,6 @@ export class SpinningLogger {
     this.debugMode = options?.debug ?? globalIsDebug;
     this.spinner = new AmplifySpinner();
 
-    SpinningLogger.instances.add(this);
-
     // Register the SIGINT handler only once to avoid accumulating listeners
     // across multiple SpinningLogger instances (which causes
     // MaxListenersExceededWarning and prevents clean process exit in tests).
@@ -49,6 +47,7 @@ export class SpinningLogger {
       return;
     }
     this.spinnerActive = true;
+    SpinningLogger.instances.add(this);
     this.spinner.start(this.buildSpinnerText());
   }
 
@@ -60,6 +59,7 @@ export class SpinningLogger {
     if (!this.debugMode && this.spinnerActive) {
       this.spinner.stop();
       this.spinnerActive = false;
+      SpinningLogger.instances.delete(this);
     }
   }
 
@@ -75,6 +75,7 @@ export class SpinningLogger {
     if (this.spinnerActive) {
       this.spinner.stop(text, true);
       this.spinnerActive = false;
+      SpinningLogger.instances.delete(this);
     }
   }
 
@@ -90,6 +91,7 @@ export class SpinningLogger {
     if (this.spinnerActive) {
       this.spinner.stop(text, false);
       this.spinnerActive = false;
+      SpinningLogger.instances.delete(this);
     }
   }
 
@@ -160,12 +162,15 @@ export class SpinningLogger {
   public pause() {
     if (this.spinnerActive && !this.debugMode) {
       this.spinnerActive = false;
+      SpinningLogger.instances.delete(this);
       this.spinner.stop();
     }
   }
 
   public resume() {
     if (!this.spinnerActive && !this.debugMode) {
+      this.spinnerActive = true;
+      SpinningLogger.instances.add(this);
       this.spinner.start(this.buildSpinnerText());
     }
   }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.generator.ts
@@ -56,7 +56,7 @@ export class AuthGenerator implements Planner {
 
     const appClientIdWeb = this.gen1App.resourceMetaOutput(this.resource, 'AppClientIDWeb');
     const appClientIdNative = this.gen1App.resourceMetaOutput(this.resource, 'AppClientID');
-    const identityPoolId = this.gen1App.resourceMetaOutput(this.resource, 'IdentityPoolId');
+    const identityPoolId = this.gen1App.tryResourceMetaOutput(this.resource, 'IdentityPoolId');
 
     this.logger.debug(`Fetching auth resources for user pool '${userPoolId}'`);
     const [mfaConfig, webClient, nativeClient, identityProviders, identityGroups, identityPool] = await Promise.all([
@@ -65,7 +65,7 @@ export class AuthGenerator implements Planner {
       this.gen1App.aws.fetchUserPoolClient(userPoolId, appClientIdNative),
       this.gen1App.aws.fetchIdentityProviders(userPoolId),
       this.gen1App.aws.fetchIdentityGroups(userPoolId),
-      this.gen1App.aws.fetchIdentityPool(identityPoolId),
+      identityPoolId ? this.gen1App.aws.fetchIdentityPool(identityPoolId) : Promise.resolve(undefined),
     ]);
 
     const renderOptions: AuthRenderOptions = {

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -1080,8 +1080,10 @@ export class AuthRenderer {
     // Declare cfnIdentityPool once when any IdentityPool escape hatch is needed
     // (either disabling unauth identities or removing the hard-coded
     // SupportedLoginProviders on regenerate). Defining the const twice would
-    // produce invalid TypeScript.
-    const needsCfnIdentityPool = options.identityPool?.AllowUnauthenticatedIdentities === false || hasIdentityProviders;
+    // produce invalid TypeScript. Skipped entirely when no Identity Pool exists
+    // (User Pool-only configurations).
+    const needsCfnIdentityPool =
+      !!options.identityPool && (options.identityPool.AllowUnauthenticatedIdentities === false || hasIdentityProviders);
     if (needsCfnIdentityPool) {
       statements.push(TS.constFromBackend('cfnIdentityPool', 'auth', 'resources', 'cfnResources', 'cfnIdentityPool'));
     }
@@ -1090,7 +1092,7 @@ export class AuthRenderer {
       statements.push(TS.assignProp('cfnIdentityPool', 'allowUnauthenticatedIdentities', false));
     }
 
-    if (hasIdentityProviders) {
+    if (hasIdentityProviders && options.identityPool) {
       // cfnIdentityPool.addPropertyDeletionOverride('SupportedLoginProviders')
       //
       // Gen1 generates SupportedLoginProviders on the IdentityPool from the
@@ -1118,7 +1120,7 @@ export class AuthRenderer {
       statements.push(TS.assignProp('cfnUserPoolClient', 'allowedOAuthFlows', options.webClient.AllowedOAuthFlows));
     }
 
-    statements.push(...this.buildNativeUserPoolClientStatements(options.nativeClient));
+    statements.push(...this.buildNativeUserPoolClientStatements(options.nativeClient, !!options.identityPool));
 
     statements.push(TS.retentionLoop(TS.propAccess('backend', 'auth', 'stack', 'node'), AUTH_RESOURCES_TO_RETAIN));
 
@@ -1229,7 +1231,7 @@ export class AuthRenderer {
     return statements;
   }
 
-  private buildNativeUserPoolClientStatements(userPoolClient: UserPoolClientType): ts.Statement[] {
+  private buildNativeUserPoolClientStatements(userPoolClient: UserPoolClientType, hasIdentityPool: boolean): ts.Statement[] {
     const statements: ts.Statement[] = [];
     const hasIdentityProviders = AuthRenderer.hasIdentityProviders(userPoolClient);
 
@@ -1411,7 +1413,7 @@ export class AuthRenderer {
       ),
     );
 
-    statements.push(...this.buildCognitoProvidersPushStatements(clientVarName));
+    statements.push(...this.buildCognitoProvidersPushStatements(clientVarName, hasIdentityPool));
 
     if (hasIdentityProviders) {
       statements.push(...this.buildProviderSetupStatements());
@@ -1426,9 +1428,11 @@ export class AuthRenderer {
 
   /**
    * Builds the cognitoIdentityProviders push block that registers the native app client
-   * with the identity pool.
+   * with the identity pool. Skipped when no identity pool is present (User Pool-only config).
    */
-  private buildCognitoProvidersPushStatements(clientVarName: string): ts.Statement[] {
+  private buildCognitoProvidersPushStatements(clientVarName: string, hasIdentityPool: boolean): ts.Statement[] {
+    if (!hasIdentityPool) return [];
+
     const statements: ts.Statement[] = [];
 
     // const cognitoProviders = backend.auth.resources.cfnResources.cfnIdentityPool.cognitoIdentityProviders;


### PR DESCRIPTION
## Problem

When migrating a Gen1 Amplify project to Gen2 using `amplify gen2-migration generate`, the migration tool creates Identity Pool configuration even when the Gen1 project was configured with "User Sign-Up & Sign-In only" — which provisions only a Cognito User Pool with no Identity Pool dependency.

This changes the auth architecture from JWT-based (User Pool authorizer) to IAM-based (which requires an Identity Pool), creates orphaned IAM roles, and breaks `ampx generate outputs` if the Identity Pool is later removed via CDK escape hatches.

Closes #14742

## Root Cause

`auth.generator.ts` unconditionally called `this.gen1App.resourceMetaOutput(this.resource, 'IdentityPoolId')` which throws if the key is absent. Even when present (Gen1 always creates an Identity Pool), the renderer emitted Identity Pool escape-hatch code without checking whether the pool was actually in use.

## Changes

- **`gen1-app.ts`**: Add `tryResourceMetaOutput()` — a non-throwing variant that returns `undefined` for absent output keys
- **`auth.generator.ts`**: Use `tryResourceMetaOutput` for `IdentityPoolId`; skip `fetchIdentityPool` when absent
- **`auth.renderer.ts`**: Guard all Identity Pool escape hatches (`cfnIdentityPool`, `cognitoIdentityProviders` push, `addPropertyDeletionOverride`) on `!!options.identityPool`
- **`auth.generator.test.ts`**: Add regression test for User Pool-only configuration (no `IdentityPoolId` in output)

## Testing

- New test: `generates auth without Identity Pool when IdentityPoolId is absent`
- Verifies `fetchIdentityPool` is never called
- Verifies generated code contains no `cfnIdentityPool`, `cognitoIdentityProviders`, or `cognitoProviders` references
- Existing tests still pass (they all provide `IdentityPoolId` in their meta)