### PR TITLE
fix(cli): gen2-migration inject required standard attrs into social IdP mappings

### DIFF
--- a/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
+++ b/amplify-migration-apps/media-vault/_snapshot.post.generate/amplify/auth/resource.ts
@@ -23,6 +23,7 @@ export const auth = defineAuth({
         scopes: ['openid', 'email', 'profile'],
         attributeMapping: {
           email: 'email',
+          phoneNumber: 'phone_number',
           custom: {
             username: 'sub',
           },
@@ -34,6 +35,7 @@ export const auth = defineAuth({
         scopes: ['email', 'public_profile'],
         attributeMapping: {
           email: 'email',
+          phoneNumber: 'phone_number',
           custom: {
             username: 'id',
           },

--- a/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
+++ b/packages/amplify-cli/src/__tests__/commands/gen2-migration/generate/amplify/auth/auth.generator.test.ts
@@ -1263,6 +1263,77 @@ describe('AuthGenerator', () => {
     `);
   });
 
+  // Regression: a Gen1 pool with phone_number as a username attribute AND a
+  // social IdP whose Gen1 attribute mapping only covers email. Cognito treats
+  // phone_number as an implicitly-required attribute and rejects any federated
+  // IdP whose attributeMapping omits it ("The attribute mapping is missing
+  // required attributes [phone_number]"), rolling the deploy back. The renderer
+  // must inject the required standard attribute into every social provider's
+  // attributeMapping so the generated Gen2 app deploys. See gen2-migration
+  // media-vault E2E.
+  it('injects required username standard attributes (phone_number) into social IdP attribute mappings', async () => {
+    const gen1App = await createGen1App({
+      providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },
+      auth: {
+        testAuth: {
+          service: 'Cognito',
+          output: {
+            UserPoolId: 'us-east-1_abc123',
+            AppClientIDWeb: 'webclient123',
+            AppClientID: 'client123',
+            IdentityPoolId: 'us-east-1:idpool',
+          },
+        },
+      },
+    });
+    // phone_number is a username attribute -> Cognito requires it in every IdP mapping.
+    jest.spyOn(gen1App.aws, 'fetchUserPool').mockResolvedValue({
+      SchemaAttributes: [],
+      UsernameAttributes: ['email', 'phone_number'],
+    });
+    jest.spyOn(gen1App.aws, 'fetchMfaConfig').mockResolvedValue({});
+    jest.spyOn(gen1App.aws, 'fetchIdentityGroups').mockResolvedValue([]);
+    jest.spyOn(gen1App.aws, 'fetchIdentityPool').mockResolvedValue({
+      IdentityPoolId: 'us-east-1:idpool',
+      IdentityPoolName: 'test-pool',
+      AllowUnauthenticatedIdentities: true,
+    });
+    // Gen1 social IdP mapping only covers email + a custom username claim.
+    jest.spyOn(gen1App.aws, 'fetchIdentityProviders').mockResolvedValue([
+      {
+        ProviderType: IdentityProviderTypeType.Google,
+        ProviderName: 'Google',
+        ProviderDetails: { authorized_scopes: 'openid email profile' },
+        AttributeMapping: { email: 'email', username: 'sub' },
+      },
+      {
+        ProviderType: IdentityProviderTypeType.Facebook,
+        ProviderName: 'Facebook',
+        ProviderDetails: { authorized_scopes: 'email public_profile' },
+        AttributeMapping: { email: 'email', username: 'id' },
+      },
+    ]);
+    jest.spyOn(gen1App.aws, 'fetchUserPoolClient').mockResolvedValue({
+      CallbackURLs: [],
+      LogoutURLs: [],
+    });
+
+    const generator = new AuthGenerator(gen1App, backendGenerator, outputDir, authResource, logger);
+    const ops = await generator.plan();
+    await ops[0].execute();
+    const resource = writtenFile('auth/resource.ts');
+
+    // The required standard attribute is injected into BOTH social provider mappings,
+    // mapped to its own claim name (the identity default Cognito accepts).
+    const phoneMappingCount = (resource.match(/phoneNumber: 'phone_number'/g) ?? []).length;
+    expect(phoneMappingCount).toBe(2);
+    // The Gen1-declared mapping is preserved (custom username claim still emitted).
+    expect(resource).toContain("username: 'sub'");
+    expect(resource).toContain("username: 'id'");
+    // phone_number remains a username attribute on the pool (login behavior preserved).
+    expect(resource).toContain("cfnUserPool.usernameAttributes = ['email', 'phone_number'];");
+  });
+
   it('generates external providers', async () => {
     const gen1App = await createGen1App({
       providers: { awscloudformation: { StackName: 'amplify-test-main-123456', Region: 'us-east-1' } },

--- a/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
+++ b/packages/amplify-cli/src/commands/gen2-migration/generate/amplify/auth/auth.renderer.ts
@@ -322,7 +322,10 @@ export class AuthRenderer {
    * Parses OIDC/SAML providers, attribute mappings, and scopes from
    * identity provider details.
    */
-  private static deriveExternalProviders(details?: readonly IdentityProviderType[]): {
+  private static deriveExternalProviders(
+    details?: readonly IdentityProviderType[],
+    requiredStandardAttributes: readonly string[] = [],
+  ): {
     readonly oidcProviders: readonly OidcProviderConfig[];
     readonly samlProvider: SamlProviderConfig | undefined;
     readonly attributeMappings: Readonly<Record<string, { standard: Record<string, string>; custom: Record<string, string> }>>;
@@ -385,12 +388,30 @@ export class AuthRenderer {
       }
     }
 
+    // Cognito requires that EVERY federated identity provider's attribute
+    // mapping include every standard attribute the user pool marks as required
+    // (a username/alias attribute such as `phone_number` is implicitly
+    // required). A Gen1 pool can carry `phone_number` as a username attribute
+    // while its social IdP mappings only cover email — a valid Gen1 shape that
+    // Gen2 rejects at deploy time with "The attribute mapping is missing
+    // required attributes [phone_number]". Ensure each social provider mapping
+    // carries the required standard attributes, mapping each to its own claim
+    // name (the identity default Cognito accepts) when the Gen1 metadata did
+    // not already provide one.
+    const requiredStandard = requiredStandardAttributes.filter((attr) => attr in MAPPED_USER_ATTRIBUTE_NAME);
+    if (requiredStandard.length > 0) {
+      for (const mapping of Object.values(attributeMappings)) {
+        for (const attr of requiredStandard) {
+          const gen2Key = MAPPED_USER_ATTRIBUTE_NAME[attr];
+          if (!(gen2Key in mapping.standard)) {
+            mapping.standard[gen2Key] = attr;
+          }
+        }
+      }
+    }
+
     return { oidcProviders, samlProvider, attributeMappings, providerScopes };
   }
-
-  /**
-   * Derives MFA configuration from Cognito SDK types.
-   */
   private static deriveMfaConfig(mfa?: GetUserPoolMfaConfigResponse): {
     readonly mode: string;
     readonly sms?: boolean;
@@ -721,7 +742,10 @@ export class AuthRenderer {
       assignments.push(factory.createPropertyAssignment(factory.createIdentifier('phone'), factory.createTrue()));
     }
 
-    const externalProviders = AuthRenderer.deriveExternalProviders(options.identityProviders);
+    const externalProviders = AuthRenderer.deriveExternalProviders(options.identityProviders, [
+      ...(options.userPool.UsernameAttributes ?? []),
+      ...(options.userPool.AliasAttributes ?? []),
+    ]);
     const hasExternalProviders =
       loginFlags.googleLogin ||
       loginFlags.amazonLogin ||


### PR DESCRIPTION
#### Description of changes

When `gen2-migration generate` migrates a Gen1 app whose Cognito user pool has `phone_number` as a **username attribute** and also uses **social sign-in** (Google/Facebook), the generated Gen2 app fails to deploy:

```
CREATE_FAILED | AWS::Cognito::UserPoolIdentityProvider | auth/amplifyAuth/GoogleIdP
  Resource handler returned message: "The attribute mapping is missing required attributes [phone_number]"
```

Cognito treats a username attribute as **implicitly required**, and then requires every federated identity provider's `attributeMapping` to include that attribute. The migration renderer copies `phone_number` forward as a username attribute but generates the social IdP `attributeMapping` from the Gen1 provider metadata only (which typically maps just `email` + a custom username claim), so `phone_number` is absent and CloudFormation rolls the auth nested stack back. This surfaced as the `l_gen2_migration_media_vault` E2E shard failing on every deploy retry.

**Approach → change:** the auth renderer now derives the pool's required standard attributes (`UsernameAttributes` ∪ `AliasAttributes`, filtered to standard attributes it knows how to map via `MAPPED_USER_ATTRIBUTE_NAME`) and injects each into every social provider's `attributeMapping` as an identity mapping (e.g. `phoneNumber: 'phone_number'`) **only when** the Gen1 metadata did not already provide one. This is a general rule derived from the pool config, applied to all providers — not a per-app or per-provider special case. It preserves Gen1 login behavior (`phone_number` stays a username attribute) and removes no capability; it only adds the mapping Cognito already requires.

This is independent of the store-locator circular-dependency fix in #14981 — it is a separate, pre-existing migration-codegen gap for the required-standard-attribute + social-IdP combination.

no linked issue: surfaced via the media-vault E2E shard, not a filed GitHub issue

#### Issue #, if available

N/A

#### Description of how you validated changes

- Added a regression test (`auth.generator.test.ts`) that generates from a pool with `UsernameAttributes: ['email', 'phone_number']` + Google/Facebook IdPs mapping only email; it asserts `phoneNumber: 'phone_number'` is injected into **both** provider mappings, the Gen1 custom username claims are preserved, and `phone_number` remains a pool username attribute. **Verified the test fails without the fix** (`Expected 2, Received 0`) and passes with it.
- Full `gen2-migration/generate` suite green: 23 suites / 260 tests / 103 snapshots, including the gated `media-vault snapshot` comparison (regenerated `_snapshot.post.generate/amplify/auth/resource.ts`).
- `tsc --noEmit` clean, prettier clean, eslint 0 errors.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Pull request labels are added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
