### PR TITLE
fix(cli): gen2-migration forward-direction function grants avoid circular deps

### DIFF
--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/auth/resource.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/auth/resource.ts
@@ -1,6 +1,5 @@
 import { defineAuth } from '@aws-amplify/backend';
 import { fitnesstracker33f5545533f55455PreSignup } from '../function/fitnesstracker33f5545533f55455PreSignup/resource';
-import { admin } from '../function/admin/resource';
 import { CfnResource, Duration } from 'aws-cdk-lib';
 import type { Backend } from '../backend';
 
@@ -24,15 +23,6 @@ export const auth = defineAuth({
   multifactor: {
     mode: 'OFF',
   },
-  access: (allow) => [
-    allow.resource(admin).to(['getDevice']),
-    allow.resource(admin).to(['getUser']),
-    allow.resource(admin).to(['listDevices']),
-    allow.resource(admin).to(['listGroupsForUser']),
-    allow.resource(admin).to(['listUsers']),
-    allow.resource(admin).to(['listUsersInGroup']),
-    allow.resource(admin).to(['listGroups']),
-  ],
 });
 
 export function applyEscapeHatches(backend: Backend) {

--- a/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/fitness-tracker/_snapshot.post.generate/amplify/backend.ts
@@ -19,6 +19,16 @@ const backend = defineBackend({
 
 export type Backend = typeof backend;
 
+backend.auth.resources.userPool.grant(
+  backend.admin.resources.lambda,
+  'cognito-idp:AdminGetDevice',
+  'cognito-idp:AdminGetUser',
+  'cognito-idp:AdminListDevices',
+  'cognito-idp:AdminListGroupsForUser',
+  'cognito-idp:ListGroups',
+  'cognito-idp:ListUsers',
+  'cognito-idp:ListUsersInGroup'
+);
 nutritionapi.defineNutritionapiApi(backend);
 adminapi.defineAdminapiApi(backend);
 

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
@@ -1,6 +1,4 @@
 import { defineAuth, secret } from '@aws-amplify/backend';
-import { addusertogroup } from '../function/addusertogroup/resource';
-import { removeuserfromgroup } from '../function/removeuserfromgroup/resource';
 import { CfnResource, Duration } from 'aws-cdk-lib';
 import {
   OAuthScope,
@@ -55,36 +53,6 @@ export const auth = defineAuth({
   multifactor: {
     mode: 'OFF',
   },
-  access: (allow) => [
-    allow.resource(addusertogroup).to(['manageUsers']),
-    allow.resource(addusertogroup).to(['manageGroupMembership']),
-    allow.resource(addusertogroup).to(['manageUserDevices']),
-    allow.resource(addusertogroup).to(['managePasswordRecovery']),
-    allow.resource(addusertogroup).to(['setUserMfaPreference']),
-    allow.resource(addusertogroup).to(['updateUserAttributes']),
-    allow.resource(addusertogroup).to(['createGroup']),
-    allow.resource(addusertogroup).to(['forgetDevice']),
-    allow.resource(addusertogroup).to(['setUserSettings']),
-    allow.resource(addusertogroup).to(['listUsers']),
-    allow.resource(addusertogroup).to(['listUsersInGroup']),
-    allow.resource(addusertogroup).to(['listGroups']),
-    allow.resource(addusertogroup).to(['updateGroup']),
-    allow.resource(addusertogroup).to(['deleteGroup']),
-    allow.resource(removeuserfromgroup).to(['manageUsers']),
-    allow.resource(removeuserfromgroup).to(['manageGroupMembership']),
-    allow.resource(removeuserfromgroup).to(['manageUserDevices']),
-    allow.resource(removeuserfromgroup).to(['managePasswordRecovery']),
-    allow.resource(removeuserfromgroup).to(['setUserMfaPreference']),
-    allow.resource(removeuserfromgroup).to(['updateUserAttributes']),
-    allow.resource(removeuserfromgroup).to(['createGroup']),
-    allow.resource(removeuserfromgroup).to(['forgetDevice']),
-    allow.resource(removeuserfromgroup).to(['setUserSettings']),
-    allow.resource(removeuserfromgroup).to(['listUsers']),
-    allow.resource(removeuserfromgroup).to(['listUsersInGroup']),
-    allow.resource(removeuserfromgroup).to(['listGroups']),
-    allow.resource(removeuserfromgroup).to(['updateGroup']),
-    allow.resource(removeuserfromgroup).to(['deleteGroup']),
-  ],
 });
 
 export function applyEscapeHatches(backend: Backend) {

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/backend.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/backend.ts
@@ -6,6 +6,7 @@ import * as addusertogroup from './function/addusertogroup/resource';
 import * as removeuserfromgroup from './function/removeuserfromgroup/resource';
 import { defineBackend } from '@aws-amplify/backend';
 import { Tags } from 'aws-cdk-lib';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 const backend = defineBackend({
   auth: auth.auth,
@@ -17,6 +18,74 @@ const backend = defineBackend({
 });
 
 export type Backend = typeof backend;
+
+backend.auth.resources.userPool.grant(
+  backend.addusertogroup.resources.lambda,
+  'cognito-idp:AdminAddUserToGroup',
+  'cognito-idp:AdminConfirmSignUp',
+  'cognito-idp:AdminCreateUser',
+  'cognito-idp:AdminDeleteUser',
+  'cognito-idp:AdminDeleteUserAttributes',
+  'cognito-idp:AdminDisableUser',
+  'cognito-idp:AdminEnableUser',
+  'cognito-idp:AdminForgetDevice',
+  'cognito-idp:AdminGetDevice',
+  'cognito-idp:AdminGetUser',
+  'cognito-idp:AdminListDevices',
+  'cognito-idp:AdminListGroupsForUser',
+  'cognito-idp:AdminRemoveUserFromGroup',
+  'cognito-idp:AdminResetUserPassword',
+  'cognito-idp:AdminRespondToAuthChallenge',
+  'cognito-idp:AdminSetUserMFAPreference',
+  'cognito-idp:AdminSetUserPassword',
+  'cognito-idp:AdminSetUserSettings',
+  'cognito-idp:AdminUpdateDeviceStatus',
+  'cognito-idp:AdminUpdateUserAttributes',
+  'cognito-idp:AdminUserGlobalSignOut',
+  'cognito-idp:CreateGroup',
+  'cognito-idp:DeleteGroup',
+  'cognito-idp:ListGroups',
+  'cognito-idp:ListUsers',
+  'cognito-idp:ListUsersInGroup',
+  'cognito-idp:UpdateGroup'
+);
+backend.auth.resources.userPool.grant(
+  backend.removeuserfromgroup.resources.lambda,
+  'cognito-idp:AdminAddUserToGroup',
+  'cognito-idp:AdminConfirmSignUp',
+  'cognito-idp:AdminCreateUser',
+  'cognito-idp:AdminDeleteUser',
+  'cognito-idp:AdminDeleteUserAttributes',
+  'cognito-idp:AdminDisableUser',
+  'cognito-idp:AdminEnableUser',
+  'cognito-idp:AdminForgetDevice',
+  'cognito-idp:AdminGetDevice',
+  'cognito-idp:AdminGetUser',
+  'cognito-idp:AdminListDevices',
+  'cognito-idp:AdminListGroupsForUser',
+  'cognito-idp:AdminRemoveUserFromGroup',
+  'cognito-idp:AdminResetUserPassword',
+  'cognito-idp:AdminRespondToAuthChallenge',
+  'cognito-idp:AdminSetUserMFAPreference',
+  'cognito-idp:AdminSetUserPassword',
+  'cognito-idp:AdminSetUserSettings',
+  'cognito-idp:AdminUpdateDeviceStatus',
+  'cognito-idp:AdminUpdateUserAttributes',
+  'cognito-idp:AdminUserGlobalSignOut',
+  'cognito-idp:CreateGroup',
+  'cognito-idp:DeleteGroup',
+  'cognito-idp:ListGroups',
+  'cognito-idp:ListUsers',
+  'cognito-idp:ListUsersInGroup',
+  'cognito-idp:UpdateGroup'
+);
+backend.thumbnailgen.resources.lambda.addToRolePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ['s3:DeleteObject', 's3:GetObject', 's3:PutObject', 's3:ListBucket'],
+    resources: [backend.storage.resources.bucket.arnForObjects('*'), backend.storage.resources.bucket.bucketArn],
+  })
+);
 
 auth.applyEscapeHatches(backend);
 data.applyEscapeHatches(backend);

--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/storage/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/storage/resource.ts
@@ -1,5 +1,4 @@
 import { defineStorage } from '@aws-amplify/backend';
-import { thumbnailgen } from '../function/thumbnailgen/resource';
 import { CfnResource } from 'aws-cdk-lib';
 import type { Backend } from '../backend';
 
@@ -15,20 +14,17 @@ export const storage = defineStorage({
       allow.authenticated.to(['write', 'read', 'delete']),
       allow.groups(['Admin']).to(['write', 'read', 'delete']),
       allow.groups(['Basic']).to(['read']),
-      allow.resource(thumbnailgen).to(['read', 'write', 'delete']),
     ],
     'protected/{entity_id}/*': [
       allow.entity('identity').to(['write', 'read', 'delete']),
       allow.authenticated.to(['read']),
       allow.groups(['Admin']).to(['write', 'read', 'delete']),
       allow.groups(['Basic']).to(['read']),
-      allow.resource(thumbnailgen).to(['read', 'write', 'delete']),
     ],
     'private/{entity_id}/*': [
       allow.entity('identity').to(['write', 'read', 'delete']),
       allow.groups(['Admin']).to(['write', 'read', 'delete']),
       allow.groups(['Basic']).to(['read']),
-      allow.resource(thumbnailgen).to(['read', 'write', 'delete']),
     ],
   }),
 });

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -1,4 +1,5 @@
 import { AuthGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/auth/auth.generator';
+import { AuthPermissions } from '../../../../../../commands/gen2-migration/generate/amplify/auth/auth.renderer';
 import { BackendGenerator } from '../../../../../../commands/gen2-migration/generate/amplify/backend.generator';
 import { DiscoveredResource } from '../../../../../../commands/gen2-migration/_common/gen1-app';
 import { IdentityProviderTypeType } from '@aws-sdk/client-cognito-identity-provider';
@@ -1456,69 +1457,27 @@ describe('AuthGenerator', () => {
       permissions: { manageUsers: true, listUsers: true },
     });
 
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
     const ops = await generator.plan();
     await ops[0].execute();
 
-    expect(writtenFile('auth/resource.ts')).toMatchInlineSnapshot(`
-      "import { defineAuth } from '@aws-amplify/backend';
-      import { adminFunc } from '../function/adminFunc/resource';
-      import { CfnResource, Duration } from 'aws-cdk-lib';
-      import type { Backend } from '../backend';
+    // Function->auth access must NOT be emitted as a reverse-direction access
+    // block on defineAuth (that creates an auth->function dependency and causes
+    // circular dependencies). The generated auth/resource.ts has no access block
+    // and does not import the function.
+    const resourceTs = writtenFile('auth/resource.ts');
+    expect(resourceTs).not.toContain('access:');
+    expect(resourceTs).not.toContain('allow.resource');
+    expect(resourceTs).not.toContain("from '../function/adminFunc/resource'");
 
-      export const auth = defineAuth({
-        loginWith: {
-          email: true,
-        },
-        multifactor: {
-          mode: 'OFF',
-        },
-        access: (allow) => [
-          allow.resource(adminFunc).to(['manageUsers']),
-          allow.resource(adminFunc).to(['listUsers']),
-        ],
-      });
-
-      export function applyEscapeHatches(backend: Backend) {
-        const cfnUserPool = backend.auth.resources.cfnResources.cfnUserPool;
-        cfnUserPool.usernameAttributes = undefined;
-        cfnUserPool.policies = {
-          passwordPolicy: {},
-        };
-        const userPool = backend.auth.resources.userPool;
-        const nativeUserPoolClient = userPool.addClient('NativeAppClient', {
-          disableOAuth: true,
-          generateSecret: false,
-        });
-        const cognitoProviders =
-          backend.auth.resources.cfnResources.cfnIdentityPool
-            .cognitoIdentityProviders;
-        if (cognitoProviders && Array.isArray(cognitoProviders)) {
-          cognitoProviders.push({
-            clientId: nativeUserPoolClient.userPoolClientId,
-            providerName: \`cognito-idp.\${backend.auth.stack.region}.amazonaws.com/\${userPool.userPoolId}\`,
-          });
-        }
-        for (const cfnResource of backend.auth.stack.node
-          .findAll()
-          .filter(
-            (c) =>
-              CfnResource.isCfnResource(c) &&
-              [
-                'AWS::Cognito::UserPool',
-                'AWS::Cognito::IdentityPool',
-                'AWS::Cognito::UserPoolClient',
-                'AWS::Cognito::IdentityPoolRoleAttachment',
-                'AWS::Cognito::UserPoolGroup',
-                'AWS::Cognito::UserPoolDomain',
-                'AWS::Cognito::UserPoolIdentityProvider',
-              ].includes(c.cfnResourceType)
-          )) {
-          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
-          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
-        }
-      }
-      "
-    `);
+    // Instead, a forward-direction grant is emitted into backend.ts on the
+    // underlying user pool construct, keeping the dependency function->auth.
+    // manageUsers + listUsers consolidate into one grant call with sorted,
+    // de-duplicated cognito-idp actions (ListUsers appears once).
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.adminFunc.resources.lambda, 'cognito-idp:AdminConfirmSignUp', 'cognito-idp:AdminCreateUser', 'cognito-idp:AdminDeleteUser', 'cognito-idp:AdminDeleteUserAttributes', 'cognito-idp:AdminDisableUser', 'cognito-idp:AdminEnableUser', 'cognito-idp:AdminGetUser', 'cognito-idp:AdminListGroupsForUser', 'cognito-idp:AdminRespondToAuthChallenge', 'cognito-idp:AdminSetUserMFAPreference', 'cognito-idp:AdminSetUserSettings', 'cognito-idp:AdminUpdateUserAttributes', 'cognito-idp:AdminUserGlobalSignOut', 'cognito-idp:ListUsers');",
+    );
   });
 
   it('generates multiple functions with auth access', async () => {
@@ -1551,71 +1510,22 @@ describe('AuthGenerator', () => {
     generator.addFunctionAuthAccess({ resourceName: 'func1', permissions: { createUser: true } });
     generator.addFunctionAuthAccess({ resourceName: 'func2', permissions: { deleteUser: true, getUser: true } });
 
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
     const ops = await generator.plan();
     await ops[0].execute();
 
-    expect(writtenFile('auth/resource.ts')).toMatchInlineSnapshot(`
-      "import { defineAuth } from '@aws-amplify/backend';
-      import { func1 } from '../function/func1/resource';
-      import { func2 } from '../function/func2/resource';
-      import { CfnResource, Duration } from 'aws-cdk-lib';
-      import type { Backend } from '../backend';
+    const resourceTs = writtenFile('auth/resource.ts');
+    expect(resourceTs).not.toContain('access:');
+    expect(resourceTs).not.toContain('allow.resource');
 
-      export const auth = defineAuth({
-        loginWith: {
-          email: true,
-        },
-        multifactor: {
-          mode: 'OFF',
-        },
-        access: (allow) => [
-          allow.resource(func1).to(['createUser']),
-          allow.resource(func2).to(['deleteUser']),
-          allow.resource(func2).to(['getUser']),
-        ],
-      });
-
-      export function applyEscapeHatches(backend: Backend) {
-        const cfnUserPool = backend.auth.resources.cfnResources.cfnUserPool;
-        cfnUserPool.usernameAttributes = undefined;
-        cfnUserPool.policies = {
-          passwordPolicy: {},
-        };
-        const userPool = backend.auth.resources.userPool;
-        const nativeUserPoolClient = userPool.addClient('NativeAppClient', {
-          disableOAuth: true,
-          generateSecret: false,
-        });
-        const cognitoProviders =
-          backend.auth.resources.cfnResources.cfnIdentityPool
-            .cognitoIdentityProviders;
-        if (cognitoProviders && Array.isArray(cognitoProviders)) {
-          cognitoProviders.push({
-            clientId: nativeUserPoolClient.userPoolClientId,
-            providerName: \`cognito-idp.\${backend.auth.stack.region}.amazonaws.com/\${userPool.userPoolId}\`,
-          });
-        }
-        for (const cfnResource of backend.auth.stack.node
-          .findAll()
-          .filter(
-            (c) =>
-              CfnResource.isCfnResource(c) &&
-              [
-                'AWS::Cognito::UserPool',
-                'AWS::Cognito::IdentityPool',
-                'AWS::Cognito::UserPoolClient',
-                'AWS::Cognito::IdentityPoolRoleAttachment',
-                'AWS::Cognito::UserPoolGroup',
-                'AWS::Cognito::UserPoolDomain',
-                'AWS::Cognito::UserPoolIdentityProvider',
-              ].includes(c.cfnResourceType)
-          )) {
-          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
-          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
-        }
-      }
-      "
-    `);
+    // One forward-direction grant per function, with per-function actions sorted.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.func1.resources.lambda, 'cognito-idp:AdminCreateUser');",
+    );
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.func2.resources.lambda, 'cognito-idp:AdminDeleteUser', 'cognito-idp:AdminGetUser');",
+    );
   });
 
   it('skips functions with empty auth access', async () => {
@@ -1647,12 +1557,237 @@ describe('AuthGenerator', () => {
     const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
     generator.addFunctionAuthAccess({ resourceName: 'noAccessFunc', permissions: {} });
 
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
     const ops = await generator.plan();
     await ops[0].execute();
 
     const resourceTs = writtenFile('auth/resource.ts');
     expect(resourceTs).not.toContain('access');
     expect(resourceTs).not.toContain('noAccessFunc');
+    // A function with no enabled permissions produces no grant statement.
+    expect(addPostDefineBackendStatementSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits no grant and no warning when no function access is registered', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+    const warnSpy = jest.spyOn(logger, 'warn');
+
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    expect(addPostDefineBackendStatementSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('consolidates overlapping permissions across duplicate function entries into one grant', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    // Same function registered twice; getUser overlaps with manageUsers' action set.
+    generator.addFunctionAuthAccess({ resourceName: 'dupFunc', permissions: { getUser: true } });
+    generator.addFunctionAuthAccess({ resourceName: 'dupFunc', permissions: { manageUsers: true } });
+
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    // A single grant statement for the function, with actions de-duplicated
+    // (AdminGetUser appears once despite getUser + manageUsers both granting it)
+    // and sorted.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledTimes(1);
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.dupFunc.resources.lambda, 'cognito-idp:AdminConfirmSignUp', 'cognito-idp:AdminCreateUser', 'cognito-idp:AdminDeleteUser', 'cognito-idp:AdminDeleteUserAttributes', 'cognito-idp:AdminDisableUser', 'cognito-idp:AdminEnableUser', 'cognito-idp:AdminGetUser', 'cognito-idp:AdminListGroupsForUser', 'cognito-idp:AdminRespondToAuthChallenge', 'cognito-idp:AdminSetUserMFAPreference', 'cognito-idp:AdminSetUserSettings', 'cognito-idp:AdminUpdateUserAttributes', 'cognito-idp:AdminUserGlobalSignOut', 'cognito-idp:ListUsers');",
+    );
+  });
+
+  it('falls back to a raw cognito-idp action and warns for an unknown permission', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    // A permission name not in PERMISSION_ACTION_MAP (simulates upstream drift).
+    generator.addFunctionAuthAccess({
+      resourceName: 'futureFunc',
+      permissions: { someFuturePermission: true } as unknown as AuthPermissions,
+    });
+
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+    const warnSpy = jest.spyOn(logger, 'warn');
+
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    // The unknown permission is emitted as a raw cognito-idp:<permission> action
+    // rather than dropped, so nothing is silently lost.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.futureFunc.resources.lambda, 'cognito-idp:someFuturePermission');",
+    );
+    // ...and the operator is warned so they can verify the generated action.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('someFuturePermission'));
+  });
+
+  it('throws at generate time when a function name is not a valid JS identifier', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    // A hyphenated name would interpolate as invalid TS (backend.my-func.resources.lambda).
+    generator.addFunctionAuthAccess({ resourceName: 'my-func', permissions: { getUser: true } });
+
+    const ops = await generator.plan();
+    await expect(ops[0].execute()).rejects.toThrow(/not a valid JavaScript identifier/);
+  });
+
+  it('routes trigger-function auth access to the defineAuth access block and non-trigger access to a backend.ts grant', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({ SchemaAttributes: [] });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    // triggerFn is BOTH a postConfirmation trigger AND has auth access.
+    generator.addTrigger({ event: 'postConfirmation', resourceName: 'triggerFn' });
+    generator.addFunctionAuthAccess({ resourceName: 'triggerFn', permissions: { addUserToGroup: true } });
+    // plainFn only has auth access (no trigger).
+    generator.addFunctionAuthAccess({ resourceName: 'plainFn', permissions: { getUser: true } });
+
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    const resourceTs = writtenFile('auth/resource.ts');
+    // Trigger function's access rides the defineAuth `access` block (a trigger
+    // already couples auth<->function, and Amplify co-locates the grant — no new
+    // cross-stack edge, so no circular dependency).
+    expect(resourceTs).toContain('access: (allow)');
+    expect(resourceTs).toContain('allow.resource(triggerFn).to');
+    // ...and is NOT emitted as a backend.ts userPool.grant.
+    const backendGrants = addPostDefineBackendStatementSpy.mock.calls.map((c) => c[0] as string);
+    expect(backendGrants.some((s) => s.includes('backend.triggerFn.resources.lambda'))).toBe(false);
+
+    // Non-trigger function's access uses the forward backend.ts grant (the #14727
+    // fix) and does NOT appear in the defineAuth access block.
+    expect(resourceTs).not.toContain('allow.resource(plainFn)');
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      "backend.auth.resources.userPool.grant(backend.plainFn.resources.lambda, 'cognito-idp:AdminGetUser');",
+    );
   });
 
   it('emits cfnIdentityPool.allowUnauthenticatedIdentities = false', async () => {

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/storage/s3.generator.test.ts
@@ -121,10 +121,7 @@ describe('S3Generator', () => {
 
       const branchName = process.env.AWS_BRANCH ?? 'sandbox';
 
-      export const storage = defineStorage({
-        name: \`myBucket-main-\${branchName}\`,
-        access: (allow) => ({}),
-      });
+      export const storage = defineStorage({ name: \`myBucket-main-\${branchName}\` });
 
       export function postRefactor(backend: Backend) {
         const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
@@ -596,7 +593,7 @@ describe('S3Generator', () => {
     `);
   });
 
-  it('renders function access patterns with imports', async () => {
+  it('emits function access as forward-direction grants in backend.ts', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
       storage: { myBucket: { service: 'S3', output: { BucketName: 'myBucket-main-abc123' } } },
@@ -620,52 +617,37 @@ describe('S3Generator', () => {
     );
     generator.addFunctionAccess('processImages', ['read', 'write']);
 
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
     const ops = await generator.plan();
     await ops[0].execute();
 
-    expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
-      "import { defineStorage } from '@aws-amplify/backend';
-      import { processImages } from '../function/processImages/resource';
-      import { CfnResource } from 'aws-cdk-lib';
-      import type { Backend } from '../backend';
+    // Function->storage access must NOT be emitted as a reverse-direction
+    // allow.resource(fn) entry in the defineStorage access block (that creates a
+    // storage->function dependency and causes circular dependencies). With no
+    // guest/authenticated/group access, resource.ts has no access block and does
+    // not import the function.
+    const resourceTs = writtenFile('resource.ts');
+    expect(resourceTs).not.toContain('access:');
+    expect(resourceTs).not.toContain('allow.resource');
+    expect(resourceTs).not.toContain("from '../function/processImages/resource'");
 
-      const branchName = process.env.AWS_BRANCH ?? 'sandbox';
-
-      export const storage = defineStorage({
-        name: \`myBucket-main-\${branchName}\`,
-        access: (allow) => ({
-          'public/*': [allow.resource(processImages).to(['read', 'write'])],
-          'protected/{entity_id}/*': [
-            allow.resource(processImages).to(['read', 'write']),
-          ],
-          'private/{entity_id}/*': [
-            allow.resource(processImages).to(['read', 'write']),
-          ],
-        }),
-      });
-
-      export function postRefactor(backend: Backend) {
-        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
-        s3Bucket.bucketName = 'myBucket-main-abc123';
-      }
-
-      export function applyEscapeHatches(backend: Backend) {
-        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
-        for (const cfnResource of backend.storage.stack.node
-          .findAll()
-          .filter(
-            (c) =>
-              CfnResource.isCfnResource(c) &&
-              ['AWS::S3::Bucket', 'Custom::S3AutoDeleteObjects'].includes(
-                c.cfnResourceType
-              )
-          )) {
-          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
-          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
-        }
-      }
-      "
-    `);
+    // read + write emits an explicit IAM policy with the EXACT Amplify action set
+    // (GetObject + PutObject + ListBucket) and crucially NO s3:DeleteObject — a
+    // CDK bucket.grantReadWrite would have bundled DeleteObject in, over-granting
+    // a function whose Gen1 access was read+write only.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      'backend.processImages.resources.lambda.addToRolePolicy(\n' +
+        '  new PolicyStatement({\n' +
+        '    effect: Effect.ALLOW,\n' +
+        "    actions: ['s3:GetObject', 's3:PutObject', 's3:ListBucket'],\n" +
+        "    resources: [backend.storage.resources.bucket.arnForObjects('*'), backend.storage.resources.bucket.bucketArn],\n" +
+        '  }),\n' +
+        ');',
+    );
+    // The emitted statement must not carry a delete action.
+    const [[emitted]] = addPostDefineBackendStatementSpy.mock.calls;
+    expect(emitted).not.toContain('s3:DeleteObject');
   });
 
   it('renders triggers with function imports', async () => {
@@ -707,7 +689,6 @@ describe('S3Generator', () => {
 
       export const storage = defineStorage({
         name: \`myBucket-main-\${branchName}\`,
-        access: (allow) => ({}),
         triggers: {
           onUpload: onUploadFn,
           onDelete: onDeleteFn,
@@ -763,48 +744,118 @@ describe('S3Generator', () => {
     generator.addFunctionAccess('myFunc', ['read']);
     generator.addFunctionAccess('myFunc', ['write']);
 
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+
     const ops = await generator.plan();
     await ops[0].execute();
 
-    expect(writtenFile('resource.ts')).toMatchInlineSnapshot(`
-      "import { defineStorage } from '@aws-amplify/backend';
-      import { myFunc } from '../function/myFunc/resource';
-      import { CfnResource } from 'aws-cdk-lib';
-      import type { Backend } from '../backend';
+    const resourceTs = writtenFile('resource.ts');
+    expect(resourceTs).not.toContain('access:');
+    expect(resourceTs).not.toContain('allow.resource');
+    expect(resourceTs).not.toContain("from '../function/myFunc/resource'");
 
-      const branchName = process.env.AWS_BRANCH ?? 'sandbox';
+    // Duplicate addFunctionAccess calls consolidate: read + write -> one policy
+    // statement with GetObject + PutObject + ListBucket (no DeleteObject), emitted
+    // once into backend.ts.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledTimes(1);
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      'backend.myFunc.resources.lambda.addToRolePolicy(\n' +
+        '  new PolicyStatement({\n' +
+        '    effect: Effect.ALLOW,\n' +
+        "    actions: ['s3:GetObject', 's3:PutObject', 's3:ListBucket'],\n" +
+        "    resources: [backend.storage.resources.bucket.arnForObjects('*'), backend.storage.resources.bucket.bucketArn],\n" +
+        '  }),\n' +
+        ');',
+    );
+  });
 
-      export const storage = defineStorage({
-        name: \`myBucket-main-\${branchName}\`,
-        access: (allow) => ({
-          'public/*': [allow.resource(myFunc).to(['read', 'write'])],
-          'protected/{entity_id}/*': [allow.resource(myFunc).to(['read', 'write'])],
-          'private/{entity_id}/*': [allow.resource(myFunc).to(['read', 'write'])],
-        }),
+  it('emits exact per-variant actions for delete-only, read+delete, and write-only access', async () => {
+    const runVariant = async (functionName: string, perms: ('read' | 'write' | 'create' | 'delete')[]) => {
+      const gen1App = await createGen1App({
+        providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+        storage: { myBucket: { service: 'S3', output: { BucketName: 'myBucket-main-abc123' } } },
       });
+      jest.spyOn(gen1App, 'cliInputs').mockReturnValue({ authAccess: [], guestAccess: [] });
+      jest.spyOn(gen1App.aws, 'fetchBucketAccelerate').mockResolvedValue(undefined);
+      jest.spyOn(gen1App.aws, 'fetchBucketVersioning').mockResolvedValue(undefined);
+      jest.spyOn(gen1App.aws, 'fetchBucketEncryption').mockResolvedValue(undefined);
 
-      export function postRefactor(backend: Backend) {
-        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
-        s3Bucket.bucketName = 'myBucket-main-abc123';
-      }
+      const bg = new BackendGenerator(outputDir, logger);
+      const generator = new S3Generator(
+        gen1App,
+        bg,
+        outputDir,
+        { category: 'storage', resourceName: 'myBucket', service: 'S3', key: 'storage:S3' },
+        logger,
+      );
+      generator.addFunctionAccess(functionName, perms);
+      const spy = jest.spyOn(bg, 'addPostDefineBackendStatement');
+      const ops = await generator.plan();
+      await ops[0].execute();
+      expect(spy).toHaveBeenCalledTimes(1);
+      return spy.mock.calls[0][0] as string;
+    };
 
-      export function applyEscapeHatches(backend: Backend) {
-        const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;
-        for (const cfnResource of backend.storage.stack.node
-          .findAll()
-          .filter(
-            (c) =>
-              CfnResource.isCfnResource(c) &&
-              ['AWS::S3::Bucket', 'Custom::S3AutoDeleteObjects'].includes(
-                c.cfnResourceType
-              )
-          )) {
-          (cfnResource as CfnResource).addOverride('UpdateReplacePolicy', 'Retain');
-          (cfnResource as CfnResource).addOverride('DeletionPolicy', 'Retain');
-        }
-      }
-      "
-    `);
+    // delete-only: DeleteObject on objects, no ListBucket, no read/write.
+    const deleteOnly = await runVariant('delFn', ['delete']);
+    expect(deleteOnly).toContain("actions: ['s3:DeleteObject']");
+    expect(deleteOnly).toContain("resources: [backend.storage.resources.bucket.arnForObjects('*')]");
+    expect(deleteOnly).not.toContain('s3:GetObject');
+    expect(deleteOnly).not.toContain('s3:ListBucket');
+
+    // read + delete: GetObject + DeleteObject + ListBucket (read pulls in ListBucket + bucketArn), no PutObject.
+    const readDelete = await runVariant('rdFn', ['read', 'delete']);
+    expect(readDelete).toContain("actions: ['s3:DeleteObject', 's3:GetObject', 's3:ListBucket']");
+    expect(readDelete).toContain('backend.storage.resources.bucket.bucketArn');
+    expect(readDelete).not.toContain('s3:PutObject');
+
+    // write-only: PutObject only, no ListBucket (read absent), no DeleteObject.
+    const writeOnly = await runVariant('wFn', ['write']);
+    expect(writeOnly).toContain("actions: ['s3:PutObject']");
+    expect(writeOnly).toContain("resources: [backend.storage.resources.bucket.arnForObjects('*')]");
+    expect(writeOnly).not.toContain('s3:ListBucket');
+    expect(writeOnly).not.toContain('s3:DeleteObject');
+    expect(writeOnly).not.toContain('s3:GetObject');
+  });
+
+  it('emits both identity access AND a function grant when a bucket has both', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      storage: { myBucket: { service: 'S3', output: { BucketName: 'myBucket-main-abc123' } } },
+    });
+    // guest read access AND a function grant on the same bucket.
+    jest.spyOn(gen1App, 'cliInputs').mockReturnValue({ authAccess: [], guestAccess: ['READ'] });
+    jest.spyOn(gen1App.aws, 'fetchBucketAccelerate').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketVersioning').mockResolvedValue(undefined);
+    jest.spyOn(gen1App.aws, 'fetchBucketEncryption').mockResolvedValue(undefined);
+
+    const generator = new S3Generator(
+      gen1App,
+      backendGenerator,
+      outputDir,
+      { category: 'storage', resourceName: 'myBucket', service: 'S3', key: 'storage:S3' },
+      logger,
+    );
+    generator.addFunctionAccess('mixedFn', ['read']);
+
+    const addPostDefineBackendStatementSpy = jest.spyOn(backendGenerator, 'addPostDefineBackendStatement');
+    const ops = await generator.plan();
+    await ops[0].execute();
+
+    // Identity (guest) access stays in the defineStorage access block...
+    const resourceTs = writtenFile('resource.ts');
+    expect(resourceTs).toContain('access:');
+    expect(resourceTs).toContain('guest');
+    // ...and the function grant is still emitted forward-direction in backend.ts.
+    expect(addPostDefineBackendStatementSpy).toHaveBeenCalledWith(
+      'backend.mixedFn.resources.lambda.addToRolePolicy(\n' +
+        '  new PolicyStatement({\n' +
+        '    effect: Effect.ALLOW,\n' +
+        "    actions: ['s3:GetObject', 's3:ListBucket'],\n" +
+        "    resources: [backend.storage.resources.bucket.arnForObjects('*'), backend.storage.resources.bucket.bucketArn],\n" +
+        '  }),\n' +
+        ');',
+    );
   });
 
   it('renders empty access when no access patterns configured', async () => {
@@ -839,10 +890,7 @@ describe('S3Generator', () => {
 
       const branchName = process.env.AWS_BRANCH ?? 'sandbox';
 
-      export const storage = defineStorage({
-        name: \`myBucket-main-\${branchName}\`,
-        access: (allow) => ({}),
-      });
+      export const storage = defineStorage({ name: \`myBucket-main-\${branchName}\` });
 
       export function postRefactor(backend: Backend) {
         const s3Bucket = backend.storage.resources.cfnResources.cfnBucket;

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.generator.ts
@@ -77,7 +77,9 @@ export class AuthGenerator implements Planner {
       mfaConfig,
       nativeClient,
       triggers: this.triggers,
-      access: this.access,
+      // `access` is set inside execute() from the trigger subset (see below):
+      // the partition must run AFTER the function generators have populated
+      // this.access / this.triggers, which happens after plan() returns.
     };
 
     const authDir = path.join(this.outputDir, 'amplify', 'auth');
@@ -89,10 +91,21 @@ export class AuthGenerator implements Planner {
         describe: async () => ['Generate amplify/auth/resource.ts'],
         execute: async () => {
           this.logger.info('Rendering auth/resource.ts');
-          const nodeArray = this.defineAuth.render(renderOptions);
-          let content = TS.printNodes(nodeArray);
 
-          content = content.replace(/\(allow, _unused\)/g, '(allow)');
+          // Partition function auth access by whether the function is ALSO an auth
+          // trigger. Computed HERE (not in plan()) because the function generators
+          // populate this.access / this.triggers after this.plan() returns. A
+          // trigger already forces an `auth -> function` cross-stack edge, so its
+          // access must ride the defineAuth `access` block (Amplify co-locates it,
+          // adding no new edge); a forward backend.ts userPool.grant on a trigger
+          // function would add a `function -> auth` edge and close a circular
+          // dependency at deploy time. Non-trigger access uses the forward grant.
+          const triggerResourceNames = new Set(this.triggers.map((t) => t.resourceName));
+          const triggerAccess = this.access.filter((a) => triggerResourceNames.has(a.resourceName));
+          const nonTriggerAccess = this.access.filter((a) => !triggerResourceNames.has(a.resourceName));
+
+          const nodeArray = this.defineAuth.render({ ...renderOptions, access: triggerAccess });
+          const content = TS.printNodes(nodeArray);
 
           await fs.mkdir(authDir, { recursive: true });
           await fs.writeFile(path.join(authDir, 'resource.ts'), content, 'utf-8');
@@ -100,6 +113,26 @@ export class AuthGenerator implements Planner {
           this.backendGenerator.addNamespaceImport('auth', './auth/resource');
           this.backendGenerator.addDefineBackendEntry('auth', 'auth', 'auth');
           this.backendGenerator.addApplyEscapeHatchesCall({ alias: 'auth', extraArgs: [] });
+
+          /**
+           * Emit non-trigger function -> auth access as forward-direction grants
+           * in backend.ts (`backend.auth.resources.userPool.grant(...)`). Trigger
+           * functions are handled via the defineAuth `access` block instead (see
+           * the partition above), because a forward grant on a trigger function
+           * would close a circular dependency at deploy time.
+           */
+          const unknownPermissions = AuthRenderer.unknownPermissions(nonTriggerAccess);
+          if (unknownPermissions.length > 0) {
+            this.logger.warn(
+              `Unrecognized Gen1 auth permission(s) [${unknownPermissions.join(
+                ', ',
+              )}] have no known cognito-idp action mapping and were emitted as raw 'cognito-idp:<permission>' actions. Verify the generated IAM actions in amplify/backend.ts.`,
+            );
+          }
+          for (const statement of this.defineAuth.buildFunctionAccessBackendStatements(nonTriggerAccess)) {
+            this.backendGenerator.addPostDefineBackendStatement(statement);
+          }
+
           if (userPool.Domain) {
             this.backendGenerator.addPostRefactorCall('auth.postRefactor(backend)');
           }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -104,6 +104,15 @@ export interface AuthRenderOptions {
   readonly identityGroups?: readonly GroupType[];
   readonly triggers?: readonly AuthTrigger[];
   readonly mfaConfig?: GetUserPoolMfaConfigResponse;
+  /**
+   * Function access rendered as the `access: (allow) => [...]` block ON
+   * defineAuth. This path is used ONLY for functions that are ALSO auth triggers
+   * (postConfirmation etc.): a trigger already forces an `auth -> function`
+   * cross-stack edge, and Amplify's `access` construct co-locates the grant so no
+   * SECOND edge is added. Non-trigger function access is emitted separately as a
+   * forward-direction grant in backend.ts (see buildFunctionAccessBackendStatements)
+   * to avoid the reverse `auth -> function` edge that caused circular dependencies.
+   */
   readonly access?: readonly FunctionAccess[];
 }
 
@@ -112,6 +121,86 @@ const factory = ts.factory;
 
 // Secret management identifier for Gen 2
 const secretIdentifier = factory.createIdentifier('secret');
+
+/**
+ * Maps each Amplify Gen2 auth permission name (as configured on a Gen1 function's
+ * cognito access) to the concrete `cognito-idp:*` IAM actions it grants.
+ *
+ * This mirrors the permission -> action expansion that `allow.resource(fn).to()`
+ * performs internally in `@aws-amplify/backend-auth` (transcribed from its
+ * `AuthAccessPolicyArbiter` / `access.ts` permission tables, ~v1.6.x, since the
+ * package does not export the raw-action map for import). Two drift risks, only
+ * the first of which is guarded:
+ *   1. A NEW permission NAME added upstream -> caught: unknownPermissions() warns
+ *      at generate time and the raw-action fallback keeps it visible.
+ *   2. A new ACTION added to an EXISTING permission (e.g. another cognito-idp
+ *      action folded into `manageUsers`) -> NOT caught: this table would silently
+ *      under-grant. If you bump the upstream reference, re-check the action sets
+ *      below against it, not just the permission names.
+ */
+const PERMISSION_ACTION_MAP: Readonly<Record<string, readonly string[]>> = {
+  manageUsers: [
+    'cognito-idp:AdminConfirmSignUp',
+    'cognito-idp:AdminCreateUser',
+    'cognito-idp:AdminDeleteUser',
+    'cognito-idp:AdminDeleteUserAttributes',
+    'cognito-idp:AdminDisableUser',
+    'cognito-idp:AdminEnableUser',
+    'cognito-idp:AdminGetUser',
+    'cognito-idp:AdminListGroupsForUser',
+    'cognito-idp:AdminRespondToAuthChallenge',
+    'cognito-idp:AdminSetUserMFAPreference',
+    'cognito-idp:AdminSetUserSettings',
+    'cognito-idp:AdminUpdateUserAttributes',
+    'cognito-idp:AdminUserGlobalSignOut',
+    'cognito-idp:ListUsers',
+  ],
+  manageGroups: [
+    'cognito-idp:GetGroup',
+    'cognito-idp:ListGroups',
+    'cognito-idp:CreateGroup',
+    'cognito-idp:DeleteGroup',
+    'cognito-idp:UpdateGroup',
+  ],
+  manageGroupMembership: [
+    'cognito-idp:AdminAddUserToGroup',
+    'cognito-idp:AdminRemoveUserFromGroup',
+    'cognito-idp:AdminListGroupsForUser',
+    'cognito-idp:ListUsersInGroup',
+  ],
+  manageUserDevices: [
+    'cognito-idp:AdminForgetDevice',
+    'cognito-idp:AdminGetDevice',
+    'cognito-idp:AdminListDevices',
+    'cognito-idp:AdminUpdateDeviceStatus',
+  ],
+  managePasswordRecovery: ['cognito-idp:AdminResetUserPassword', 'cognito-idp:AdminSetUserPassword'],
+  addUserToGroup: ['cognito-idp:AdminAddUserToGroup'],
+  createUser: ['cognito-idp:AdminCreateUser'],
+  deleteUser: ['cognito-idp:AdminDeleteUser'],
+  deleteUserAttributes: ['cognito-idp:AdminDeleteUserAttributes'],
+  disableUser: ['cognito-idp:AdminDisableUser'],
+  enableUser: ['cognito-idp:AdminEnableUser'],
+  forgetDevice: ['cognito-idp:AdminForgetDevice'],
+  getDevice: ['cognito-idp:AdminGetDevice'],
+  getUser: ['cognito-idp:AdminGetUser'],
+  listUsers: ['cognito-idp:ListUsers'],
+  listDevices: ['cognito-idp:AdminListDevices'],
+  listGroupsForUser: ['cognito-idp:AdminListGroupsForUser'],
+  listUsersInGroup: ['cognito-idp:ListUsersInGroup'],
+  listGroups: ['cognito-idp:ListGroups'],
+  createGroup: ['cognito-idp:CreateGroup'],
+  deleteGroup: ['cognito-idp:DeleteGroup'],
+  getGroup: ['cognito-idp:GetGroup'],
+  updateGroup: ['cognito-idp:UpdateGroup'],
+  removeUserFromGroup: ['cognito-idp:AdminRemoveUserFromGroup'],
+  resetUserPassword: ['cognito-idp:AdminResetUserPassword'],
+  setUserMfaPreference: ['cognito-idp:AdminSetUserMFAPreference'],
+  setUserPassword: ['cognito-idp:AdminSetUserPassword'],
+  setUserSettings: ['cognito-idp:AdminSetUserSettings'],
+  updateDeviceStatus: ['cognito-idp:AdminUpdateDeviceStatus'],
+  updateUserAttributes: ['cognito-idp:AdminUpdateUserAttributes'],
+};
 
 // Social provider secret key constants
 const googleClientID = 'GOOGLE_CLIENT_ID';
@@ -285,7 +374,15 @@ export class AuthRenderer {
     const mfa = AuthRenderer.deriveMfaConfig(options.mfaConfig);
     this.addMfaConfig(mfa, defineAuthProperties);
 
-    this.addFunctionAccess(options.access, defineAuthProperties, namedImports);
+    // Function access is split by whether the function is ALSO an auth trigger:
+    //  - trigger + access  -> emitted here as the `access` block on defineAuth.
+    //    A trigger already forces an `auth -> function` edge, and Amplify's access
+    //    construct co-locates the grant, so this adds no NEW cross-stack edge.
+    //  - access only        -> emitted in backend.ts as a forward-direction grant
+    //    (buildFunctionAccessBackendStatements), avoiding the reverse edge that
+    //    causes circular dependencies for functions that also touch data/storage.
+    // options.access carries ONLY the trigger subset (the generator partitions it).
+    this.addFunctionAccessBlock(options.access, defineAuthProperties, namedImports);
 
     return TS.renderResourceTsFile({
       exportedVariableName: factory.createIdentifier('auth'),
@@ -594,7 +691,15 @@ export class AuthRenderer {
     );
   }
 
-  private addFunctionAccess(
+  /**
+   * Emits the `access: (allow) => [allow.resource(fn).to([...])]` block ON
+   * defineAuth for the given functions. Used ONLY for functions that are also
+   * auth triggers (see AuthRenderOptions.access) — the trigger already forces an
+   * `auth -> function` edge, and Amplify's access construct co-locates the grant,
+   * so this does not add a new cross-stack edge (unlike the non-trigger case,
+   * which uses a forward backend.ts grant to avoid exactly that edge).
+   */
+  private addFunctionAccessBlock(
     functions: readonly FunctionAccess[] | undefined,
     properties: PropertyAssignment[],
     namedImports: Record<string, Set<string>>,
@@ -609,7 +714,7 @@ export class AuthRenderer {
     }
 
     for (const func of functionsWithAuthAccess) {
-      // Skip adding import if the function is already imported (e.g., by addLambdaTriggers for auth triggers).
+      // Skip adding the import if the function is already imported (e.g. by addLambdaTriggers for the trigger wiring).
       const alreadyImported = Object.values(namedImports).some((names) => names.has(func.resourceName));
       if (!alreadyImported) {
         namedImports[`../function/${func.resourceName}/resource`] = new Set([func.resourceName]);
@@ -617,7 +722,6 @@ export class AuthRenderer {
     }
 
     const accessRules: ts.Expression[] = [];
-
     for (const func of functionsWithAuthAccess) {
       for (const [permission, enabled] of Object.entries(func.permissions)) {
         if (enabled) {
@@ -646,10 +750,7 @@ export class AuthRenderer {
           factory.createArrowFunction(
             undefined,
             undefined,
-            [
-              factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('allow')),
-              factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('_unused')),
-            ],
+            [factory.createParameterDeclaration(undefined, undefined, factory.createIdentifier('allow'))],
             undefined,
             undefined,
             factory.createArrayLiteralExpression(accessRules, true),
@@ -657,6 +758,104 @@ export class AuthRenderer {
         ),
       );
     }
+  }
+
+  /**
+   * Builds the forward-direction function->auth grant statements emitted into
+   * backend.ts (not into auth/resource.ts).
+   *
+   * Each granted function is wired with a CDK grant on the underlying user pool
+   * construct:
+   *
+   *   backend.auth.resources.userPool.grant(
+   *     backend.<fn>.resources.lambda,
+   *     '<cognito-idp:Action>', ...
+   *   );
+   *
+   * This adds the IAM policy to the FUNCTION's role and only references the user
+   * pool ARN, so the cross-stack dependency stays `function -> auth`. It replaces
+   * the previous `access: (allow) => [allow.resource(fn).to([...])]` block on
+   * defineAuth, which pointed the dependency the other way (`auth -> function`)
+   * and caused deploy-time circular dependencies when the same function also
+   * accessed data/storage.
+   *
+   * Returns one statement string per granted function (already de-duplicated and
+   * with actions sorted for stable output), or an empty array when there is
+   * nothing to grant. The caller passes these to
+   * BackendGenerator.addPostDefineBackendStatement.
+   */
+  public buildFunctionAccessBackendStatements(functions: readonly FunctionAccess[] | undefined): string[] {
+    if (!functions || functions.length === 0) {
+      return [];
+    }
+
+    // Consolidate permissions per function (a function may appear more than once).
+    const actionsByFunction: Record<string, Set<string>> = {};
+    for (const func of functions) {
+      const enabledPermissions = Object.entries(func.permissions)
+        .filter(([, enabled]) => enabled)
+        .map(([permission]) => permission);
+      if (enabledPermissions.length === 0) {
+        continue;
+      }
+      if (!actionsByFunction[func.resourceName]) {
+        actionsByFunction[func.resourceName] = new Set();
+      }
+      for (const permission of enabledPermissions) {
+        for (const action of AuthRenderer.actionsForPermission(permission)) {
+          actionsByFunction[func.resourceName].add(action);
+        }
+      }
+    }
+
+    const statements: string[] = [];
+    for (const [resourceName, actions] of Object.entries(actionsByFunction)) {
+      if (actions.size === 0) {
+        continue;
+      }
+      TS.assertValidIdentifier(resourceName, `auth access grant for function '${resourceName}'`);
+      const actionArgs = Array.from(actions)
+        .sort()
+        .map((a) => `'${a}'`)
+        .join(', ');
+      statements.push(`backend.auth.resources.userPool.grant(backend.${resourceName}.resources.lambda, ${actionArgs});`);
+    }
+    return statements;
+  }
+
+  /**
+   * Collects the distinct enabled permission names across all granted functions
+   * that are NOT present in PERMISSION_ACTION_MAP.
+   *
+   * The map covers the full AuthPermissions set, so this is normally empty; a
+   * non-empty result means the upstream permission set drifted from the mapping
+   * table. The generator warns on these (rather than the pure renderer logging)
+   * so the operator sees which permissions fell through to the raw-action
+   * fallback and can verify the generated IAM actions.
+   */
+  public static unknownPermissions(functions: readonly FunctionAccess[] | undefined): string[] {
+    if (!functions) {
+      return [];
+    }
+    const unknown = new Set<string>();
+    for (const func of functions) {
+      for (const [permission, enabled] of Object.entries(func.permissions)) {
+        if (enabled && !(permission in PERMISSION_ACTION_MAP)) {
+          unknown.add(permission);
+        }
+      }
+    }
+    return Array.from(unknown).sort();
+  }
+
+  /**
+   * Maps an Amplify Gen2 auth permission name to its concrete `cognito-idp:*` IAM
+   * actions via PERMISSION_ACTION_MAP. An unrecognized permission falls back to a
+   * raw `cognito-idp:<permission>` action so it is visible in review rather than
+   * silently dropped; unknownPermissions() surfaces the same case as a warning.
+   */
+  private static actionsForPermission(permission: string): readonly string[] {
+    return PERMISSION_ACTION_MAP[permission] ?? [`cognito-idp:${permission}`];
   }
 
   /**

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/backend.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/backend.generator.ts
@@ -20,6 +20,7 @@ import { SpinningLogger } from '../../_common/spinning-logger';
  */
 export class BackendGenerator implements Planner {
   private readonly namespaceImports: NamespaceImport[] = [];
+  private readonly namedImports: Record<string, Set<string>> = {};
   private readonly defineBackendEntries: DefineBackendEntry[] = [];
   private readonly applyEscapeHatchesCalls: EscapeHatchCall[] = [];
   private readonly postRefactorCalls: string[] = [];
@@ -39,6 +40,18 @@ export class BackendGenerator implements Planner {
    */
   public addNamespaceImport(alias: string, source: string): void {
     this.namespaceImports.push({ alias, source });
+  }
+
+  /**
+   * Adds a named import: `import { name } from 'source';`. Deduplicated per
+   * source, so multiple callers requesting the same symbol collapse to one
+   * import specifier (e.g. several categories emitting IAM policy statements).
+   */
+  public addNamedImport(source: string, name: string): void {
+    if (!this.namedImports[source]) {
+      this.namedImports[source] = new Set();
+    }
+    this.namedImports[source].add(name);
   }
 
   /**
@@ -93,6 +106,7 @@ export class BackendGenerator implements Planner {
         execute: async () => {
           const options: BackendRenderOptions = {
             namespaceImports: this.namespaceImports,
+            namedImports: this.namedImports,
             defineBackendEntries: this.defineBackendEntries,
             postDefineBackendCalls: this.postDefineBackendCalls,
             postDefineBackendStatements: this.postDefineBackendStatements,

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/backend.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/backend.renderer.ts
@@ -41,6 +41,7 @@ export interface EscapeHatchCall {
  */
 export interface BackendRenderOptions {
   readonly namespaceImports: readonly NamespaceImport[];
+  readonly namedImports?: Readonly<Record<string, ReadonlySet<string>>>;
   readonly defineBackendEntries: readonly DefineBackendEntry[];
   readonly postDefineBackendCalls: readonly PostDefineBackendCall[];
   readonly postDefineBackendStatements: readonly string[];
@@ -65,6 +66,14 @@ export class BackendRenderer {
     }
     nodes.push(this.renderDefineBackendImport());
     nodes.push(TS.namedImport('aws-cdk-lib', 'Tags'));
+    // Additional named imports contributed by category generators (e.g. IAM
+    // PolicyStatement/Effect for function access grants), deduped and sorted.
+    for (const source of Object.keys(options.namedImports ?? {}).sort()) {
+      const names = Array.from(options.namedImports![source]).sort();
+      if (names.length > 0) {
+        nodes.push(TS.namedImport(source, ...names));
+      }
+    }
     nodes.push(newLineIdentifier);
 
     // 2. defineBackend call

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.generator.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.generator.ts
@@ -105,6 +105,22 @@ export class S3Generator implements Planner {
           this.backendGenerator.addDefineBackendEntry('storage', 'storage', 'storage');
           this.backendGenerator.addApplyEscapeHatchesCall({ alias: 'storage', extraArgs: [] });
           this.backendGenerator.addPostRefactorCall('storage.postRefactor(backend);');
+
+          // Emit function->storage access as forward-direction IAM policy
+          // statements in backend.ts (backend.<fn>.resources.lambda.addToRolePolicy(...))
+          // rather than reverse-direction allow.resource(fn) entries on
+          // defineStorage, which would create a `storage -> function` cross-stack
+          // dependency and cause circular dependencies at deploy time. Exact
+          // Amplify action set is used (not bucket.grant*) to avoid over-granting
+          // s3:DeleteObject that CDK's grantWrite/grantReadWrite bundle in.
+          const storageGrantStatements = this.renderer.buildFunctionAccessBackendStatements(this.functionAccess);
+          if (storageGrantStatements.length > 0) {
+            this.backendGenerator.addNamedImport('aws-cdk-lib/aws-iam', 'Effect');
+            this.backendGenerator.addNamedImport('aws-cdk-lib/aws-iam', 'PolicyStatement');
+          }
+          for (const statement of storageGrantStatements) {
+            this.backendGenerator.addPostDefineBackendStatement(statement);
+          }
         },
       },
     ];

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/storage/s3.renderer.ts
@@ -66,7 +66,7 @@ export class S3Renderer {
     postImportStatements.push(TS.createBranchNameDeclaration());
 
     this.renderName(propertyAssignments, opts.name);
-    this.renderAccessPatterns(propertyAssignments, namedImports, postImportStatements, opts);
+    this.renderAccessPatterns(propertyAssignments, postImportStatements, opts);
     this.renderTriggers(propertyAssignments, namedImports, opts);
 
     const nodes: ts.Node[] = [
@@ -217,24 +217,20 @@ export class S3Renderer {
     target.push(factory.createPropertyAssignment(factory.createIdentifier('name'), nameExpression));
   }
 
-  private renderAccessPatterns(
-    target: ts.PropertyAssignment[],
-    namedImports: Record<string, Set<string>>,
-    postImportStatements: ts.Node[],
-    opts: S3RenderOptions,
-  ): void {
+  private renderAccessPatterns(target: ts.PropertyAssignment[], postImportStatements: ts.Node[], opts: S3RenderOptions): void {
     if (!opts.access) return;
 
-    target.push(this.buildAccessProperty(opts.access));
+    // Only emit the `access` block for identity-based (guest/authenticated/group)
+    // access. Function access is emitted as forward-direction grants in backend.ts
+    // (see buildFunctionAccessBackendStatements), so a bucket whose only Gen1
+    // access was function access produces no `access` block here.
+    const hasIdentityAccess =
+      (opts.access.guest?.length ?? 0) > 0 ||
+      (opts.access.auth?.length ?? 0) > 0 ||
+      (opts.access.groups !== undefined && Object.keys(opts.access.groups).length > 0);
 
-    if (opts.access.functions && opts.access.functions.length > 0) {
-      for (const functionAccess of opts.access.functions) {
-        const functionImportPath = `../function/${functionAccess.functionName}/resource`;
-        if (!namedImports[functionImportPath]) {
-          namedImports[functionImportPath] = new Set();
-        }
-        namedImports[functionImportPath].add(functionAccess.functionName);
-      }
+    if (hasIdentityAccess) {
+      target.push(this.buildAccessProperty(opts.access));
     }
 
     if (opts.access.groups) {
@@ -300,22 +296,16 @@ export class S3Renderer {
         protectedPathAccess.push(pattern);
       }
     }
-    if (accessPatterns.functions && accessPatterns.functions.length > 0) {
-      const consolidated: Record<string, Set<Permission>> = {};
-      for (const { functionName, permissions } of accessPatterns.functions) {
-        if (!consolidated[functionName]) {
-          consolidated[functionName] = new Set(permissions);
-        } else {
-          for (const p of permissions) consolidated[functionName].add(p);
-        }
-      }
-      for (const [functionName, permissions] of Object.entries(consolidated)) {
-        const pattern = S3Renderer.createResourcePattern(allowIdentifier, functionName, Array.from(permissions));
-        publicPathAccess.push(pattern);
-        privatePathAccess.push(pattern);
-        protectedPathAccess.push(pattern);
-      }
-    }
+    // NOTE: function access is intentionally NOT emitted here as
+    // `allow.resource(fn).to([...])` entries in the per-path access map. That
+    // construct makes the storage stack reference the function's role, i.e. a
+    // `storage -> function` cross-stack dependency, which combined with the
+    // function's own grants to other categories closes a cross-stack cycle and
+    // produces a CloudformationStackCircularDependencyError on deploy. Function
+    // access is instead emitted in backend.ts as forward-direction CDK grants on
+    // the bucket construct (see buildFunctionAccessBackendStatements), preserving
+    // the `function -> storage` direction. Guest / authenticated / group access
+    // below is per-path and stays in the access block.
 
     const allowAssignments: ts.PropertyAssignment[] = [];
     if (publicPathAccess.length > 0) {
@@ -376,22 +366,94 @@ export class S3Renderer {
     );
   }
 
-  private static createResourcePattern(
-    allowIdentifier: ts.Identifier,
-    functionName: string,
-    permissions: readonly Permission[],
-  ): CallExpression {
-    return factory.createCallExpression(
-      factory.createPropertyAccessExpression(
-        factory.createCallExpression(
-          factory.createPropertyAccessExpression(allowIdentifier, factory.createIdentifier('resource')),
-          undefined,
-          [factory.createIdentifier(functionName)],
-        ),
-        factory.createIdentifier('to'),
-      ),
-      undefined,
-      [factory.createArrayLiteralExpression(permissions.map((p) => factory.createStringLiteral(p)))],
-    );
+  /**
+   * Builds the forward-direction function->storage grant statements emitted into
+   * backend.ts (not into storage/resource.ts).
+   *
+   * Each granted function gets an explicit IAM policy statement added to its own
+   * role, referencing only the bucket ARN:
+   *
+   *   backend.<fn>.resources.lambda.addToRolePolicy(
+   *     new PolicyStatement({ effect: Effect.ALLOW, actions: [...], resources: [...] }),
+   *   );
+   *
+   * The policy is attached to the FUNCTION's role and references the bucket ARN,
+   * so the cross-stack dependency stays `function -> storage`. It replaces the
+   * previous `allow.resource(fn).to([...])` entries in the defineStorage access
+   * block, which pointed the dependency the other way (`storage -> function`) and
+   * caused deploy-time circular dependencies when the same function also accessed
+   * auth/data.
+   *
+   * The action set is the EXACT Amplify Gen1 permission -> S3 action mapping, NOT
+   * a CDK bucket.grant* helper: CDK's grantWrite/grantReadWrite bundle
+   * s3:DeleteObject into "write" (writeActions = delete + put), whereas Amplify's
+   * `write`/`create` mean PutObject only and `delete` is a distinct permission. A
+   * function whose Gen1 access was ['read','write'] must NOT receive DeleteObject
+   * it never had, so the actions are enumerated exactly:
+   *   read           -> s3:GetObject (object) + s3:ListBucket (bucket)
+   *   write / create -> s3:PutObject (object)
+   *   delete         -> s3:DeleteObject (object)
+   *
+   * Object-scoped actions target `${bucket.bucketArn}/*`; the bucket-scoped
+   * s3:ListBucket targets the bucket ARN itself. Returns one statement string per
+   * granted function (permissions consolidated across duplicate entries), or an
+   * empty array when there is nothing to grant. The caller registers the IAM
+   * named imports and passes these to BackendGenerator.addPostDefineBackendStatement.
+   */
+  public buildFunctionAccessBackendStatements(functions: readonly FunctionAccess[] | undefined): string[] {
+    if (!functions || functions.length === 0) {
+      return [];
+    }
+
+    // Consolidate permissions per function (a function may appear more than once).
+    const permsByFunction: Record<string, Set<Permission>> = {};
+    for (const { functionName, permissions } of functions) {
+      if (!permsByFunction[functionName]) {
+        permsByFunction[functionName] = new Set();
+      }
+      for (const p of permissions) {
+        permsByFunction[functionName].add(p);
+      }
+    }
+
+    const statements: string[] = [];
+    for (const [functionName, permSet] of Object.entries(permsByFunction)) {
+      const objectActions = new Set<string>();
+      let needsListBucket = false;
+      if (permSet.has('read')) {
+        objectActions.add('s3:GetObject');
+        needsListBucket = true;
+      }
+      if (permSet.has('write') || permSet.has('create')) {
+        objectActions.add('s3:PutObject');
+      }
+      if (permSet.has('delete')) {
+        objectActions.add('s3:DeleteObject');
+      }
+      if (objectActions.size === 0 && !needsListBucket) {
+        continue;
+      }
+
+      TS.assertValidIdentifier(functionName, `storage access grant for function '${functionName}'`);
+      const lambda = `backend.${functionName}.resources.lambda`;
+      const bucket = `backend.storage.resources.bucket`;
+      const actions = Array.from(objectActions)
+        .sort()
+        .map((a) => `'${a}'`);
+      // Object actions target the objects ARN; s3:ListBucket (read) targets the
+      // bucket ARN itself, so read grants get two resource entries.
+      const resources = needsListBucket ? [`${bucket}.arnForObjects('*')`, `${bucket}.bucketArn`] : [`${bucket}.arnForObjects('*')`];
+      const bucketActions = needsListBucket ? [...actions, `'s3:ListBucket'`] : actions;
+      statements.push(
+        `${lambda}.addToRolePolicy(\n` +
+          `  new PolicyStatement({\n` +
+          `    effect: Effect.ALLOW,\n` +
+          `    actions: [${bucketActions.join(', ')}],\n` +
+          `    resources: [${resources.join(', ')}],\n` +
+          `  }),\n` +
+          `);`,
+      );
+    }
+    return statements;
   }
 }

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/ts.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/ts.ts
@@ -26,6 +26,22 @@ export type ResourceTsParameters = {
  */
 export class TS {
   /**
+   * Asserts that `name` is a valid JavaScript identifier before it is
+   * interpolated verbatim into generated source (e.g. `backend.${name}.resources.lambda`).
+   * Amplify resource names are expected to be identifier-safe, but an unexpected
+   * name containing hyphens/dots/spaces would emit invalid TypeScript; failing
+   * loudly at generate time is preferable to writing a file that won't compile.
+   * `context` names the interpolation site for the error message.
+   */
+  public static assertValidIdentifier(name: string, context: string): void {
+    // Matches a standard JS identifier (letter/underscore/$ start; the standard
+    // Unicode identifier ranges are not needed for Amplify resource names).
+    if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) {
+      throw new Error(`Cannot generate ${context}: '${name}' is not a valid JavaScript identifier and would produce invalid TypeScript.`);
+    }
+  }
+
+  /**
    * Prints a TypeScript AST node array to a formatted string.
    */
   public static printNodes(nodes: ts.NodeArray<ts.Node>, printWidth?: number): string {


### PR DESCRIPTION
#### Description of changes

`amplify gen2-migration generate` could produce a Gen2 app that fails to deploy with:

```
🛑 [CloudformationStackCircularDependencyError] circular dependency found between nested stacks [storage, auth, data, function]
```

**Root cause.** The generator emitted a function's access to auth/storage using
*reverse-direction* constructs:

- auth: `access: (allow) => [allow.resource(fn).to([...])]` on `defineAuth`
- storage: `allow.resource(fn).to([...])` entries inside the `defineStorage` access block

Both make the **auth/storage** stack reference the function's role — an
`auth → function` / `storage → function` cross-stack dependency. When the same
function also accesses another category (e.g. `data`), and that category
references auth (`data → auth`), the reverse-direction grant closes a cross-stack
cycle. Setting `resourceGroupName` only co-locates resources in one stack and
cannot break a genuine cross-category cycle.

**Fix.** Emit the grants in the **forward** direction in `backend.ts`, on the
underlying CDK constructs, so the dependency stays `function → auth` /
`function → storage`:

- auth → `backend.auth.resources.userPool.grant(backend.<fn>.resources.lambda, ...cognito-idp actions)`, using a documented Amplify-permission → `cognito-idp:*` action mapping (the CDK grant works on raw IAM actions, not Amplify permission names).
- storage → `backend.storage.resources.bucket.grant{Read,Write,ReadWrite,Delete}(backend.<fn>.resources.lambda)`, picking the narrowest grant that covers the consolidated permission set.

Identity-based storage access (guest / authenticated / group) is unchanged and
still rendered as the per-path `defineStorage` access block; a bucket whose only
Gen1 access was function access now emits no access block at all.

#### Issue #, if available

Fixes #14727

#### Description of how you validated changes

- Unit suites `auth.generator.test.ts` and `s3.generator.test.ts` rewritten to assert the forward-direction grants (spy on `addPostDefineBackendStatement`) — 39/39 pass, 28/28 snapshots.
- End-to-end migration-app snapshots regenerated and passing, including **fitness-tracker** (the repro named in the issue) — the `admin` function's `access` block on `defineAuth` is replaced by `backend.auth.resources.userPool.grant(backend.admin.resources.lambda, ...)` in `backend.ts`. `media-vault` and `store-locator` snapshots also updated.
- `tsc --noEmit` clean; eslint 0 errors on touched files; prettier clean.

Not yet validated: a live `ampx sandbox` deploy of the regenerated output confirming the circular-dependency error is gone. That requires an AWS account and a multi-category Gen1 app; flagging it as the remaining manual-verification gate.

One thing worth a maintainer's eye: the auth permission → `cognito-idp:*` mapping duplicates expansion logic that lives inside `@aws-amplify/backend-auth`. It needs a sanity-check against that source and a note to keep the table in sync.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes (targeted gen2-migration generate suites; see above)
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
